### PR TITLE
feat(kvd): auto-offload plain GQA/MHA fp8 KV cache to L3

### DIFF
--- a/infera/engine/vllm/kvd_connector.py
+++ b/infera/engine/vllm/kvd_connector.py
@@ -344,10 +344,13 @@ def _is_packed_quant_kv_dtype(dtype: Any) -> bool:
     chunked-fusion gather/scatter kernel copies raw elements with NO scale
     awareness. For a scale-packed cache the copy can silently mis-stride into
     garbage on reload. So register_kv_caches SKIPS a packed-dtype group UNLESS
-    it is the provably-safe plain-MLA-fp8 case — hidden == kv_lora_rank +
-    qk_rope_head_dim, a plain cast with no interleaved scale (auto-detected via
-    `_expected_plain_mla_hidden`; Kimi-K2.6 576 = 512 + 64, validated byte-exact).
-    bf16/fp16/fp32 are NOT packed and pass through unconditionally."""
+    it is a provably-safe PLAIN fp8 cast (no interleaved scale, hidden matches
+    the unquantized width exactly, auto-detected): a plain MLA latent — hidden
+    == kv_lora_rank + qk_rope_head_dim (`_expected_plain_mla_hidden`; Kimi-K2.6
+    576 = 512 + 64, validated byte-exact), or a plain GQA/MHA head layout —
+    hidden == (num_key_value_heads // tp) * head_dim (`_expected_plain_gqa_
+    hidden`; MiniMax-M2.5 8 x 128 = 1024). bf16/fp16/fp32 are NOT packed and
+    pass through unconditionally."""
     import torch
 
     names = (
@@ -414,6 +417,63 @@ def _expected_plain_mla_hidden(vllm_config: Any) -> int | None:
             rope = getattr(cand, "qk_rope_head_dim", None)
             if isinstance(klr, int) and klr > 0 and isinstance(rope, int) and rope > 0:
                 return klr + rope
+    except Exception:
+        return None
+    return None
+
+
+def _expected_plain_gqa_hidden(vllm_config: Any, tp_size: int) -> int | None:
+    """Return the per-rank PLAIN hidden width of a GQA / MHA KV head layout —
+    ``(num_key_value_heads // tp_size) * head_dim`` — else None.
+
+    Standard vLLM fp8 KV cache (``--kv-cache-dtype fp8``) is a PLAIN per-tensor
+    static-scale cast: ``k_scale`` / ``v_scale`` are scalars kept on the
+    attention layer (reloaded with the weights), NOT interleaved into the
+    cache. So the fp8 KV tensor has the SAME dims as its bf16 counterpart —
+    just 1-byte elements — and ``hidden == num_kv_heads_per_rank * head_dim``.
+    That contiguous cast has no scale bytes to mis-stride over, so the raw-byte
+    chunked gather/scatter round-trips it byte-exact (validated on MiniMax-M2.5
+    GQA: 8 kv-heads x 128 = 1024). A scale-PACKED fp8 format (per-token /
+    per-head scales appended into the hidden run) stores a LARGER hidden, so it
+    will NOT match this and stays guarded.
+
+    This is the non-MLA analogue of `_expected_plain_mla_hidden`. Unlike the
+    MLA latent (replicated across TP ranks), GQA KV heads are SHARDED across
+    tensor-parallel ranks, so the per-rank width is TP-dependent. Returns None
+    (→ stays skipped, correctness over the optimization) for an MLA model, or
+    when the per-rank head count can't be resolved cleanly (kv_heads neither
+    <= tp nor divisible by tp)."""
+    if _is_mla_from_config(vllm_config):
+        return None
+    try:
+        mc = getattr(vllm_config, "model_config", None)
+        if mc is None:
+            return None
+        hf = getattr(mc, "hf_text_config", None) or getattr(mc, "hf_config", None)
+        tp = tp_size if isinstance(tp_size, int) and tp_size > 0 else 1
+        for cand in (hf, getattr(hf, "text_config", None)):
+            if cand is None:
+                continue
+            kv_heads = getattr(cand, "num_key_value_heads", None)
+            if not (isinstance(kv_heads, int) and kv_heads > 0):
+                kv_heads = getattr(cand, "num_attention_heads", None)  # MHA
+            head_dim = getattr(cand, "head_dim", None)
+            if not (isinstance(head_dim, int) and head_dim > 0):
+                hs = getattr(cand, "hidden_size", None)
+                nh = getattr(cand, "num_attention_heads", None)
+                if isinstance(hs, int) and isinstance(nh, int) and nh > 0:
+                    head_dim = hs // nh
+            if not (isinstance(kv_heads, int) and kv_heads > 0):
+                continue
+            if not (isinstance(head_dim, int) and head_dim > 0):
+                continue
+            if kv_heads <= tp:
+                per_rank = 1  # vLLM replicates when kv_heads < tp
+            elif kv_heads % tp == 0:
+                per_rank = kv_heads // tp
+            else:
+                return None  # ragged shard — can't predict per-rank width
+            return per_rank * head_dim
     except Exception:
         return None
     return None
@@ -1003,6 +1063,12 @@ class InferaKvdConnector(KVConnectorBase_V1, SupportsHMA):  # type: ignore[misc]
         # (656/584/nvfp4) have a larger hidden and stay skipped. See
         # `_expected_plain_mla_hidden`.
         self._plain_mla_hidden = _expected_plain_mla_hidden(vllm_config)
+        # Plain-GQA-fp8 auto-detect: (num_key_value_heads // tp) * head_dim. A
+        # packed GQA KV tensor (num_kv_channels == 2) whose hidden matches this
+        # EXACTLY is a plain per-tensor-scale fp8 cast (no interleaved scale) →
+        # byte-exact copyable → safe to offload. Scale-packed layouts have a
+        # larger hidden and stay skipped. See `_expected_plain_gqa_hidden`.
+        self._plain_gqa_hidden = _expected_plain_gqa_hidden(vllm_config, self._tp_size)
         # Set True once a non-paged (Mamba / linear-attention / conv) cache
         # group is observed (register_kv_caches / bootstrap). vLLM 0.22.x does
         # NOT support external KV-connector LOADS for hybrid models — its
@@ -2497,28 +2563,38 @@ class InferaKvdConnector(KVConnectorBase_V1, SupportsHMA):  # type: ignore[misc]
                     # is skipped (no toggle: correctness over the optimization;
                     # a new safe format is added HERE, not via a runtime env).
                     _pmh = getattr(self, "_plain_mla_hidden", None)
+                    _gqh = getattr(self, "_plain_gqa_hidden", None)
                     _plain_mla_fp8 = (
                         num_kv_channels == 1 and _pmh is not None and hidden_dim == _pmh
                     )
+                    # GQA/MHA plain fp8: per-rank hidden == (kv_heads//tp)*head_dim,
+                    # a per-tensor-scale cast with no interleaved scale bytes →
+                    # byte-exact copyable (MiniMax-M2.5: 8 kv-heads x 128 = 1024).
+                    _plain_gqa_fp8 = (
+                        num_kv_channels == 2 and _gqh is not None and hidden_dim == _gqh
+                    )
                     if _is_packed_quant_kv_dtype(sample.dtype):
-                        if _plain_mla_fp8:
+                        if _plain_mla_fp8 or _plain_gqa_fp8:
                             logger.info(
                                 "register_kv_caches: group %d layer %r packed KV "
-                                "dtype %s hidden=%d == kv_lora_rank+qk_rope_head_dim "
-                                "— plain MLA fp8 cast (no interleaved scale), "
-                                "offloading to L3.",
+                                "dtype %s hidden=%d == plain %s width — per-tensor-"
+                                "scale cast (no interleaved scale), offloading to L3.",
                                 gid,
                                 present[0],
                                 sample.dtype,
                                 hidden_dim,
+                                "MLA latent (kv_lora_rank+qk_rope_head_dim)"
+                                if _plain_mla_fp8
+                                else "GQA ((kv_heads//tp)*head_dim)",
                             )
                         else:
                             logger.warning(
                                 "register_kv_caches: group %d layer %r has packed/"
                                 "quantized KV dtype %s (shape %s) that is NOT a plain "
-                                "MLA fp8 latent (hidden != kv_lora_rank+qk_rope_head_"
-                                "dim) — scale-packed/unrecognized layout is unvalidated,"
-                                " chunked fusion SKIPS it (no L3, no corruption).",
+                                "fp8 cast (hidden != plain MLA latent nor GQA "
+                                "(kv_heads//tp)*head_dim) — scale-packed/unrecognized "
+                                "layout is unvalidated, chunked fusion SKIPS it (no L3, "
+                                "no corruption).",
                                 gid,
                                 present[0],
                                 sample.dtype,
@@ -2614,23 +2690,27 @@ class InferaKvdConnector(KVConnectorBase_V1, SupportsHMA):  # type: ignore[misc]
                         block_size_in_shape = int(shape[1])
                         hidden_dim = int(shape[2])
                     _fb_pmh = getattr(self, "_plain_mla_hidden", None)
+                    _fb_gqh = getattr(self, "_plain_gqa_hidden", None)
                     _fallback_plain_mla_fp8 = (
                         num_kv_channels == 1 and _fb_pmh is not None and hidden_dim == _fb_pmh
+                    )
+                    _fallback_plain_gqa_fp8 = (
+                        num_kv_channels == 2 and _fb_gqh is not None and hidden_dim == _fb_gqh
                     )
                     if (
                         num_kv_channels
                         and _is_packed_quant_kv_dtype(sample.dtype)
-                        and not _fallback_plain_mla_fp8
+                        and not (_fallback_plain_mla_fp8 or _fallback_plain_gqa_fp8)
                     ):
                         # Same packed/quantized-dtype guard as the primary
                         # probe: skip scale-packed fp8/uint8 caches (no L3, no
-                        # corruption). The plain-MLA-fp8 case (hidden ==
-                        # kv_lora_rank+qk_rope_head_dim, no interleaved scale)
-                        # is auto-detected above and offloads normally.
+                        # corruption). The plain-fp8 cases (hidden == plain MLA
+                        # latent, or GQA (kv_heads//tp)*head_dim — no interleaved
+                        # scale) are auto-detected above and offload normally.
                         logger.warning(
                             "register_kv_caches (fallback): layer %r has packed/"
                             "quantized KV dtype %s (shape %s) that is NOT a plain "
-                            "MLA fp8 latent — scale-packed/unrecognized layout is "
+                            "fp8 cast — scale-packed/unrecognized layout is "
                             "unvalidated, chunked fusion SKIPS it (no L3, no "
                             "corruption).",
                             first_name,

--- a/tests/engine/vllm/test_attention_layout_roundtrip.py
+++ b/tests/engine/vllm/test_attention_layout_roundtrip.py
@@ -212,6 +212,40 @@ def test_roundtrip_fullattention_interleaved(dtype_name):
 
 
 @torch_skip
+@pytest.mark.parametrize("layout", ["regular", "interleaved"])
+def test_roundtrip_gqa_fp8_minimax_dims(layout):
+    """GQA fp8 KV at MiniMax-M2.5 head dims (8 kv-heads x 128 = 1024 hidden),
+    both the [2, nb, bs, H, D] and the [nb, 2, bs, H, D] layouts vLLM emits.
+
+    This is the exact packed layout `register_kv_caches` now OFFLOADS for a
+    plain GQA fp8 cache (hidden == (num_key_value_heads // tp) * head_dim, no
+    interleaved scale) — see `_expected_plain_gqa_hidden`. A plain fp8 cast is
+    a contiguous per-tensor-scale byte run, so the gather/pack/unpack/scatter
+    round-trips it byte-exact regardless of head dims. Pinning MiniMax's real
+    dims guards the production shape (observed live: (64465, 2, 16, 8, 128)).
+    """
+
+    mh, md = 8, 128  # MiniMax-M2.5: num_key_value_heads x head_dim -> hidden 1024
+    dt = _fp8_or_uint8()
+    if layout == "regular":
+        make_fn, page_fn, empty = _make_regular, _page_regular, (2, NB, BS, mh, md)
+    else:
+        make_fn, page_fn, empty = _make_interleaved, _page_interleaved, (NB, 2, BS, mh, md)
+    src, dst, pp, cp = _roundtrip(
+        lambda dtype: make_fn(NL, NB, BS, mh, md, dtype),
+        page_fn,
+        nl=NL,
+        nb=NB,
+        bs=BS,
+        hidden=mh * md,
+        num_kv_channels=2,
+        dtype=dt,
+        empty_shape=empty,
+    )
+    _assert_pages_equal(src, dst, page_fn, pp, cp, NL)
+
+
+@torch_skip
 @pytest.mark.parametrize("dtype_name", ["bf16", "fp8"])
 def test_roundtrip_mla(dtype_name):
     """MLA combined latent [num_blocks, block_size, hidden]; fp8 == fp8_ds_mla."""

--- a/tests/unit/kvd/test_kvd_connector_layout.py
+++ b/tests/unit/kvd/test_kvd_connector_layout.py
@@ -10,12 +10,17 @@ skipped, from a few pure helpers. This pins the support matrix so the
 non-obvious cases can't silently regress:
 
     model / layout      KV dtype     L3 offload
-    ------------------  -----------  -----------
+    ------------------  -----------  ----------------------------------------
     MLA (plain latent)  fp8          yes  (hidden == kv_lora_rank+qk_rope_head_dim)
+    GQA / MHA (plain)   fp8          yes  (hidden == (kv_heads//tp)*head_dim)
     MLA / any           bf16/fp16    yes  (not packed -> passthrough)
     GQA / MHA           bf16/fp16    yes  (not packed -> passthrough)
-    GQA / MHA           fp8          NO   (scale-packed, could mis-stride -> skip)
     MLA scale-packed    fp8 (656/…)  NO   (hidden != plain latent -> skip)
+    GQA scale-packed    fp8          NO   (hidden != (kv_heads//tp)*head_dim -> skip)
+
+Both plain-fp8 cases are per-tensor-scale casts (no scale bytes interleaved
+into the hidden run), so the raw-byte chunked gather/scatter round-trips them
+byte-exact. A scale-PACKED format stores a LARGER hidden and is skipped.
 
 Pure functions only — no GPU / engine / model. The matrix decision below is
 torch-free; only the dtype->packed classification needs torch (guarded).
@@ -26,16 +31,32 @@ from types import SimpleNamespace
 import pytest
 
 from infera.engine.vllm.kvd_connector import (
+    _expected_plain_gqa_hidden,
     _expected_plain_mla_hidden,
     _is_mla_from_config,
     _is_packed_quant_kv_dtype,
 )
 
 
-def _cfg(*, use_mla=None, kv_lora_rank=None, qk_rope_head_dim=None):
+def _cfg(
+    *,
+    use_mla=None,
+    kv_lora_rank=None,
+    qk_rope_head_dim=None,
+    num_key_value_heads=None,
+    num_attention_heads=None,
+    head_dim=None,
+    hidden_size=None,
+):
     """Minimal stand-in for the vLLM config the helpers read (model_config.*)."""
     hf = SimpleNamespace(
-        kv_lora_rank=kv_lora_rank, qk_rope_head_dim=qk_rope_head_dim, text_config=None
+        kv_lora_rank=kv_lora_rank,
+        qk_rope_head_dim=qk_rope_head_dim,
+        num_key_value_heads=num_key_value_heads,
+        num_attention_heads=num_attention_heads,
+        head_dim=head_dim,
+        hidden_size=hidden_size,
+        text_config=None,
     )
     mc = SimpleNamespace(use_mla=use_mla, hf_text_config=hf, hf_config=hf)
     return SimpleNamespace(model_config=mc)
@@ -71,41 +92,145 @@ def test_plain_mla_hidden_none_when_not_mla():
     assert _expected_plain_mla_hidden(SimpleNamespace(model_config=None)) is None
 
 
+# --- plain-GQA-fp8 hidden width = (num_key_value_heads // tp) * head_dim ------
+
+
+def test_plain_gqa_hidden_minimax_like_tp1():
+    # MiniMax-M2.5: 8 kv-heads x 128 head_dim = 1024 (single card, tp=1).
+    cfg = _cfg(num_key_value_heads=8, head_dim=128, num_attention_heads=48)
+    assert _expected_plain_gqa_hidden(cfg, 1) == 1024
+
+
+def test_plain_gqa_hidden_qwen_like_tp1():
+    # Qwen2.5-7B: 4 kv-heads x 128 = 512.
+    cfg = _cfg(num_key_value_heads=4, head_dim=128, num_attention_heads=28)
+    assert _expected_plain_gqa_hidden(cfg, 1) == 512
+
+
+def test_plain_gqa_hidden_is_tp_sharded():
+    # KV heads shard across TP: per-rank width halves at tp=2.
+    cfg = _cfg(num_key_value_heads=8, head_dim=128, num_attention_heads=48)
+    assert _expected_plain_gqa_hidden(cfg, 2) == 512  # (8//2)*128
+    assert _expected_plain_gqa_hidden(cfg, 4) == 256  # (8//4)*128
+
+
+def test_plain_gqa_hidden_replicated_when_kv_heads_below_tp():
+    # kv_heads < tp -> vLLM replicates one kv head per rank.
+    cfg = _cfg(num_key_value_heads=2, head_dim=128, num_attention_heads=32)
+    assert _expected_plain_gqa_hidden(cfg, 8) == 128  # 1 * 128
+
+
+def test_plain_gqa_hidden_none_on_ragged_shard():
+    # kv_heads not divisible by tp (and > tp) -> can't predict -> None (skip).
+    cfg = _cfg(num_key_value_heads=6, head_dim=128, num_attention_heads=48)
+    assert _expected_plain_gqa_hidden(cfg, 4) is None
+
+
+def test_plain_gqa_hidden_none_for_mla():
+    # MLA latent is not a GQA head layout -> None (handled by the MLA path).
+    assert _expected_plain_gqa_hidden(_cfg(kv_lora_rank=512, qk_rope_head_dim=64), 1) is None
+
+
+def test_plain_gqa_hidden_head_dim_fallback():
+    # No explicit head_dim -> derive from hidden_size // num_attention_heads.
+    cfg = _cfg(num_key_value_heads=4, num_attention_heads=32, hidden_size=4096)
+    assert _expected_plain_gqa_hidden(cfg, 1) == 512  # 4 * (4096//32=128)
+
+
+def test_plain_gqa_hidden_none_when_missing_config():
+    assert _expected_plain_gqa_hidden(SimpleNamespace(model_config=None), 1) is None
+
+
 # --- the offload/skip matrix (torch-free: takes is_packed directly) ----------
 
 
-def _would_offload(*, is_packed, num_kv_channels, hidden_dim, plain_mla_hidden):
+def _would_offload(*, is_packed, num_kv_channels, hidden_dim, plain_mla_hidden, plain_gqa_hidden):
     """Mirror of ``register_kv_caches``' packed-dtype gate: a non-packed group
-    always offloads; a packed (fp8/…) group offloads ONLY in the provably-safe
-    plain-MLA-fp8 case (num_kv_channels == 1 and hidden equals the plain latent
-    width kv_lora_rank + qk_rope_head_dim)."""
+    always offloads; a packed (fp8/…) group offloads ONLY in a provably-safe
+    PLAIN fp8 case — either a plain MLA latent (num_kv_channels == 1, hidden ==
+    kv_lora_rank + qk_rope_head_dim) or a plain GQA head layout
+    (num_kv_channels == 2, hidden == (kv_heads//tp)*head_dim)."""
     if not is_packed:
         return True
-    return num_kv_channels == 1 and plain_mla_hidden is not None and hidden_dim == plain_mla_hidden
+    plain_mla = (
+        num_kv_channels == 1 and plain_mla_hidden is not None and hidden_dim == plain_mla_hidden
+    )
+    plain_gqa = (
+        num_kv_channels == 2 and plain_gqa_hidden is not None and hidden_dim == plain_gqa_hidden
+    )
+    return plain_mla or plain_gqa
 
 
 def test_matrix_mla_fp8_plain_latent_offloads():
     # MLA latent (3-D shape -> num_kv_channels=1) + fp8 + hidden==576 -> offload
-    assert _would_offload(is_packed=True, num_kv_channels=1, hidden_dim=576, plain_mla_hidden=576)
+    assert _would_offload(
+        is_packed=True,
+        num_kv_channels=1,
+        hidden_dim=576,
+        plain_mla_hidden=576,
+        plain_gqa_hidden=None,
+    )
+
+
+def test_matrix_gqa_fp8_plain_offloads():
+    # GQA (num_kv_channels=2) + fp8 + hidden==(kv_heads//tp)*head_dim -> offload
+    assert _would_offload(
+        is_packed=True,
+        num_kv_channels=2,
+        hidden_dim=1024,
+        plain_mla_hidden=None,
+        plain_gqa_hidden=1024,
+    )
 
 
 def test_matrix_bf16_always_offloads():
     # not packed -> passthrough, regardless of MLA vs GQA
-    assert _would_offload(is_packed=False, num_kv_channels=1, hidden_dim=576, plain_mla_hidden=576)
-    assert _would_offload(is_packed=False, num_kv_channels=2, hidden_dim=512, plain_mla_hidden=None)
+    assert _would_offload(
+        is_packed=False,
+        num_kv_channels=1,
+        hidden_dim=576,
+        plain_mla_hidden=576,
+        plain_gqa_hidden=None,
+    )
+    assert _would_offload(
+        is_packed=False,
+        num_kv_channels=2,
+        hidden_dim=512,
+        plain_mla_hidden=None,
+        plain_gqa_hidden=512,
+    )
 
 
-def test_matrix_gqa_fp8_is_skipped():
-    # GQA (num_kv_channels=2) + fp8 -> scale-packed / unrecognized -> SKIP
+def test_matrix_gqa_fp8_scale_packed_hidden_mismatch_is_skipped():
+    # GQA + fp8 but hidden != (kv_heads//tp)*head_dim (extra scale bytes) -> SKIP
     assert not _would_offload(
-        is_packed=True, num_kv_channels=2, hidden_dim=512, plain_mla_hidden=None
+        is_packed=True,
+        num_kv_channels=2,
+        hidden_dim=1152,
+        plain_mla_hidden=None,
+        plain_gqa_hidden=1024,
+    )
+
+
+def test_matrix_gqa_fp8_unknown_width_is_skipped():
+    # GQA + fp8 but plain width couldn't be resolved (ragged/None) -> SKIP
+    assert not _would_offload(
+        is_packed=True,
+        num_kv_channels=2,
+        hidden_dim=1024,
+        plain_mla_hidden=None,
+        plain_gqa_hidden=None,
     )
 
 
 def test_matrix_mla_fp8_scale_packed_hidden_mismatch_is_skipped():
     # MLA + fp8 but hidden != plain latent (fp8_ds_mla 656/584 packs scales) -> SKIP
     assert not _would_offload(
-        is_packed=True, num_kv_channels=1, hidden_dim=656, plain_mla_hidden=576
+        is_packed=True,
+        num_kv_channels=1,
+        hidden_dim=656,
+        plain_mla_hidden=576,
+        plain_gqa_hidden=None,
     )
 
 


### PR DESCRIPTION
## What

`register_kv_caches` skipped **all** packed (fp8/uint8) non-MLA KV groups, so GQA/MHA models (Qwen, MiniMax-M2.5, …) never got L3 offload under `--kv-cache-dtype fp8`. But standard vLLM fp8 KV is a **plain per-tensor-scale cast** — `k_scale`/`v_scale` live on the attention layer, not interleaved into the cache — so it's byte-identical in layout to bf16, just 1-byte elements, and the raw-byte chunked gather/scatter round-trips it byte-exact.

This adds `_expected_plain_gqa_hidden`, the non-MLA analogue of `_expected_plain_mla_hidden`:

```
(num_key_value_heads // tp) * head_dim
```

the per-rank plain hidden width (GQA KV heads shard across TP, unlike the replicated MLA latent). `register_kv_caches` now offloads a packed GQA/MHA group **iff** its hidden exactly matches this. Anything else — scale-packed formats (per-token/per-head scales → larger hidden), an unresolved/ragged per-rank width, or MLA — still skips. No runtime toggle: correctness over the optimization.

## Why it's safe

The concern the guard protects against is scale-**packed** fp8 (e.g. `fp8_ds_mla` 656/584, nvfp4) where scales are interleaved into the hidden run and a raw copy would mis-stride. A plain cast has no such bytes; matching the config-derived plain width exactly distinguishes the two.

## Validation

- **Decision matrix** — `tests/unit/kvd/test_kvd_connector_layout.py`: offload plain GQA fp8; skip scale-packed / unknown / ragged / MLA; TP sharding + MHA/head_dim-fallback edge cases.
- **Byte-exact data path** — `tests/engine/vllm/test_attention_layout_roundtrip.py`: added a GQA fp8 case at MiniMax-M2.5 head dims (8 kv-heads × 128 = 1024 hidden), for both the `[2, nb, bs, H, D]` and `[nb, 2, bs, H, D]` layouts vLLM emits. Deterministic `gather → pack → unpack → scatter`, asserts byte equality.
- **Model-level** on `amd/MiniMax-M2.5-MXFP4` (GQA fp8, single MI355X): the live 1024-hidden packed KV (observed shape `(64465, 2, 16, 8, 128)`) offloaded and saved to L2+L3 — `sets_total>0`, `long_bytes>0`, `misses_total=0`.

Output comparison is deliberately **not** used as a correctness signal: MoE recompute on reload is nondeterministic (see #122), so reload output diverges even when the KV is byte-exact. Byte-exactness is gated by the deterministic roundtrip test.

## Note

Stacked on #8 (`fix/codeql-security-high-value`) — it builds on the connector guard and the `test_kvd_connector_layout.py` that #8 adds. Retarget to `main` once #8 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)