### PR TITLE
Upgrade vLLM base image to stable v0.25.1 (digest-pinned)

### DIFF
--- a/deploy/docker/Dockerfile.vllm
+++ b/deploy/docker/Dockerfile.vllm
@@ -3,9 +3,13 @@
 # hipFile + libionic onto a digest-pinned nightly base, then the infera source,
 # and runs via `python -m infera.engine.vllm`.
 #
-# Base pinned by DIGEST for reproducibility (= vLLM 0.23.1rc1.dev861+gcbe9c40f9,
-# torch 2.11.0, ROCm 7.2.3). To move: bump the digest + re-verify patch no-ops.
-ARG VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:nightly-cbe9c40f998f13975b967773ac7e7920e115387f
+# Base pinned by DIGEST to the stable vLLM v0.25.1 release (was the rolling nightly
+# cbe9c40f = 0.23.1rc0.dev861+gcbe9c40f9, which DockerHub has since rolled off).
+# The tag ":v0.25.1" is kept in the ref for readability; the @sha256 is what pins
+# it (= vllm 0.25.1, torch 2.11.0, ROCm 7.2.3). To move: bump the digest +
+# re-verify patch no-ops (the patch loop swallows a patch's sys.exit(1), so a
+# moved anchor silently drops the patch — check the build log per layer).
+ARG VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:v0.25.1@sha256:84459732ca98b40fe2f5338a3f050be6d522504e47a484a5180d58fb75956f86
 FROM ${VLLM_BASE_IMAGE}
 
 # ---- 1) AITER (flydsl fp4 for DSv4 MXFP4 MoE) ------------------------------
@@ -29,6 +33,14 @@ RUN if [ "${BUILD_AITER}" = "1" ]; then \
 # vllm-dsv4/ (DSv4-specific: moriio_dsv4 {hybrid_blocksize, sparse_backend,
 # noncontig_register} + aiter flydsl). Each patch no-ops if its anchor is absent,
 # so a base bump degrades gracefully. legacy/ is upstream on this base, not applied.
+#
+# DEAD ON v0.25.1 (kept in-tree, but no-op — verified 2026-07-21): the three
+# GLM-5.1 moriio patches patch_moriio_dsa_write.py, patch_moriio_hetero.py and
+# patch_vllm_moriio_blocksize.py skip on this base because v0.25.1 refactored the
+# MoRIIO connector into moriio_layout.py, which already covers all three fixes
+# (full-layer wait_for_save; per-layer transfer geometry; kernel/logical block
+# ratio). Their skip in the build log is EXPECTED, not a regression. GLM-5.1 PD
+# has no e2e coverage here; re-anchor against moriio_layout.py only if it lands.
 COPY deploy/docker/patches/vllm/ /tmp/vllm-patches/
 COPY deploy/docker/patches/vllm-dsv4/ /tmp/vllm-dsv4-patches/
 RUN for f in /tmp/vllm-patches/*.py; do echo "[vllm-patch] $f"; python "$f" || echo "[vllm-patch] skipped $f"; done \


### PR DESCRIPTION
  ## Summary
  - Move `deploy/docker/Dockerfile.vllm` off the rolling nightly base
    (`nightly-cbe9c40f` = vLLM `0.23.1rc0.dev861`, since rolled off DockerHub and
    now unpullable → build was non-reproducible) to the stable **v0.25.1** release.
  - Pin the base by **digest** (`v0.25.1@sha256:84459732…`) for byte-reproducible
    builds even if the tag ever moves. Verified: a fresh digest-pinned build
    reproduces the identical image id.
  - Annotate in-tree that three GLM-5.1 MoRIIO patches (`patch_moriio_dsa_write`,
    `patch_moriio_hetero`, `patch_vllm_moriio_blocksize`) are now **no-ops** on
    v0.25.1: upstream refactored the MoRIIO connector into `moriio_layout.py`,
    which already covers all three fixes (full-layer `wait_for_save`, per-layer
    transfer geometry, kernel/logical block-size ratio). Their skip in the build
    log is expected, not a regression. Patches kept in-tree (not deleted).

  ## Why
  The old nightly tag is gone from DockerHub, so the image could no longer be
  rebuilt. v0.25.1 is the first stable release containing the same mainline code
  (commit cbe9c40f first ships in v0.25.0).

  ## Validation (8×MI355X / gfx950, chi2879)
  Rebuilt with latest infera code → `inferaimage/infera:vllm-v0.25.1-20260721`
  (vllm 0.25.1 / torch 2.11.0 / ROCm 7.2.3). All 6 build layers behaved
  (aiter, vllm patches, mooncake, hipfile, libionic); `mooncake-prom` patch applied.

  | tier | result |
  |---|---|
  | unit | ✅ 1139 passed |
  | engine (tests/engine/vllm + sglang) | ✅ all passed |
  | e2e PD-mixed Qwen3-8B (tp2) | ✅ passed |
  | e2e PD-mixed Kimi-K2.6-MXFP4 (tp4) | ✅ passed |
  | e2e PD-mixed DeepSeek-V4-Pro (tp8) | ✅ passed (correctness verified) |

  ## Test plan
  - [x] `docker build -f deploy/docker/Dockerfile.vllm .` resolves the digest-pinned base
  - [x] `python -c "import vllm; print(vllm.__version__)"` → `0.25.1`
  - [x] `bash tests/run_tests.sh unit && bash tests/run_tests.sh engine`
  - [x] `bash tests/run_tests.sh e2e vllm mixed` (needs staged weights + 8 GPUs)


  PD + Mooncake smoke test on v0.25.1 — both models PASS

 2-node PD-disaggregated with Mooncake RDMA KV transfer:

  ┌─────────────────┬──────────────────────────────────────────────┬───────────────────────────────────────────────────────┬─────────────────┐
  │      model      │                    config                    │                        result                         │   fingerprint   │
  ├─────────────────┼──────────────────────────────────────────────┼───────────────────────────────────────────────────────┼─────────────────┤
  │ DeepSeek-V4-Pro │ tp8 prefill (chi2879) + tp8 decode (chi2866) │ ✅ "capital of China is Beijing", counting coherent   │ vllm-0.25.1-tp8 │
  ├─────────────────┼──────────────────────────────────────────────┼───────────────────────────────────────────────────────┼─────────────────┤
  │ Kimi-K2.6-MXFP4 │ tp4 prefill + tp4 decode                     │ ✅ "capital of France is Paris", "1,2,...,10" perfect │ vllm-0.25.1-tp4 │
  └─────────────────┴──────────────────────────────────────────────┴───────────────────────────────────────────────────────┴─────────────────┘

  🤖 Generated with [Claude Code](https://claude.com/claude-code)