### PR TITLE
fix: persist e2e worker logs to shared NFS — and fix the first crash they exposed

### DIFF
--- a/infera/engine/rocm_dsa_env.py
+++ b/infera/engine/rocm_dsa_env.py
@@ -1,0 +1,61 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""ROCm opt-out for SGLang's CUDA-only DSA ``topk_v2`` JIT kernel.
+
+SGLang >= v0.5.15 defaults ``SGLANG_OPT_USE_TOPK_V2`` ON, but that kernel's
+header includes ``<cooperative_groups.h>`` (CUDA-only; ROCm ships only
+``hip/hip_cooperative_groups.h``), so hipcc fails at JIT time and the engine
+dies in decode CUDA-graph capture. Upstream turns the flag off on HIP only in
+the ``DeepseekV4ForCausalLM`` branch of ``server_args.py``, yet the kernel is
+shared by every DSA arch — GLM-5.x, DeepseekV32, LongcatFlash, MistralLarge3 —
+which therefore still hit it. Default it OFF on ROCm instead; the backend then
+takes the legacy transform path ROCm used before v0.5.15.
+
+Set-if-unset, so it self-retires: once upstream guards the kernel, its own value
+(or an explicit ``SGLANG_OPT_USE_TOPK_V2=1``) wins and this becomes a no-op.
+
+Verified 2026-07-30, MI355X/gfx950, sglang v0.5.15.post1, GLM-5.1-FP8 tp4:
+capture dies at 0/4 without it, completes 4/4 with it.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# env var -> default value (applied only if unset).
+_ROCM_DSA_DEFAULTS: dict[str, str] = {
+    "SGLANG_OPT_USE_TOPK_V2": "0",  # sglang reads this as EnvBool (default True)
+}
+
+
+def _is_rocm() -> bool:
+    """True iff running on ROCm/HIP. Probe ``/dev/kfd`` to avoid importing torch."""
+    return os.path.exists("/dev/kfd")
+
+
+def apply_rocm_dsa_env_defaults() -> dict[str, str]:
+    """Set the ROCm DSA env defaults (set-if-unset); no-op elsewhere.
+
+    Call ONCE at engine startup, BEFORE the sglang subprocess is spawned — the
+    flag is read in that subprocess, at CUDA-graph capture. Returns the vars
+    actually applied (empty if none / not ROCm).
+    """
+    if not _is_rocm():
+        return {}
+    applied: dict[str, str] = {}
+    for key, value in _ROCM_DSA_DEFAULTS.items():
+        if os.environ.get(key) in (None, ""):
+            os.environ[key] = value
+            applied[key] = value
+    if applied:
+        logger.info(
+            "ROCm DSA env defaults applied (set-if-unset; override via env): %s",
+            applied,
+        )
+    return applied

--- a/infera/engine/sglang/__main__.py
+++ b/infera/engine/sglang/__main__.py
@@ -210,12 +210,16 @@ async def main() -> None:
     # BEFORE engine.start() spawns the sglang subprocess so it's inherited.
     # Without these the transfer engine silently falls back to TCP / hangs.
     from infera.engine.dsv4_gfx942 import apply_gfx942_dsv4
+    from infera.engine.rocm_dsa_env import apply_rocm_dsa_env_defaults
     from infera.engine.rocm_rdma_env import (
         apply_kv_host_ip_default,
         apply_rocm_rdma_env_defaults,
     )
 
     apply_rocm_rdma_env_defaults()
+    # Disable sglang's CUDA-only DSA topk_v2 JIT on ROCm (set-if-unset), else every
+    # non-DeepseekV4 DSA arch dies in CUDA-graph capture. See rocm_dsa_env.py.
+    apply_rocm_dsa_env_defaults()
     # Pin the KV host IP to the RDMA rail (else get_ip() picks the public NIC and
     # KV transfer targets the wrong interface). Must follow the GID default above.
     apply_kv_host_ip_default()

--- a/tests/engine/test_rocm_dsa_env.py
+++ b/tests/engine/test_rocm_dsa_env.py
@@ -1,0 +1,28 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""Unit tests for infera.engine.rocm_dsa_env (DSA topk_v2 ROCm opt-out)."""
+
+from __future__ import annotations
+
+import os
+
+import infera.engine.rocm_dsa_env as rde
+
+
+def test_disables_topk_v2_on_rocm(monkeypatch):
+    monkeypatch.delenv("SGLANG_OPT_USE_TOPK_V2", raising=False)
+    monkeypatch.setattr(rde, "_is_rocm", lambda: True)
+    assert rde.apply_rocm_dsa_env_defaults() == {"SGLANG_OPT_USE_TOPK_V2": "0"}
+    assert os.environ["SGLANG_OPT_USE_TOPK_V2"] == "0"
+
+
+def test_operator_override_wins(monkeypatch):
+    """Set-if-unset is how this workaround self-retires once upstream fixes the
+    kernel — an explicit opt-in must survive."""
+    monkeypatch.setattr(rde, "_is_rocm", lambda: True)
+    monkeypatch.setenv("SGLANG_OPT_USE_TOPK_V2", "1")
+    assert rde.apply_rocm_dsa_env_defaults() == {}
+    assert os.environ["SGLANG_OPT_USE_TOPK_V2"] == "1"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -118,6 +118,22 @@ trap _cleanup_scratch EXIT
 trap '_cancel_dispatched; exit 130' INT TERM
 echo "[scratch] $SCRATCH  (worker logs: $E2E_LOG_DIR${SHARED_LOG_DIR:+ [shared NFS, live]})"
 
+# Banner the ABSOLUTE worker-log dir at both ends of the run: the GH Actions log
+# is long and usually read from the bottom after a failure, so repeating it means
+# a debugger never has to hunt for the path. _log_dir_banner is reused on exit.
+_log_dir_banner() {
+  echo ""
+  echo "=================== E2E WORKER LOG LOCATION ==================="
+  echo "  $E2E_LOG_DIR"
+  if [ -n "$SHARED_LOG_DIR" ]; then
+    echo "  (shared NFS, written live — survives scancel/preempt/SIGKILL)"
+  else
+    echo "  (node-local /tmp — NOT shared; lost when this machine is reclaimed)"
+  fi
+  echo "==============================================================="
+}
+_log_dir_banner
+
 # INFERA_E2E_MODEL_DIR: bind the model tree read-only at the same path + forward
 # the var. If absent here (lives on the compute node) just forward it; the remote
 # re-run mounts it.
@@ -594,6 +610,13 @@ if [ "$rc" -ne 0 ]; then
     echo "   build error or a native crash before pytest ran; scan above.)"
   fi
   echo "==============================================================="
+fi
+
+# Repeat the log location last (pass or fail): on a failure this is the first
+# thing visible at the bottom of the GH Actions log, right where debugging starts.
+_log_dir_banner
+if [ -d "$E2E_LOG_DIR" ]; then
+  ls -1 "$E2E_LOG_DIR"/*.log 2>/dev/null | sed 's|^|  |' || true
 fi
 
 [ "$rc" -eq 0 ] && echo "RESULT: PASS" || echo "RESULT: FAIL"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -49,11 +49,37 @@ mkdir -p "$SCRATCH/hf"
 : > "$SCRATCH/failures.txt"
 chmod 666 "$SCRATCH/failures.txt" 2>/dev/null || true
 SCRATCH_FLAGS=(-v "$SCRATCH":/scratch -e HF_HOME=/scratch/hf)
-# Worker (engine) logs persist on the host at a fixed dir, mounted at /e2e-logs
-# in the container (the harness writes there when that mount exists).
-E2E_LOG_DIR="/tmp/infera-e2e-logs"
+# Worker (engine) logs, mounted at /e2e-logs in the container (the harness writes
+# one file per case there when that mount exists).
+#
+# In CI (or when INFERA_DISPATCH_LOGDIR forces the shared path) this is a per-run
+# folder on shared NFS, keyed by the job tag ($run_id-$engine), so the harness
+# writes each case's log LIVE onto NFS as it runs. That means the log survives no
+# matter how the run dies — SLURM scancel/preempt, container kill, even SIGKILL of
+# the script (no exit-time copy to race). It also sits on the same NFS folder as the
+# dispatch stream log, so a run's whole trace is in one place. We create the folder
+# here as the USER and make it world-writable (see the chmod below) so the
+# in-container writer can create files in it; verified on Spur that this works.
+#
+# Locally (no CI env) it stays a node-local /tmp dir: single machine, nothing to
+# rescue, and no shared filesystem to assume.
+if [ -n "${GITHUB_ACTIONS:-}" ] || [ "${CI:-}" = "true" ] || [ -n "${INFERA_DISPATCH_LOGDIR:-}" ]; then
+  SHARED_LOG_DIR="${INFERA_DISPATCH_LOGDIR:-$HOME/infera-cicd-shared-logs}/${INFERA_E2E_JOB_TAG:-local}"
+  E2E_LOG_DIR="$SHARED_LOG_DIR"
+else
+  SHARED_LOG_DIR=""
+  E2E_LOG_DIR="/tmp/infera-e2e-logs"
+fi
 mkdir -p "$E2E_LOG_DIR"
+# World-writable so the container's writer (root, or nobody under an NFS squash) can
+# create per-case logs directly on NFS — we can't assume it shares the invoking
+# user's uid/gid, so group perms alone won't do. The sticky bit (the leading 1)
+# keeps it safe: only a file's owner can rename/delete it, so a co-tenant can't
+# swap in a symlink or clobber another run's logs. Shared dir only; the local /tmp
+# path needs no loosening.
+if [ -n "$SHARED_LOG_DIR" ]; then chmod 1777 "$E2E_LOG_DIR" 2>/dev/null || true; fi
 SCRATCH_FLAGS+=(-v "$E2E_LOG_DIR":/e2e-logs)
+
 _cleanup_scratch() {
   local img="$IMG_SGLANG"
   docker image inspect "$IMG_VLLM" >/dev/null 2>&1 && img="$IMG_VLLM"
@@ -90,7 +116,7 @@ _cancel_dispatched() {
 }
 trap _cleanup_scratch EXIT
 trap '_cancel_dispatched; exit 130' INT TERM
-echo "[scratch] $SCRATCH  (worker logs: $E2E_LOG_DIR, kept)"
+echo "[scratch] $SCRATCH  (worker logs: $E2E_LOG_DIR${SHARED_LOG_DIR:+ [shared NFS, live]})"
 
 # INFERA_E2E_MODEL_DIR: bind the model tree read-only at the same path + forward
 # the var. If absent here (lives on the compute node) just forward it; the remote
@@ -211,13 +237,14 @@ _dispatch_slurm() {
   _CUR_DISPATCH_OUT="$out"   # let the INT/TERM trap scancel this job if aborted
 
   # CI (buffered srun) -> remote writes to a SHARED-NFS file we `tail -F`; local ->
-  # srun forwards to $out. INFERA_DISPATCH_LOGDIR forces the shared path.
+  # srun forwards to $out. The dispatch stream log lands in the SAME per-run folder
+  # ($SHARED_LOG_DIR, keyed by job tag) as the live worker logs, so one run's entire
+  # trace — dispatch banners + every engine worker's log — sits together on NFS.
   local shared=0 logdir="" logf="" tailf="$out"
-  if [ -n "${GITHUB_ACTIONS:-}" ] || [ "${CI:-}" = "true" ] || [ -n "${INFERA_DISPATCH_LOGDIR:-}" ]; then
+  if [ -n "$SHARED_LOG_DIR" ]; then
     shared=1
-    logdir="${INFERA_DISPATCH_LOGDIR:-$HOME/infera-cicd-shared-logs}"
-    mkdir -p "$logdir" 2>/dev/null || true
-    logf="$logdir/${label}-${INFERA_E2E_JOB_TAG:-local}-$$.log"
+    logdir="$SHARED_LOG_DIR"   # already created + chmod'd at startup
+    logf="$logdir/dispatch-${label}-$$.log"
     tailf="$logf"
   fi
 
@@ -316,9 +343,15 @@ _dispatch_slurm() {
     fi
     break  # genuine test/build failure
   done
-  # Shared mode only: prune logs older than 10 days (INFERA_DISPATCH_LOG_TTL_MIN).
-  [ "$shared" -eq 1 ] && find "$logdir" -maxdepth 1 -type f -name '*.log' \
-    -mmin "+${INFERA_DISPATCH_LOG_TTL_MIN:-14400}" -delete 2>/dev/null
+  # Shared mode only: prune old logs (10 days, INFERA_DISPATCH_LOG_TTL_MIN). Reap
+  # both the .log files under the per-run folders and the now-empty folders left
+  # behind (logs live one level down: <shared-root>/<job-tag>/*.log).
+  if [ "$shared" -eq 1 ]; then
+    local ttl="${INFERA_DISPATCH_LOG_TTL_MIN:-14400}" root
+    root="$(dirname "$logdir")"
+    find "$root" -mindepth 2 -maxdepth 2 -type f -name '*.log' -mmin "+$ttl" -delete 2>/dev/null || true
+    find "$root" -mindepth 1 -maxdepth 1 -type d -empty -delete 2>/dev/null || true
+  fi
   return "$prc"
 }
 


### PR DESCRIPTION
Three commits: the logging change that made e2e worker crashes visible, the
first real bug it surfaced, and a usability follow-up on the logging itself.

## 1. `fix(ci)`: write e2e worker logs live to shared NFS per-run folder

### Problem
e2e engine **worker logs** — the real crash site, e.g. an sglang worker that
`exited with code -15 before becoming active` — were written to the dispatched
SLURM node's **node-local `/tmp/infera-e2e-logs`**. Never tee'd into pytest
stdout, never uploaded, and `/tmp` is not shared, so once the SLURM allocation
is reclaimed the log is **gone**. Any worker that dies before becoming active
was undiagnosable from CI.

### Fix
In CI, point `E2E_LOG_DIR` **directly at a shared NFS per-run folder**
(`$HOME/infera-cicd-shared-logs/<run_id>-<engine>/`), created as the user before
the container starts. The harness then writes each case's log **LIVE onto NFS**
as it runs, next to the dispatch stream log for that leg. No exit-time copy.

**Why live writes (not an exit-time copy)**
- **Survives any death mode** — scancel/preempt, `docker kill`, even SIGKILL of
  the script. Bytes are on NFS the moment they're written; there is no exit-time
  copy to lose the race against SIGKILL / the SLURM kill grace period.
- **No cross-contamination** — the per-run folder is unique per `<run_id>-<engine>`,
  so there is no reused `/tmp` to mix a prior run's logs into this one.
- **root_squash** — verified on Spur that an in-container root writer can create
  files in a user-made, world-writable NFS dir, so no squash barrier.

**Directory permissions (`1777`)** — world-writable because the in-container
writer may not share the invoking user's uid/gid (and may be squashed to
`nobody`), so group perms alone won't let it create files. The **sticky bit**
keeps it safe: only a file's owner can rename/delete it, blocking symlink swaps /
cross-run tampering by a co-tenant. (Flagged by automated security review;
`1777` is the mitigation.)

Considered but rejected: `mktemp -d` random names (the dispatcher and the
re-entered remote script are separate processes that must derive the SAME folder
from the job tag — the name has to be deterministic); `docker run --user` to avoid
a world-writable dir (would change the whole privileged/ionic/GPU container's run
identity — out of scope for a logging fix).

**Organisation** — one folder per matrix leg (`<run_id>-<engine>`), engines never
collide; each case → one worker log, so a run's whole trace sits together. TTL
prune updated to reap `.log` files one level down + the now-empty per-run dirs.
Local dev keeps the node-local `/tmp` path unchanged.

## 2. `fix(sglang)`: disable the CUDA-only DSA topk_v2 JIT on ROCm

The first thing those logs surfaced. The e2e sglang **GLM-5.1-FP8-tp4** case dies
in decode CUDA-graph capture:

```
topk_impl.cuh:27:10: fatal error: 'cooperative_groups.h' file not found
Capture cuda graph failed: ninja exited with status 1
```

### Root cause (upstream defect, two gaps)
SGLang >= v0.5.15 defaults `SGLANG_OPT_USE_TOPK_V2` **ON**, but that JIT kernel's
header includes `<cooperative_groups.h>` **unguarded** — a CUDA-only header. ROCm
ships only `hip/hip_cooperative_groups.h` (verified inside the CI image), so hipcc
can *never* build it.

Upstream does gate this, but incompletely:
1. `jit_kernel/dsv4/topk.py` guards its **v1** path with `is_hip_runtime()` but not
   `plan_topk_v2` — despite the module already importing `is_hip_runtime`.
2. `server_args.py` turns the flag off on HIP only inside the
   `DeepseekV4ForCausalLM` branch. The kernel is **shared** by every DSA arch
   ("Shared by DeepSeek-V3.2 and GLM DSA", per `dsa/dsa_topk_backend.py`), so
   GLM-5.x, DeepseekV32, LongcatFlash and MistralLarge3 keep the default-ON flag
   and hit the broken kernel.

### Fix
Default the flag **OFF on ROCm** at the sglang entrypoint, set-if-unset, mirroring
`rocm_rdma_env`. The backend then takes the legacy transform path ROCm used before
v0.5.15 — correctness unaffected, and this repo's DeepSeek-V4 case has shipped
`SGLANG_OPT_USE_TOPK_V2=0` all along. Scoped to sglang because the var is
sglang-only (vLLM/atom don't read it). Set-if-unset means it **self-retires**:
once upstream guards the kernel, its own value (or an explicit `=1`) wins and this
becomes a no-op.

**Blast radius checked** — the flag has 6 read sites, all inside DSA/DSv4 attention
backends (only reachable when `attention_backend` resolves to `dsa`/`dsv4`), each
behind an if/else with a working fallback. One site is already `and not _is_hip`,
i.e. dead on ROCm regardless.

**Not a regression from commit 1** — earlier runs failed the same way; their worker
logs just died with the node-local `/tmp`, so nobody could see it.

### Verification
Unit: 12 passed (new + sibling `test_rocm_rdma_env`), ruff clean. Full
`tests/engine` matches the pre-change baseline exactly (`3 failed, 227 passed, 23
errors` — pre-existing, missing deps in the bare base image).

E2E on spur `crsuse2-m2m-214` (MI355X/gfx950), sglang `v0.5.15.post1-rocm720-mi35x`,
GLM-5.1-FP8 tp4 — via **both** a direct `launch_server` run and infera's own
`python -m infera.engine.sglang` path:
- **without** the opt-out: capture dies at 0/4 with the error above
- **with** it: capture completes **4/4** (132 s), `worker ready`, `/health` 200,
  and a temp=0 probe returns **"Paris"** with `reasoning_content` split cleanly

## 3. `fix(ci)`: banner the absolute worker-log dir at both ends of a run

The path from commit 1 was printed once, inline in the `[scratch]` line near the
top of a run that emits thousands of lines. In a GH Actions log — which you
scroll to the **bottom** of after a failure — that line is effectively
unreachable, so the logs this PR just made durable were still awkward to find.

Print a delimited banner with the **absolute** directory twice: at startup, and
again at the very end on pass or fail, after the failure summary. The closing one
also lists the per-case `.log` files actually produced, so a debugger can jump
straight to the failing case's file. The banner names which mode is in effect:

```
=================== E2E WORKER LOG LOCATION ===================
  /home/<user>/infera-cicd-shared-logs/30466212605-sglang
  (shared NFS, written live — survives scancel/preempt/SIGKILL)
===============================================================
```

Both `E2E_LOG_DIR` branches are already absolute (`$HOME/...` or `/tmp/...`), so
the banner is always copy-pasteable. `bash -n` clean; rendering verified for both
the shared-NFS and local-dev cases.


Worth an upstream issue: one `is_hip_runtime()` in `plan_topk_v2` fixes it at the root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
