### PR TITLE
test(e2e): add mixed + kvd L3 offload test to CI

### DIFF
--- a/tests/e2e/harness/kvd_offload.py
+++ b/tests/e2e/harness/kvd_offload.py
@@ -1,0 +1,102 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""Aggregated (mixed) + kvd L3 offload e2e scenario — vLLM only.
+
+CI's mixed suite runs a bare mixed worker; it never exercises the kvd tiered
+KV cache. This spawns the SAME mixed worker but with the ``InferaKvdConnector``
+wired to a live ``infera.kvd`` daemon, drives a long shared-prefix request
+through the router, and asserts the produced KV was offloaded to L3 (daemon
+``sets_total`` > 0, ``misses_total`` == 0, ``long_bytes`` > 0).
+
+bf16 KV (``INFERA_DEFAULT_KV_FP8=0``, overriding infera's fp8 product default)
+so the offload is an unconditional plain passthrough — independent of the fp8
+packed-KV path, which the connector's own unit + gather/scatter roundtrip tests
+gate. See ``manual/features/kv_cache_offload.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+
+from . import client
+from .adapter import emit_reporter_line
+from .params import EngineParams
+
+_KV_CONNECTOR_CFG = (
+    '{"kv_connector":"InferaKvdConnector","kv_role":"kv_both",'
+    '"kv_connector_module_path":"infera.engine.vllm.kvd_connector"}'
+)
+
+# A long shared prefix — many tokens over INFERA_KVD_CHUNK_TOKENS below — so at
+# least one full chunk is produced and offloaded on a single request.
+_PARA = (
+    "The kvd tiered KV cache keeps warm prefixes across three storage tiers "
+    "instead of recomputing them: GPU HBM is the fastest and smallest, host RAM "
+    "is larger but slower, and local NVMe storage is the largest, the slowest, "
+    "and durable across engine restarts. As HBM fills, blocks are demoted "
+    "downward through the tiers, and on a cache hit they are promoted back up. "
+)
+_PROMPT = _PARA * 8 + " Question: name the three tiers, fastest to slowest. Answer:"
+
+
+def kvd_params(base: EngineParams, socket: str) -> EngineParams:
+    """Layer the kvd connector + a bf16-KV env onto ``base``."""
+    return dataclasses.replace(
+        base,
+        extra_args=(
+            *base.extra_args,
+            "--enable-prefix-caching",
+            "--kv-transfer-config",
+            _KV_CONNECTOR_CFG,
+        ),
+        extra_env=(
+            *base.extra_env,
+            ("INFERA_KVD_SOCKET", socket),
+            # Override infera's fp8 KV product default -> true bf16 KV, which the
+            # connector offloads unconditionally (a plain passthrough, no packed
+            # scale to reason about).
+            ("INFERA_DEFAULT_KV_FP8", "0"),
+            # Small fixed chunk grain so the request's prefix forms >=1 chunk.
+            ("INFERA_KVD_CHUNK_TOKENS", "256"),
+            # Stable block hashes so scheduler + worker derive the same chunk
+            # keys (else misses_total > 0).
+            ("PYTHONHASHSEED", "0"),
+        ),
+        server_ready_timeout=max(base.server_ready_timeout, 600),
+    )
+
+
+async def run_mixed_kvd_offload(server: dict, spawn, base_params: EngineParams, kvd: dict) -> None:
+    """Spawn a kvd-enabled mixed worker, drive one long request through the
+    router, and assert the KV was offloaded to the L3 tier."""
+    params = kvd_params(base_params, kvd["socket"])
+    await spawn(server, params)
+
+    text = await client.completion_text(
+        server["url"], params.model, _PROMPT, max_tokens=32, temperature=0.0
+    )
+    assert text, "empty completion from the kvd-enabled mixed worker"
+
+    # The connector flushes chunk saves asynchronously after the step; poll the
+    # daemon counters until the offload lands (or time out).
+    stats: dict = {}
+    for _ in range(40):
+        stats = kvd["stats"]()
+        if stats.get("sets_total", 0) > 0:
+            break
+        await asyncio.sleep(1.0)
+
+    emit_reporter_line(f"[e2e kvd] daemon stats after request: {stats}")
+    assert stats.get("sets_total", 0) > 0, (
+        f"kvd offloaded nothing (sets_total=0); stats={stats}. Expected the mixed "
+        "worker's InferaKvdConnector to save KV chunk(s) to L3."
+    )
+    assert stats.get("misses_total", 0) == 0, (
+        f"kvd chunk-key mismatch (misses_total>0): {stats} — scheduler and worker "
+        "derived different keys (PYTHONHASHSEED / INFERA_KVD_CHUNK_TOKENS skew?)."
+    )
+    assert stats.get("long_bytes", 0) > 0, f"nothing written to the L3 (long) tier: {stats}"

--- a/tests/e2e/pd_mixed/vllm/conftest.py
+++ b/tests/e2e/pd_mixed/vllm/conftest.py
@@ -11,6 +11,10 @@ spawns ``vllm serve``); only the argv mapping is vLLM-specific.
 
 from __future__ import annotations
 
+import os
+
+import pytest_asyncio
+
 from ...harness import EngineAdapter, EngineParams
 from ...harness.fixtures import make_worker_fixture
 
@@ -66,3 +70,67 @@ class VllmAdapter(EngineAdapter):
 
 
 worker = make_worker_fixture(VllmAdapter)
+
+
+@pytest_asyncio.fixture
+async def kvd_daemon(tmp_path):
+    """Start one ``infera.kvd`` daemon (RAM + local-disk L3) for the kvd-offload
+    test, and yield a small handle: the socket path a worker's InferaKvdConnector
+    connects to, plus a ``stats()`` reader over ``infera.kvd.statctl``.
+
+    RAM tier kept small (``--max-bytes``) so the hot set spills to the disk (L3)
+    tier under ``tmp_path``; both are torn down with the daemon.
+    """
+    import json
+    import subprocess
+    import time
+
+    sock = str(tmp_path / "kvd.sock")
+    long_dir = tmp_path / "l3"
+    long_dir.mkdir()
+    proc = subprocess.Popen(
+        [
+            "python3",
+            "-m",
+            "infera.kvd",
+            "--socket",
+            sock,
+            "--max-bytes",
+            "4G",
+            "--long-path",
+            str(long_dir),
+            "--long-bytes",
+            "64G",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+    )
+
+    def _stats() -> dict:
+        try:
+            out = subprocess.run(
+                ["python3", "-m", "infera.kvd.statctl", "--socket", sock],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            ).stdout
+            return json.loads(out)
+        except Exception:
+            return {}
+
+    # Wait for the daemon's unix socket to appear (fail-fast if it never boots).
+    for _ in range(100):
+        if os.path.exists(sock):
+            break
+        if proc.poll() is not None:
+            raise RuntimeError(f"infera.kvd daemon exited early (rc={proc.returncode})")
+        time.sleep(0.1)
+
+    try:
+        yield {"socket": sock, "long_dir": str(long_dir), "stats": _stats}
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            proc.kill()

--- a/tests/e2e/pd_mixed/vllm/test_mixed_kvd.py
+++ b/tests/e2e/pd_mixed/vllm/test_mixed_kvd.py
@@ -1,0 +1,31 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""vLLM e2e — mixed worker WITH kvd L3 offload (aggregated + offload).
+
+The plain mixed suite (``test_mixed.py``) runs a bare worker and never touches
+the kvd tiered cache. This one spawns the same aggregated worker but wired to a
+live ``infera.kvd`` daemon (the ``kvd_daemon`` fixture), drives a long request
+through the router, and asserts the KV was offloaded to L3. kvd is a vLLM-only
+feature, so this test lives in the vLLM suite only.
+"""
+
+import pytest
+
+from ...harness import resources
+from ...harness.kvd_offload import run_mixed_kvd_offload
+from ...harness.matrix import QWEN3_8B, resolve_model
+from ...harness.params import EngineParams
+
+
+@pytest.mark.slow
+async def test_mixed_kvd(infera_server, worker, kvd_daemon):
+    """Aggregated worker + kvd: one long request must offload KV to the L3 tier
+    (daemon sets_total>0, misses_total==0)."""
+    params = EngineParams(model=resolve_model(QWEN3_8B), tensor_parallel_size=1)
+    resources.require_gpus(params)
+
+    server = await infera_server()
+    await run_mixed_kvd_offload(server, worker, params, kvd_daemon)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -367,7 +367,11 @@ run_e2e_mixed() {
       vllm)   img="$IMG_VLLM" ;;
       atom)   img="$IMG_ATOM" ;;
     esac
-    run_e2e_engine "$img" "tests/e2e/pd_mixed/$e/test_mixed.py" || rc=1
+    # vLLM's mixed dir carries an extra kvd-offload test (test_mixed_kvd.py) —
+    # run the whole dir so it's collected; other engines have only test_mixed.py.
+    local testpath="tests/e2e/pd_mixed/$e/test_mixed.py"
+    [ "$e" = vllm ] && testpath="tests/e2e/pd_mixed/$e/"
+    run_e2e_engine "$img" "$testpath" || rc=1
   done
 
   docker rm -f "$ETCD_CTR" >/dev/null 2>&1 || true


### PR DESCRIPTION
## What

CI's `e2e-mixed` suite runs a bare aggregated worker and never touches the **kvd** tiered KV cache — the offload path had no e2e gate (only unit + CPU-roundtrip coverage). This adds an **aggregated + offload** test that rides the existing `e2e-mixed` job.

A `kvd_daemon` fixture starts an `infera.kvd` daemon (RAM + local-disk L3); the mixed worker is spawned with the `InferaKvdConnector` wired to it; a long shared-prefix request through the router must offload KV to L3 — asserted via the daemon counters: `sets_total > 0`, `misses_total == 0`, `long_bytes > 0`.

## Design notes

- **vLLM only** — kvd is a vLLM-only feature (`manual/features/kv_cache_offload.md`), so the test lives in the vLLM mixed suite.
- **bf16 KV** (`INFERA_DEFAULT_KV_FP8=0`, overriding infera's fp8 product default) so the offload is an *unconditional plain passthrough* — decoupled from the fp8 packed-KV path, which is gated separately by the connector's own unit + gather/scatter roundtrip tests.
- **Wiring:** vLLM's mixed dispatch now runs the whole `pd_mixed/vllm/` dir so `test_mixed_kvd.py` is collected alongside `test_mixed.py`; sglang/atom keep the single-file path. **No `ci.yml` change** — the existing `e2e-mixed` job picks it up.

## Validation

Ran the test through the real CI harness in-container (etcd + router + registered worker + kvd daemon) on Qwen3-8B / MI355X:

```
tests/e2e/pd_mixed/vllm/test_mixed_kvd.py::test_mixed_kvd PASSED
[e2e kvd] daemon stats after request: {'sets_total': 2, 'long_bytes': 75505664,
                                       'misses_total': 0, ...}
1 passed in 134.16s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)