### PR TITLE
docs: require DCO sign-off + expand contribution guide, enforce in CI

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,55 @@
+name: DCO
+
+# Verify the Developer Certificate of Origin: every non-merge commit in a PR
+# must carry a `Signed-off-by` trailer matching its author (git commit -s).
+# See CONTRIBUTING.md > Developer Certificate of Origin.
+
+on:
+  pull_request:
+    branches: ["**"]
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Verify Signed-off-by on every commit
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          fail=0
+          commits=$(git rev-list --no-merges "$BASE..$HEAD")
+          if [ -z "$commits" ]; then echo "no non-merge commits to check"; exit 0; fi
+          for c in $commits; do
+            subj=$(git show -s --format='%s' "$c")
+            aemail=$(git show -s --format='%ae' "$c" | tr '[:upper:]' '[:lower:]')
+            body=$(git show -s --format='%B' "$c")
+            # 1) a Signed-off-by trailer must be present
+            if ! printf '%s\n' "$body" | grep -qiE '^[[:space:]]*Signed-off-by:[[:space:]]*.+[[:space:]]+<[^>]+@[^>]+>'; then
+              echo "::error::commit ${c:0:12} is missing 'Signed-off-by' — $subj"
+              fail=1; continue
+            fi
+            # 2) the author's email must be among the sign-off emails
+            soemails=$(printf '%s\n' "$body" \
+              | grep -iE '^[[:space:]]*Signed-off-by:' \
+              | grep -oiE '<[^>]+>' | tr -d '<>' | tr '[:upper:]' '[:lower:]')
+            if ! printf '%s\n' "$soemails" | grep -qixF "$aemail"; then
+              echo "::error::commit ${c:0:12} Signed-off-by does not match author <$aemail> — $subj"
+              fail=1
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo ""
+            echo "DCO check failed. Sign your commits and push again:"
+            echo "    git rebase --signoff main   # signs every commit on the branch"
+            echo "    git push --force-with-lease"
+            echo "See CONTRIBUTING.md > Developer Certificate of Origin."
+            exit 1
+          fi
+          echo "DCO: all commits are signed off by their author."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,25 +1,103 @@
 # Contributing to Infera
 
-Thanks for your interest in contributing.
+Thanks for your interest in contributing. Infera welcomes bug reports, features,
+performance work, documentation, and reviews.
 
-## Reporting Issues
+## Reporting issues
 
-Use [GitHub Issues](../../issues) to report bugs or request features. Include a clear description, reproduction steps, and your environment (OS, ROCm/CUDA version, Python version).
+Use [GitHub Issues](../../issues) to report bugs or request features. Include a
+clear description, reproduction steps, and your environment (OS, ROCm version,
+Python version, engine).
 
-## Pull Request Workflow
+For security issues, do **not** open a public issue — see [SECURITY.md](SECURITY.md).
+
+## Development setup
+
+Fork and clone, then install Infera with the dev tools and at least one engine,
+and enable the pre-commit hooks:
+
+```bash
+pip install -e ".[dev,sglang]"     # or .[dev,vllm] / .[dev,atom]
+pre-commit install                 # runs the formatters/linters on every commit
+```
+
+The optional Rust router builds with a [Rust toolchain](https://rustup.rs):
+`cd rust && cargo build --release`.
+
+## Code style, linting, and tests
+
+- **Formatting & lint** are enforced by [pre-commit](.pre-commit-config.yaml):
+  `ruff` (format + lint) for Python and `cargo fmt` for Rust. Run the whole set
+  with `pre-commit run --all-files`.
+- **License header** — new source files carry the MIT SPDX header:
+  ```
+  # SPDX-License-Identifier: MIT
+  # Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+  ```
+- **Tests** — add or update tests for behavior changes:
+  - Unit / CPU: `pytest -m "not slow and not integration"`
+  - Engine + end-to-end (GPU): `tests/run_tests.sh` (see `tests/`)
+
+  CI runs lint, unit, the Rust suite, and the GPU e2e matrix; a docs/examples-only
+  change skips the code jobs automatically.
+
+## Pull request workflow
 
 1. Fork the repository and create a branch from `main`:
    ```bash
-   git checkout -b feature/short-description
+   git checkout -b feat/short-description
    ```
 2. Make your change. Add tests and update docs if behavior changes.
-3. Open a PR against `main`. Describe *what* changed and *why*; link any related issue.
-4. Ensure CI passes and request review from the relevant [CODEOWNERS](.github/CODEOWNERS).
+3. Write clear commit messages — conventional prefixes are preferred
+   (`feat:`, `fix:`, `docs:`, `test:`, `ci:`, `chore:`) — and **sign off every
+   commit** (see [DCO](#developer-certificate-of-origin-dco) below):
+   ```bash
+   git commit -s -m "fix: ..."
+   ```
+4. Open a PR against `main`. Describe *what* changed and *why*; link any related
+   issue. Ensure CI passes and request review from the relevant
+   [CODEOWNERS](.github/CODEOWNERS).
 
-By opening a PR, you agree your contribution is licensed under the terms in [LICENSE](LICENSE).
+## Developer Certificate of Origin (DCO)
 
-## External Contributors
+Infera requires every commit to be **signed off** under the
+[Developer Certificate of Origin](https://developercertificate.org/) (DCO). By
+adding a `Signed-off-by` line you certify that you wrote the patch — or otherwise
+have the right to submit it — and agree to contribute it under the project's
+[MIT license](LICENSE). The DCO is a lightweight certification; it is **not** a
+copyright assignment.
 
-This repo is part of the AMD-AGI org. Non-AMD contributors need admin approval before being added as collaborators.
+Add the sign-off with the `-s` flag — it appends a trailer built from your git
+name and email:
 
-For security issues, do **not** open a public issue — see [SECURITY.md](SECURITY.md).
+```bash
+git commit -s -m "feat: ..."
+```
+
+```
+Signed-off-by: Your Name <you@amd.com>
+```
+
+Make it automatic so you don't forget:
+
+```bash
+git config --global format.signoff true
+```
+
+Forgot to sign off? Add it to the commits already on your branch:
+
+```bash
+git rebase --signoff main       # all commits on the branch
+git commit --amend -s           # just the most recent commit
+```
+
+A CI check (`.github/workflows/dco.yml`) verifies that **every** commit in a PR
+carries a `Signed-off-by` matching its author. The sign-off must use a real
+identity: an auto-generated machine hostname (e.g. `you@buildhost.internal`) is
+rejected — set a proper email with `git config --global user.email you@amd.com`
+(and `git config --global user.useConfigOnly true` so git never invents one).
+
+## External contributors
+
+This repo is part of the AMD-AGI org. Non-AMD contributors need admin approval
+before being added as collaborators.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/AMD-AGI/Infera/actions/workflows/ci.yml/badge.svg)](https://github.com/AMD-AGI/Infera/actions/workflows/ci.yml)
 [![Release](https://github.com/AMD-AGI/Infera/actions/workflows/release.yml/badge.svg)](https://github.com/AMD-AGI/Infera/actions/workflows/release.yml)
+[![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://rocm.docs.amd.com/projects/infera/en/latest/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 [What's Infera?](#whats-infera) | [Key features](#key-features) | [Quick Start](#quick-start) | [Engine images](#engine-images) | [Documentation](#documentation) | [License](#license)
@@ -144,7 +145,10 @@ steps are in [`examples/kimi_agentic_bench/`](examples/kimi_agentic_bench/README
 
 ## Documentation
 
-Full guides, deployment recipes, and reference live in the Sphinx manual:
+Full guides, deployment recipes, and reference are hosted at
+**[rocm.docs.amd.com/projects/infera](https://rocm.docs.amd.com/projects/infera/en/latest/)**.
+
+To build the same Sphinx manual locally:
 
 ```bash
 sudo apt-get install -y graphviz                            # `dot`, for the diagrams


### PR DESCRIPTION
Adds a **Developer Certificate of Origin (DCO)** requirement (modeled on [ROCm/aiter's CONTRIBUTE.md](https://github.com/ROCm/aiter/blob/main/CONTRIBUTE.md)) and the CI that enforces it.

## CONTRIBUTING.md (expanded)

The existing 25-line guide gains: development setup (`pip install -e ".[dev,…]"` + `pre-commit install`), code style / lint / tests, conventional commit prefixes, and a **DCO section**:
- sign off with `git commit -s`; make it default with `git config --global format.signoff true`;
- fix unsigned history with `git rebase --signoff main`;
- the sign-off email must be a **real identity** — an auto-generated machine hostname is rejected (ties into the pre-commit email hook in #20).

DCO is a lightweight contributor certification (**not** a copyright assignment).

## .github/workflows/dco.yml (enforcement)

A self-contained check (no third-party action) that verifies **every non-merge commit** in a PR carries a `Signed-off-by` matching its author. Tested against signed/unsigned/mismatched/co-authored cases. This PR's own commit is signed off, so it passes its own gate.

## Notes

- **Whether to *require* DCO** (make this a required status check / adopt DCO vs a CLA) is an AMD legal / OSS-program-office policy call — this just wires it up so it can be flipped to required when you decide.
- Existing open PRs (e.g. #12, #20) will need their commits signed off (`git rebase --signoff main`) once this lands, if DCO is made required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)