### PR TITLE
ci: skip code jobs for examples/ and *.md/LICENSE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ permissions:
   actions: read
 
 jobs:
-  # Classify the change: does it touch code, or only the Sphinx manual? A
-  # manual/-only change skips every code job below (a job skipped by `if`
+  # Classify the change: does it touch package code, or only docs/examples? A
+  # docs-only change (manual/, examples/, *.md, LICENSE) skips every code job below (a job skipped by `if`
   # counts as success for required status checks); the manual itself is built
   # and checked by the ReadTheDocs PR integration, so no docs job is needed here.
   changes:
@@ -47,7 +47,10 @@ jobs:
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
-              manual/*) ;;            # docs-only: validated by the ReadTheDocs check
+              # docs / examples / meta — no package code to lint, test, or run on
+              # GPU. manual/ is validated by the ReadTheDocs check; examples/ are
+              # standalone recipes; *.md / LICENSE are prose.
+              manual/*|examples/*|*.md|LICENSE) ;;
               *)        code=true ;;
             esac
           done <<< "$files"


### PR DESCRIPTION
Extends #11's docs-only CI filter. Today an **examples-only** PR (e.g. #5) still triggers the full `engine` + `e2e-mixed` GPU matrix and fails on it, even though `examples/` are standalone recipes with no importable package code.

This adds `examples/*`, `*.md`, and `LICENSE` to the docs-only classification in the `changes` job, so those PRs skip the code jobs (a job skipped by `if` counts as success for required checks). Package code (`infera/**`, `tests/**`, `rust/**`, `deploy/**`, and `ci.yml` itself) is unaffected → `code=true` → full CI.

Verified the classifier against #5's file list (`README.md` + `examples/kimi_agentic_bench/**`) → `code=false`; a real code path (`infera/router/mixed.py`) → `code=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)