### PR TITLE
docs(manual): add compatibility matrix page; fix k8s-deployments links

### DIFF
--- a/manual/conf.py
+++ b/manual/conf.py
@@ -65,4 +65,3 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "README.md", ".venv", ".
 # https://llmstxt.org/). See the rocm-docs-core guide:
 # https://rocm.docs.amd.com/projects/rocm-docs-core/en/latest/user_guide/llms.html
 rocm_docs_generate_llms = True
-

--- a/manual/features/compatibility_matrix.md
+++ b/manual/features/compatibility_matrix.md
@@ -22,9 +22,9 @@ is validated against these engine versions and images.
 | **Engine version** | 0.25.1 | 0.5.13 | 0.1.4 |
 | **Docker image** | `vllm/vllm-openai-rocm:v0.25.1` (ROCm base, digest-pinned) | `lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-20260612` | `rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.4_20260612` |
 | **ROCm (image base)** | 7.2.3 | 7.2.0 | 7.2.4 |
-| **OS (image base)** | — | — | Ubuntu 24.04 |
-| **Python (image base)** | — | — | 3.12 |
-| **PyTorch (image base)** | 2.11.0 | — | 2.10.0 |
+| **OS (image base)** | — | Ubuntu 22.04.5 | Ubuntu 24.04 |
+| **Python (image base)** | — | 3.10.12 | 3.12 |
+| **PyTorch (image base)** | 2.11.0 | 2.9.1 | 2.10.0 |
 | **Build date** | — | 2026-06-12 | 2026-06-12 |
 
 Fields marked `—` are not encoded in the released image tag and are not

--- a/manual/features/compatibility_matrix.md
+++ b/manual/features/compatibility_matrix.md
@@ -19,13 +19,13 @@ is validated against these engine versions and images.
 
 | | vLLM | SGLang | ATOM |
 | --- | --- | --- | --- |
-| **Engine version** | 0.25.1 | 0.5.13 | 0.1.4 |
-| **Docker image** | `vllm/vllm-openai-rocm` (ROCm nightly base, digest-pinned) | `lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-20260612` | `rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.4_20260612` |
-| **ROCm (image base)** | ROCm nightly | 7.2.0 | 7.2.4 |
-| **OS (image base)** | — | — | Ubuntu 24.04 |
-| **Python (image base)** | — | — | 3.12 |
-| **PyTorch (image base)** | — | — | 2.10.0 |
-| **Build date** | — | 2026-06-12 | 2026-06-12 |
+| **Engine version** | 0.23.1rc1.dev861 (nightly `cbe9c40f9`) | 0.5.13 | 0.1.4 |
+| **Docker image** | `vllm/vllm-openai-rocm:nightly-cbe9c40f9` (ROCm nightly base, digest-pinned) | `lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-20260612` | `rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.4_20260612` |
+| **ROCm (image base)** | 7.2.3 | 7.2.0 | 7.2.4 |
+| **OS (image base)** | Ubuntu 22.04.5 | — | Ubuntu 24.04 |
+| **Python (image base)** | 3.12.13 | — | 3.12 |
+| **PyTorch (image base)** | 2.11.0 | — | 2.10.0 |
+| **Build date** | 2026-07-17 | 2026-06-12 | 2026-06-12 |
 
 Fields marked `—` are not encoded in the released image tag and are not
 separately stated here — see the platform table below for the validated baseline

--- a/manual/features/compatibility_matrix.md
+++ b/manual/features/compatibility_matrix.md
@@ -19,13 +19,13 @@ is validated against these engine versions and images.
 
 | | vLLM | SGLang | ATOM |
 | --- | --- | --- | --- |
-| **Engine version** | 0.23.1rc1.dev861 (nightly `cbe9c40f9`) | 0.5.13 | 0.1.4 |
-| **Docker image** | `vllm/vllm-openai-rocm:nightly-cbe9c40f9` (ROCm nightly base, digest-pinned) | `lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-20260612` | `rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.4_20260612` |
+| **Engine version** | 0.25.1 | 0.5.13 | 0.1.4 |
+| **Docker image** | `vllm/vllm-openai-rocm:v0.25.1` (ROCm base, digest-pinned) | `lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-20260612` | `rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.4_20260612` |
 | **ROCm (image base)** | 7.2.3 | 7.2.0 | 7.2.4 |
-| **OS (image base)** | Ubuntu 22.04.5 | — | Ubuntu 24.04 |
-| **Python (image base)** | 3.12.13 | — | 3.12 |
+| **OS (image base)** | — | — | Ubuntu 24.04 |
+| **Python (image base)** | — | — | 3.12 |
 | **PyTorch (image base)** | 2.11.0 | — | 2.10.0 |
-| **Build date** | 2026-07-17 | 2026-06-12 | 2026-06-12 |
+| **Build date** | — | 2026-06-12 | 2026-06-12 |
 
 Fields marked `—` are not encoded in the released image tag and are not
 separately stated here — see the platform table below for the validated baseline

--- a/manual/features/compatibility_matrix.md
+++ b/manual/features/compatibility_matrix.md
@@ -1,0 +1,57 @@
+# Compatibility matrix
+
+This page lists the exact versions Infera **0.1.0** has been validated against.
+Everything here is what we have tested — combinations not listed are outside the
+validated set for this release, not necessarily unsupported.
+
+```{admonition} How to read this page
+:class: note
+Where a component is pinned to a specific image tag, use that exact artifact. The
+validated engine images bundle the Infera connector, the `sitecustomize` hook,
+and the RDMA transport shims on top of the vendor ROCm base — so the tag is the
+tested unit, not just the engine version inside it.
+```
+
+## Engines
+
+Infera orchestrates one or more engines. Install at least one. The 0.1.0 release
+is validated against these engine versions and images.
+
+| | vLLM | SGLang | ATOM |
+| --- | --- | --- | --- |
+| **Engine version** | 0.25.1 | 0.5.13 | 0.1.4 |
+| **Docker image** | `vllm/vllm-openai-rocm` (ROCm nightly base, digest-pinned) | `lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-20260612` | `rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.4_20260612` |
+| **ROCm (image base)** | ROCm nightly | 7.2.0 | 7.2.4 |
+| **OS (image base)** | — | — | Ubuntu 24.04 |
+| **Python (image base)** | — | — | 3.12 |
+| **PyTorch (image base)** | — | — | 2.10.0 |
+| **Build date** | — | 2026-06-12 | 2026-06-12 |
+
+Fields marked `—` are not encoded in the released image tag and are not
+separately stated here — see the platform table below for the validated baseline
+that applies across all engines.
+
+```{admonition} Engine images bundle more than the engine
+:class: tip
+The validated engine images layer the Infera connector, the `sitecustomize`
+hook, and the Mooncake / ionic RDMA shims on top of the vendor ROCm base. For
+serving, prefer the prebuilt image over a manual `pip install` of the engine.
+See [Deployment → Engine images](../serving/deployment.md).
+```
+
+## Platform
+
+| Component | Validated version |
+| --- | --- |
+| GPU | AMD Instinct MI355X (`gfx950`) |
+| ROCm | 7.2 |
+| Operating system | Ubuntu 24.04 (Linux x86-64) |
+| Python | 3.10+ |
+| Docker | Required — runs `etcd` in dev and builds engine images |
+| RDMA NIC | AMD AINIC — required only for cross-node prefill-decode |
+
+## Infera
+
+| Package | Validated version |
+| --- | --- |
+| `amd-infera` | 0.1.0 |

--- a/manual/features/compatibility_matrix.md
+++ b/manual/features/compatibility_matrix.md
@@ -22,14 +22,14 @@ is validated against these engine versions and images.
 | **Engine version** | 0.25.1 | 0.5.13 | 0.1.4 |
 | **Docker image** | `vllm/vllm-openai-rocm:v0.25.1` (ROCm base, digest-pinned) | `lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-20260612` | `rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.4_20260612` |
 | **ROCm (image base)** | 7.2.3 | 7.2.0 | 7.2.4 |
-| **OS (image base)** | — | Ubuntu 22.04.5 | Ubuntu 24.04 |
-| **Python (image base)** | — | 3.10.12 | 3.12 |
+| **OS (image base)** | Ubuntu 22.04.5 | Ubuntu 22.04.5 | Ubuntu 24.04.4 |
+| **Python (image base)** | 3.12.13 | 3.10.12 | 3.12.3 |
 | **PyTorch (image base)** | 2.11.0 | 2.9.1 | 2.10.0 |
-| **Build date** | — | 2026-06-12 | 2026-06-12 |
+| **Build date** | 2026-07-12 | 2026-06-12 | 2026-06-12 |
 
-Fields marked `—` are not encoded in the released image tag and are not
-separately stated here — see the platform table below for the validated baseline
-that applies across all engines.
+OS / Python / PyTorch above were read from inside each validated base image (not
+the tag). See the platform table below for the baseline that applies across all
+engines.
 
 ```{admonition} Engine images bundle more than the engine
 :class: tip

--- a/manual/features/kv_cache_offload.md
+++ b/manual/features/kv_cache_offload.md
@@ -236,4 +236,3 @@ connector doesn't expose either per request — `ephemeral` maps to `long` and
   offload/onboard mechanism, the tablespace on-disk format, and optimization.
 - [CLI reference](../reference/cli.md) · [Environment variables](../reference/environment.md)
   — the daemon flags and connector env vars.
-

--- a/manual/serving/kubernetes.md
+++ b/manual/serving/kubernetes.md
@@ -5,7 +5,7 @@ NATS + LeaderWorkerSet controller) with Helm, submit an **`InferaDeployment`**
 CRD, and let the operator reconcile it into Deployments / LeaderWorkerSets,
 Services, and the KV-event plane. Ready-to-fill `InferaDeployment` templates
 (single-node, prefill/decode, multi-node TP, GAIE) live under
-[`examples/k8s-deployments/`](../../examples/k8s-deployments/README.md).
+[`examples/k8s-deployments/`](https://github.com/AMD-AGI/Infera/tree/main/examples/k8s-deployments).
 
 ## Prerequisites
 
@@ -123,7 +123,7 @@ curl localhost:8000/v1/chat/completions \
 ## Deployment templates
 
 Instead of hand-writing the CR above, start from the ready-to-fill templates in
-[`examples/k8s-deployments/`](../../examples/k8s-deployments/README.md) — one per
+[`examples/k8s-deployments/`](https://github.com/AMD-AGI/Infera/tree/main/examples/k8s-deployments) — one per
 topology (single-node aggregated, prefill/decode disaggregated, multi-node TP,
 and GAIE), each with a shared model-store PVC and documented `<PLACEHOLDERS>`.
 

--- a/manual/sphinx/_toc.yml.in
+++ b/manual/sphinx/_toc.yml.in
@@ -35,6 +35,8 @@ subtrees:
     entries:
       - file: features/feature_matrix.md
         title: Feature matrix
+      - file: features/compatibility_matrix.md
+        title: Compatibility matrix
       - file: features/pd_disaggregation.md
         title: Prefill-decode disaggregation
       - file: features/kv_cache_offload.md


### PR DESCRIPTION
## What

Two documentation changes to the Sphinx manual:

### 1. New page: Compatibility matrix
Adds `manual/features/compatibility_matrix.md` — the versions Infera **0.1.0** is validated against (engines: vLLM / SGLang / ATOM with their image tags; platform baseline; `amd-infera` package). Registered in the **Features** section of the TOC source `manual/sphinx/_toc.yml.in`, so it renders at **`features/compatibility_matrix.html`** and appears in the sidebar.

> Note: `manual/sphinx/_toc.yml` is generated from `_toc.yml.in` at build time (and gitignored), so the TOC entry lives in the `.in` source.

### 2. Fix broken `examples/k8s-deployments` links
`serving/kubernetes.md` linked to `../../examples/k8s-deployments/README.md`, which is outside the Sphinx source tree and unresolvable (`myst.xref_missing` → a `-W` build failure). Both links now point at the GitHub directory URL, matching the manual's self-contained "no links into the source tree" rule.

## Verification
Built locally (Sphinx 9.1.0 + rocm-docs-core, `graphviz` installed):
- New page renders at `features/compatibility_matrix.html` and shows in the sidebar; no orphan/toctree warning.
- `myst.xref_missing` warnings: **0** (was 4).
- Remaining warnings are only external-inventory fetch failures from building offline (intersphinx), which pass in CI/ReadTheDocs with network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)