### PR TITLE
docs: standardize published image names to rocm/infera:<component>-<version>

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ docker run --rm -it --network host --ipc host --shm-size 32g             \
   --device /dev/kfd --device /dev/dri --device /dev/infiniband           \
   --group-add video --group-add render --cap-add IPC_LOCK                \
   -v /usr/lib/x86_64-linux-gnu/libionic.so:/host-libionic/libionic.so:ro \
-  docker.io/rocm/infera-sglang:v0.1.0 bash
+  docker.io/rocm/infera:sglang-v0.1.1 bash
 
 # Step 3 — inside the container: start the server and a worker
 python -m infera.server --port 8000 --etcd-endpoint 127.0.0.1:2379 \
@@ -75,7 +75,7 @@ curl localhost:8000/v1/chat/completions -H 'Content-Type: application/json' \
 ```
 
 To build the image yourself, see [Engine images](#engine-images) and replace
-`rocm/infera-sglang:v0.1.0` above with your local `infera-sglang:dev` tag.
+`rocm/infera:sglang-v0.1.1` above with your local `rocm/infera:sglang-dev` tag.
 
 ### Option B — From source (pip)
 
@@ -120,8 +120,24 @@ placeholders are in [`examples/k8s-deployments/`](examples/k8s-deployments/READM
 
 ## Engine images
 
-Each engine has one canonical Dockerfile under `deploy/docker/` that overlays Infera on a
-vendor base. Build from the repo root; override the base with `--build-arg <ENGINE>_BASE_IMAGE=...`.
+Prebuilt images are published to the `rocm/infera` repository, tagged
+`<component>-<version>`:
+
+| Image | Component |
+|-------|-----------|
+| `rocm/infera:vllm-v0.1.1`   | vLLM engine + Infera |
+| `rocm/infera:sglang-v0.1.1` | SGLang engine + Infera |
+| `rocm/infera:atom-v0.1.1`   | ATOM engine + Infera |
+| `rocm/infera:kvd-v0.1.1`    | tiered KV-cache daemon (`infera.kvd`) |
+| `rocm/infera:server-v0.1.1` | OpenAI-compatible server + router |
+
+```bash
+docker pull rocm/infera:sglang-v0.1.1
+```
+
+To build one yourself, each engine has one canonical Dockerfile under
+`deploy/docker/` that overlays Infera on a vendor base. Build from the repo root;
+override the base with `--build-arg <ENGINE>_BASE_IMAGE=...`.
 
 | Dockerfile          | Base image                                      |
 |---------------------|-------------------------------------------------|
@@ -130,9 +146,9 @@ vendor base. Build from the repo root; override the base with `--build-arg <ENGI
 | `Dockerfile.atom`   | `rocm/atom:rocm7.2.4_…_atom0.1.4_20260612`      |
 
 ```bash
-docker build -f deploy/docker/Dockerfile.sglang -t infera-sglang:dev .
-docker build -f deploy/docker/Dockerfile.vllm   -t infera-vllm:dev .
-docker build -f deploy/docker/Dockerfile.atom   -t infera-atom:dev .
+docker build -f deploy/docker/Dockerfile.sglang -t rocm/infera:sglang-dev .
+docker build -f deploy/docker/Dockerfile.vllm   -t rocm/infera:vllm-dev .
+docker build -f deploy/docker/Dockerfile.atom   -t rocm/infera:atom-dev .
 ```
 
 ## Benchmarks

--- a/manual/components/operator.md
+++ b/manual/components/operator.md
@@ -29,7 +29,7 @@ metadata:
   name: demo
 spec:
   backendFramework: sglang
-  image: infera/engine-sglang:dev
+  image: rocm/infera:sglang-v0.1.1
   discoveryBackend: kubernetes             # in-cluster API; no external etcd
   nats: {deploy: true, storageSize: 4Gi}   # operator-managed JetStream (KV events)
   services:

--- a/manual/examples/sglang_1p1d_dsv4.md
+++ b/manual/examples/sglang_1p1d_dsv4.md
@@ -39,7 +39,7 @@ a large prefill chunk. Both legs share these; they differ only by
 ```bash
 HF_CACHE=/path/to/hf-cache                     # TODO: HuggingFace cache / model dir (host path)
 MODEL=$HF_CACHE/DeepSeek-V4-Pro                 # fp4 DSv4-Pro checkpoint (real weights, not stubs)
-IMG=inferaimage/infera:infera-sglang-...        # TODO: update to the image you validated
+IMG=rocm/infera:sglang-v0.1.1                   # published SGLang engine image
 P_IP=10.0.0.1                                   # TODO: prefill node data-plane (RDMA-rail) IP
 D_IP=10.0.0.2                                   # TODO: decode  node data-plane (RDMA-rail) IP
 ETCD=$P_IP:2379                                 # etcd lives on the prefill node

--- a/manual/examples/sglang_1p2d_kimi2.6.md
+++ b/manual/examples/sglang_1p2d_kimi2.6.md
@@ -58,7 +58,7 @@ Shared by both: `--attention-backend aiter --kv-cache-dtype fp8_e4m3 --trust-rem
 - **Hardware:** 3 nodes, 8× MI355X each (ROCm 7.2.0), Docker with GPU access.
   node-0 prefill uses 4 GPUs; each decode node uses all 8.
 - **Model:** `amd/Kimi-K2.6-MXFP4` (~550B, license modified-mit, NOT gated).
-- **Image:** `inferaimage/infera:<current-tag>`.
+- **Image:** `rocm/infera:sglang-v0.1.1`.
 
 Download the model to a **local directory** (it is bind-mounted read-only) and
 point `MODEL` at it. Benchmarking needs a local clone of InferenceX (`IX`). Full
@@ -94,7 +94,7 @@ single-node: engine -> verify -> benchmark
 **Single-node** (any 4-GPU MI355X):
 
 ```bash
-IMAGE=inferaimage/infera:<current-tag> \
+IMAGE=rocm/infera:sglang-v0.1.1 \
 MODEL=/your/path/Kimi-K2.6-MXFP4 bash sglang_naive_engine.sh
 ```
 

--- a/manual/examples/sglang_mix_dsv4.md
+++ b/manual/examples/sglang_mix_dsv4.md
@@ -37,7 +37,7 @@ HF_CACHE=/path/to/hf-cache                     # TODO: your HuggingFace cache / 
 MODEL=$HF_CACHE/DeepSeek-V4-Pro-fixed          # fp4 DSv4-Pro checkpoint
 HOST=127.0.0.1                                  # single node
 ETCD=$HOST:2379
-IMG=inferaimage/infera:infera-sglang-...        # TODO: update to the image you validated
+IMG=rocm/infera:sglang-v0.1.1                   # published SGLang engine image
 ```
 
 ## 1. etcd — shared registry (on the host)

--- a/manual/getting_started/installation.md
+++ b/manual/getting_started/installation.md
@@ -66,15 +66,15 @@ Build the engine image for the runtime you'll serve with, from the repo root
 ```bash
 # vLLM
 docker build -f deploy/docker/Dockerfile.vllm \
-  -t infera/engine-vllm:dev .
+  -t rocm/infera:vllm-dev .
 
 # SGLang
 docker build -f deploy/docker/Dockerfile.sglang \
-  -t infera/engine-sglang:dev .
+  -t rocm/infera:sglang-dev .
 
 # ATOM
 docker build -f deploy/docker/Dockerfile.atom \
-  -t infera/engine-atom:dev .
+  -t rocm/infera:atom-dev .
 ```
 
 Then bring up a full stack (etcd + server + engine). The per-runtime

--- a/manual/serving/deployment.md
+++ b/manual/serving/deployment.md
@@ -64,7 +64,7 @@ Build from the repo root, e.g.:
 
 ```bash
 docker build -f deploy/docker/Dockerfile.sglang \
-  -t infera/engine-sglang:rocm720-mi35x .
+  -t rocm/infera:sglang-dev .
 ```
 
 ```{admonition} Pin the SGLang base image

--- a/manual/serving/kubernetes.md
+++ b/manual/serving/kubernetes.md
@@ -70,7 +70,7 @@ metadata:
   name: qwen
 spec:
   backendFramework: sglang
-  image: infera/engine-sglang:dev
+  image: rocm/infera:sglang-v0.1.1
   nats: {deploy: true}
   services:
     server:


### PR DESCRIPTION
Released images live in the **`rocm/infera`** repo, tagged `<component>-<version>`:

| Image | Component |
|-------|-----------|
| `rocm/infera:vllm-v0.1.1`   | vLLM engine + Infera |
| `rocm/infera:sglang-v0.1.1` | SGLang engine + Infera |
| `rocm/infera:atom-v0.1.1`   | ATOM engine + Infera |
| `rocm/infera:kvd-v0.1.1`    | tiered KV-cache daemon |
| `rocm/infera:server-v0.1.1` | server + router |

Updates the **README and manual** to use that scheme everywhere the old, inconsistent names appeared (`rocm/infera-sglang:v0.1.0`, `inferaimage/infera:<current-tag>`, `infera/engine-sglang:dev`, …):

- **README** — Quick Start `docker run` pull; new prebuilt-images table; build-example tags → `rocm/infera:<engine>-dev`.
- **manual** — `serving/deployment.md` + `getting_started/installation.md` build tags; `serving/kubernetes.md` + `components/operator.md` `image:` fields; the DSv4/Kimi examples' `IMG`/`IMAGE` vars.

Docs-only (code CI skips); commit is signed off (DCO passes). Base images (`vllm-openai-rocm`, `lmsysorg/sglang`, `rocm/atom`) are unchanged — those are upstream vendor bases, not the `rocm/infera` repo.

Note: `examples/k8s-deployments/*.yaml` also carry placeholder image refs — out of scope here (README + manual only), can follow up if you want them aligned too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)