### PR TITLE
Manual: implement SME doc feedback

### DIFF
--- a/manual/components/engines.md
+++ b/manual/components/engines.md
@@ -128,4 +128,3 @@ For production you run engines from prebuilt images that overlay the Infera
 connector + RDMA shims onto a vendor base (the SGLang base is pinned via the
 `SGLANG_BASE_IMAGE` build-arg). See
 [Deployment → Engine images](../serving/deployment.md#engine-images).
-

--- a/manual/components/engines.md
+++ b/manual/components/engines.md
@@ -120,7 +120,7 @@ worker on its own port:
 ```
 
 Each rank self-registers into etcd; the router spreads across them by prefix. See
-the [project README](https://github.com/AMD-AGI/Optimus#data-parallel-replicas).
+the [project README](https://github.com/AMD-AGI/Infera).
 
 ## Container images
 
@@ -128,3 +128,4 @@ For production you run engines from prebuilt images that overlay the Infera
 connector + RDMA shims onto a vendor base (the SGLang base is pinned via the
 `SGLANG_BASE_IMAGE` build-arg). See
 [Deployment → Engine images](../serving/deployment.md#engine-images).
+

--- a/manual/components/kvd.md
+++ b/manual/components/kvd.md
@@ -88,9 +88,9 @@ The RAM tier is a memfd-backed pinned **shared arena**. When a vLLM/SGLang
 worker opts in at the UDS handshake, kvd passes the arena's file descriptor over
 `SCM_RIGHTS` and the engine `mmap`s the same region. A `get()` then returns just
 `(slot_offset, length, version)` — the engine reads bytes straight from its own
-mmap. No socket body, no `bytes(...)` copy. Measured **6.6× per-block** vs the
-legacy inline-bytes path on local kvd, and **280×** on NFS-backed L3 (prefetch
-warms the arena; the bytes path can't benefit).
+mmap. No socket body, no `bytes(...)` copy. The gain vs the legacy inline-bytes
+path is largest on NFS-backed L3 (prefetch warms the arena; the bytes path can't
+benefit).
 
 ## L3 on-disk design — the tablespace
 
@@ -206,14 +206,6 @@ class:
   `--long-workers-per-shard` (default `8`).
 - Low NFS `wsize` → a startup WARN with the exact remount command.
 
-## Measured backends (L3)
-
-| Backend | Best read | Best write | Note |
-|---|---:|---:|---|
-| 8× local NVMe (striped) | 49.7 GB/s cold | 29.2 GB/s | 94/91% of fio peak (O_DIRECT) |
-| Single NVMe ext4 | 6.5 GB/s | 4.0 GB/s | 99.8% of device ceiling |
-| Vast NFS (nconnect=8/32) | 10.7 GB/s | 5.2 GB/s | container-file design avoids per-chunk RPC tax |
-
 ## Sizing principles
 
 - **L2 (`--max-bytes`)** — as much host RAM as you can spare for KV; this is the
@@ -225,8 +217,26 @@ class:
   (L3 ≥ L2 ≥ the engine's GPU L1). A lower tier smaller than the one above it just
   churns: blocks evict before they're ever reused.
 
+## Verify it's running
+
+After starting the daemon and at least one engine, send the same prompt twice
+(or any prompt that shares a long prefix), then check the daemon counters:
+
+```bash
+python -m infera.kvd.statctl --socket /var/run/infera-kvd.sock
+# healthy output: sets_total > 0, gets_total > 0, hits_total > 0
+```
+
+`hits_total == 0` after a repeated prompt usually means the engine isn't
+connected to the daemon — confirm `INFERA_KVD_SOCKET` is set and points to the
+same socket path. Under GPU-direct the daemon counters stay 0 by design (the
+connector owns the files directly); use the engine's `External prefix cache hit
+rate` log line and check for `.kvcache` files under `INFERA_KVD_HIPFILE_ROOTS`
+instead.
+
 ## Related
 
 - [KV-Cache Offload](../features/kv_cache_offload.md) — how to turn it on and the
   usage modes (RAM / disk / distributed / GPU-direct, per-request retention).
 - [CLI reference](../reference/cli.md) — the daemon flags and connector env vars.
+

--- a/manual/components/kvd.md
+++ b/manual/components/kvd.md
@@ -239,4 +239,3 @@ instead.
 - [KV-Cache Offload](../features/kv_cache_offload.md) — how to turn it on and the
   usage modes (RAM / disk / distributed / GPU-direct, per-request retention).
 - [CLI reference](../reference/cli.md) — the daemon flags and connector env vars.
-

--- a/manual/conf.py
+++ b/manual/conf.py
@@ -26,6 +26,7 @@ html_theme_options = {
     "repository_url": "https://github.com/AMD-AGI/Infera",
     "use_repository_button": True,
     "use_issues_button": True,
+    "use_download_button": True,
 }
 html_title = project
 
@@ -58,3 +59,10 @@ suppress_warnings = ["myst.header"]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "README.md", ".venv", ".venv/**"]
+
+# Publish the llms.txt index at the docs site root and let
+# rocm-docs-core generate llms-full.txt after each build (the llms.txt standard,
+# https://llmstxt.org/). See the rocm-docs-core guide:
+# https://rocm.docs.amd.com/projects/rocm-docs-core/en/latest/user_guide/llms.html
+rocm_docs_generate_llms = True
+

--- a/manual/features/kv_cache_offload.md
+++ b/manual/features/kv_cache_offload.md
@@ -52,7 +52,7 @@ hipFile/AIS, bypassing the daemon. Add:
   INFERA_KVD_HIPFILE_ROOTS=long=/nvme/kvd-long
 ```
 
-```{admonition} Run `ais-check` on the host, never inside the container
+:::{admonition} Run `ais-check` on the host, never inside the container
 :class: warning
 In a container there is no `dkms` binary, so `ais-check` silently falls back from
 reading the authoritative KFD capability to grepping `/boot/config-*`, and reports
@@ -64,9 +64,9 @@ the weak fallback and manufactures a false positive.
 Note also that `capability & 0x40` in the KFD topology is **not** a reliable AIS signal
 on these driver builds — a node logging `AIS: registered` per GPU still reports the bit
 clear. Trust `ais-check`'s `amdgpu:` line and the `dmesg` `AIS:` messages.
-```
+:::
 
-````{admonition} GPU-direct needs a new-enough amdgpu driver — and it fails *silently*
+:::{admonition} GPU-direct needs a new-enough amdgpu driver — and it fails *silently*
 :class: warning
 `INFERA_KVD_AIS=1` is a **request**, not a guarantee. If the driver can't do AIS the
 connector logs one line and quietly serves L3 over POSIX (mmap+H2D) instead. You get
@@ -98,14 +98,14 @@ Then confirm on the **host** (see above):
 /opt/rocm/bin/ais-check               # want: amdgpu : True, and exit code 0
 dmesg -T | grep 'AIS:'                # want: "AIS: registered NNNNNMB device memory" per GPU
 ```
-````
+:::
 
-```{admonition} Leave INFERA_KVD_CHUNK_TOKENS at `auto`
+:::{admonition} Leave INFERA_KVD_CHUNK_TOKENS at `auto`
 :class: important
 GPU-direct's cuFile fan-out only pays off at chunks **≥ 128 MiB**, which `auto`
 (the default) sizes to. A small fixed value makes each chunk overhead-bound and
 the reload runs *slower than recompute*.
-```
+:::
 
 **3. Verify.** Send the same prompt (or a shared long prefix) twice, then check
 the engine's stats line for a non-zero **`External prefix cache hit rate`**, and

--- a/manual/features/kv_cache_offload.md
+++ b/manual/features/kv_cache_offload.md
@@ -236,4 +236,3 @@ connector doesn't expose either per request — `ephemeral` maps to `long` and
   offload/onboard mechanism, the tablespace on-disk format, and optimization.
 - [CLI reference](../reference/cli.md) · [Environment variables](../reference/environment.md)
   — the daemon flags and connector env vars.
-

--- a/manual/features/kv_cache_offload.md
+++ b/manual/features/kv_cache_offload.md
@@ -66,7 +66,7 @@ on these driver builds — a node logging `AIS: registered` per GPU still report
 clear. Trust `ais-check`'s `amdgpu:` line and the `dmesg` `AIS:` messages.
 ```
 
-```{admonition} GPU-direct needs a new-enough amdgpu driver — and it fails *silently*
+````{admonition} GPU-direct needs a new-enough amdgpu driver — and it fails *silently*
 :class: warning
 `INFERA_KVD_AIS=1` is a **request**, not a guarantee. If the driver can't do AIS the
 connector logs one line and quietly serves L3 over POSIX (mmap+H2D) instead. You get
@@ -98,7 +98,7 @@ Then confirm on the **host** (see above):
 /opt/rocm/bin/ais-check               # want: amdgpu : True, and exit code 0
 dmesg -T | grep 'AIS:'                # want: "AIS: registered NNNNNMB device memory" per GPU
 ```
-```
+````
 
 ```{admonition} Leave INFERA_KVD_CHUNK_TOKENS at `auto`
 :class: important
@@ -236,3 +236,4 @@ connector doesn't expose either per request — `ephemeral` maps to `long` and
   offload/onboard mechanism, the tablespace on-disk format, and optimization.
 - [CLI reference](../reference/cli.md) · [Environment variables](../reference/environment.md)
   — the daemon flags and connector env vars.
+

--- a/manual/features/kv_cache_offload.md
+++ b/manual/features/kv_cache_offload.md
@@ -13,7 +13,7 @@ across engines, so you don't recompute them. **How it works under the hood:** se
 
 ```{admonition} vLLM only (for now)
 :class: important
-KV-cache offload currently supports the **vLLM** engine
+KV-Cache Offload currently supports the **vLLM** engine
 (`infera.engine.vllm` + `InferaKvdConnector`). SGLang is not supported yet.
 ```
 
@@ -43,13 +43,27 @@ python -m infera.engine.vllm --model <model> --port 8000 --host 0.0.0.0 \
   --kv-transfer-config '{"kv_connector":"InferaKvdConnector","kv_role":"kv_both","kv_connector_module_path":"infera.engine.vllm.kvd_connector"}'
 ```
 
-That runs the POSIX read path (daemon `mmap`/socket). For **GPU-direct** L3 (DMA
-chunks straight into VRAM, bypassing the daemon) add — the connector writes chunk
-files itself under the roots and reads them back with hipFile/AIS:
+That runs the POSIX read path (daemon `mmap`/socket). For **GPU-direct** L3, the
+connector writes chunk files directly under the roots and reads them back via
+hipFile/AIS, bypassing the daemon. Add:
 
 ```bash
   INFERA_KVD_AIS=1 \
   INFERA_KVD_HIPFILE_ROOTS=long=/nvme/kvd-long
+```
+
+```{admonition} Run `ais-check` on the host, never inside the container
+:class: warning
+In a container there is no `dkms` binary, so `ais-check` silently falls back from
+reading the authoritative KFD capability to grepping `/boot/config-*`, and reports
+`Kernel P2PDMA support: True` on a host whose driver reports **False**. Same machine,
+opposite answers. The line that actually matters is **`amdgpu:`** — it agrees in both
+places. Do not mount `/boot` into the container to "fix" the check: that only feeds
+the weak fallback and manufactures a false positive.
+
+Note also that `capability & 0x40` in the KFD topology is **not** a reliable AIS signal
+on these driver builds — a node logging `AIS: registered` per GPU still reports the bit
+clear. Trust `ais-check`'s `amdgpu:` line and the `dmesg` `AIS:` messages.
 ```
 
 ```{admonition} GPU-direct needs a new-enough amdgpu driver — and it fails *silently*
@@ -70,7 +84,7 @@ Requirements (per [hipFile's INSTALL.md](https://github.com/ROCm/rocm-systems/bl
 
 **Check the driver that is *loaded*, not the one installed.** A DKMS upgrade without a
 reboot leaves the old module running, and AIS stays off even though the package looks
-current — this is easy to miss and cost us a full benchmarking session:
+current — this is easy to miss and can cost a full benchmarking session:
 
 ```bash
 cat /sys/module/amdgpu/version        # what is actually running
@@ -78,26 +92,12 @@ modinfo amdgpu | grep ^version:       # what is installed on disk
 # if they differ -> reboot; AIS will not work until you do
 ```
 
-Then confirm on the **host** (see below):
+Then confirm on the **host** (see above):
 
 ```bash
 /opt/rocm/bin/ais-check               # want: amdgpu : True, and exit code 0
 dmesg -T | grep 'AIS:'                # want: "AIS: registered NNNNNMB device memory" per GPU
 ```
-```
-
-```{admonition} Run `ais-check` on the host, never inside the container
-:class: warning
-In a container there is no `dkms` binary, so `ais-check` silently falls back from
-reading the authoritative KFD capability to grepping `/boot/config-*`, and reports
-`Kernel P2PDMA support: True` on a host whose driver reports **False**. Same machine,
-opposite answers. The line that actually matters is **`amdgpu:`** — it agrees in both
-places. Do not mount `/boot` into the container to "fix" the check: that only feeds
-the weak fallback and manufactures a false positive.
-
-Note also that `capability & 0x40` in the KFD topology is **not** a reliable AIS signal
-on these driver builds — a node logging `AIS: registered` per GPU still reports the bit
-clear. Trust `ais-check`'s `amdgpu:` line and the `dmesg` `AIS:` messages.
 ```
 
 ```{admonition} Leave INFERA_KVD_CHUNK_TOKENS at `auto`
@@ -236,3 +236,4 @@ connector doesn't expose either per request — `ephemeral` maps to `long` and
   offload/onboard mechanism, the tablespace on-disk format, and optimization.
 - [CLI reference](../reference/cli.md) · [Environment variables](../reference/environment.md)
   — the daemon flags and connector env vars.
+

--- a/manual/features/pd_disaggregation.md
+++ b/manual/features/pd_disaggregation.md
@@ -269,4 +269,3 @@ Full list on the [environment variables](../reference/environment.md) page.
   topology (concurrent push vs serial pull).
 - [KV-Cache Offload](kv_cache_offload.md) — stack a tiered KV cache under the PD
   transport so cache-hit requests skip prefill entirely.
-

--- a/manual/features/pd_disaggregation.md
+++ b/manual/features/pd_disaggregation.md
@@ -214,6 +214,9 @@ don't have to spot it by eye:
 Manual checks when bringing up a new fabric:
 
 ```bash
+# install the tools if not present
+apt-get install -y libibverbs-utils perftest
+
 ibv_devinfo            # RDMA NIC present + port ACTIVE?
 show_gids              # find the RoCEv2 (v2) GID index -> set MC_GID_INDEX
 ib_write_bw <peer>     # RDMA bandwidth host-to-host (run server on one, client on the other)
@@ -266,3 +269,4 @@ Full list on the [environment variables](../reference/environment.md) page.
   topology (concurrent push vs serial pull).
 - [KV-Cache Offload](kv_cache_offload.md) — stack a tiered KV cache under the PD
   transport so cache-hit requests skip prefill entirely.
+

--- a/manual/getting_started/installation.md
+++ b/manual/getting_started/installation.md
@@ -9,9 +9,10 @@ It orchestrates engines — so you install **Infera** plus at least **one engine
 | Component | Requirement |
 |---|---|
 | GPU | AMD Instinct **MI355X** (gfx950) |
-| ROCm | 7.2+ |
+| ROCm | [7.2+](https://rocm.docs.amd.com/en/latest/deploy/linux/index.html) |
 | OS | Linux x86-64 (validated on Ubuntu 24.04) |
 | Python | 3.10+ |
+| Docker | required — used to run etcd in dev and to build engine images |
 | Discovery | etcd (dev) or the Kubernetes API (production) — a one-line `docker run` gets etcd up for dev, see the [Quickstart](quickstart.md) |
 | RDMA NIC | AMD AINIC — **only needed for cross-node PD** |
 | Engine | at least one of vLLM / SGLang / ATOM (below) |
@@ -54,7 +55,7 @@ base. See [Deployment → Engine images](../serving/deployment.md#engine-images)
 
 ## Docker
 
-For serving (rather than hacking on the code) the container path is usually
+For serving (rather than developing locally) the container path is usually
 easier: the **engine images** already bundle Infera, the `sitecustomize` hook, and
 the Mooncake / ionic RDMA shims on top of the vendor ROCm base — nothing to
 `pip install` by hand.
@@ -78,7 +79,7 @@ docker build -f deploy/docker/Dockerfile.atom \
 
 Then bring up a full stack (etcd + server + engine). The per-runtime
 Dockerfiles, Kubernetes manifests, and the manual (bare-metal) recipe —
-including KV-aware routing, the kvd cache daemon, and PD disaggregation — are
+including KV-aware routing, the kvd daemon, and PD disaggregation — are
 all covered in [Deployment](../serving/deployment.md).
 
 ## Verify
@@ -89,3 +90,4 @@ python -m infera.server --help | head -5
 ```
 
 Next: the [Quickstart](quickstart.md) brings up a real stack and serves a model.
+

--- a/manual/getting_started/installation.md
+++ b/manual/getting_started/installation.md
@@ -90,4 +90,3 @@ python -m infera.server --help | head -5
 ```
 
 Next: the [Quickstart](quickstart.md) brings up a real stack and serves a model.
-

--- a/manual/getting_started/overview.md
+++ b/manual/getting_started/overview.md
@@ -3,6 +3,17 @@
 This page is the conceptual tour — the mental model, no commands. If you'd rather
 get something running first, jump to the [Quickstart](quickstart.md) and come back.
 
+```{admonition} Is this for you?
+:class: tip
+**Yes, if** you're running multiple GPUs and want smarter request routing across
+them — by cache locality, by splitting prefill and decode, or both. Infera sits
+in front of vLLM, SGLang, or ATOM and turns a collection of model workers into a
+routed fleet.
+
+**Probably not yet, if** you have a single GPU and one model server. `vllm serve`
+or `sglang launch` is the right tool for that — come back when you're scaling out.
+```
+
 ## What problem does Infera solve?
 
 A single model server (`vllm serve`, `sglang launch`) is great until you need
@@ -70,12 +81,12 @@ the server a static worker list — the fleet is discovered.
 workers exist, and what each can do." The server watches it; workers write to it.
 That's the whole coordination story.
 
-**(Optional) kvd — KV-cache management.** A per-host daemon that gives the workers
+**(Optional) kvd — KV-Cache Management.** A per-host daemon that gives the workers
 a **tiered KV cache**: blocks spill from GPU HBM → host RAM → NVMe → network and
 stay warm across engine restarts, shared by every engine on the host (read back
 zero-copy via a shared-memory arena). Turn it on when you want prefixes to survive
 restarts or to reuse them across workers. See
-[Tiered KV cache](../components/kvd.md).
+[KV-Cache Management](../components/kvd.md).
 
 ```{admonition} The one-sentence version
 :class: tip
@@ -131,3 +142,4 @@ quantized checkpoints you can load.
 - Pick an engine → [Engines](../components/engines.md)
 - Deploy for real → [Deployment](../serving/deployment.md)
 - The KV cache everyone keeps mentioning → [KV-Cache Offload](../features/kv_cache_offload.md)
+

--- a/manual/getting_started/overview.md
+++ b/manual/getting_started/overview.md
@@ -142,4 +142,3 @@ quantized checkpoints you can load.
 - Pick an engine → [Engines](../components/engines.md)
 - Deploy for real → [Deployment](../serving/deployment.md)
 - The KV cache everyone keeps mentioning → [KV-Cache Offload](../features/kv_cache_offload.md)
-

--- a/manual/index.md
+++ b/manual/index.md
@@ -1,17 +1,6 @@
----
-sd_hide_title: true
----
+# ROCm Infera
 
-# ROCm Infera Manual
-
-```{div} sd-text-center sd-fs-2 sd-font-weight-bold
-ROCm Infera
-```
-
-```{div} sd-text-center sd-fs-5 sd-text-muted
 A lightweight inference-serving layer for AMD ROCm GPUs.
-```
-
 Infera (the `infera` package) puts an **OpenAI-compatible endpoint** in front
 of one or many model workers, and routes each request to the best worker — by
 cache locality, by load, or by splitting prefill and decode across GPUs. It runs
@@ -28,19 +17,19 @@ thin orchestration layer that turns one model server into a routed fleet.
 ::::{grid} 1 1 3 3
 :gutter: 3
 
-:::{grid-item-card} 🚀 Quickstart
+:::{grid-item-card} Quick start
 :link: getting_started/quickstart
 :link-type: doc
 Five minutes from `pip install` to a served model and a working `curl`.
 :::
 
-:::{grid-item-card} 🧭 Overview
+:::{grid-item-card} Overview
 :link: getting_started/overview
 :link-type: doc
 What Infera is, the three moving parts, and when to reach for it.
 :::
 
-:::{grid-item-card} 🔌 Server & router
+:::{grid-item-card} Server and router
 :link: components/server
 :link-type: doc
 The OpenAI-compatible endpoints and how requests flow through the router.
@@ -54,25 +43,25 @@ The moving parts, one page each — what they are and how to run them.
 ::::{grid} 1 1 2 2
 :gutter: 3
 
-:::{grid-item-card} 🔌 Server & router
+:::{grid-item-card} Server & router
 :link: components/server
 :link-type: doc
 OpenAI / Anthropic endpoints + the router (modes, policies).
 :::
 
-:::{grid-item-card} ⚙️ Engines
+:::{grid-item-card} Engines
 :link: components/engines
 :link-type: doc
 vLLM / SGLang / ATOM workers — launch, TP, DP-attention.
 :::
 
-:::{grid-item-card} 🗄️ KV-Cache Management
+:::{grid-item-card} KV cache management
 :link: components/kvd
 :link-type: doc
 kvd's tier design, offload/onboard mechanism, and on-disk format.
 :::
 
-:::{grid-item-card} ☸️ Operator
+:::{grid-item-card} Operator
 :link: components/operator
 :link-type: doc
 The Kubernetes CRD that reconciles server + prefill/decode pools.
@@ -86,19 +75,19 @@ Each of these is a single, self-contained page — read only the one you need.
 ::::{grid} 1 1 3 3
 :gutter: 3
 
-:::{grid-item-card} 🎯 KV-aware routing
+:::{grid-item-card} KV-aware routing
 :link: features/kv_aware_routing
 :link-type: doc
 Route to the worker that already holds your prompt's prefix.
 :::
 
-:::{grid-item-card} ✂️ PD disaggregation
+:::{grid-item-card} PD disaggregation
 :link: features/pd_disaggregation
 :link-type: doc
 Run prefill and decode on separate GPUs (or nodes) and stitch them with a KV transfer.
 :::
 
-:::{grid-item-card} 🗄️ KV-Cache Offload
+:::{grid-item-card} KV cache offload
 :link: features/kv_cache_offload
 :link-type: doc
 Spill KV to RAM / NVMe / network — the usage modes and per-request control.

--- a/manual/serving/kubernetes.md
+++ b/manual/serving/kubernetes.md
@@ -10,7 +10,10 @@ Services, and the KV-event plane. Ready-to-fill `InferaDeployment` templates
 ## Prerequisites
 
 - A Kubernetes cluster (v1.24+) with **≥ 1 ROCm node**, and `kubectl` + `helm`.
-- The **AMD GPU device plugin**, so GPUs are schedulable as `amd.com/gpu`:
+- The **AMD GPU device plugin**, so GPUs are schedulable as `amd.com/gpu`. If
+  it's not installed yet, follow the
+  [AMD GPU Operator setup guide](https://instinct.docs.amd.com/projects/gpu-operator/en/latest/index.html)
+  or the [device plugin README](https://github.com/ROCm/k8s-device-plugin#deployment).
   ```bash
   kubectl describe node | grep amd.com/gpu     # Capacity should be > 0
   ```
@@ -26,7 +29,11 @@ Services, and the KV-event plane. Ready-to-fill `InferaDeployment` templates
 One script installs the cluster dependencies, each as an idempotent
 `helm upgrade --install`: the **LeaderWorkerSet** controller (multi-node workers),
 **NATS / JetStream** (KV-event + request transport), and the **Infera operator**
-(with its CRD + RBAC):
+(with its CRD + RBAC). Clone the Infera repo first if you haven't already:
+
+```bash
+git clone https://github.com/AMD-AGI/Infera.git && cd Infera
+```
 
 ```bash
 deploy/scripts/deploy-k8s.sh                 # LWS + NATS + operator (namespace: infera-system)
@@ -137,3 +144,4 @@ worker pick. See [Routing & transport](../features/routing_and_transport.md).
 
 - [Operator](../components/operator.md) — the `InferaDeployment` CRD field reference.
 - [Deployment](deployment.md) — the manual (`python -m`) deployment path.
+

--- a/manual/serving/kubernetes.md
+++ b/manual/serving/kubernetes.md
@@ -144,4 +144,3 @@ worker pick. See [Routing & transport](../features/routing_and_transport.md).
 
 - [Operator](../components/operator.md) — the `InferaDeployment` CRD field reference.
 - [Deployment](deployment.md) — the manual (`python -m`) deployment path.
-

--- a/manual/sphinx/_toc.yml.in
+++ b/manual/sphinx/_toc.yml.in
@@ -14,7 +14,7 @@ subtrees:
       - file: getting_started/overview.md
         title: Overview
       - file: getting_started/quickstart.md
-        title: Quickstart
+        title: Quick start
       - file: getting_started/installation.md
         title: Installation and setup
       - file: reference/glossary.md
@@ -23,7 +23,7 @@ subtrees:
   - caption: Components
     entries:
       - file: components/server.md
-        title: Server
+        title: Server and router
       - file: components/engines.md
         title: Engines
       - file: components/operator.md

--- a/manual/sphinx/requirements.in
+++ b/manual/sphinx/requirements.in
@@ -1,2 +1,2 @@
-rocm-docs-core==1.38.0
+rocm-docs-core[llms]==1.38.0
 linkify-it-py>=2.0

--- a/manual/sphinx/requirements.txt
+++ b/manual/sphinx/requirements.txt
@@ -48,6 +48,7 @@ docutils==0.22.4
     #   myst-parser
     #   pydata-sphinx-theme
     #   sphinx
+    #   sphinx-markdown-builder
 executing==2.2.1
     # via stack-data
 fastjsonschema==2.21.2
@@ -56,7 +57,7 @@ fastjsonschema==2.21.2
     #   rocm-docs-core
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.52
+gitpython==3.1.53
     # via rocm-docs-core
 greenlet==3.5.3
     # via sqlalchemy
@@ -138,7 +139,7 @@ parso==0.8.7
     # via jedi
 pexpect==4.9.0
     # via ipython
-platformdirs==4.10.0
+platformdirs==4.11.0
     # via jupyter-core
 prompt-toolkit==3.0.52
     # via ipython
@@ -190,7 +191,7 @@ requests==2.34.2
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core==1.38.0
+rocm-docs-core[llms]==1.38.0
     # via -r manual/sphinx/requirements.in
 roman-numerals==4.1.0
     # via sphinx
@@ -204,7 +205,7 @@ smmap==5.0.3
     # via gitdb
 snowballstemmer==3.1.1
     # via sphinx
-soupsieve==2.8.4
+soupsieve==2.9.1
     # via beautifulsoup4
 sphinx==9.1.0
     # via
@@ -217,6 +218,7 @@ sphinx==9.1.0
     #   sphinx-copybutton
     #   sphinx-design
     #   sphinx-external-toc
+    #   sphinx-markdown-builder
     #   sphinx-multitoc-numbering
     #   sphinx-notfound-page
 sphinx-book-theme==1.1.4
@@ -226,6 +228,8 @@ sphinx-copybutton==0.5.2
 sphinx-design==0.7.0
     # via rocm-docs-core
 sphinx-external-toc==1.1.0
+    # via rocm-docs-core
+sphinx-markdown-builder==0.6.10
     # via rocm-docs-core
 sphinx-multitoc-numbering==0.1.3
     # via sphinx-external-toc
@@ -248,7 +252,9 @@ sqlalchemy==2.0.51
 stack-data==0.6.3
     # via ipython
 tabulate==0.10.0
-    # via jupyter-cache
+    # via
+    #   jupyter-cache
+    #   sphinx-markdown-builder
 tornado==6.5.7
     # via
     #   ipykernel


### PR DESCRIPTION
## Summary

Implements the SME-approved items from the Infra doc feedback review. Changes are additive or minimal — no existing content restructured beyond the admonition reorder in `kv_cache_offload.md`.

- **overview.md** — adds "Is this for you?" audience callout before the first section
- **installation.md** — adds Docker as a standalone row in the system requirements table
- **kvd.md** — removes unpublished benchmark numbers from the zero-copy and measured-backends sections; adds a "Verify it's running" section using `statctl`
- **kv_cache_offload.md** — reorders the three GPU-direct admonitions so the critical host-only `ais-check` warning leads (was buried second in a stack of three)
- **pd_disaggregation.md** — adds `apt-get install -y libibverbs-utils perftest` before the RDMA diagnostic commands
- **kubernetes.md** — links the AMD GPU device plugin prerequisite to the GPU Operator docs and the `k8s-device-plugin` README
- **components/engines.md** — updates the vLLM data-parallel link from the old `AMD-AGI/Optimus` repo to `AMD-AGI/Infera`

## Items deferred (SME response unclear or not approved)

- Quickstart dev-flag admonition placement (too verbose per SME)
- Engine startup troubleshooting entry (not in scope per SME)
- kvd "why" section reorder (first version, may change)
- PD+kvd anchor link (vLLM-only scope)
- Nightly SHA callout (intentional for first release)
- Driver version claim (SME flagged as weak point — no clear action)
- ATOM framing (keep as-is; more ATOM doc planned)