### PR TITLE
docs: kvd offload is vLLM-only

### DIFF
--- a/manual/features/feature_matrix.md
+++ b/manual/features/feature_matrix.md
@@ -13,10 +13,10 @@ engine. **Legend:** ✅ supported · 🚧 work in progress · blank = not suppor
 | **Disaggregated Serving (PD)** | ✅ | ✅ | ✅ | [PD Disaggregation][pd] |
 | **KV-Aware Routing** | ✅ | ✅ | ✅ | [KV-Aware Routing][kv] |
 | **KV-Aware Routing + DP-Attention** | ✅ | ✅ | ✅ | [KV-Aware Routing][kv] |
-| **Tiered KV Cache Offload (kvd)** | ✅[^gpu-direct] | ✅ | 🚧 | [KV Cache Offload][kvd] |
+| **Tiered KV Cache Offload (kvd)** | ✅ | 🚧 | 🚧 | [KV Cache Offload][kvd] |
 | **Multimodal (image / audio / video)** |  |  |  |  |
 
-[^gpu-direct]: The AIC GPU-Direct path is currently supported only by vLLM.
+KV-cache offload (`kvd`), including AIC GPU-Direct, is **vLLM-only** today.
 
 [pd]: ./pd_disaggregation.md
 [kv]: ./kv_aware_routing.md

--- a/manual/features/kv_cache_offload.md
+++ b/manual/features/kv_cache_offload.md
@@ -11,10 +11,10 @@ across engines, so you don't recompute them. **How it works under the hood:** se
 
 ## Turn it on — single host
 
-```{admonition} vLLM only (for now)
+```{admonition} Limitation — vLLM only (for now)
 :class: important
-KV-Cache Offload currently supports the **vLLM** engine
-(`infera.engine.vllm` + `InferaKvdConnector`). SGLang is not supported yet.
+KV-Cache Offload, including the AIC GPU-Direct read path, currently supports the
+**vLLM** engine only. SGLang and ATOM support is planned.
 ```
 
 One `infera.kvd` daemon per host; every engine on that host shares it.


### PR DESCRIPTION
Corrects engine support for tiered KV-cache offload.

- **Feature matrix** — `kvd` (incl. AIC GPU-Direct) is **vLLM-only**; SGLang and ATOM move to 🚧 (was SGLang ✅, which contradicted the offload page).
- **Offload page** — states the vLLM-only limitation.

The roadmap lives in the tracking issue (#9), not the docs. Docs-only; signed off (DCO).