### PR TITLE
Upgrade SGLang base image to v0.5.15.post1 (official release repo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ vendor base. Build from the repo root; override the base with `--build-arg <ENGI
 
 | Dockerfile          | Base image                                      |
 |---------------------|-------------------------------------------------|
-| `Dockerfile.sglang` | `lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-…`  |
+| `Dockerfile.sglang` | `lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x`   |
 | `Dockerfile.vllm`   | `vllm/vllm-openai-rocm:nightly-cbe9c40f…`       |
 | `Dockerfile.atom`   | `rocm/atom:rocm7.2.4_…_atom0.1.4_20260612`      |
 

--- a/deploy/docker/Dockerfile.sglang
+++ b/deploy/docker/Dockerfile.sglang
@@ -1,7 +1,7 @@
 # Infera SGLang engine image: layers the infera source onto the ROCm SGLang
 # base and sets an entrypoint that injects the host's libionic before exec'ing
 # the command.
-ARG SGLANG_BASE_IMAGE=lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-20260612
+ARG SGLANG_BASE_IMAGE=lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
 FROM ${SGLANG_BASE_IMAGE}
 
 WORKDIR /opt/infera

--- a/manual/features/compatibility_matrix.md
+++ b/manual/features/compatibility_matrix.md
@@ -19,13 +19,13 @@ is validated against these engine versions and images.
 
 | | vLLM | SGLang | ATOM |
 | --- | --- | --- | --- |
-| **Engine version** | 0.25.1 | 0.5.13 | 0.1.4 |
-| **Docker image** | `vllm/vllm-openai-rocm:v0.25.1` (ROCm base, digest-pinned) | `lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-20260612` | `rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.4_20260612` |
+| **Engine version** | 0.25.1 | 0.5.15.post1 | 0.1.4 |
+| **Docker image** | `vllm/vllm-openai-rocm:v0.25.1` (ROCm base, digest-pinned) | `lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x` | `rocm/atom:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0_atom0.1.4_20260612` |
 | **ROCm (image base)** | 7.2.3 | 7.2.0 | 7.2.4 |
 | **OS (image base)** | Ubuntu 22.04.5 | Ubuntu 22.04.5 | Ubuntu 24.04.4 |
 | **Python (image base)** | 3.12.13 | 3.10.12 | 3.12.3 |
 | **PyTorch (image base)** | 2.11.0 | 2.9.1 | 2.10.0 |
-| **Build date** | 2026-07-12 | 2026-06-12 | 2026-06-12 |
+| **Build date** | 2026-07-12 | 2026-07-15 | 2026-06-12 |
 
 OS / Python / PyTorch above were read from inside each validated base image (not
 the tag). See the platform table below for the baseline that applies across all

--- a/manual/getting_started/installation.md
+++ b/manual/getting_started/installation.md
@@ -44,7 +44,7 @@ Pick whichever you'll serve with (you can install more than one):
 
 - **vLLM (ROCm)** — `vllm/vllm-openai-rocm:nightly-cbe9c40f…` is the validated
   base image (digest-pinned nightly), or a matching ROCm `pip` build.
-- **SGLang (ROCm)** — `lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-20260612` is
+- **SGLang (ROCm)** — `lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x` is
   the validated base image.
 - **ATOM** — `rocm/atom:rocm7.2.4_...atom0.1.4`.
 

--- a/manual/serving/deployment.md
+++ b/manual/serving/deployment.md
@@ -57,7 +57,7 @@ Mooncake/ionic RDMA shims on top of a vendor base. Pick by runtime:
 | Dockerfile (under `deploy/docker/`) | Base | Use for |
 |---|---|---|
 | `Dockerfile.vllm` | `vllm/vllm-openai-rocm:nightly-cbe9c40f…` | vLLM on MI355X (incl. hipFile) |
-| `Dockerfile.sglang` | `lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-…` | SGLang on ROCm |
+| `Dockerfile.sglang` | `lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x` | SGLang on ROCm |
 | `Dockerfile.atom` | `rocm/atom:rocm7.2.4_…atom0.1.4` | ATOM on ROCm |
 
 Build from the repo root, e.g.:


### PR DESCRIPTION
## Summary
- Switch the SGLang engine base from the **daily-build repo** (`lmsysorg/sglang-rocm`, date-stamped rolling tags that get discarded) to the **official release repo** (`lmsysorg/sglang`, one clean tag per upstream release, published across cu/rocm/cann/xeon together).
- Bump engine version **0.5.13 → 0.5.15.post1**: `lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x`.
- Update the 4 doc references + compatibility matrix (engine version, image tag, build date 2026-07-15).

## Why the repo switch
The previously pinned tag `lmsysorg/sglang-rocm:v0.5.13-rocm720-mi35x-20260612` lives only in the daily-build repo; it 404s in `lmsysorg/sglang`. The release repo is the correct thing to pin — one stable tag per release, no date-stamp churn.

## Image baseline (read from inside the new image)
OS / ROCm / Python / PyTorch are **unchanged** from the old 0.5.13 base — this is a pure engine-version bump, no platform base change:
- ROCm 7.2.0 · Ubuntu 22.04.5 · Python 3.10.12 · PyTorch 2.9.1

The `infera/engine/sglang/` integration uses feature-detection (hasattr probes), not hard version pins, so no code changes were required.

## Test plan
- [x] Build infera SGLang image on new base (MI355X / gfx950 / ROCm 7.2) — OK (rust router compile + pip)
- [x] `tests/engine/sglang/` full suite — **66 passed, 0 failed** (incl. version-sensitive hicache field probe, kvd adapter, hipfile shim)
- [ ] PD (disagg) e2e — pending (separate node)
- [ ] CI e2e-mixed sglang (self-hosted runner, triggered by this PR)