### PR TITLE
chore(pre-commit): reject local-hostname / auto-generated git emails

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,13 @@ repos:
         language: system
         files: ^rust/.*\.rs$
         pass_filenames: false
+
+      # Refuse a commit whose git email is a machine-generated local hostname
+      # (git's fallback when user.email is unset), so an internal build-host
+      # name can't leak into permanent public history. Skipped in CI.
+      - id: check-author-email
+        name: reject local-hostname / auto-generated git emails
+        entry: scripts/check-author-email.sh
+        language: script
+        always_run: true
+        pass_filenames: false

--- a/scripts/check-author-email.sh
+++ b/scripts/check-author-email.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# pre-commit hook: refuse a commit whose author/committer email is a
+# machine-generated local hostname — git's fallback when user.email is unset
+# (e.g. user@crs-m2m-cpu-spur-009.us-east2-a.compute.internal). This keeps an
+# internal build-host name from leaking into permanent (public) git history.
+#
+# Local commit-time gate only: skipped in CI (the runner has no real identity;
+# enforce PR-author emails there with a separate commit-range check).
+set -euo pipefail
+
+# CI runners have no meaningful committer identity — don't fail the lint job.
+[ -n "${CI:-}" ] && exit 0
+
+fail=0
+host_fqdn="$({ hostname -f 2>/dev/null || hostname 2>/dev/null || true; } | tr '[:upper:]' '[:lower:]')"
+
+check() {
+  local who="$1" email domain
+  email="$(git var "GIT_${who}_IDENT" 2>/dev/null | sed -n 's/.*<\(.*\)>.*/\1/p' | tr '[:upper:]' '[:lower:]')"
+  if [ -z "$email" ]; then echo "  ✖ ${who}: empty email"; fail=1; return; fi
+  domain="${email#*@}"
+  case "$email" in
+    *@*.internal|*@*.local|*@*.localdomain|*@*.lan|*@localhost|*@localhost.*|*@*.localhost)
+      echo "  ✖ ${who} email is internal/local: <$email>"; fail=1 ;;
+    *@*.*) : ;;                                    # dotted, public-looking domain — OK
+    *@?*)  echo "  ✖ ${who} email has no domain (bare hostname): <$email>"; fail=1 ;;
+    *)     echo "  ✖ ${who} email malformed: <$email>"; fail=1 ;;
+  esac
+  # git's auto-generated identity uses the machine FQDN as the domain
+  if [ -n "$host_fqdn" ] && [ "$domain" = "$host_fqdn" ]; then
+    echo "  ✖ ${who} email domain == this machine's hostname ($host_fqdn): <$email>"; fail=1
+  fi
+}
+
+check AUTHOR
+check COMMITTER
+
+if [ "$fail" -ne 0 ]; then
+  cat >&2 <<'MSG'
+
+Refusing the commit: the git email looks machine-generated, not a real address.
+It would be baked into permanent history. Set a real email once, then re-commit:
+
+  git config --global user.name  "Your Name"
+  git config --global user.email you@amd.com
+
+And make git refuse to auto-generate one from the hostname ever again:
+
+  git config --global user.useConfigOnly true
+MSG
+  exit 1
+fi


### PR DESCRIPTION
## Why

A commit recently landed with an author/committer email of `xiaobche@crs-m2m-cpu-spur-009.us-east2-a.compute.internal` — git's fallback identity when `user.email` is unset, which bakes an **internal build-host name into permanent history**. This adds a guard so it can't recur.

## What

A local pre-commit hook (`scripts/check-author-email.sh`) that, at commit time, reads `git var GIT_{AUTHOR,COMMITTER}_IDENT` and **refuses the commit** when the email is:
- an internal/local domain — `*.internal`, `*.local`, `*.localdomain`, `*.lan`, `localhost`;
- a bare hostname with no dotted domain (e.g. `root@buildbox`);
- or a domain equal to the local machine's FQDN (the auto-generated pattern).

It points the developer at the fix (`git config user.email …` + `git config --global user.useConfigOnly true`).

**Skipped in CI** (`CI` env) — GitHub runners have no meaningful committer identity, so it won't fail the lint job. Real emails (`@amd.com`, `@users.noreply.github.com`, `@gmail.com`) pass.

## Tested

Direct + via the pre-commit framework: internal-hostname and bare-hostname emails are rejected; `xiaobo.chen@amd.com`, GitHub noreply, and gmail pass; CI env skips.

Note: pre-commit is opt-in per developer. For a hard gate against bypass, a CI job that checks every commit's author email in the PR range is the complement — happy to add that too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)