### PR TITLE
feat(sglang): unified Mooncake image — one engine.so, every PD path runtime-decided

### DIFF
--- a/deploy/docker/Dockerfile.sglang
+++ b/deploy/docker/Dockerfile.sglang
@@ -6,6 +6,33 @@ FROM ${SGLANG_BASE_IMAGE}
 
 WORKDIR /opt/infera
 
+# ---- Mooncake unified rebuild: one engine.so, every PD path runtime-decided --
+# The v0.5.15.post1 base bundles Mooncake at upstream #2682. Rebuild it IN PLACE
+# (no extra version) so a single image supports every KV-transfer config and the
+# choice is made at RUNTIME:
+#   * HIP intra-node P2P transport — opt-in via MC_ENABLE_HIP_TRANSPORT=1 (default
+#     OFF so CROSS-NODE PD stays on RDMA; #2682 installs it unconditionally and
+#     prefers it over RDMA, breaking cross-node PD — hipIpcOpenMemHandle can't
+#     open a peer's handle).
+#   * dma-buf GPUDirect (ibv_reg_dmabuf_mr) vs bare ibv_reg_mr+peermem — the
+#     dma-buf branch is COMPILED IN (fixing #2682's CMake propagation bug that
+#     silently drops it), and #2682's own runtime switch then decides per
+#     memory-type/kernel. Force bare with MOONCAKE_DISABLE_HIP_DMABUF=1 (infera's
+#     default — the AMD fleet is ionic/no-ODP, where dma-buf pins+doubles the KV
+#     pool); a dma-buf run opts in with MOONCAKE_DISABLE_HIP_DMABUF=0.
+# The HIP gate + auto-chunk-MR come from the SAME reusable mooncake_cpp diffs the
+# vLLM image applies (no duplicated source edit). Self-verifying (fails the build
+# if dma-buf/gate did not compile in); skip with BUILD_MOONCAKE=0. See the script.
+ARG BUILD_MOONCAKE=1
+COPY deploy/docker/patches/mooncake_cpp/ /tmp/mooncake_cpp/
+COPY deploy/docker/scripts/build_mooncake_sglang.sh /tmp/build_mooncake_sglang.sh
+RUN if [ "${BUILD_MOONCAKE}" = "1" ]; then \
+        MC_CPP_PATCH_DIR=/tmp/mooncake_cpp bash /tmp/build_mooncake_sglang.sh; \
+    else \
+        echo "BUILD_MOONCAKE=0 — leaving base Mooncake as-is"; \
+    fi \
+    && rm -rf /tmp/build_mooncake_sglang.sh /tmp/mooncake_cpp
+
 # Install infera + its declared deps from pyproject (single source of truth).
 # The base already ships torch/sglang and most of infera's runtime stack; pip
 # leaves those satisfied versions untouched and only pulls what's missing (e.g.

--- a/deploy/docker/scripts/build_mooncake_sglang.sh
+++ b/deploy/docker/scripts/build_mooncake_sglang.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Rebuild the sglang base image's bundled Mooncake ONE TIME, IN PLACE, so that a
+# single engine.so supports EVERY PD KV-transfer configuration and the choice is
+# made entirely at RUNTIME (no per-feature image variant):
+#
+#   * single-node  vs  cross-node PD        — decided by how you launch the legs
+#   * dma-buf GPUDirect (ibv_reg_dmabuf_mr)  — the DEFAULT registration path
+#   * bare ibv_reg_mr + peermem              — MOONCAKE_DISABLE_HIP_DMABUF=1
+#   * HIP intra-node P2P transport           — opt-in via MC_ENABLE_HIP_TRANSPORT=1
+#
+# WHY this is a single in-place build (not two images):
+#   The base bundles Mooncake at upstream #2682 (commit 01d1eb2a), whose
+#   rdma_context.cpp ALREADY carries a full RUNTIME dma-buf switch:
+#     - hipMemoryTypeDevice + kernel support -> ibv_reg_dmabuf_mr (GPUDirect),
+#     - MOONCAKE_DISABLE_HIP_DMABUF=1 (or host/managed mem, or a kernel lacking
+#       CONFIG_PCI_P2PDMA / CONFIG_DMABUF_MOVE_NOTIFY) -> bare ibv_reg_mr.
+#   So "compile dma-buf in, decide at runtime" needs NOTHING but compiling that
+#   branch. #2682 has TWO defects that stop it, both fixed here:
+#     (a) CMake propagation bug: USE_HIP_DMABUF is defined only on the
+#         transfer_engine target, but the ibv_reg_dmabuf_mr call lives in
+#         rdma_context.cpp -> the rdma_transport OBJECT lib. Without the define
+#         there the #elif USE_HIP_DMABUF branch compiles out and registration
+#         SILENTLY falls back to bare ibv_reg_mr (the dma-buf path is dead code).
+#         Fix: propagate USE_HIP_DMABUF + hsa-runtime64 to rdma_transport.
+#     (b) it installs a HIP IPC transport UNCONDITIONALLY and selectTransport
+#         prefers it over RDMA, so CROSS-NODE PD breaks (hipIpcOpenMemHandle
+#         cannot open a peer's handle). Fix: gate it behind MC_ENABLE_HIP_TRANSPORT
+#         (default OFF) — the reusable in-tree B-group C++ patch, shared verbatim
+#         with the vLLM build (deploy/docker/patches/mooncake_cpp), so there is no
+#         duplicated hand-written source edit.
+#
+# Reuse + dedup: the HIP-transport gate and the auto-chunk-MR correctness fix come
+# from the SAME deploy/docker/patches/mooncake_cpp diffs the vLLM image applies via
+# build_mooncake_rocm.sh; this script only adds the dma-buf CMake propagation on
+# top and flips the build to -DUSE_HIP_DMABUF=ON. Both diffs are `git apply --check`
+# CLEAN on #2682.
+#
+# Idempotent + self-verifying: skips already-applied steps and FAILS the build if
+# the rebuilt object does not actually reference ibv_reg_dmabuf_mr / link hsa.
+set -euo pipefail
+
+MC_ROOT="${MC_ROOT:-/sgl-workspace/Mooncake}"
+PATCH_DIR="${MC_CPP_PATCH_DIR:-/tmp/mooncake_cpp}"
+RCM="$MC_ROOT/mooncake-transfer-engine/src/transport/rdma_transport/CMakeLists.txt"
+
+[ -f "$MC_ROOT/mooncake-transfer-engine/src/CMakeLists.txt" ] \
+    || { echo "[mc-build] ERR: $MC_ROOT is not a Mooncake tree — base image layout changed; re-anchor" >&2; exit 1; }
+[ -f "$PATCH_DIR/apply_mooncake_cpp_patches.sh" ] \
+    || { echo "[mc-build] ERR: $PATCH_DIR/apply_mooncake_cpp_patches.sh missing — COPY the mooncake_cpp patch dir" >&2; exit 1; }
+
+# ---- [1/4] reusable in-tree B-group C++ patches (HIP gate + auto-chunk MR) ----
+# Shared verbatim with the vLLM build — no duplicated source edit. The gate makes
+# HIP transport default-OFF so cross-node PD stays on RDMA; auto-chunk MR splits
+# buffers larger than the device max_mr_size into <=max_mr_size MRs.
+echo "=== [1/4] apply reusable mooncake_cpp B-group patches ==="
+MC_ROOT="$MC_ROOT" bash "$PATCH_DIR/apply_mooncake_cpp_patches.sh"
+
+# ---- [2/4] propagate USE_HIP_DMABUF to the rdma_transport OBJECT lib -----------
+# rdma_context.cpp (the ibv_reg_dmabuf_mr call site) compiles here; upstream only
+# defines USE_HIP_DMABUF on transfer_engine, so add it (and the hsa-runtime64 link
+# the export helper needs) to this target too. Idempotent.
+echo "=== [2/4] propagate USE_HIP_DMABUF -> rdma_transport ==="
+if grep -q 'USE_HIP_DMABUF' "$RCM"; then
+    echo "  already propagated — skip"
+else
+    cat >> "$RCM" <<'CM'
+
+# infera(unified sglang): rdma_context.cpp calls ibv_reg_dmabuf_mr but lives in
+# this OBJECT lib; upstream #2682 defines USE_HIP_DMABUF only on the
+# transfer_engine target, so the #elif USE_HIP_DMABUF branch compiles out here and
+# device-KV registration silently falls back to bare ibv_reg_mr. Mirror the base's
+# transfer_engine block: define USE_HIP_DMABUF + link hsa-runtime64 so the dma-buf
+# path is actually compiled. Runtime still decides bare vs dma-buf (see
+# rdma_context.cpp: MOONCAKE_DISABLE_HIP_DMABUF / kernel-support probe).
+if(USE_HIP)
+  target_include_directories(rdma_transport PRIVATE ${HIP_INCLUDE_DIRS})
+  option(USE_HIP_DMABUF "Enable HIP dmabuf RDMA MR registration" ON)
+  if(USE_HIP_DMABUF)
+    find_package(hsa-runtime64 CONFIG)
+    if(hsa-runtime64_FOUND)
+      target_compile_definitions(rdma_transport PRIVATE USE_HIP_DMABUF)
+      target_link_libraries(rdma_transport PRIVATE hsa-runtime64::hsa-runtime64 hip::host)
+      message(STATUS "rdma_transport: HIP dmabuf MR registration enabled")
+    else()
+      message(FATAL_ERROR "USE_HIP_DMABUF requested but hsa-runtime64 not found")
+    endif()
+  endif()
+endif()
+CM
+    echo "  propagated to $RCM"
+fi
+
+# ---- [3/4] cmake configure + ninja the engine module (USE_HIP_DMABUF=ON) -------
+# `docker build` has NO GPU, so ROCm's amdgpu-arch probe fails and cmake would
+# drop the HIP engine target from the graph (leaving the base's unpatched .so).
+# Pin the target arch explicitly so the build is GPU-independent. gfx950 = MI355X.
+export PYTORCH_ROCM_ARCH="${PYTORCH_ROCM_ARCH:-gfx950}"
+export GPU_ARCHS="${GPU_ARCHS:-gfx950}" AMDGPU_TARGETS="${AMDGPU_TARGETS:-gfx950}"
+export HIP_ARCHITECTURES="${HIP_ARCHITECTURES:-gfx950}"
+export CMAKE_PREFIX_PATH="/opt/rocm:/opt/rocm/lib/cmake:/opt/rocm-7.2.0/lib/cmake:$(python3 -c 'import pybind11;print(pybind11.get_cmake_dir())' 2>/dev/null):${CMAKE_PREFIX_PATH:-}"
+echo "=== [3/4] cmake configure + ninja (USE_HIP=ON USE_HIP_DMABUF=ON) ==="
+cd "$MC_ROOT"
+rm -rf build && mkdir build && cd build
+cmake .. -DUSE_HIP=ON -DUSE_HIP_DMABUF=ON -DUSE_ETCD=OFF -DWITH_STORE=OFF \
+    -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=OFF -DWITH_STORE_RUST=OFF \
+    -DCMAKE_HIP_ARCHITECTURES=gfx950 -GNinja 2>&1 \
+    | grep -iE "dmabuf|hsa-runtime|hip transport|error" | head -20 || true
+# Build the pybind engine module explicitly — plain `ninja` builds only the
+# default target set, which does NOT include it, so the prebuilt (unpatched) one
+# would survive. Target it by name.
+ninja engine.cpython-310-x86_64-linux-gnu.so 2>&1 | tail -8
+
+# ---- [4/4] install over the pip engine.so + verify all three properties -------
+echo "=== [4/4] install + verify (HIP gate + dma-buf compiled-in + hsa link) ==="
+SO="$(ls "$MC_ROOT"/build/mooncake-integration/engine.cpython-*-x86_64-linux-gnu.so | head -1)"
+DEST="$(python3 -c 'import mooncake.engine as e; print(e.__file__)')"
+cp "$SO" "$DEST"
+ASIO="$(ls "$MC_ROOT"/build/mooncake-common/libasio.so 2>/dev/null | head -1 || true)"
+[ -n "$ASIO" ] && { cp "$ASIO" "$(dirname "$DEST")/" 2>/dev/null || true; cp "$ASIO" /usr/local/lib/ 2>/dev/null || true; ldconfig 2>/dev/null || true; }
+
+# (a) HIP-transport gate present (grep into a var, not `strings | grep -q`: under
+#     pipefail, grep -q closing the pipe early SIGPIPEs strings -> false negative).
+if ! strings "$DEST" | grep -c MC_ENABLE_HIP_TRANSPORT | grep -qv '^0$'; then
+    echo "[mc-build] ERROR: rebuilt engine.so lacks the HIP-transport gate — patch/build did not take" >&2
+    exit 1
+fi
+echo "  HIP_GATE=yes"
+
+# (b) dma-buf actually compiled into rdma_context.o (EXTERNAL symbols, so inspect
+#     the object's undefined refs — not `strings`).
+OBJ="$MC_ROOT/build/mooncake-transfer-engine/src/transport/rdma_transport/CMakeFiles/rdma_transport.dir/rdma_context.cpp.o"
+if [ -f "$OBJ" ] && nm "$OBJ" 2>/dev/null | grep -qiE "ibv_reg_dmabuf_mr|hsa_amd_portable_export_dmabuf"; then
+    echo "  DMABUF_COMPILED_IN=yes ($(nm "$OBJ" | grep -ioE 'ibv_reg_dmabuf_mr|hsa_amd_portable_export_dmabuf' | sort -u | tr '\n' ' '))"
+else
+    echo "[mc-build] ERROR: ibv_reg_dmabuf_mr NOT compiled into rdma_context.o — CMake propagation did not take" >&2
+    exit 1
+fi
+
+# (c) engine.so links hsa-runtime64 (the export helper's runtime dep).
+if ldd "$DEST" 2>/dev/null | grep -qi hsa-runtime64; then
+    echo "  LINKS_HSA=yes"
+else
+    echo "[mc-build] ERROR: engine.so not linked to hsa-runtime64 — dma-buf export would fail at runtime" >&2
+    exit 1
+fi
+
+python3 -c "from mooncake.engine import TransferEngine" || { echo "[mc-build] import failed" >&2; exit 1; }
+echo "[mc-build] DONE — one engine.so: HIP gated (MC_ENABLE_HIP_TRANSPORT), dma-buf"
+echo "           compiled-in (default ibv_reg_dmabuf_mr; MOONCAKE_DISABLE_HIP_DMABUF=1"
+echo "           forces bare ibv_reg_mr). Runtime decides every path."
+
+# trim the build tree to keep the image lean
+rm -rf "$MC_ROOT/build"

--- a/infera/engine/rocm_rdma_env.py
+++ b/infera/engine/rocm_rdma_env.py
@@ -34,6 +34,12 @@ logger = logging.getLogger(__name__)
 _ROCM_RDMA_DEFAULTS: dict[str, str] = {
     "MC_GID_INDEX": "1",  # Mooncake transfer engine: ionic RoCE v2 GID
     "MC_DISABLE_HIP_TRANSPORT": "1",  # Mooncake: use RDMA, not the HIP P2P transport
+    # The unified sglang image compiles the dma-buf MR path IN, but the whole AMD
+    # fleet is ionic (no ODP): ibv_reg_dmabuf_mr there PINS + DUPLICATES the KV
+    # pool in VRAM (and can exhaust a KFD resource). Default the safe bare
+    # ibv_reg_mr path ON; a dma-buf run (mlx5 / capped pool) opts back in by
+    # setting MOONCAKE_DISABLE_HIP_DMABUF=0 (or 'unset') in the launch env.
+    "MOONCAKE_DISABLE_HIP_DMABUF": "1",
     "MORI_IB_GID_INDEX": "1",  # MoRI transfer engine: ionic RoCE v2 GID
 }
 


### PR DESCRIPTION
## Summary

Rebuild the v0.5.15.post1 base image's bundled Mooncake (**#2682**) **in place** so **one** sglang image supports **every** PD KV-transfer configuration, decided entirely at **runtime** — no per-feature image variant, no extra Mooncake version. Supersedes this PR's original HIP-gate-only scope, fixing its two gaps.

**Runtime knobs (launch-time, not build-time):**
- `MC_ENABLE_HIP_TRANSPORT` — HIP intra-node P2P transport, default **OFF** so cross-node PD stays on RDMA (#2682 installs HIP unconditionally and prefers it, breaking cross-node — `hipIpcOpenMemHandle` can't open a peer's handle).
- `MOONCAKE_DISABLE_HIP_DMABUF` — dma-buf GPUDirect (`ibv_reg_dmabuf_mr`) vs bare `ibv_reg_mr`+peermem, decided per memory-type/kernel by **#2682's own runtime switch** (already ships in the base, just compiled out — see below).
- single- vs multi-node — same image either way.

## What changed vs this PR's original approach

1. **Dedup.** The HIP-transport gate was a hand-written python string-replace, duplicating `deploy/docker/patches/mooncake_cpp/transfer_engine_impl.diff` that the vLLM build already applies. `build_mooncake_sglang.sh` now calls the **same** reusable `apply_mooncake_cpp_patches.sh` (HIP gate + auto-chunk MR); the duplicate `patch_mooncake_sglang.sh` is **deleted**.
2. **dma-buf now compiled in.** #2682 defines `USE_HIP_DMABUF` only on the `transfer_engine` target, but the `ibv_reg_dmabuf_mr` call lives in `rdma_context.cpp` → the `rdma_transport` OBJECT lib, so the branch was silently preprocessed out and the shipped `.so` used bare `ibv_reg_mr` (not even linking `libhsa-runtime64`). The build now propagates `USE_HIP_DMABUF` + `hsa-runtime64` to `rdma_transport` and builds `-DUSE_HIP_DMABUF=ON`.

**Key insight:** the base's Mooncake #2682 `rdma_context.cpp` **already** carries the full runtime dma-buf switch (`MOONCAKE_DISABLE_HIP_DMABUF` + a kernel `CONFIG_PCI_P2PDMA` probe + the `ibv_reg_dmabuf_mr` branch). "Compile in, decide at runtime" needed nothing but fixing the CMake propagation bug — no mooncake `main`, no extra version.

## Behavior contract (please note)

`infera/engine/rocm_rdma_env.py` set-defaults **`MOONCAKE_DISABLE_HIP_DMABUF=1`** (bare `ibv_reg_mr`) on ROCm — **matching this PR's original safe behavior**, since the AMD fleet is ionic/no-ODP where dma-buf pins + doubles the KV pool. A dma-buf run opts in with `MOONCAKE_DISABLE_HIP_DMABUF=0`; operator env still overrides. So this PR does **not** change the default production KV path — it only makes dma-buf *available* at runtime.

`build_mooncake_sglang.sh` is **self-verifying**: the build fails unless the rebuilt `engine.so` (a) contains the HIP gate, (b) has `ibv_reg_dmabuf_mr` compiled into `rdma_context.cpp.o` (checked via `nm`, not `strings` — external symbol), and (c) links `libhsa-runtime64`.

## Test plan

Verified end-to-end on chi2798+chi2878 (MI355X gfx950, ionic), DSv4-Pro fp8, all **conc=128** with **zero KV-transfer failures**:

- [x] cross-node TP8+TP8 1P1D, dma-buf **OFF** (bare `ibv_reg_mr`) — 254/256, 2127 tok/s
- [x] single-node TP4+TP4 1P1D (ionic loopback) — 254/256, 1801 tok/s
- [x] cross-node TP8+TP8 1P1D, dma-buf **ON** (`ibv_reg_dmabuf_mr`) — 254/256, 2277 tok/s, with gmu 0.75 + `--max-total-tokens 262144` so the ionic 2× dma-buf pin (KV pool 3.6 GB/card → 7.2 GB pinned) stays well under VRAM; **no HIP-209 / SIGSEGV / OOM**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
