### PR TITLE
Fix high-severity CodeQL security findings

### DIFF
--- a/bench/kvcache/hipfile/bench_concurrent_load.py
+++ b/bench/kvcache/hipfile/bench_concurrent_load.py
@@ -57,7 +57,7 @@ def _seed_files(root: str, num_chunks: int, payload_bytes: int) -> list[str]:
     for c in range(num_chunks):
         p = os.path.join(root, f"chunk_{c:04d}.bin")
         if not (os.path.exists(p) and os.path.getsize(p) == payload_bytes):
-            fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+            fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
             os.write(fd, bytes([(c + 1) % 251]) + base[1:])
             os.close(fd)
         paths.append(p)

--- a/bench/kvcache/hipfile/bench_mla_read_dedup.py
+++ b/bench/kvcache/hipfile/bench_mla_read_dedup.py
@@ -45,7 +45,7 @@ def _seed(path: str, nbytes: int) -> None:
     if os.path.exists(path) and os.path.getsize(path) == nbytes:
         return
     buf = b"\xa5" * (1 << 20)
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
         written = 0
         while written < nbytes:

--- a/infera/api/anthropic.py
+++ b/infera/api/anthropic.py
@@ -67,6 +67,8 @@ import uuid
 from collections.abc import AsyncIterable, AsyncIterator
 from typing import Any
 
+from infera.common.logsafe import scrub
+
 logger = logging.getLogger(__name__)
 
 
@@ -354,8 +356,8 @@ def _translate_tool_choice(tc: Any) -> Any:
     # the field and let the engine pick. Log so operators can spot
     # a client using something we haven't translated yet.
     logger.warning(
-        "anthropic tool_choice type=%r not recognized — falling back to engine default",
-        t,
+        "anthropic tool_choice type=%s not recognized — falling back to engine default",
+        scrub(t),
     )
     return None
 

--- a/infera/common/logsafe.py
+++ b/infera/common/logsafe.py
@@ -1,0 +1,35 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""Helpers for safely logging untrusted (client-supplied) values.
+
+CodeQL's ``py/log-injection`` flags any flow from request data (headers,
+body fields, query params) into a log record: a value containing CR/LF can
+forge additional, attacker-controlled log lines. ``scrub`` coerces a value to
+``str`` and escapes CR/LF/tab so a single logged value can never span more
+than one line, and bounds its length so a client can't flood the log.
+"""
+
+from __future__ import annotations
+
+_MAX_LEN = 256
+
+
+def scrub(value: object, *, max_len: int = _MAX_LEN) -> str:
+    """Return a single-line, length-bounded string for logging ``value``.
+
+    Escapes backslash, CR, LF and tab so untrusted input can't inject new
+    log lines, then truncates to ``max_len`` characters.
+    """
+    s = (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+        .replace("\t", "\\t")
+    )
+    if len(s) > max_len:
+        s = s[:max_len] + "...(truncated)"
+    return s

--- a/infera/common/net.py
+++ b/infera/common/net.py
@@ -17,7 +17,10 @@ def free_tcp_port() -> int:
     and matches what SGLang itself does internally.
     """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
+        # Bind to loopback only: we just need a free port number, not a
+        # publicly reachable listener. Binding to "" (all interfaces) would
+        # briefly expose the probe socket on every NIC.
+        s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
 
 
@@ -41,7 +44,8 @@ def free_tcp_port_block(count: int) -> int:
         try:
             for off in range(count):
                 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                s.bind(("", base + off))
+                # Loopback-only reservation; see free_tcp_port() rationale.
+                s.bind(("127.0.0.1", base + off))
                 socks.append(s)
             return base
         except OSError:

--- a/infera/engine/sglang/hipfile_shim.py
+++ b/infera/engine/sglang/hipfile_shim.py
@@ -334,7 +334,7 @@ class HipFile:
             flags |= getattr(os, "O_DIRECT", 0)
 
         # New binding API (rocm-systems/hipfile current):
-        # `FileHandle(path, flags, mode=0o644)` constructs but does NOT
+        # `FileHandle(path, flags, mode=0o600)` constructs but does NOT
         # open. Call `.open()` (or use the binding's context manager)
         # to actually open the fd inside the binding — it owns the fd
         # lifecycle; we don't `os.open` it ourselves.
@@ -347,10 +347,10 @@ class HipFile:
         # behavior.
         self._fd = None
         try:
-            self._handle = hipfile.FileHandle(self._path, flags, 0o644)
+            self._handle = hipfile.FileHandle(self._path, flags, 0o600)
         except TypeError:
             # Legacy binding — open the fd here and pass it in.
-            self._fd = os.open(self._path, flags, 0o644)
+            self._fd = os.open(self._path, flags, 0o600)
             try:
                 self._handle = hipfile.FileHandle(self._fd)
             except Exception:

--- a/infera/engine/vllm/kvd_connector.py
+++ b/infera/engine/vllm/kvd_connector.py
@@ -2585,7 +2585,15 @@ class InferaKvdConnector(KVConnectorBase_V1, SupportsHMA):  # type: ignore[misc]
                 else:
                     sample = self._kv_caches[first_name]
                     shape = tuple(sample.shape)
+                    # Defaults for shapes that match none of the branches
+                    # below: num_kv_channels stays 0, which gates every use
+                    # of the dims via `if num_kv_channels:` — but initialize
+                    # them explicitly so an unrecognized layout can never hit
+                    # an UnboundLocalError.
                     num_kv_channels = 0
+                    num_blocks = 0
+                    block_size_in_shape = 0
+                    hidden_dim = 0
                     if len(shape) >= 4 and shape[0] == 2:
                         num_kv_channels = 2
                         hidden_dim = 1
@@ -4453,7 +4461,7 @@ class InferaKvdConnector(KVConnectorBase_V1, SupportsHMA):  # type: ignore[misc]
             try:
 
                 def _write_and_publish() -> None:
-                    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+                    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
                     try:
                         _w(fd, header_bytes)
                         _w(fd, memoryview(pinned_view.numpy()).cast("B"))
@@ -4708,7 +4716,7 @@ class InferaKvdConnector(KVConnectorBase_V1, SupportsHMA):  # type: ignore[misc]
         # 1. POSIX-create + write header + ftruncate.
         total_size = len(header_bytes) + payload_bytes
         try:
-            fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+            fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
             try:
                 view = memoryview(header_bytes)
                 written = 0

--- a/infera/kvd/storage_selfcheck.py
+++ b/infera/kvd/storage_selfcheck.py
@@ -141,7 +141,7 @@ def run_storage_selfcheck(
             )
             t0 = time.monotonic()
             for f in w_assign[i]:
-                fd = os.open(f, fl, 0o644)
+                fd = os.open(f, fl, 0o600)
                 for c in range(per):
                     os.pwrite(fd, view, c * chunk)
                 os.fsync(fd)

--- a/infera/router/cache_control.py
+++ b/infera/router/cache_control.py
@@ -57,6 +57,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
+from infera.common.logsafe import scrub
+
 logger = logging.getLogger(__name__)
 
 
@@ -198,7 +200,7 @@ def _parse_openai_retention(body: dict[str, Any]) -> Retention | None:
         if retention in {"none", "off", "disabled"}:
             return _NONE
         # Unrecognized value: warn once but don't crash.
-        logger.debug("unknown prompt_cache_retention value: %r", retention)
+        logger.debug("unknown prompt_cache_retention value: %s", scrub(retention))
         return None
 
     # `prompt_cache_key` alone (no retention specified) → implicit short.

--- a/infera/router/direct.py
+++ b/infera/router/direct.py
@@ -10,6 +10,7 @@ import logging
 from fastapi import Response
 from fastapi.responses import JSONResponse
 
+from infera.common.logsafe import scrub
 from infera.router.cache_control import parse_cache_hints
 from infera.router.disagg import DisaggRouter
 from infera.router.mixed import MixedRouter, _Retry
@@ -83,7 +84,7 @@ class DirectRouter(MixedRouter):
             worker = self.pool.get(worker_id)
             if worker is None:
                 obs["outcome"] = "503"
-                logger.warning("direct: worker %r from header not in pool", worker_id)
+                logger.warning("direct: worker %s from header not in pool", scrub(worker_id))
                 return JSONResponse(
                     content={"error": f"worker {worker_id!r} not found (stale gateway routing?)"},
                     status_code=503,

--- a/infera/router/disagg.py
+++ b/infera/router/disagg.py
@@ -584,9 +584,7 @@ class DisaggRouter(BaseRouter):
                 p_failed = True
                 obs["outcome"] = "502"
                 metrics.pd_bootstrap_failures_total.labels(reason="handoff_extract_failed").inc()
-                logger.warning(
-                    "handoff extraction failed (%s: %s)", type(exc).__name__, exc
-                )
+                logger.warning("handoff extraction failed (%s: %s)", type(exc).__name__, exc)
                 return JSONResponse(
                     content={
                         "error": "handoff extraction failed",

--- a/infera/router/disagg.py
+++ b/infera/router/disagg.py
@@ -35,6 +35,18 @@ from infera.server import metrics
 logger = logging.getLogger(__name__)
 
 
+def _sanitized_error(reason: str, exc: BaseException, *, status_code: int) -> JSONResponse:
+    """Return a client-safe error response while logging the full exception.
+
+    Interpolating ``str(exc)`` into an HTTP response can leak internal details
+    or stack information to the caller (CodeQL ``py/stack-trace-exposure``).
+    The exception is logged server-side for debugging; the client receives
+    only the generic ``reason``.
+    """
+    logger.warning("%s (%s: %s)", reason, type(exc).__name__, exc)
+    return JSONResponse(content={"error": reason}, status_code=status_code)
+
+
 def _generate_room_id() -> int:
     """Random u63 ID for the per-request session (SGLang's bootstrap_room,
     vLLM connectors' transfer_id)."""
@@ -175,7 +187,7 @@ class DisaggRouter(BaseRouter):
         except (ProtocolMismatch, UnknownProtocol) as exc:
             obs["outcome"] = "500"
             metrics.pd_bootstrap_failures_total.labels(reason="protocol_unresolved").inc()
-            return JSONResponse(content={"error": str(exc)}, status_code=500)
+            return _sanitized_error("protocol resolution failed", exc, status_code=500)
 
         # SGLang's follow_bootstrap_room balancer ties the prefill DP rank to
         # bootstrap_room % dp_size; encode the steered rank so the prefill
@@ -199,7 +211,7 @@ class DisaggRouter(BaseRouter):
         except ValueError as exc:
             obs["outcome"] = "500"
             metrics.pd_bootstrap_failures_total.labels(reason="protocol_request_id_failed").inc()
-            return JSONResponse(content={"error": str(exc)}, status_code=500)
+            return _sanitized_error("protocol request-id generation failed", exc, status_code=500)
 
         self.policy.on_request_started(p_target.route_key, p_blocks)
         self.policy.on_request_started(d_target.route_key, d_blocks)
@@ -258,7 +270,7 @@ class DisaggRouter(BaseRouter):
             self.policy.on_request_finished(d_target.route_key, d_blocks)
             obs["outcome"] = "500"
             metrics.pd_bootstrap_failures_total.labels(reason="protocol_annotate_failed").inc()
-            return JSONResponse(content={"error": str(exc)}, status_code=500)
+            return _sanitized_error("protocol annotation failed", exc, status_code=500)
 
         # Deliver both legs over NATS when both workers registered for it. KV
         # transfer stays engine<->engine (bootstrap_room in the bodies), so the
@@ -329,10 +341,7 @@ class DisaggRouter(BaseRouter):
             except httpx.HTTPError as exc:
                 obs["outcome"] = "502"
                 metrics.pd_bootstrap_failures_total.labels(reason="worker_unreachable").inc()
-                return JSONResponse(
-                    content={"error": f"PD request failed: {exc}"},
-                    status_code=502,
-                )
+                return _sanitized_error("PD request failed", exc, status_code=502)
 
             if p_resp.status_code >= 400:
                 logger.warning(
@@ -527,7 +536,7 @@ class DisaggRouter(BaseRouter):
             self.policy.on_request_finished(d_target.route_key, d_blocks)
             obs["outcome"] = "500"
             metrics.pd_bootstrap_failures_total.labels(reason="protocol_annotate_failed").inc()
-            return JSONResponse(content={"error": str(exc)}, status_code=500)
+            return _sanitized_error("protocol annotation failed", exc, status_code=500)
 
         p_failed = False
         try:
@@ -538,10 +547,7 @@ class DisaggRouter(BaseRouter):
                     p_failed = True
                     obs["outcome"] = "502"
                     metrics.pd_bootstrap_failures_total.labels(reason="prefill_unreachable").inc()
-                    return JSONResponse(
-                        content={"error": f"prefill leg failed: {exc}"},
-                        status_code=502,
-                    )
+                    return _sanitized_error("prefill leg failed", exc, status_code=502)
 
             if p_resp.status_code >= 400:
                 p_failed = True
@@ -578,9 +584,12 @@ class DisaggRouter(BaseRouter):
                 p_failed = True
                 obs["outcome"] = "502"
                 metrics.pd_bootstrap_failures_total.labels(reason="handoff_extract_failed").inc()
+                logger.warning(
+                    "handoff extraction failed (%s: %s)", type(exc).__name__, exc
+                )
                 return JSONResponse(
                     content={
-                        "error": f"handoff extraction failed: {exc}",
+                        "error": "handoff extraction failed",
                         "prefill_payload": p_payload,
                     },
                     status_code=502,
@@ -607,7 +616,7 @@ class DisaggRouter(BaseRouter):
             self.policy.on_request_finished(d_target.route_key, d_blocks)
             obs["outcome"] = "500"
             metrics.pd_bootstrap_failures_total.labels(reason="protocol_annotate_failed").inc()
-            return JSONResponse(content={"error": str(exc)}, status_code=500)
+            return _sanitized_error("protocol annotation failed", exc, status_code=500)
 
         if stream:
             obs["outcome"] = "ok"  # commit at hand-off
@@ -625,10 +634,7 @@ class DisaggRouter(BaseRouter):
                 except httpx.HTTPError as exc:
                     obs["outcome"] = "502"
                     metrics.pd_bootstrap_failures_total.labels(reason="decode_unreachable").inc()
-                    return JSONResponse(
-                        content={"error": f"decode leg failed: {exc}"},
-                        status_code=502,
-                    )
+                    return _sanitized_error("decode leg failed", exc, status_code=502)
 
             try:
                 d_payload = d_resp.json()
@@ -673,7 +679,7 @@ class DisaggRouter(BaseRouter):
                     exc or "<no message>",
                 )
                 metrics.pd_bootstrap_failures_total.labels(reason="decode_unreachable").inc()
-                err = json.dumps({"error": f"decode unreachable: {type(exc).__name__}: {exc}"})
+                err = json.dumps({"error": "decode unreachable"})
                 yield f"data: {err}\n\n".encode()
                 return
 
@@ -728,7 +734,7 @@ class DisaggRouter(BaseRouter):
                     exc or "<no message>",
                 )
                 metrics.pd_bootstrap_failures_total.labels(reason="decode_stream_broken").inc()
-                err = json.dumps({"error": f"decode stream failed: {type(exc).__name__}: {exc}"})
+                err = json.dumps({"error": "decode stream failed"})
                 yield f"data: {err}\n\n".encode()
         finally:
             if d_resp is not None:
@@ -828,7 +834,7 @@ class DisaggRouter(BaseRouter):
                     )
                     metrics.pd_bootstrap_failures_total.labels(reason="decode_unreachable").inc()
                     # json.dumps: exc text may contain chars that break SSE.
-                    err = json.dumps({"error": f"decode unreachable: {type(exc).__name__}: {exc}"})
+                    err = json.dumps({"error": "decode unreachable"})
                     yield f"data: {err}\n\n".encode()
                     return
 
@@ -890,7 +896,7 @@ class DisaggRouter(BaseRouter):
                     exc or "<no message>",
                 )
                 metrics.pd_bootstrap_failures_total.labels(reason="decode_stream_broken").inc()
-                err = json.dumps({"error": f"decode stream failed: {type(exc).__name__}: {exc}"})
+                err = json.dumps({"error": "decode stream failed"})
                 yield f"data: {err}\n\n".encode()
         finally:
             if d_resp is not None:

--- a/infera/router/mixed.py
+++ b/infera/router/mixed.py
@@ -249,9 +249,15 @@ class MixedRouter(BaseRouter):
             resp = await self._client.post(url, json=forwarded_body, headers=dp_headers)
         except httpx.HTTPError as exc:
             obs["outcome"] = "502"
+            logger.warning(
+                "worker %s unreachable (%s: %s)",
+                worker.worker_id,
+                type(exc).__name__,
+                exc,
+            )
             raise _Retry(
                 JSONResponse(
-                    content={"error": f"worker {worker.worker_id} unreachable: {exc}"},
+                    content={"error": f"worker {worker.worker_id} unreachable"},
                     status_code=502,
                 )
             ) from exc
@@ -295,4 +301,10 @@ class MixedRouter(BaseRouter):
                         yield (TYPE_DATA, None, chunk)
             yield (TYPE_DONE, 200, b"")
         except httpx.HTTPError as exc:
-            yield (TYPE_ERROR, None, str(exc).encode())
+            logger.warning(
+                "stream from worker %s failed before first byte: %s: %s",
+                worker.worker_id,
+                type(exc).__name__,
+                exc,
+            )
+            yield (TYPE_ERROR, None, b"worker stream transport error")

--- a/infera/server/app.py
+++ b/infera/server/app.py
@@ -14,6 +14,7 @@ import httpx
 from fastapi import FastAPI, HTTPException, Request, Response
 
 from infera.common.discovery import Registry
+from infera.common.logsafe import scrub
 from infera.common.worker_pool import DisaggMode, WorkerStatus
 from infera.kvd.client import KvdClient, KvdConnectionError
 from infera.router.base import BaseRouter
@@ -395,11 +396,21 @@ async def anthropic_messages(request: Request) -> Any:
     try:
         anthropic_body = await request.json()
     except Exception as exc:
+        # Log the parser detail server-side; return a generic message so
+        # internal error text can't leak to the client (py/stack-trace-exposure).
+        logger.warning(
+            "anthropic-messages: malformed JSON body (%s: %s)",
+            type(exc).__name__,
+            exc,
+        )
         return JSONResponse(
             status_code=400,
             content={
                 "type": "error",
-                "error": {"type": "invalid_request_error", "message": str(exc)},
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "malformed JSON in request body",
+                },
             },
         )
 
@@ -429,11 +440,14 @@ async def anthropic_messages(request: Request) -> Any:
     try:
         openai_body = anthropic_to_openai_request(anthropic_body)
     except AnthropicRequestRejected as exc:
+        # AnthropicRequestRejected carries a developer-authored, client-facing
+        # reason (unsupported feature / precondition violation). Keep it, but
+        # run it through scrub() to bound length and strip control chars.
         return JSONResponse(
             status_code=400,
             content={
                 "type": "error",
-                "error": {"type": "invalid_request_error", "message": str(exc)},
+                "error": {"type": "invalid_request_error", "message": scrub(exc)},
             },
         )
 

--- a/infera/tools/preflight/storage/perf.py
+++ b/infera/tools/preflight/storage/perf.py
@@ -147,7 +147,7 @@ def _odirect_ok(d: str) -> bool:
         return False
     p = os.path.join(d, ".odtest")
     try:
-        fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_DIRECT, 0o644)
+        fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_DIRECT, 0o600)
         b = mmap.mmap(-1, _ALIGN)
         os.pwrite(fd, memoryview(b)[:_ALIGN], 0)
         os.close(fd)
@@ -188,7 +188,7 @@ def _measure(target_dir: str, size_gb: float, workers: int, prefer_direct: bool)
     odf = os.O_DIRECT if (prefer_direct and _odirect_ok(d)) else 0
 
     def w(i: int) -> float:
-        fd = os.open(files[i], os.O_WRONLY | os.O_CREAT | os.O_TRUNC | odf, 0o644)
+        fd = os.open(files[i], os.O_WRONLY | os.O_CREAT | os.O_TRUNC | odf, 0o600)
         t0 = time.monotonic()
         for c in range(per):
             os.pwrite(fd, view, c * _CHUNK)
@@ -246,7 +246,7 @@ def _nvme_hbm_staged(target_dir: str, size_gb: float, torch) -> dict:
     mv = memoryview(host.numpy())
     odf = os.O_DIRECT if _odirect_ok(d) else 0
     try:
-        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | odf, 0o644)
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | odf, 0o600)
         torch.cuda.synchronize()
         t0 = time.monotonic()
         for c in range(n):

--- a/tests/e2e/harness/adapter.py
+++ b/tests/e2e/harness/adapter.py
@@ -146,7 +146,7 @@ class EngineAdapter(ABC):
 
     def pick_port(self) -> int:
         with socket.socket() as s:
-            s.bind(("", 0))
+            s.bind(("127.0.0.1", 0))
             return s.getsockname()[1]
 
     def worker_id(self, host: str, port: int) -> str:

--- a/tests/e2e/harness/server.py
+++ b/tests/e2e/harness/server.py
@@ -30,7 +30,7 @@ from infera.server.app import init_app
 
 def _free_port() -> int:
     with socket.socket() as s:
-        s.bind(("", 0))
+        s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
 
 

--- a/tests/unit/api/test_anthropic_route.py
+++ b/tests/unit/api/test_anthropic_route.py
@@ -30,8 +30,14 @@ from infera.server import app as app_module
 from infera.server.app import init_app
 
 
-class _FakeRouter(BaseRouter):
-    """Captures the dispatched body and returns a canned response."""
+class _FakeRouter:
+    """Captures the dispatched body and returns a canned response.
+
+    Deliberately does NOT inherit ``BaseRouter``: that __init__ requires a
+    real ``pool``/``policy`` we don't have in this test. Instead the class is
+    registered as a virtual subclass (see ``BaseRouter.register`` below) so
+    any ``isinstance(router, BaseRouter)`` checks still pass.
+    """
 
     def __init__(
         self,
@@ -39,7 +45,6 @@ class _FakeRouter(BaseRouter):
         canned_response: dict[str, Any] | None = None,
         stream_chunks: list[bytes] | None = None,
     ) -> None:
-        # Skip parent __init__ — we don't have pool/policy here.
         self.last_body: dict | None = None
         self.last_path: str | None = None
         self.last_stream: bool | None = None
@@ -61,6 +66,11 @@ class _FakeRouter(BaseRouter):
 
             return StreamingResponse(_gen(), media_type="text/event-stream")
         return JSONResponse(content=self._canned or {})
+
+
+# Register as a virtual subclass so isinstance(_FakeRouter(), BaseRouter) is
+# True without inheriting BaseRouter.__init__ (which needs a real pool/policy).
+BaseRouter.register(_FakeRouter)
 
 
 @pytest.fixture

--- a/tests/unit/kvd/test_kvd_connector_layout.py
+++ b/tests/unit/kvd/test_kvd_connector_layout.py
@@ -1,0 +1,122 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""kvd connector — KV-cache (model-type x dtype) offload support matrix.
+
+``register_kv_caches`` decides whether a KV-cache group is offloaded to L3 or
+skipped, from a few pure helpers. This pins the support matrix so the
+non-obvious cases can't silently regress:
+
+    model / layout      KV dtype     L3 offload
+    ------------------  -----------  -----------
+    MLA (plain latent)  fp8          yes  (hidden == kv_lora_rank+qk_rope_head_dim)
+    MLA / any           bf16/fp16    yes  (not packed -> passthrough)
+    GQA / MHA           bf16/fp16    yes  (not packed -> passthrough)
+    GQA / MHA           fp8          NO   (scale-packed, could mis-stride -> skip)
+    MLA scale-packed    fp8 (656/…)  NO   (hidden != plain latent -> skip)
+
+Pure functions only — no GPU / engine / model. The matrix decision below is
+torch-free; only the dtype->packed classification needs torch (guarded).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from infera.engine.vllm.kvd_connector import (
+    _expected_plain_mla_hidden,
+    _is_mla_from_config,
+    _is_packed_quant_kv_dtype,
+)
+
+
+def _cfg(*, use_mla=None, kv_lora_rank=None, qk_rope_head_dim=None):
+    """Minimal stand-in for the vLLM config the helpers read (model_config.*)."""
+    hf = SimpleNamespace(
+        kv_lora_rank=kv_lora_rank, qk_rope_head_dim=qk_rope_head_dim, text_config=None
+    )
+    mc = SimpleNamespace(use_mla=use_mla, hf_text_config=hf, hf_config=hf)
+    return SimpleNamespace(model_config=mc)
+
+
+# --- MLA detection (config-only) ---------------------------------------------
+
+
+def test_mla_detected_from_use_mla_flag():
+    assert _is_mla_from_config(_cfg(use_mla=True)) is True
+    assert _is_mla_from_config(_cfg(use_mla=False)) is False
+
+
+def test_mla_detected_from_kv_lora_rank_marker():
+    assert _is_mla_from_config(_cfg(kv_lora_rank=512)) is True
+
+
+def test_non_mla_or_missing_config_is_false():
+    assert _is_mla_from_config(_cfg()) is False
+    assert _is_mla_from_config(SimpleNamespace(model_config=None)) is False
+
+
+# --- plain-MLA-fp8 hidden width = kv_lora_rank + qk_rope_head_dim -------------
+
+
+def test_plain_mla_hidden_kimi_like():
+    # Kimi-K2.6: 512 + 64 = 576 (validated byte-exact on real hardware).
+    assert _expected_plain_mla_hidden(_cfg(kv_lora_rank=512, qk_rope_head_dim=64)) == 576
+
+
+def test_plain_mla_hidden_none_when_not_mla():
+    assert _expected_plain_mla_hidden(_cfg()) is None
+    assert _expected_plain_mla_hidden(SimpleNamespace(model_config=None)) is None
+
+
+# --- the offload/skip matrix (torch-free: takes is_packed directly) ----------
+
+
+def _would_offload(*, is_packed, num_kv_channels, hidden_dim, plain_mla_hidden):
+    """Mirror of ``register_kv_caches``' packed-dtype gate: a non-packed group
+    always offloads; a packed (fp8/…) group offloads ONLY in the provably-safe
+    plain-MLA-fp8 case (num_kv_channels == 1 and hidden equals the plain latent
+    width kv_lora_rank + qk_rope_head_dim)."""
+    if not is_packed:
+        return True
+    return num_kv_channels == 1 and plain_mla_hidden is not None and hidden_dim == plain_mla_hidden
+
+
+def test_matrix_mla_fp8_plain_latent_offloads():
+    # MLA latent (3-D shape -> num_kv_channels=1) + fp8 + hidden==576 -> offload
+    assert _would_offload(is_packed=True, num_kv_channels=1, hidden_dim=576, plain_mla_hidden=576)
+
+
+def test_matrix_bf16_always_offloads():
+    # not packed -> passthrough, regardless of MLA vs GQA
+    assert _would_offload(is_packed=False, num_kv_channels=1, hidden_dim=576, plain_mla_hidden=576)
+    assert _would_offload(is_packed=False, num_kv_channels=2, hidden_dim=512, plain_mla_hidden=None)
+
+
+def test_matrix_gqa_fp8_is_skipped():
+    # GQA (num_kv_channels=2) + fp8 -> scale-packed / unrecognized -> SKIP
+    assert not _would_offload(
+        is_packed=True, num_kv_channels=2, hidden_dim=512, plain_mla_hidden=None
+    )
+
+
+def test_matrix_mla_fp8_scale_packed_hidden_mismatch_is_skipped():
+    # MLA + fp8 but hidden != plain latent (fp8_ds_mla 656/584 packs scales) -> SKIP
+    assert not _would_offload(
+        is_packed=True, num_kv_channels=1, hidden_dim=656, plain_mla_hidden=576
+    )
+
+
+# --- dtype -> "packed/quantized" classification (needs torch) ----------------
+
+
+def test_dtype_packed_classification():
+    torch = pytest.importorskip("torch")
+    for name in ("float8_e4m3fn", "float8_e5m2", "float8_e4m3fnuz", "uint8", "int8"):
+        dt = getattr(torch, name, None)
+        if dt is not None:
+            assert _is_packed_quant_kv_dtype(dt) is True, name
+    for dt in (torch.bfloat16, torch.float16, torch.float32):
+        assert _is_packed_quant_kv_dtype(dt) is False

--- a/tests/unit/kvd/test_ssd.py
+++ b/tests/unit/kvd/test_ssd.py
@@ -210,8 +210,10 @@ class TestSpilloverRegion:
         region = SpilloverRegion(tmp_path / "spillover", max_bytes=100)
         region.start()
         region.put(_key("a"), b"hello", retention="short")
-        assert region.remove(_key("a")) is True
-        assert region.remove(_key("a")) is False  # idempotent
+        removed = region.remove(_key("a"))
+        assert removed is True
+        removed_again = region.remove(_key("a"))
+        assert removed_again is False  # idempotent
         assert region.get_bytes(_key("a")) is None
 
     def test_clear(self, tmp_path: Path):

--- a/tests/unit/kvd/test_striped_long_region.py
+++ b/tests/unit/kvd/test_striped_long_region.py
@@ -276,10 +276,12 @@ def test_remove_works_through_correct_shard(tmp_path: Path):
         ok, _ = r.put(b"k", b"v" * 64, retention="long", model="m", compat_key="ck")
         assert ok
         assert r.get_bytes(b"k", model="m", compat_key="ck") is not None
-        assert r.remove(b"k", model="m", compat_key="ck") is True
+        removed = r.remove(b"k", model="m", compat_key="ck")
+        assert removed is True
         assert r.get_bytes(b"k", model="m", compat_key="ck") is None
         # Idempotent.
-        assert r.remove(b"k", model="m", compat_key="ck") is False
+        removed_again = r.remove(b"k", model="m", compat_key="ck")
+        assert removed_again is False
     finally:
         r.shutdown()
 

--- a/tests/unit/kvd/test_tablespace.py
+++ b/tests/unit/kvd/test_tablespace.py
@@ -416,9 +416,11 @@ def test_remove_drops_entry(tmp_path: Path):
     r.start()
     try:
         r.put(b"k", b"v", retention="long", model="m", compat_key="ck")
-        assert r.remove(b"k", model="m", compat_key="ck") is True
+        removed = r.remove(b"k", model="m", compat_key="ck")
+        assert removed is True
         assert r.get_bytes(b"k", model="m", compat_key="ck") is None
-        assert r.remove(b"k", model="m", compat_key="ck") is False  # already gone
+        removed_again = r.remove(b"k", model="m", compat_key="ck")
+        assert removed_again is False  # already gone
     finally:
         r.shutdown()
 

--- a/tests/unit/kvd/test_tablespace_multipool.py
+++ b/tests/unit/kvd/test_tablespace_multipool.py
@@ -277,10 +277,13 @@ def test_remove_works_across_pools(tmp_path: Path):
         r.put(b"k-small", b"s" * 100, retention="long", model="m", compat_key="c")
         r.put(b"k-big", b"b" * 50000, retention="long", model="m", compat_key="c")
 
-        assert r.remove(b"k-small", model="m", compat_key="c") is True
-        assert r.remove(b"k-big", model="m", compat_key="c") is True
+        removed_small = r.remove(b"k-small", model="m", compat_key="c")
+        assert removed_small is True
+        removed_big = r.remove(b"k-big", model="m", compat_key="c")
+        assert removed_big is True
         assert r.entries_count == 0
-        assert r.remove(b"k-missing", model="m", compat_key="c") is False
+        removed_missing = r.remove(b"k-missing", model="m", compat_key="c")
+        assert removed_missing is False
     finally:
         r.shutdown()
 


### PR DESCRIPTION
## Summary

Fixes the high-value security and correctness findings surfaced by a CodeQL
`python-security-and-quality` scan of the repo. Grouped by the CodeQL rule:

### 1. Overly permissive file permissions — `py/overly-permissive-file` (High, CVSS 7.8) — 9 sites
Scratch/probe/benchmark files were created world-readable (`0o644`). Tightened
to owner-only (`0o600`) in `perf.py`, `kvd_connector.py`, `hipfile_shim.py`,
`storage_selfcheck.py`, `bench_concurrent_load.py`, `bench_mla_read_dedup.py`.

### 2. Stack-trace / internal-error exposure — `py/stack-trace-exposure` — 15 sites
The routers returned `str(exc)` / `f"...: {exc}"` directly to clients, leaking
internal detail. Introduced a `_sanitized_error()` helper in `disagg.py` that
logs the full exception server-side and returns a generic message; applied
across `disagg.py` (JSON + streamed SSE errors) and `mixed.py`. In
`server/app.py`, malformed-JSON errors now return a generic message (detail
logged), and `AnthropicRequestRejected` validation messages are preserved
(they're a developer-authored client contract) but bounded/escaped via the new
`scrub()` helper.

### 3. Socket bound to all interfaces — `py/bind-socket-all-network-interfaces` — 4 sites
Free-port probes (`common/net.py`) and the e2e harness (`tests/e2e/harness/`)
now bind to `127.0.0.1` instead of `""` (all interfaces).

### 4. Log injection + test-only correctness — `py/log-injection` (3), `py/side-effect-in-assert` (9), `py/missing-call-to-init` (1)
- New `infera/common/logsafe.py` with `scrub()` (single-line, length-bounded);
  client-controlled values are scrubbed before logging in `anthropic.py`,
  `cache_control.py`, `direct.py`.
- Hoisted side-effecting `remove()` calls out of `assert` statements in the kvd
  unit tests so they aren't stripped under `python -O`.
- Registered the test `_FakeRouter` as a virtual subclass of `BaseRouter`
  instead of subclassing it (avoids skipping `BaseRouter.__init__`).

Also included: initialize `num_blocks`/`block_size_in_shape`/`hidden_dim`
before the shape branches in `kvd_connector.py` (`py/uninitialized-local-variable`,
a genuine `UnboundLocalError` guard).

## CI status
- `pre_check`, `lint`, `unit`, `unit-torch-cpu`, `engine`, `rust` — **pass**.
- `e2e-mixed` (atom/sglang/vllm, GPU) — running at time of writing; not affected
  by these changes beyond the harness loopback bind.
- A follow-up commit fixes the `lint` job: `ruff-format` collapsed a
  `logger.warning(...)` call in `disagg.py` onto one line, and `end-of-file-fixer`
  trimmed a trailing blank line from two pre-existing docs (`manual/conf.py`,
  `manual/features/kv_cache_offload.md`) that the all-files hook flags.

## Test plan
- [x] `pre-commit` hooks (ruff-format, ruff-check, end-of-file-fixer, trailing-whitespace) at the repo-pinned versions — pass
- [x] `unit` + `unit-torch-cpu` CI jobs — pass
- [x] `engine`, `rust` CI jobs — pass
- [ ] `e2e-mixed` GPU matrix — in progress
- [ ] Re-run CodeQL to confirm the findings clear

## Notes
- No functional/API behavior changes intended beyond error-message text: clients
  now get generic messages for internal 5xx errors (detail moved to server logs).
- The `AnthropicRequestRejected` 400 message is intentionally retained (safe,
  developer-authored) and may still appear in a strict CodeQL run as a reviewed
  false positive.
