### PR TITLE
Enable PD-disaggregation e2e on dma-buf-only RoCE fabrics (crusoe)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,17 +220,13 @@ jobs:
             sleep 5
           done
 
-  # PD-disaggregated e2e (prefill and decode on two nodes, KV over RDMA). Runs on
-  # PRs like e2e-mixed, and on manual dispatch under its OWN run_e2e_disag box —
-  # separate job + separate switch so a PD-transport break is legible on its own.
   e2e-disag:
     needs: [lint, changes]
     if: >-
       always() &&
       needs.changes.outputs.code == 'true' &&
       needs.lint.result != 'failure' && needs.lint.result != 'cancelled' &&
-      (github.event_name == 'pull_request' ||
-       (github.event_name == 'workflow_dispatch' && inputs.run_e2e_disag))
+      (github.event_name == 'workflow_dispatch' && inputs.run_e2e_disag)
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,10 +236,13 @@ jobs:
       matrix:
         engine: [vllm, sglang, atom]
     runs-on: [self-hosted, crusoe]
-    timeout-minutes: 120
+    timeout-minutes: 70
     env:
       INFERA_E2E_SLURM_PARTITION: amd-spur
       INFERA_E2E_MODEL_DIR: /shared_nfs/huggingface_models
+      # Ceiling on every disagg srun step, inside the job timeout above so the
+      # scheduler reclaims a node even if the runner is killed first.
+      INFERA_E2E_SLURM_TIME: "01:00:00"
       # Disagg is many short sruns; the reservation keeps the pair held across
       # them. QoS is left at the cluster default — the harness falls back to the
       # burst QoS by itself if a step is refused for a group node limit.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,12 @@ on:
     branches: [main]
   workflow_dispatch:   # manual "Run workflow" button (Actions tab)
     inputs:
-      run_e2e:
+      run_e2e_mixed:
         description: "also run e2e-mixed"
+        type: boolean
+        default: false
+      run_e2e_disag:
+        description: "also run e2e-disag"
         type: boolean
         default: false
 
@@ -171,7 +175,7 @@ jobs:
   e2e-mixed:
     # Run on PRs into main (pre-merge; pull_request already filters base=main), so
     # the merge is validated BEFORE landing and not re-run on the main push after.
-    # Also on manual dispatch when run_e2e is checked. Skipped for docs-only PRs.
+    # Also on manual dispatch when run_e2e_mixed is checked. Skipped for docs-only PRs.
     # Gated behind lint: run only if lint did not fail. `always()` + result check
     # (instead of a plain success dependency) is needed so e2e still runs when lint
     # is *skipped* as a duplicate (pre_check), but is held back when lint fails.
@@ -181,7 +185,7 @@ jobs:
       needs.changes.outputs.code == 'true' &&
       needs.lint.result != 'failure' && needs.lint.result != 'cancelled' &&
       (github.event_name == 'pull_request' ||
-       (github.event_name == 'workflow_dispatch' && inputs.run_e2e))
+       (github.event_name == 'workflow_dispatch' && inputs.run_e2e_mixed))
     strategy:
       fail-fast: false
       matrix:
@@ -215,6 +219,45 @@ jobs:
             echo "reclaiming SLURM job(s): $ids (try $i)"; scancel $ids 2>&1 || true
             sleep 5
           done
+
+  # PD-disaggregated e2e (prefill and decode on two nodes, KV over RDMA). Runs on
+  # PRs like e2e-mixed, and on manual dispatch under its OWN run_e2e_disag box —
+  # separate job + separate switch so a PD-transport break is legible on its own.
+  e2e-disag:
+    needs: [lint, changes]
+    if: >-
+      always() &&
+      needs.changes.outputs.code == 'true' &&
+      needs.lint.result != 'failure' && needs.lint.result != 'cancelled' &&
+      (github.event_name == 'pull_request' ||
+       (github.event_name == 'workflow_dispatch' && inputs.run_e2e_disag))
+    strategy:
+      fail-fast: false
+      matrix:
+        engine: [vllm, sglang, atom]
+    runs-on: [self-hosted, crusoe]
+    timeout-minutes: 120
+    env:
+      INFERA_E2E_SLURM_PARTITION: amd-spur
+      INFERA_E2E_MODEL_DIR: /shared_nfs/huggingface_models
+      # Disagg is many short sruns; the reservation keeps the pair held across
+      # them. QoS is left at the cluster default — the harness falls back to the
+      # burst QoS by itself if a step is refused for a group node limit.
+      INFERA_E2E_RESERVATION: infera-cicd-reserved
+      # No ib_peer_mem here, so bare ibv_reg_mr cannot pin VRAM: Mooncake must
+      # register via dma-buf, compiled in at build time and selected at run time.
+      # The rail is mlx5 (ionic dma-buf dies on a production KV pool); its
+      # routable GID is index 3, its 0 and 1 are link-local.
+      INFERA_E2E_GID_INDEX: "3"
+      INFERA_E2E_WORKER_ENV: MC_TE_FILTERS=mlx5_0,MOONCAKE_DISABLE_HIP_DMABUF=0
+      INFERA_E2E_BUILD_ARGS: MOONCAKE_HIP_DMABUF=1
+      INFERA_E2E_JOB_TAG: ${{ github.run_id }}-${{ matrix.engine }}-disag
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: e2e ${{ matrix.engine }} disag
+        run: bash tests/run_tests.sh e2e ${{ matrix.engine }} disag
 
   unit-torch-cpu:
     needs: [lint, pre_check, changes]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,20 @@ jobs:
           fetch-depth: 0
       - name: e2e ${{ matrix.engine }} disag
         run: bash tests/run_tests.sh e2e ${{ matrix.engine }} disag
+      - name: reclaim this job's SLURM jobs (on cancel/failure)
+        if: always() && (cancelled() || failure())
+        run: |
+          # Catches the infera-ci-hold-* pair holder too: it is a -N2 --gres=gpu:8
+          # batch job, so a leaked one keeps TWO reserved nodes out of the pool.
+          # Retry: a single scancel can hit a transient Spur controller error.
+          suf="-${{ github.run_id }}-${{ matrix.engine }}-disag"
+          for i in 1 2 3 4 5; do
+            ids=$(squeue -h -u "$(id -un)" -o '%i %j' 2>/dev/null \
+              | awk -v suf="$suf" '$2 ~ /^infera-ci-/ && substr($2, length($2)-length(suf)+1)==suf {print $1}')
+            [ -z "$ids" ] && { echo "no (more) SLURM jobs to reclaim"; break; }
+            echo "reclaiming SLURM job(s): $ids (try $i)"; scancel $ids 2>&1 || true
+            sleep 5
+          done
 
   unit-torch-cpu:
     needs: [lint, pre_check, changes]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,13 @@ jobs:
           skip_after_successful_duplicate: "true"
           concurrent_skipping: "never"
 
+  # Sign-off gate for the GPU tiers below — `needs:` cannot reach a job in
+  # another workflow, so dco.yml is called here as one. Skipped off a PR (there
+  # is nothing to check), which the tiers below read as "did not fail".
+  dco:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/dco.yml
+
   lint:
     needs: [pre_check, changes]
     if: >-
@@ -136,12 +143,17 @@ jobs:
 
   # Engine GPU tests — run on each branch push (same-repo PRs reuse that run).
   engine:
-    needs: [lint, pre_check, changes]
     # Skip on docs-only changes, and on same-repo PRs (already covered by the
-    # branch push event); still run on push and on fork PRs.
+    # branch push event); still run on push and on fork PRs. `always()` + result
+    # checks (not a plain success dependency) so a *skipped* lint/dco — dco does
+    # not run off a PR — does not drag this down with it.
+    needs: [lint, pre_check, changes, dco]
     if: >-
+      always() &&
       needs.pre_check.outputs.should_skip != 'true' &&
       needs.changes.outputs.code == 'true' &&
+      needs.lint.result != 'failure' && needs.lint.result != 'cancelled' &&
+      needs.dco.result != 'failure' && needs.dco.result != 'cancelled' &&
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: [self-hosted, crusoe]
@@ -179,11 +191,12 @@ jobs:
     # Gated behind lint: run only if lint did not fail. `always()` + result check
     # (instead of a plain success dependency) is needed so e2e still runs when lint
     # is *skipped* as a duplicate (pre_check), but is held back when lint fails.
-    needs: [lint, changes]
+    needs: [lint, changes, dco]
     if: >-
       always() &&
       needs.changes.outputs.code == 'true' &&
       needs.lint.result != 'failure' && needs.lint.result != 'cancelled' &&
+      needs.dco.result != 'failure' && needs.dco.result != 'cancelled' &&
       (github.event_name == 'pull_request' ||
        (github.event_name == 'workflow_dispatch' && inputs.run_e2e_mixed))
     strategy:
@@ -221,11 +234,12 @@ jobs:
           done
 
   e2e-disag:
-    needs: [lint, changes]
+    needs: [lint, changes, dco]
     if: >-
       always() &&
       needs.changes.outputs.code == 'true' &&
       needs.lint.result != 'failure' && needs.lint.result != 'cancelled' &&
+      needs.dco.result != 'failure' && needs.dco.result != 'cancelled' &&
       (github.event_name == 'pull_request' ||
        (github.event_name == 'workflow_dispatch' && inputs.run_e2e_disag))
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,13 +236,13 @@ jobs:
       matrix:
         engine: [vllm, sglang, atom]
     runs-on: [self-hosted, crusoe]
-    timeout-minutes: 70
+    timeout-minutes: 120
     env:
       INFERA_E2E_SLURM_PARTITION: amd-spur
       INFERA_E2E_MODEL_DIR: /shared_nfs/huggingface_models
       # Ceiling on every disagg srun step, inside the job timeout above so the
       # scheduler reclaims a node even if the runner is killed first.
-      INFERA_E2E_SLURM_TIME: "01:00:00"
+      INFERA_E2E_SLURM_TIME: "01:50:00"
       # Disagg is many short sruns; the reservation keeps the pair held across
       # them. QoS is left at the cluster default — the harness falls back to the
       # burst QoS by itself if a step is refused for a group node limit.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,8 @@ jobs:
       always() &&
       needs.changes.outputs.code == 'true' &&
       needs.lint.result != 'failure' && needs.lint.result != 'cancelled' &&
-      (github.event_name == 'workflow_dispatch' && inputs.run_e2e_disag)
+      (github.event_name == 'pull_request' ||
+       (github.event_name == 'workflow_dispatch' && inputs.run_e2e_disag))
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -5,8 +5,11 @@ name: DCO
 # See CONTRIBUTING.md > Developer Certificate of Origin.
 
 on:
+  # Standalone on a PR into any branch; ci.yml additionally calls this one as a
+  # job, which is what lets its GPU tiers gate on the sign-off via `needs:`.
   pull_request:
     branches: ["**"]
+  workflow_call:
 
 permissions:
   contents: read

--- a/deploy/docker/Dockerfile.atom
+++ b/deploy/docker/Dockerfile.atom
@@ -12,6 +12,25 @@ COPY deploy/docker/patches/atom/ /tmp/atom-patches/
 RUN for f in /tmp/atom-patches/patch_*.py; do echo "[atom-patch] $f"; python3 "$f" || echo "[atom-patch] skipped $f"; done \
     && rm -rf /tmp/atom-patches
 
+# ---- Mooncake (main + B-group C++ patches) --------------------------------
+# The base ships a Mooncake whose GPU MR path is bare ibv_reg_mr, which needs
+# the legacy ib_peer_mem module. Rebuild from the ref vLLM uses ONLY when
+# MOONCAKE_HIP_DMABUF=1; at the default 0 the base's Mooncake is left untouched.
+ARG BUILD_MOONCAKE=1
+ARG MOONCAKE_GIT_REF=747003c058015c4077a266e7ccd7549bbc9baede
+ARG MOONCAKE_HIP_DMABUF=0
+COPY deploy/docker/scripts/build_mooncake_rocm.sh /tmp/build_mooncake_rocm.sh
+COPY deploy/docker/patches/mooncake_cpp/ /tmp/mooncake_cpp/
+RUN if [ "${BUILD_MOONCAKE}" = "1" ] && [ "${MOONCAKE_HIP_DMABUF}" = "1" ]; then \
+        MOONCAKE_DMABUF=1 MOONCAKE_HIP_DMABUF=1 \
+        MOONCAKE_GIT_REF="${MOONCAKE_GIT_REF}" \
+        MC_CPP_PATCH_DIR=/tmp/mooncake_cpp \
+        bash /tmp/build_mooncake_rocm.sh; \
+    else \
+        echo "MOONCAKE_HIP_DMABUF=0 — using the base image's Mooncake"; \
+    fi \
+    && rm -rf /tmp/build_mooncake_rocm.sh /tmp/mooncake_cpp
+
 WORKDIR /opt/infera
 
 # Install infera + its declared deps from pyproject (single source of truth).
@@ -48,4 +67,9 @@ RUN SITE_PKGS=$(python3 -c "import site; print(site.getsitepackages()[0])") \
     && echo "import infera.engine.atom.hooks.kv_event_bootstrap" \
         > "${SITE_PKGS}/zzz_infera_atom_bootstrap.pth"
 
-ENTRYPOINT ["/bin/bash"]
+# Host libionic injected at container start, as in the vllm/sglang images: with a
+# mismatched provider libibverbs enumerates 0 devices and RDMA degrades to TCP.
+COPY deploy/docker/scripts/infera_inject_host_ionic.sh /usr/local/bin/infera-inject-host-ionic
+
+ENTRYPOINT ["/usr/local/bin/infera-inject-host-ionic"]
+CMD ["/bin/bash"]

--- a/deploy/docker/Dockerfile.vllm
+++ b/deploy/docker/Dockerfile.vllm
@@ -58,18 +58,24 @@ RUN for f in /tmp/vllm-patches/*.py; do echo "[vllm-patch] $f"; python "$f" || e
     && for f in /tmp/vllm-dsv4-patches/*.py; do echo "[vllm-dsv4-patch] $f"; python "$f" || echo "[vllm-dsv4-patch] skipped $f"; done \
     && rm -rf /tmp/vllm-patches /tmp/vllm-dsv4-patches
 
-# ---- 3) Mooncake (main + B-group C++ patches, bare ibv_reg_mr) -------------
+# ---- 3) Mooncake (main + B-group C++ patches) ------------------------------
 # WHY: cross-node RDMA on ionic needs the B-group C++ patches (B.2 hip-transport
-# gate + B.3 auto-chunk MR), carried against mooncake main. The dma-buf GPUDirect
-# path was dropped in #154 (exhausts a KFD resource at high util -> HIP-209); bare
-# ibv_reg_mr via host-libionic injection is the only supported path. HOW: shared
-# build_mooncake_rocm.sh mode 1 (MOONCAKE_DMABUF=1 = main + B-group, no dma-buf).
+# gate + B.3 auto-chunk MR), carried against mooncake main. How GPU memory is
+# registered for RDMA is chosen by the MOONCAKE_HIP_DMABUF build ARG:
+#   0 (default) = bare ibv_reg_mr via host-libionic injection — needs the legacy
+#                 ib_peer_mem kernel module (do NOT use at high util; HIP-209).
+#   1           = B.1 dma-buf GPUDirect (ibv_reg_dmabuf_mr) — REQUIRED on a
+#                 dma-buf-only RoCE fabric with no ib_peer_mem (e.g. crusoe
+#                 amd-spur), where bare ibv_reg_mr cannot pin VRAM at all.
+# HOW: shared build_mooncake_rocm.sh mode 1 (MOONCAKE_DMABUF=1 = main + B-group).
 ARG BUILD_MOONCAKE=1
 ARG MOONCAKE_GIT_REF=747003c058015c4077a266e7ccd7549bbc9baede
+ARG MOONCAKE_HIP_DMABUF=0
 COPY deploy/docker/scripts/build_mooncake_rocm.sh /tmp/build_mooncake_rocm.sh
 COPY deploy/docker/patches/mooncake_cpp/ /tmp/mooncake_cpp/
 RUN if [ "${BUILD_MOONCAKE}" = "1" ]; then \
-        MOONCAKE_DMABUF=1 MOONCAKE_GIT_REF="${MOONCAKE_GIT_REF}" \
+        MOONCAKE_DMABUF=1 MOONCAKE_HIP_DMABUF="${MOONCAKE_HIP_DMABUF}" \
+        MOONCAKE_GIT_REF="${MOONCAKE_GIT_REF}" \
         MC_CPP_PATCH_DIR=/tmp/mooncake_cpp \
         bash /tmp/build_mooncake_rocm.sh; \
     else \

--- a/deploy/docker/patches/mooncake_cpp/apply_mooncake_cpp_patches.sh
+++ b/deploy/docker/patches/mooncake_cpp/apply_mooncake_cpp_patches.sh
@@ -38,16 +38,16 @@ apply_one() {
     fi
 }
 
-# B.1 (rdma_transport_CMakeLists.diff, USE_HIP_DMABUF -> ibv_reg_dmabuf_mr) REMOVED.
-# That dma-buf GPUDirect registration path exhausts a driver/KFD resource at high
-# gpu_memory_utilization (>=0.7): registering the whole KV pool (~156 GiB/GPU at
-# util 0.8) via ibv_reg_dmabuf_mr makes EVERY subsequent hipModuleLoad fail with
-# HIP-209 "no kernel image is available for execution", crashing the decode engine
-# at kernel_warmup / first inference (_compute_slot_mapping_kernel, torch fill_,
-# ...). The GPU BAR is 512 GiB (not the limit); reproduces on Kimi-K2.6 AND
-# DeepSeek-V4-Pro. Bare ibv_reg_mr (VRAM RDMA via host-libionic injection) does NOT
-# exhaust it and transfers KV correctly on ionic (validated util 0.8 P<->D, both
-# models). The diff is dropped entirely — bare ibv_reg_mr is the only supported path.
+# B.1 (USE_HIP_DMABUF -> ibv_reg_dmabuf_mr) is OPT-IN. It was dropped in #154
+# because dma-buf at high util exhausts a KFD resource (later hipModuleLoad ->
+# HIP-209) where ib_peer_mem is available; but on a dma-buf-only fabric (no
+# ib_peer_mem) it is the ONLY path that can register VRAM at all.
+if [ "${MOONCAKE_HIP_DMABUF:-0}" = "1" ]; then
+    echo "MOONCAKE_HIP_DMABUF=1 -> applying B.1 (dma-buf GPUDirect MR registration)"
+    apply_one rdma_transport_dmabuf_cmake.diff
+else
+    echo "MOONCAKE_HIP_DMABUF=0 (default) -> B.1 not applied (bare ibv_reg_mr; needs ib_peer_mem)"
+fi
 apply_one transfer_engine_impl.diff
 apply_one rdma_auto_chunk_mr_2017.diff
 

--- a/deploy/docker/patches/mooncake_cpp/rdma_transport_dmabuf_cmake.diff
+++ b/deploy/docker/patches/mooncake_cpp/rdma_transport_dmabuf_cmake.diff
@@ -1,0 +1,39 @@
+diff --git a/mooncake-transfer-engine/src/transport/rdma_transport/CMakeLists.txt b/mooncake-transfer-engine/src/transport/rdma_transport/CMakeLists.txt
+--- a/mooncake-transfer-engine/src/transport/rdma_transport/CMakeLists.txt
++++ b/mooncake-transfer-engine/src/transport/rdma_transport/CMakeLists.txt
+@@ -7,3 +7,35 @@ target_link_libraries(rdma_transport PRIVATE JsonCpp::JsonCpp glog::glog
+ if(USE_MLX5DV)
+   target_compile_definitions(rdma_transport PRIVATE USE_MLX5DV)
+ endif()
++
++# infera B.1: enable the HIP dma-buf GPU-direct MR registration path for THIS
++# object library. rdma_context.cpp (the file that actually calls
++# ibv_reg_dmabuf_mr / hsa_amd_portable_export_dmabuf) is compiled into the
++# `rdma_transport` OBJECT lib, NOT into `transfer_engine`. Upstream only defines
++# USE_HIP_DMABUF on the `transfer_engine` target (src/CMakeLists.txt), so the
++# #elif defined(USE_HIP_DMABUF) branch in rdma_context.cpp compiles OUT here and
++# GPU buffers fall through to the bare ibv_reg_mr() branch. Bare ibv_reg_mr on a
++# device pointer only works when the legacy ib_peer_mem kernel module is loaded;
++# on a dma-buf-only RoCE fabric (no ib_peer_mem) it cannot pin VRAM and the KV
++# registration fails (huge host-memory pin / OOM). Mirror the transfer_engine
++# block so the dmabuf verb is compiled into the code path that uses it.
++#
++# USE_HIP is a global compile definition (mooncake-common/common.cmake) and the
++# option is a cache var, so both are visible here. hsa/hip headers are already on
++# the global include path (include_directories(${HIP_INCLUDE_DIRS})); we still
++# link hsa-runtime64 so hsa_amd_portable_export_dmabuf resolves. At runtime
++# rdma_context.cpp::isKernelDmabufSupported() self-checks CONFIG_PCI_P2PDMA /
++# CONFIG_DMABUF_MOVE_NOTIFY and falls back to ibv_reg_mr if the kernel lacks
++# them, and MOONCAKE_DISABLE_HIP_DMABUF=1 forces the old path — so this is safe
++# to compile in unconditionally on the images that opt into it.
++if(USE_HIP)
++  option(USE_HIP_DMABUF "Enable HIP dmabuf RDMA MR registration" ON)
++  if(USE_HIP_DMABUF)
++    find_package(hsa-runtime64 CONFIG QUIET)
++    target_compile_definitions(rdma_transport PRIVATE USE_HIP_DMABUF)
++    if(hsa-runtime64_FOUND)
++      target_link_libraries(rdma_transport PRIVATE hsa-runtime64::hsa-runtime64)
++    endif()
++    message(STATUS "rdma_transport: USE_HIP_DMABUF enabled (ibv_reg_dmabuf_mr GPU-direct path; hsa-runtime64_FOUND=${hsa-runtime64_FOUND})")
++  endif()
++endif()

--- a/deploy/docker/scripts/build_mooncake_rocm.sh
+++ b/deploy/docker/scripts/build_mooncake_rocm.sh
@@ -13,18 +13,20 @@
 # Two build modes via MOONCAKE_DMABUF (default 0): 0 = release -DUSE_HIP=ON (VRAM
 #   RDMA via host-libionic injection); 1 = main @ pinned ref + B-group C++ patches
 #   (B.2 hip-transport gate + B.3 auto-chunk MR) for DSv4 cross-node RDMA.
-#   NOTE: the dma-buf GPUDirect path (B.1 CMake + -DUSE_HIP_DMABUF=ON) was dropped
-#   in #154 — it exhausts a KFD resource at high util (HIP-209). Both modes now use
-#   bare ibv_reg_mr; the flag name is kept only for its Dockerfile call sites.
+#
+# GPU MR registration path via MOONCAKE_HIP_DMABUF (default 0, mode 1 only):
+#   0 = bare ibv_reg_mr, needs the legacy ib_peer_mem module; 1 = B.1 dma-buf
+#   GPUDirect, the only path that registers VRAM where ib_peer_mem is absent.
 #
 # Idempotent: reuses an existing build artifact if present.
 #
 # Environment overrides:
-#   MOONCAKE_DMABUF    0 (release ref) | 1 (main ref + B-group patches); no dma-buf
-#   MOONCAKE_GIT_REF   git tag/branch/commit (default depends on MOONCAKE_DMABUF)
-#   MOONCAKE_REPO      git remote   (default https://github.com/kvcache-ai/Mooncake.git)
-#   MC_ROOT            checkout dir (default /opt/mooncake/Mooncake)
-#   MC_CPP_PATCH_DIR   B-group patch dir (mode 1 only)
+#   MOONCAKE_DMABUF      0 (release ref) | 1 (main ref + B-group patches)
+#   MOONCAKE_HIP_DMABUF  0 (bare ibv_reg_mr) | 1 (dma-buf GPUDirect; mode 1 only)
+#   MOONCAKE_GIT_REF     git tag/branch/commit (default depends on MOONCAKE_DMABUF)
+#   MOONCAKE_REPO        git remote   (default https://github.com/kvcache-ai/Mooncake.git)
+#   MC_ROOT              checkout dir (default /opt/mooncake/Mooncake)
+#   MC_CPP_PATCH_DIR     B-group patch dir (mode 1 only)
 #
 # Usage (inside a ROCm container with hipcc/cmake/ninja/git):
 #   bash deploy/docker/scripts/build_mooncake_rocm.sh                    # release ref
@@ -36,17 +38,25 @@ export DEBIAN_FRONTEND=noninteractive
 
 # ---- mode-dependent settings (all resolved up front) -----------------------
 MOONCAKE_DMABUF="${MOONCAKE_DMABUF:-0}"
+MOONCAKE_HIP_DMABUF="${MOONCAKE_HIP_DMABUF:-0}"
+export MOONCAKE_HIP_DMABUF  # read by apply_mooncake_cpp_patches.sh (B.1 gate)
 MOONCAKE_REPO="${MOONCAKE_REPO:-https://github.com/kvcache-ai/Mooncake.git}"
 MC_ROOT="${MC_ROOT:-/opt/mooncake/Mooncake}"
 MC_CPP_PATCH_DIR="${MC_CPP_PATCH_DIR:-$SCRIPT_DIR/patches/mooncake_cpp}"
 
 if [ "$MOONCAKE_DMABUF" = "1" ]; then
     MOONCAKE_GIT_REF="${MOONCAKE_GIT_REF:-747003c058015c4077a266e7ccd7549bbc9baede}"
-    MODE_DESC="main + B-group C++ patches (bare ibv_reg_mr, no dma-buf)"
-    # main defaults RUST store ON; turn it off and pin pybind11. USE_HIP_DMABUF is
-    # intentionally NOT set — the dma-buf path was dropped in #154 (HIP-209).
-    EXTRA_CMAKE=(-DWITH_STORE_RUST=OFF
-        -Dpybind11_DIR=/usr/local/lib/python3.12/dist-packages/pybind11/share/cmake/pybind11)
+    if [ "$MOONCAKE_HIP_DMABUF" = "1" ]; then
+        MODE_DESC="main + B-group C++ patches + B.1 dma-buf GPUDirect (ibv_reg_dmabuf_mr)"
+    else
+        MODE_DESC="main + B-group C++ patches (bare ibv_reg_mr, needs ib_peer_mem)"
+    fi
+    # main defaults RUST store ON; turn it off and pin pybind11. pybind11_DIR is
+    # auto-detected from the ACTIVE interpreter, since the engine images lay
+    # Python out differently (vLLM /usr/local, sglang + ATOM /opt/venv).
+    PYBIND11_CMAKE_DIR="$(python3 -c 'import pybind11; print(pybind11.get_cmake_dir())' 2>/dev/null \
+        || echo /usr/local/lib/python3.12/dist-packages/pybind11/share/cmake/pybind11)"
+    EXTRA_CMAKE=(-DWITH_STORE_RUST=OFF -Dpybind11_DIR="$PYBIND11_CMAKE_DIR")
 else
     MOONCAKE_GIT_REF="${MOONCAKE_GIT_REF:-v0.3.7.post2}"
     MODE_DESC="release, no dma-buf (host-libionic injection)"
@@ -122,7 +132,18 @@ fi
 # ---- verify ----------------------------------------------------------------
 SO="$(python3 -c 'import mooncake.engine as e; print(e.__file__)')"
 echo "installed: $SO"
-# (The dma-buf symbol check was removed with B.1 in #154 — the build no longer
-# compiles hsa_amd_portable_export_dmabuf; bare ibv_reg_mr is the only path.)
+# Assert the dmabuf verbs really compiled in — a CMake define that failed to
+# reach rdma_transport would silently leave the bare ibv_reg_mr path. Capture
+# `nm -D` into a var first so pipefail can't trip on grep's exit status.
+if [ "$MOONCAKE_HIP_DMABUF" = "1" ]; then
+    _dynsyms="$(nm -D "$SO" 2>/dev/null || true)"
+    if printf '%s\n' "$_dynsyms" | grep -qE 'ibv_reg_dmabuf_mr|hsa_amd_portable_export_dmabuf'; then
+        echo "MC_DMABUF_VERIFY OK (dma-buf GPUDirect symbols present)"
+    else
+        echo "ERROR: MOONCAKE_HIP_DMABUF=1 but dma-buf symbols absent from $SO" >&2
+        echo "       -> B.1 CMake patch did not reach rdma_transport; check build log." >&2
+        exit 1
+    fi
+fi
 python3 -c "from mooncake.engine import TransferEngine; print('MOONCAKE IMPORT OK')"
 echo "MC_BUILD_DONE"

--- a/deploy/docker/scripts/infera_inject_host_ionic.sh
+++ b/deploy/docker/scripts/infera_inject_host_ionic.sh
@@ -44,4 +44,10 @@ if [ -e "$SRC" ]; then
     fi
 fi
 
+# A leading flag means the caller expects the old `ENTRYPOINT ["/bin/bash"]`
+# contract (`docker run <img> -c '...'`), which a bare exec cannot honour.
+case "${1:-}" in
+    -*) exec /bin/bash "$@" ;;
+esac
+
 exec "$@"

--- a/tests/e2e/harness/__init__.py
+++ b/tests/e2e/harness/__init__.py
@@ -23,7 +23,7 @@ PD-disaggregated (cross-node) placement lives in :mod:`.cluster` (SLURM topology
 + :mod:`.launcher` (``SrunDockerLauncher``); the shared bodies are
 :mod:`.mixed_suite` (``run_mixed_case``) and :mod:`.disagg_suite`
 (``run_disagg_case``). Shared parametrize building blocks live in :mod:`.matrix`
-(a declarative ``[model, tp, ep, dp_attn]`` case table expanded by
+(a declarative ``[enable, model, tp, ep, dp_attn]`` case table expanded by
 ``expand_cases``); each engine's own grid lives in its dir under
 ``tests/e2e/pd_mixed/`` / ``tests/e2e/pd_disag/``.
 """

--- a/tests/e2e/harness/cluster.py
+++ b/tests/e2e/harness/cluster.py
@@ -47,7 +47,13 @@ _SPUR = bool(os.environ.get("SPUR_CONTROLLER_ADDR"))
 # QoS until one is refused for a group node limit, then the rest of the run keeps
 # the fallback so that stall is paid once instead of per step.
 _QOS_FALLBACK = os.environ.get("INFERA_E2E_SLURM_QOS_FALLBACK", "amd-burst-qos")
-_QOS_PROBE_TIMEOUT = float(os.environ.get("INFERA_E2E_QOS_PROBE_TIMEOUT", "90"))
+_QOS_PROBE_TIMEOUT = float(os.environ.get("INFERA_E2E_QOS_PROBE_TIMEOUT", "30"))
+
+# Every disagg step carries this name (traceable to its CI run, and matched by
+# ci.yml's `infera-ci-` reclaim filter) and this ceiling. The longest step by far
+# is the image build, so the default is generous.
+JOB_NAME = "infera-ci-" + (os.environ.get("INFERA_E2E_JOB_TAG") or "disag-local")
+STEP_TIME = os.environ.get("INFERA_E2E_SLURM_TIME", "01:00:00")
 _QOS_LIMIT_RE = re.compile(
     r"QOSGrp\w*Limit|QOSMax\w*Limit|reached terminal state before allocation|"
     r"Unable to allocate resources",
@@ -70,7 +76,7 @@ def _job_id() -> str | None:
     return os.environ.get("SLURM_JOB_ID") or os.environ.get("SLURM_JOBID")
 
 
-def srun_argv(node: str) -> list[str]:
+def srun_argv(node: str, *, job: str = "") -> list[str]:
     """The ``srun`` prefix pinning one task to ``node`` — the one place scheduler
     flags are assembled. ``INFERA_E2E_RESERVATION`` keeps a disagg run's many
     short steps on the reserved pair; ``INFERA_E2E_SRUN_EXTRA`` adds site flags."""
@@ -81,6 +87,10 @@ def srun_argv(node: str) -> list[str]:
         argv = ["srun", "--overlap", "--nodes=1", "--ntasks=1", "--nodelist", node]
         if _job_id():
             argv += ["--jobid", _job_id()]
+    # Name and timebox every step: unnamed, SLURM labels them after the command
+    # ("docker") and leaves them UNLIMITED, so a leaked one is neither traceable
+    # to its CI run nor self-expiring. The prefix matches ci.yml's reclaim filter.
+    argv += ["-J", job or JOB_NAME, "-t", STEP_TIME]
     reservation = os.environ.get("INFERA_E2E_RESERVATION")
     if reservation:
         argv.append(f"--reservation={reservation}")
@@ -102,10 +112,11 @@ def probe_qos(node: str) -> None:
     global _qos_fallback_on
     if _qos_fallback_on or not _QOS_FALLBACK:
         return
-    job = f"infera-qos-probe-{os.getpid()}"
+    # Its own name so the scancel below cannot take the run's other steps with it.
+    job = f"{JOB_NAME}-qosprobe-{os.getpid()}"
     try:
         proc = subprocess.run(
-            srun_argv(node) + ["-J", job, "true"],
+            srun_argv(node, job=job) + ["true"],
             capture_output=True,
             text=True,
             timeout=_QOS_PROBE_TIMEOUT,
@@ -115,9 +126,11 @@ def probe_qos(node: str) -> None:
         blocked = bool(_QOS_LIMIT_RE.search((proc.stdout or "") + (proc.stderr or "")))
         detail = (proc.stderr or proc.stdout or "").strip().splitlines()[-1:]
     except subprocess.TimeoutExpired:
-        # Killing the srun client does not cancel the queued job; drop it by name.
-        subprocess.run(["scancel", "-n", job], capture_output=True, timeout=_SRUN_TIMEOUT)
         blocked, detail = True, [f"still queued after {_QOS_PROBE_TIMEOUT:.0f}s"]
+    finally:
+        # Killing the srun client does not cancel the queued job; drop it by name
+        # on every path (a no-op once it has already run).
+        subprocess.run(["scancel", "-n", job], capture_output=True, timeout=_SRUN_TIMEOUT)
     if blocked:
         _qos_fallback_on = True
         print(

--- a/tests/e2e/harness/cluster.py
+++ b/tests/e2e/harness/cluster.py
@@ -15,6 +15,10 @@ where auto-discovery guesses wrong.
 Optional env overrides (all unset => pure auto-discovery):
   INFERA_E2E_NODE_IPS  ``node=ip,node=ip`` — pin a node's advertise/data-plane
                        IP instead of the ``hostname -I`` auto-pick.
+  INFERA_E2E_RESERVATION / INFERA_E2E_SRUN_EXTRA /
+  INFERA_E2E_SLURM_QOS_FALLBACK  — scheduler flags, see :func:`srun_argv`.
+  INFERA_E2E_GID_INDEX / INFERA_E2E_WORKER_ENV / INFERA_E2E_BUILD_ARGS — the
+                       fabric's KV transport (see :func:`kv_transport_env`).
 
 Everything here is best-effort and side-effect free: on a non-SLURM host (or no
 allocation) the discovery helpers return empty/None and the suite skips.
@@ -24,6 +28,8 @@ from __future__ import annotations
 
 import functools
 import os
+import re
+import shlex
 import shutil
 import socket
 import subprocess
@@ -33,6 +39,21 @@ import subprocess
 DEFAULT_GID_INDEX = "1"
 
 _SRUN_TIMEOUT = 60
+
+# The Spur scheduler exposes only a subset of srun (no --overlap/--jobid).
+_SPUR = bool(os.environ.get("SPUR_CONTROLLER_ADDR"))
+
+# Burst QoS is a FALLBACK, never the default: steps run on the cluster's normal
+# QoS until one is refused for a group node limit, then the rest of the run keeps
+# the fallback so that stall is paid once instead of per step.
+_QOS_FALLBACK = os.environ.get("INFERA_E2E_SLURM_QOS_FALLBACK", "amd-burst-qos")
+_QOS_PROBE_TIMEOUT = float(os.environ.get("INFERA_E2E_QOS_PROBE_TIMEOUT", "90"))
+_QOS_LIMIT_RE = re.compile(
+    r"QOSGrp\w*Limit|QOSMax\w*Limit|reached terminal state before allocation|"
+    r"Unable to allocate resources",
+    re.I,
+)
+_qos_fallback_on = False
 
 
 def have_slurm() -> bool:
@@ -47,6 +68,63 @@ def in_allocation() -> bool:
 
 def _job_id() -> str | None:
     return os.environ.get("SLURM_JOB_ID") or os.environ.get("SLURM_JOBID")
+
+
+def srun_argv(node: str) -> list[str]:
+    """The ``srun`` prefix pinning one task to ``node`` — the one place scheduler
+    flags are assembled. ``INFERA_E2E_RESERVATION`` keeps a disagg run's many
+    short steps on the reserved pair; ``INFERA_E2E_SRUN_EXTRA`` adds site flags."""
+    part = os.environ.get("INFERA_E2E_SLURM_PARTITION")
+    if _SPUR:
+        argv = ["srun", "-N1", "-n1"] + (["-p", part] if part else []) + ["-w", node]
+    else:
+        argv = ["srun", "--overlap", "--nodes=1", "--ntasks=1", "--nodelist", node]
+        if _job_id():
+            argv += ["--jobid", _job_id()]
+    reservation = os.environ.get("INFERA_E2E_RESERVATION")
+    if reservation:
+        argv.append(f"--reservation={reservation}")
+    if _qos_fallback_on:
+        argv.append(f"--qos={_QOS_FALLBACK}")
+    return argv + shlex.split(os.environ.get("INFERA_E2E_SRUN_EXTRA", ""))
+
+
+def run_on_node(node: str, argv: list[str], *, timeout: float = _SRUN_TIMEOUT):
+    """Run ``argv`` on ``node`` and capture its output (never raises on rc!=0)."""
+    return subprocess.run(srun_argv(node) + argv, capture_output=True, text=True, timeout=timeout)
+
+
+def probe_qos(node: str) -> None:
+    """Choose this run's QoS once, before the stack comes up. A refused step does
+    not fail fast — it queues — so a trivial step is timeboxed instead; if it does
+    not land, every later step takes the burst QoS (and fails normally if it too
+    is refused). Idempotent, and a no-op with INFERA_E2E_SLURM_QOS_FALLBACK=''."""
+    global _qos_fallback_on
+    if _qos_fallback_on or not _QOS_FALLBACK:
+        return
+    job = f"infera-qos-probe-{os.getpid()}"
+    try:
+        proc = subprocess.run(
+            srun_argv(node) + ["-J", job, "true"],
+            capture_output=True,
+            text=True,
+            timeout=_QOS_PROBE_TIMEOUT,
+        )
+        if proc.returncode == 0:
+            return
+        blocked = bool(_QOS_LIMIT_RE.search((proc.stdout or "") + (proc.stderr or "")))
+        detail = (proc.stderr or proc.stdout or "").strip().splitlines()[-1:]
+    except subprocess.TimeoutExpired:
+        # Killing the srun client does not cancel the queued job; drop it by name.
+        subprocess.run(["scancel", "-n", job], capture_output=True, timeout=_SRUN_TIMEOUT)
+        blocked, detail = True, [f"still queued after {_QOS_PROBE_TIMEOUT:.0f}s"]
+    if blocked:
+        _qos_fallback_on = True
+        print(
+            f"[e2e disagg] default QoS unavailable ({' '.join(detail)}) — "
+            f"using --qos={_QOS_FALLBACK} for this run",
+            flush=True,
+        )
 
 
 def _parse_ip_overrides() -> dict[str, str]:
@@ -117,12 +195,8 @@ def node_ip(node: str) -> str | None:
         pass
     if not have_slurm():
         return None
-    argv = ["srun", "--overlap", "--nodes=1", "--ntasks=1", "--nodelist", node]
-    if _job_id():
-        argv += ["--jobid", _job_id()]
-    argv += ["hostname", "-I"]
     try:
-        out = subprocess.run(argv, capture_output=True, text=True, timeout=_SRUN_TIMEOUT)
+        out = run_on_node(node, ["hostname", "-I"])
     except (OSError, subprocess.SubprocessError):
         return None
     if out.returncode != 0:
@@ -135,8 +209,34 @@ def node_ip(node: str) -> str | None:
 
 
 def gid_index() -> str:
-    """RoCEv2 GID index for the RDMA KV transport (fixed default 1)."""
-    return DEFAULT_GID_INDEX
+    """RoCEv2 GID index for the RDMA KV transport. Defaults to the ionic ULA GID;
+    ``INFERA_E2E_GID_INDEX`` overrides it for a rail that sits elsewhere (mlx5's
+    routable GID is index 3 — its 0 and 1 are link-local)."""
+    return os.environ.get("INFERA_E2E_GID_INDEX") or DEFAULT_GID_INDEX
+
+
+def _kv_list(var: str) -> dict[str, str]:
+    """``VAR='K=V,K=V'`` -> ``{K: V}`` (``{}`` when unset)."""
+    out: dict[str, str] = {}
+    for item in os.environ.get(var, "").split(","):
+        key, sep, value = item.strip().partition("=")
+        if sep and key:
+            out[key] = value
+    return out
+
+
+def kv_transport_env() -> dict[str, str]:
+    """``INFERA_E2E_WORKER_ENV`` (``K=V,K=V``) merged into every PD worker. Which
+    rail carries the KV and how its VRAM registers are fabric properties, so they
+    are set per run (see ci.yml's e2e-disag), not baked into an adapter."""
+    return _kv_list("INFERA_E2E_WORKER_ENV")
+
+
+def image_build_args() -> dict[str, str]:
+    """``INFERA_E2E_BUILD_ARGS`` (``K=V,K=V``) as image ``--build-arg`` pairs.
+    Some fabric constraints only bind at build time: without
+    ``MOONCAKE_HIP_DMABUF=1`` the vLLM image has no dma-buf path compiled in."""
+    return _kv_list("INFERA_E2E_BUILD_ARGS")
 
 
 def pd_nodes() -> tuple[str, str] | None:

--- a/tests/e2e/harness/disagg_fixtures.py
+++ b/tests/e2e/harness/disagg_fixtures.py
@@ -67,7 +67,6 @@ def make_disagg_stack_fixture(
     *,
     image: str,
     dockerfile: str,
-    shell_entrypoint: bool = False,
 ):
     """Return a function-scoped ``disagg_stack`` fixture bound to ``adapter_factory``.
 
@@ -82,9 +81,7 @@ def make_disagg_stack_fixture(
     @pytest_asyncio.fixture
     async def disagg_stack():
         adapter = adapter_factory()
-        launcher = SrunDockerLauncher(
-            image=image, dockerfile=dockerfile, shell_entrypoint=shell_entrypoint
-        )
+        launcher = SrunDockerLauncher(image=image, dockerfile=dockerfile)
         handles: list = []  # torn down in reverse order
 
         async def _up(params: EngineParams | None = None) -> dict:
@@ -101,6 +98,7 @@ def make_disagg_stack_fixture(
             tp = max(1, params.tensor_parallel_size)
             gpu_ids = list(range(tp))
 
+            cluster.probe_qos(prefill_node)
             launcher.cleanup_stale([prefill_node, decode_node])
             launcher.ensure_images([prefill_node, decode_node])
 
@@ -151,6 +149,8 @@ def make_disagg_stack_fixture(
                 env = adapter.disagg_worker_env(
                     params, role, advertise_host=ip, gpu_ids=gpu_ids, gid_index=gid
                 )
+                # Fabric settings last: they override the adapter's fleet default.
+                env.update(cluster.kv_transport_env())
                 h = launcher.start(
                     node=node,
                     argv=argv,
@@ -166,6 +166,8 @@ def make_disagg_stack_fixture(
             await wait_workers_active(
                 launcher, server_ctx["url"], workers, timeout=params.server_ready_timeout
             )
+            # Exposed for disagg_suite.assert_rdma_kv_transport (reads their logs).
+            server_ctx["launcher"], server_ctx["workers"] = launcher, workers
             return server_ctx
 
         yield _up

--- a/tests/e2e/harness/disagg_suite.py
+++ b/tests/e2e/harness/disagg_suite.py
@@ -21,10 +21,42 @@ Nothing infera runs on the driver host — it only drives srun/docker + probes.
 
 from __future__ import annotations
 
+import re
+
 from . import resources, scenarios
+from .adapter import emit_reporter_line
 from .params import EngineParams
 
 __all__ = ["run_disagg_case"]
+
+# The two ways Mooncake reports its transport. Either fallback still delivers the
+# KV over sockets and still passes the correctness probes, so the log is the only
+# place a run that never touched RDMA can be told apart from one that did.
+_TRANSPORT_BANNER = re.compile(r"installTransport, type=(\w+)")
+_NO_HCA = re.compile(r"Topology discovery complete\. Found 0 HCAs")
+
+
+def assert_rdma_kv_transport(server: dict) -> None:
+    """Fail if a PD worker moved KV over anything but RDMA. A worker whose log
+    says nothing about Mooncake is reported "unverified" rather than failed, so
+    this never blocks an engine whose transport it cannot read."""
+    launcher, workers = server.get("launcher"), server.get("workers") or []
+    for h in workers:
+        log = launcher.collect_logs(h)
+        where = f"{h.role} @ {h.node}"
+        assert not _NO_HCA.search(log), (
+            f"{where}: Mooncake found 0 RDMA devices and served KV over TCP — the "
+            f"engine asked for a NIC this fabric does not have; see {h.log_path}"
+        )
+        kinds = sorted(set(_TRANSPORT_BANNER.findall(log)))
+        if not kinds:
+            emit_reporter_line(f"[e2e disagg transport] {where}: unverified (no Mooncake log)")
+            continue
+        emit_reporter_line(f"[e2e disagg transport] {where}: {', '.join(kinds)}")
+        assert kinds == ["rdma"], (
+            f"{where} did not run KV over RDMA alone (installed: {', '.join(kinds)}); "
+            f"see {h.log_path}"
+        )
 
 
 async def run_disagg_case(params: EngineParams, disagg_stack) -> None:
@@ -44,3 +76,6 @@ async def run_disagg_case(params: EngineParams, disagg_stack) -> None:
     # probe is tolerant — so completions-only PD engines (e.g. ATOM) pass on the
     # counting probe alone while the P->D KV transfer is still exercised end-to-end.
     await scenarios.assert_correctness(server["url"], params.model)
+
+    # …and that it got there over RDMA, which correctness alone cannot show.
+    assert_rdma_kv_transport(server)

--- a/tests/e2e/harness/launcher.py
+++ b/tests/e2e/harness/launcher.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import shlex
 import subprocess
 from abc import ABC, abstractmethod
@@ -35,6 +36,7 @@ from dataclasses import dataclass, field
 
 import httpx
 
+from . import cluster
 from .adapter import emit_reporter_line
 
 # Repo root (…/tests/e2e/harness/launcher.py -> 4 up). Bind-mounted into each
@@ -51,15 +53,6 @@ _LIBIONIC = "/usr/lib/x86_64-linux-gnu/libionic.so"
 ETCD_IMAGE = "quay.io/coreos/etcd:v3.5.14"
 ETCD_PORT = 2379
 ROUTER_PORT = 8000
-
-_SRUN = ["srun", "--overlap", "--nodes=1", "--ntasks=1"]
-
-# The Spur scheduler exposes only a subset of srun (no --overlap/--jobid): it's
-# detected by its controller env var. On Spur we place work with plain
-# ``srun -N1 -n1 [-p PART] -w NODE`` (each step self-allocates the pinned node);
-# on stock SLURM we keep --overlap/--jobid to co-schedule inside an allocation.
-_SPUR = bool(os.environ.get("SPUR_CONTROLLER_ADDR"))
-_PART = os.environ.get("INFERA_E2E_SLURM_PARTITION")
 
 # ROCm + RoCE flags for GPU worker containers (see module docstring).
 _GPU_RDMA_FLAGS = [
@@ -83,19 +76,8 @@ _GPU_RDMA_FLAGS = [
 ]
 
 
-def _job_id() -> str | None:
-    return os.environ.get("SLURM_JOB_ID") or os.environ.get("SLURM_JOBID")
-
-
 def _srun(node: str, argv: list[str], *, timeout: float) -> subprocess.CompletedProcess:
-    if _SPUR:
-        cmd = ["srun", "-N1", "-n1"] + (["-p", _PART] if _PART else []) + ["-w", node]
-    else:
-        cmd = list(_SRUN) + ["--nodelist", node]
-        if _job_id():
-            cmd += ["--jobid", _job_id()]
-    cmd += argv
-    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    return cluster.run_on_node(node, argv, timeout=timeout)
 
 
 @dataclass
@@ -165,20 +147,20 @@ class SrunDockerLauncher(WorkerLauncher):
         log_dir: str | None = None,
         build_timeout: float = 3600.0,
         start_timeout: float = 300.0,
-        shell_entrypoint: bool = False,
     ):
-        self.image = image
+        # A build-arg'd image is a DIFFERENT image, so it gets its own tag: the
+        # unit/engine/PD-mixed tiers build the plain tag on these same nodes, and
+        # sharing one would let either tier hand the other its build.
+        self.build_args = cluster.image_build_args()
+        suffix = "-".join(f"{k}{v}" for k, v in sorted(self.build_args.items())).lower()
+        self.image = f"{image}-{re.sub(r'[^a-z0-9_.-]', '', suffix)}" if suffix else image
         self.dockerfile = dockerfile
-        # Some engine images set ENTRYPOINT ["/bin/bash"] (e.g. ATOM) rather than
-        # the host-ionic injector that execs "$@" (vllm/sglang). For the former we
-        # must override --entrypoint bash and pass just "-lc <cmd>", else the CMD's
-        # leading "bash" is treated as a script ("cannot execute binary file").
-        self.shell_entrypoint = shell_entrypoint
         self.model_dir = model_dir or os.environ.get("INFERA_E2E_MODEL_DIR")
         self.log_dir = log_dir or "/tmp/infera-e2e-logs"
         self.build_timeout = build_timeout
         self.start_timeout = start_timeout
         self._built: set[str] = set()
+        self._libionic: dict[str, bool] = {}
         os.makedirs(self.log_dir, exist_ok=True)
 
     # -- cleanup --------------------------------------------------------
@@ -224,16 +206,9 @@ class SrunDockerLauncher(WorkerLauncher):
             )
             built = _srun(
                 node,
-                [
-                    "docker",
-                    "build",
-                    "--network=host",
-                    "-f",
-                    os.path.join(REPO, self.dockerfile),
-                    "-t",
-                    self.image,
-                    REPO,
-                ],
+                ["docker", "build", "--network=host"]
+                + [a for kv in self.build_args.items() for a in ("--build-arg", "=".join(kv))]
+                + ["-f", os.path.join(REPO, self.dockerfile), "-t", self.image, REPO],
                 timeout=self.build_timeout,
             )
             if built.returncode != 0:
@@ -245,13 +220,26 @@ class SrunDockerLauncher(WorkerLauncher):
             self._built.add(node)
 
     # -- low-level container run ---------------------------------------
-    def _engine_mounts(self) -> list[str]:
+    def _has_libionic(self, node: str) -> bool:
+        """Whether ``node`` has the host libionic to inject, probed ON THE NODE:
+        the orchestrator is a login box with no ionic stack, so a local exists()
+        would drop the mount everywhere and libibverbs would find 0 devices."""
+        if node not in self._libionic:
+            probe = _srun(node, ["test", "-e", _LIBIONIC], timeout=self.start_timeout)
+            self._libionic[node] = probe.returncode == 0
+            if not self._libionic[node]:
+                emit_reporter_line(
+                    f"[e2e disagg] WARNING: {node} has no {_LIBIONIC}; RDMA may degrade to TCP"
+                )
+        return self._libionic[node]
+
+    def _engine_mounts(self, node: str) -> list[str]:
         mounts = ["-v", f"{REPO}:{REPO}"]
         # Mount when set (the dir lives on the compute NODE, not necessarily on
         # this orchestrator host, so don't gate on a local isdir check).
         if self.model_dir:
             mounts += ["-v", f"{self.model_dir}:{self.model_dir}:ro"]
-        if os.path.exists(_LIBIONIC):
+        if self._has_libionic(node):
             mounts += ["-v", f"{_LIBIONIC}:/host-libionic/libionic.so"]
         return mounts
 
@@ -277,23 +265,17 @@ class SrunDockerLauncher(WorkerLauncher):
     def _run_infera(
         self, node: str, container: str, argv: list[str], env: dict[str, str], *, gpu: bool
     ) -> None:
-        """Run an infera process (worker or router) in the engine image: keep the
-        image ENTRYPOINT (host-ionic inject), cd into the mounted repo, exec argv."""
+        """Run an infera process (worker or router) in the engine image: cd into
+        the mounted repo and exec argv. The ENTRYPOINT is never overridden — it
+        is the host-ionic injector, and skipping it silently drops KV to TCP."""
         docker_args = ["--network", "host"]
         if gpu:
             docker_args += _GPU_RDMA_FLAGS
-        docker_args += self._engine_mounts()
+        docker_args += self._engine_mounts(node)
         for key, val in {"PYTHONPATH": REPO, **env}.items():
             docker_args += ["-e", f"{key}={val}"]
         inner = f"cd {shlex.quote(REPO)} && exec {shlex.join(argv)}"
-        if self.shell_entrypoint:
-            # ENTRYPOINT is a bare shell (e.g. ATOM's /bin/bash) -> override it and
-            # pass only the shell flags, not a leading "bash" arg.
-            docker_args += ["--entrypoint", "bash"]
-            self._run(node, container, self.image, docker_args, ["-lc", inner])
-        else:
-            # ENTRYPOINT execs "$@" (host-ionic injector) -> hand it a full argv.
-            self._run(node, container, self.image, docker_args, ["bash", "-lc", inner])
+        self._run(node, container, self.image, docker_args, ["bash", "-lc", inner])
 
     # -- services -------------------------------------------------------
     def start_etcd(self, *, node: str, container: str, advertise_host: str) -> LaunchHandle:

--- a/tests/e2e/harness/launcher.py
+++ b/tests/e2e/harness/launcher.py
@@ -272,7 +272,11 @@ class SrunDockerLauncher(WorkerLauncher):
         if gpu:
             docker_args += _GPU_RDMA_FLAGS
         docker_args += self._engine_mounts(node)
-        for key, val in {"PYTHONPATH": REPO, **env}.items():
+        # No .pyc: the repo is bind-mounted read-write and the container runs as
+        # root, so byte-compiling it litters the checkout with root-owned
+        # __pycache__ that the next actions/checkout cannot delete (EACCES).
+        base = {"PYTHONPATH": REPO, "PYTHONDONTWRITEBYTECODE": "1"}
+        for key, val in {**base, **env}.items():
             docker_args += ["-e", f"{key}={val}"]
         inner = f"cd {shlex.quote(REPO)} && exec {shlex.join(argv)}"
         self._run(node, container, self.image, docker_args, ["bash", "-lc", inner])

--- a/tests/e2e/harness/matrix.py
+++ b/tests/e2e/harness/matrix.py
@@ -12,22 +12,27 @@ matrix.py``), so per-engine model/knob choices stay local to that engine.
 
 Declarative case table
 -----------------------
-Each engine grid is a list of rows, ``[model, tp, ep, dp_attn]`` with an
+Each engine grid is a list of rows, ``[enable, model, tp, ep, dp_attn]`` with an
 optional trailing ``opts`` dict::
 
     CASES = [
-        # model, tp, ep, dp_attn
-        ["openai/gpt-oss-120b", 2, False, False],
+        # enable, model, tp, ep, dp_attn
+        [True, "openai/gpt-oss-120b", 2, False, False],
         # ...with per-case extra launch args / extra env:
-        ["openai/gpt-oss-120b", 2, [False, True], False, {
+        [True, "openai/gpt-oss-120b", 2, [False, True], False, {
             "args": ["--kv-cache-dtype", "fp8_e4m3",   # verbatim launch args
                      "--attention-backend", "aiter"],
             "env":  {"SGLANG_USE_AITER": "1"},         # worker subprocess env
         }],
+        # kept in the tree, not run until someone flips it:
+        [False, "deepseek-ai/DeepSeek-V4-Pro", 8, False, False],
     ]
 
 and is expanded with :func:`expand_cases`. Row axes:
 
+- ``enable``   ``True`` collects the row; ``False`` keeps the (often long and
+               hard-won) launch recipe in the tree without running it, so
+               parking a case no longer means commenting the block out.
 - ``model``    HF repo id (the logical id — used for the pytest id and the MoE
                lookup; the *launched* path is resolved via :func:`resolve_model`).
 - ``tp``       tensor-parallel size — an ``int`` or a list of ints.
@@ -192,15 +197,18 @@ def _axis(value) -> tuple:
 def expand_cases(table) -> list[EngineParams]:
     """Expand a declarative case table (see the module docstring) to params.
 
-    Each row is ``[model, tp, ep, dp_attn]`` with an optional trailing ``opts``
-    dict (``args`` / ``env``). Each axis is normalised via :func:`_axis`
-    (a list/tuple enumerates), then the cartesian product of the axes
-    yields one :class:`EngineParams` per combination.
+    Each row is ``[enable, model, tp, ep, dp_attn]`` with an optional trailing
+    ``opts`` dict (``args`` / ``env``). Rows with ``enable`` false are dropped
+    here, so a parked case is never collected. Each axis is normalised via
+    :func:`_axis` (a list/tuple enumerates), then the cartesian product of the
+    axes yields one :class:`EngineParams` per combination.
     """
     params: list[EngineParams] = []
     for row in table:
-        model_id, tp, ep, dp_attn = row[0], row[1], row[2], row[3]
-        opts = row[4] if len(row) > 4 and row[4] else {}
+        enable, model_id, tp, ep, dp_attn = row[0], row[1], row[2], row[3], row[4]
+        opts = row[5] if len(row) > 5 and row[5] else {}
+        if not enable:
+            continue
         for t, e, d in itertools.product(_axis(tp), _axis(ep), _axis(dp_attn)):
             params.append(
                 make_params(

--- a/tests/e2e/pd_disag/atom/conftest.py
+++ b/tests/e2e/pd_disag/atom/conftest.py
@@ -17,10 +17,9 @@ ATOM quirks vs vllm/sglang:
 - OpenAI HTTP port is ``--server-port`` (``--port`` is the torch MASTER_PORT).
 - PD requests only work over ``/v1/completions`` (the shared disagg correctness
   uses the counting probe, which is completions-based — see disagg_suite).
-- Cross-node RDMA needs the prefill/decode ``ib_device`` on the SAME subnet/rail
-  (same-named ionic_N can differ by subnet across nodes). Set
-  ``INFERA_E2E_ATOM_IB_DEVICE`` to pin it when auto-selection picks a mismatched
-  rail (see the regression doc's "how to pick IB_DEV").
+- Cross-node RDMA needs both roles' ``ib_device`` on the same subnet/rail; it
+  follows the cluster's ``MC_TE_FILTERS`` and ``INFERA_E2E_ATOM_IB_DEVICE``
+  overrides that.
 """
 
 from __future__ import annotations
@@ -29,6 +28,7 @@ import json
 import os
 
 from ...harness import EngineAdapter, EngineParams
+from ...harness.cluster import kv_transport_env
 from ...harness.disagg_fixtures import make_disagg_stack_fixture
 from ...harness.params import DisaggRole
 
@@ -71,8 +71,13 @@ class AtomDisaggAdapter(EngineAdapter):
             "http_port": port,
             "proxy_ip": advertise_host,
         }
-        # Cross-node rail pairing: pin the ionic device when set (see module note).
-        ib_device = os.environ.get("INFERA_E2E_ATOM_IB_DEVICE")
+        # ATOM names its own Mooncake NIC and guesses the MI300X "rdma<N>"; where
+        # devices are named otherwise that discovers 0 HCAs and Mooncake drops to
+        # TCP. Default to the rail the cluster pinned for every engine.
+        ib_device = (
+            os.environ.get("INFERA_E2E_ATOM_IB_DEVICE")
+            or kv_transport_env().get("MC_TE_FILTERS", "").split(",")[0]
+        )
         if ib_device:
             kv_cfg["ib_device"] = ib_device
 
@@ -126,8 +131,4 @@ class AtomDisaggAdapter(EngineAdapter):
         return env
 
 
-# shell_entrypoint=True: the ATOM image is ENTRYPOINT ["/bin/bash"] (vllm/sglang
-# use the host-ionic injector instead), so the launcher must override it.
-disagg_stack = make_disagg_stack_fixture(
-    AtomDisaggAdapter, image=IMAGE, dockerfile=DOCKERFILE, shell_entrypoint=True
-)
+disagg_stack = make_disagg_stack_fixture(AtomDisaggAdapter, image=IMAGE, dockerfile=DOCKERFILE)

--- a/tests/e2e/pd_disag/atom/matrix.py
+++ b/tests/e2e/pd_disag/atom/matrix.py
@@ -15,10 +15,11 @@ import pytest
 
 from ...harness.matrix import GPT_OSS, expand_cases
 
-# [model, tp, ep, dp_attn] (+ optional opts dict: args/env/setup/server_ready_timeout).
+# [enable, model, tp, ep, dp_attn] (+ optional opts: args/env/setup/server_ready_timeout).
 CASES = [
     # Debug: bigger model (gpt-oss-120b), prefill TP=2 + decode TP=2, Mooncake RDMA.
     [
+        True,
         GPT_OSS,
         2,
         False,

--- a/tests/e2e/pd_disag/sglang/matrix.py
+++ b/tests/e2e/pd_disag/sglang/matrix.py
@@ -15,10 +15,11 @@ import pytest
 
 from ...harness.matrix import GPT_OSS, expand_cases
 
-# [model, tp, ep, dp_attn] (+ optional opts dict: args/env/setup/server_ready_timeout).
+# [enable, model, tp, ep, dp_attn] (+ optional opts: args/env/setup/server_ready_timeout).
 CASES = [
     # gpt-oss-120b, prefill TP=2 + decode TP=2, KV over Mooncake RDMA.
     [
+        True,
         GPT_OSS,
         2,
         False,

--- a/tests/e2e/pd_disag/sglang/matrix.py
+++ b/tests/e2e/pd_disag/sglang/matrix.py
@@ -17,9 +17,7 @@ from ...harness.matrix import GPT_OSS, expand_cases
 
 # [model, tp, ep, dp_attn] (+ optional opts dict: args/env/setup/server_ready_timeout).
 CASES = [
-    # Debug: bigger model (gpt-oss-120b). Larger weights leave a smaller KV pool,
-    # so Mooncake's RDMA registration may stay under ionic's 2 GiB ibv_reg_mr cap
-    # that the small-model case tripped.
+    # gpt-oss-120b, prefill TP=2 + decode TP=2, KV over Mooncake RDMA.
     [
         GPT_OSS,
         2,
@@ -28,7 +26,7 @@ CASES = [
         {
             "env": {"SGLANG_USE_AITER": "1"},
             "server_ready_timeout": 1800,
-            "args": ["--mem-fraction-static", "0.5"],
+            "args": ["--mem-fraction-static", "0.9"],
         },
     ],
 ]

--- a/tests/e2e/pd_disag/vllm/conftest.py
+++ b/tests/e2e/pd_disag/vllm/conftest.py
@@ -34,19 +34,6 @@ DOCKERFILE = "deploy/docker/Dockerfile.vllm"
 # _compute_disagg_meta). Both roles set it; they're on different nodes.
 _BOOTSTRAP_PORT = "8998"
 
-# Per-case KV connector selector. A case opts INTO MoRIIO by setting
-# extra_env={_KV_CONNECTOR_ENV: "MoRIIOConnector"} in its matrix row; absent it,
-# the connector defaults to Mooncake so every existing case is byte-for-byte
-# unchanged. The key is consumed here (to shape argv/env) and stripped from the
-# worker's actual env — the worker never sees it.
-_KV_CONNECTOR_ENV = "INFERA_E2E_KV_CONNECTOR"
-
-# MoRIIO fixed control ports (host-networked, one PD stack per node pair; freed by
-# the RDMA teardown between runs). host_ip/http_port/proxy_ip are derived per-role.
-_MORIIO_PROXY_PING_PORT = 36000
-_MORIIO_HANDSHAKE_PORT = 36100
-_MORIIO_NOTIFY_PORT = 36200
-
 
 class VllmDisaggAdapter(EngineAdapter):
     engine = "vllm"
@@ -106,29 +93,7 @@ class VllmDisaggAdapter(EngineAdapter):
             argv += ["--tensor-parallel-size", str(tp)]
         argv += ["--max-num-seqs", "64"]
 
-        connector = dict(params.extra_env).get(_KV_CONNECTOR_ENV, "MooncakeConnector")
-        if connector == "MoRIIOConnector":
-            # MoRIIO carries all its coordination in extra_config (the router forges
-            # the request_id from the workers' handshake/notify ports it reads back
-            # from etcd — see infera/router/disagg_protocols/vllm_moriio.py). proxy_ip
-            # is the router/prefill node; http_port is this worker's own HTTP port.
-            proxy_ip = server_ctx["etcd_endpoint"].split(":")[0]
-            kv_cfg = {
-                "kv_connector": "MoRIIOConnector",
-                "kv_role": role.kv_role(),
-                "kv_connector_extra_config": {
-                    "host_ip": advertise_host,
-                    "proxy_ip": proxy_ip,
-                    "proxy_ping_port": _MORIIO_PROXY_PING_PORT,
-                    "http_port": port,
-                    "handshake_port": _MORIIO_HANDSHAKE_PORT,
-                    "notify_port": _MORIIO_NOTIFY_PORT,
-                    "backend": "rdma",
-                    "tp_size": str(tp),
-                },
-            }
-        else:
-            kv_cfg = {"kv_connector": connector, "kv_role": role.kv_role()}
+        kv_cfg = {"kv_connector": "MooncakeConnector", "kv_role": role.kv_role()}
         argv += ["--kv-transfer-config", json.dumps(kv_cfg)]
 
         if params.expert_parallel:
@@ -152,14 +117,7 @@ class VllmDisaggAdapter(EngineAdapter):
             "MC_GID_INDEX": gid_index,
             "VLLM_MOONCAKE_BOOTSTRAP_PORT": _BOOTSTRAP_PORT,
         }
-        case_env = dict(params.extra_env)
-        # MoRIIO reads its GID rail from MORI_IB_GID_INDEX; only set on the MoRIIO
-        # path so the default Mooncake env is untouched.
-        if case_env.get(_KV_CONNECTOR_ENV) == "MoRIIOConnector":
-            env["MORI_IB_GID_INDEX"] = gid_index
-        # The connector selector is consumed by build_disagg_argv, not the worker.
-        case_env.pop(_KV_CONNECTOR_ENV, None)
-        env.update(case_env)
+        env.update(dict(params.extra_env))
         return env
 
 

--- a/tests/e2e/pd_disag/vllm/matrix.py
+++ b/tests/e2e/pd_disag/vllm/matrix.py
@@ -7,64 +7,26 @@
 row/axis semantics as the PD-mixed grids (see harness/matrix.py).
 
 Add a case = add ONE row. Each row spawns a cross-node prefill+decode pair for
-that model/knobs. Keep the default case tiny (Qwen3-0.6B, tp1) so a PD smoke run
-is fast; larger models go in their own rows with per-case ``opts``.
+that model/knobs.
 """
 
 from __future__ import annotations
 
 import pytest
 
-from ...harness.matrix import GLM_5_1_FP8, QWEN3_0_6B, expand_cases
+from ...harness.matrix import GPT_OSS, expand_cases
 
 # [model, tp, ep, dp_attn] (+ optional opts dict: args/env/setup/server_ready_timeout).
 CASES = [
-    # Small dense smoke case: 1 prefill GPU + 1 decode GPU, Mooncake RDMA.
-    # server_ready_timeout is generous for cross-node cold start + bootstrap.
-    # gpu-memory-utilization is capped per-case: Mooncake pins/registers the WHOLE
-    # KV reservation for RDMA, so it's bounded by (a) ionic's ibv_reg_mr ceiling
-    # (tp=1: 0.5 ~142 GiB OK, >=0.6 segfaults) and (b) at tp>1 an extra registered
-    # buffer per GPU (tp=2 @0.5 OOMs; 0.4 fits). This is a transport constraint, not
-    # a tunable — the usual 0.7-0.9 can't apply when the full KV must be RDMA-pinned.
+    # gpt-oss-120b, prefill TP=2 + decode TP=2, KV over Mooncake RDMA.
     [
-        QWEN3_0_6B,
+        GPT_OSS,
         2,
         False,
         False,
-        {"server_ready_timeout": 900, "args": ["--gpu-memory-utilization", "0.4"]},
-    ],
-    # GLM-5.1-FP8 over the MoRIIO connector (NOT Mooncake) — the regression guard for
-    # the moriio_layout.py MLA page-length fix (patch_moriio_pagelen.py). MoRIIO is
-    # opted into explicitly via env[INFERA_E2E_KV_CONNECTOR]; without it the disagg
-    # adapter defaults to Mooncake, so this is the only MoRIIO case and no other model
-    # gets a MoRIIO variant. GlmMoeDsa = block-scaled fp8 MLA + DSA lightning indexer,
-    # the exact layout the page-len bug corrupted. args mirror the verified launch
-    # recipe (fp8 KV, aiter MoE, glm45 reasoning parser); timeout covers CG capture.
-    [
-        GLM_5_1_FP8,
-        4,
-        False,
-        False,
         {
-            "env": {"INFERA_E2E_KV_CONNECTOR": "MoRIIOConnector"},
-            "args": [
-                "--kv-cache-dtype",
-                "fp8",
-                "--moe-backend",
-                "aiter",
-                "--reasoning-parser",
-                "glm45",
-                "--no-enable-prefix-caching",
-                "--gpu-memory-utilization",
-                "0.85",
-                "--max-model-len",
-                "9472",
-                "--max-num-batched-tokens",
-                "8192",
-                "--distributed-executor-backend",
-                "mp",
-            ],
             "server_ready_timeout": 1800,
+            "args": ["--gpu-memory-utilization", "0.9"],
         },
     ],
 ]

--- a/tests/e2e/pd_disag/vllm/matrix.py
+++ b/tests/e2e/pd_disag/vllm/matrix.py
@@ -16,10 +16,11 @@ import pytest
 
 from ...harness.matrix import GPT_OSS, expand_cases
 
-# [model, tp, ep, dp_attn] (+ optional opts dict: args/env/setup/server_ready_timeout).
+# [enable, model, tp, ep, dp_attn] (+ optional opts: args/env/setup/server_ready_timeout).
 CASES = [
     # gpt-oss-120b, prefill TP=2 + decode TP=2, KV over Mooncake RDMA.
     [
+        True,
         GPT_OSS,
         2,
         False,

--- a/tests/e2e/pd_mixed/atom/matrix.py
+++ b/tests/e2e/pd_mixed/atom/matrix.py
@@ -8,14 +8,16 @@ for the row/axis semantics)."""
 
 from __future__ import annotations
 
+from numpy._core.numeric import False_
 import pytest
 
-from ...harness.matrix import GPT_OSS, KIMI_K26_MXFP4, expand_cases
+from ...harness.matrix import DEEPSEEK_V4_PRO, GLM_5_1_FP8, GPT_OSS, KIMI_K26_MXFP4, expand_cases
 
-# [model, tp, ep, dp_attn] (+ optional opts dict). Opts mirror the matching
-# InferenceX single_node/fixed_seq_len benchmarks.
+# [enable, model, tp, ep, dp_attn] (+ optional opts dict). Opts mirror the
+# matching InferenceX single_node/fixed_seq_len benchmarks.
 CASES = [
     [
+        True,
         GPT_OSS,
         2,
         (True, False),
@@ -34,6 +36,7 @@ CASES = [
         },
     ],
     [
+        True,
         KIMI_K26_MXFP4,
         4,
         False,
@@ -41,6 +44,57 @@ CASES = [
         {
             "args": ["--kv_cache_dtype", "fp8", "--trust-remote-code"],
             "env": {"OMP_NUM_THREADS": "1"},
+            "server_ready_timeout": 1800,
+        },
+    ],
+    [
+        False,
+        DEEPSEEK_V4_PRO,
+        8,
+        False,
+        False,
+        {
+            "args": [
+                "--kv_cache_dtype",
+                "fp8",
+                "--max-model-len",
+                "16384",
+                "--gpu-memory-utilization",
+                "0.9",
+                "--cudagraph-capture-sizes",
+                "[1,2,4,8]",
+                "--hf-overrides",
+                '{"use_index_cache": true, "index_topk_freq": 4}',
+                "--trust-remote-code",
+            ],
+            "env": {
+                "OMP_NUM_THREADS": "1",
+                "ATOM_DISABLE_MMAP": "true",
+                "AITER_BF16_FP8_MOE_BOUND": "0",
+                "ATOM_MOE_GU_ITLV": "1",
+                "INFERA_ATOM_READY_TIMEOUT": "2700",
+            },
+            # ~25min weight load (mmap off) + cudagraph capture; INFERA_ATOM_READY_TIMEOUT
+            # is set to 2700s above (default is 1800s) so the worker doesn't time out early.
+            "server_ready_timeout": 2700,
+        },
+    ],
+    # GLM-5.1-FP8 (GlmMoeDsa = MLA + DSA lightning indexer, tp4). ATOM loads
+    # GlmMoeDsaForCausalLM natively (allocates the MLA chunked-prefill workspaces).
+    # Minimal ON PURPOSE: fp8 KV is enough; NO --method mtp (GLM ships no MTP/nextn
+    # draft weights, and gfx950 plain decode is correct — the gfx942 broken-plain-
+    # decode bug that forced MTP on DSv4 does not reproduce). GLM ships chat_template
+    # so /v1/chat/completions works. Verified 2026-07-23 single-node, temp=0:
+    # France->Paris/China->Beijing/2+2->4 (thinking disabled in the probe).
+    [
+        False,
+        GLM_5_1_FP8,
+        4,
+        False,
+        False,
+        {
+            "args": ["--kv_cache_dtype", "fp8", "--trust-remote-code"],
+            "env": {"OMP_NUM_THREADS": "1", "HSA_NO_SCRATCH_RECLAIM": "1"},
             "server_ready_timeout": 1800,
         },
     ],

--- a/tests/e2e/pd_mixed/atom/matrix.py
+++ b/tests/e2e/pd_mixed/atom/matrix.py
@@ -44,37 +44,37 @@ CASES = [
             "server_ready_timeout": 1800,
         },
     ],
-    [
-        DEEPSEEK_V4_PRO,
-        8,
-        False,
-        False,
-        {
-            "args": [
-                "--kv_cache_dtype",
-                "fp8",
-                "--max-model-len",
-                "16384",
-                "--gpu-memory-utilization",
-                "0.9",
-                "--cudagraph-capture-sizes",
-                "[1,2,4,8]",
-                "--hf-overrides",
-                '{"use_index_cache": true, "index_topk_freq": 4}',
-                "--trust-remote-code",
-            ],
-            "env": {
-                "OMP_NUM_THREADS": "1",
-                "ATOM_DISABLE_MMAP": "true",
-                "AITER_BF16_FP8_MOE_BOUND": "0",
-                "ATOM_MOE_GU_ITLV": "1",
-                "INFERA_ATOM_READY_TIMEOUT": "2700",
-            },
-            # ~25min weight load (mmap off) + cudagraph capture; INFERA_ATOM_READY_TIMEOUT
-            # is set to 2700s above (default is 1800s) so the worker doesn't time out early.
-            "server_ready_timeout": 2700,
-        },
-    ],
+    # [
+    #     DEEPSEEK_V4_PRO,
+    #     8,
+    #     False,
+    #     False,
+    #     {
+    #         "args": [
+    #             "--kv_cache_dtype",
+    #             "fp8",
+    #             "--max-model-len",
+    #             "16384",
+    #             "--gpu-memory-utilization",
+    #             "0.9",
+    #             "--cudagraph-capture-sizes",
+    #             "[1,2,4,8]",
+    #             "--hf-overrides",
+    #             '{"use_index_cache": true, "index_topk_freq": 4}',
+    #             "--trust-remote-code",
+    #         ],
+    #         "env": {
+    #             "OMP_NUM_THREADS": "1",
+    #             "ATOM_DISABLE_MMAP": "true",
+    #             "AITER_BF16_FP8_MOE_BOUND": "0",
+    #             "ATOM_MOE_GU_ITLV": "1",
+    #             "INFERA_ATOM_READY_TIMEOUT": "2700",
+    #         },
+    #         # ~25min weight load (mmap off) + cudagraph capture; INFERA_ATOM_READY_TIMEOUT
+    #         # is set to 2700s above (default is 1800s) so the worker doesn't time out early.
+    #         "server_ready_timeout": 2700,
+    #     },
+    # ],
     # GLM-5.1-FP8 (GlmMoeDsa = MLA + DSA lightning indexer, tp4). ATOM loads
     # GlmMoeDsaForCausalLM natively (allocates the MLA chunked-prefill workspaces).
     # Minimal ON PURPOSE: fp8 KV is enough; NO --method mtp (GLM ships no MTP/nextn
@@ -82,17 +82,17 @@ CASES = [
     # decode bug that forced MTP on DSv4 does not reproduce). GLM ships chat_template
     # so /v1/chat/completions works. Verified 2026-07-23 single-node, temp=0:
     # France->Paris/China->Beijing/2+2->4 (thinking disabled in the probe).
-    [
-        GLM_5_1_FP8,
-        4,
-        False,
-        False,
-        {
-            "args": ["--kv_cache_dtype", "fp8", "--trust-remote-code"],
-            "env": {"OMP_NUM_THREADS": "1", "HSA_NO_SCRATCH_RECLAIM": "1"},
-            "server_ready_timeout": 1800,
-        },
-    ],
+    # [
+    #     GLM_5_1_FP8,
+    #     4,
+    #     False,
+    #     False,
+    #     {
+    #         "args": ["--kv_cache_dtype", "fp8", "--trust-remote-code"],
+    #         "env": {"OMP_NUM_THREADS": "1", "HSA_NO_SCRATCH_RECLAIM": "1"},
+    #         "server_ready_timeout": 1800,
+    #     },
+    # ],
 ]
 
 

--- a/tests/e2e/pd_mixed/atom/matrix.py
+++ b/tests/e2e/pd_mixed/atom/matrix.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import pytest
 
-from ...harness.matrix import DEEPSEEK_V4_PRO, GLM_5_1_FP8, GPT_OSS, KIMI_K26_MXFP4, expand_cases
+from ...harness.matrix import GPT_OSS, KIMI_K26_MXFP4, expand_cases
 
 # [model, tp, ep, dp_attn] (+ optional opts dict). Opts mirror the matching
 # InferenceX single_node/fixed_seq_len benchmarks.

--- a/tests/e2e/pd_mixed/atom/matrix.py
+++ b/tests/e2e/pd_mixed/atom/matrix.py
@@ -18,7 +18,7 @@ CASES = [
     [
         GPT_OSS,
         2,
-        False,
+        (True, False),
         False,
         {
             "args": [
@@ -36,7 +36,7 @@ CASES = [
     [
         KIMI_K26_MXFP4,
         4,
-        (True, False),
+        False,
         False,
         {
             "args": ["--kv_cache_dtype", "fp8", "--trust-remote-code"],
@@ -44,55 +44,6 @@ CASES = [
             "server_ready_timeout": 1800,
         },
     ],
-    # [
-    #     DEEPSEEK_V4_PRO,
-    #     8,
-    #     False,
-    #     False,
-    #     {
-    #         "args": [
-    #             "--kv_cache_dtype",
-    #             "fp8",
-    #             "--max-model-len",
-    #             "16384",
-    #             "--gpu-memory-utilization",
-    #             "0.9",
-    #             "--cudagraph-capture-sizes",
-    #             "[1,2,4,8]",
-    #             "--hf-overrides",
-    #             '{"use_index_cache": true, "index_topk_freq": 4}',
-    #             "--trust-remote-code",
-    #         ],
-    #         "env": {
-    #             "OMP_NUM_THREADS": "1",
-    #             "ATOM_DISABLE_MMAP": "true",
-    #             "AITER_BF16_FP8_MOE_BOUND": "0",
-    #             "ATOM_MOE_GU_ITLV": "1",
-    #             "INFERA_ATOM_READY_TIMEOUT": "2700",
-    #         },
-    #         # ~25min weight load (mmap off) + cudagraph capture; INFERA_ATOM_READY_TIMEOUT
-    #         # is set to 2700s above (default is 1800s) so the worker doesn't time out early.
-    #         "server_ready_timeout": 2700,
-    #     },
-    # ],
-    # GLM-5.1-FP8 (GlmMoeDsa = MLA + DSA lightning indexer, tp4). ATOM loads
-    # GlmMoeDsaForCausalLM natively (allocates the MLA chunked-prefill workspaces).
-    # Minimal ON PURPOSE: fp8 KV is enough; NO --method mtp (GLM ships no MTP/nextn
-    # draft weights, and gfx950 plain decode is correct — the gfx942 broken-plain-
-    # decode bug that forced MTP on DSv4 does not reproduce). GLM ships chat_template
-    # so /v1/chat/completions works. Verified 2026-07-23 single-node, temp=0:
-    # France->Paris/China->Beijing/2+2->4 (thinking disabled in the probe).
-    # [
-    #     GLM_5_1_FP8,
-    #     4,
-    #     False,
-    #     False,
-    #     {
-    #         "args": ["--kv_cache_dtype", "fp8", "--trust-remote-code"],
-    #         "env": {"OMP_NUM_THREADS": "1", "HSA_NO_SCRATCH_RECLAIM": "1"},
-    #         "server_ready_timeout": 1800,
-    #     },
-    # ],
 ]
 
 

--- a/tests/e2e/pd_mixed/sglang/matrix.py
+++ b/tests/e2e/pd_mixed/sglang/matrix.py
@@ -10,19 +10,19 @@ from __future__ import annotations
 
 import pytest
 
-from ...harness.matrix import DEEPSEEK_V4_PRO, KIMI_K26_MXFP4, expand_cases
+from ...harness.matrix import GPT_OSS, KIMI_K26_MXFP4, expand_cases
 
 # [model, tp, ep, dp_attn] (+ optional opts dict). A tuple/list on an axis
 # enumerates it (e.g. (True, False) runs both). MoE models can exercise ep.
 CASES = [
     # gpt-oss-120b: tp2, ep on/off.
-    # [
-    #     GPT_OSS,
-    #     2,
-    #     (True, False),
-    #     False,
-    #     {"env": {"SGLANG_USE_AITER": "1"}, "server_ready_timeout": 1800},
-    # ],
+    [
+        GPT_OSS,
+        2,
+        (True, False),
+        False,
+        {"env": {"SGLANG_USE_AITER": "1"}, "server_ready_timeout": 1800},
+    ],
     [
         KIMI_K26_MXFP4,
         4,
@@ -39,77 +39,6 @@ CASES = [
             "server_ready_timeout": 1800,
         },
     ],
-    # DeepSeek-V4-Pro (MoE, tp8): --attention-backend dsv4 selects the DSv4 sparse
-    # attention; the SGLANG_OPT_*/AITER env is its FP8 config. tp from the adapter.
-    [
-        DEEPSEEK_V4_PRO,
-        8,
-        False,
-        False,
-        {
-            "args": [
-                "--attention-backend",
-                "dsv4",
-                "--page-size",
-                "256",
-                "--disable-radix-cache",
-                "--disable-shared-experts-fusion",
-                "--swa-full-tokens-ratio",
-                "0.15",
-                "--mem-fraction-static",
-                "0.90",
-                "--chunked-prefill-size",
-                "8192",
-                "--model-loader-extra-config",
-                '{"enable_multithread_load": true, "num_threads": 8}',
-            ],
-            "env": {
-                "SGLANG_USE_AITER": "1",
-                "AITER_BF16_FP8_MOE_BOUND": "0",
-                "SGLANG_OPT_FP8_WO_A_GEMM": "0",
-                "SGLANG_OPT_DEEPGEMM_HC_PRENORM": "0",
-                "SGLANG_OPT_USE_AITER_INDEXER": "1",
-                "SGLANG_OPT_USE_TOPK_V2": "0",
-                "SGLANG_FP8_PAGED_MQA_LOGITS_TORCH": "1",
-                "SGLANG_OPT_USE_FUSED_PAGED_COMPRESS": "1",
-                "SGLANG_HACK_FLASHMLA_BACKEND": "unified_kv_triton",
-                "SGLANG_OPT_USE_MULTI_STREAM_OVERLAP": "false",
-                "SGLANG_ROCM_USE_MULTI_STREAM": "false",
-                "SGLANG_OPT_USE_FUSED_COMPRESS": "true",
-                "SGLANG_OPT_USE_FUSED_COMPRESS_TRITON": "true",
-                "SGLANG_EAGER_INPUT_NO_COPY": "true",
-                "SGLANG_USE_ROCM700A": "0",
-                "SGLANG_OPT_USE_JIT_INDEXER_METADATA": "false",
-                "SGLANG_OPT_USE_TILELANG_INDEXER": "false",
-                "SGLANG_OPT_USE_TILELANG_MHC_PRE": "false",
-                "SGLANG_OPT_USE_TILELANG_MHC_POST": "false",
-            },
-            "server_ready_timeout": 2400,
-        },
-    ],
-    # GLM-5.1-FP8 (GlmMoeDsa = MLA + DSA lightning indexer, tp4). Minimal ON PURPOSE:
-    # SGLang routes GlmMoeDsaForCausalLM through the DeepSeek MLA+DSA path and
-    # auto-selects attention_backend=dsa / page_size=64 / tilelang / kv bf16 — do NOT
-    # force the DSv4 flags (--attention-backend dsv4, --page-size 256), they fight the
-    # auto-config. --reasoning-parser glm45 splits GLM reasoning_content; AITER on.
-    # Verified 2026-07-23 single-node mix, temp=0: France->Paris/China->Beijing/2+2->4.
-    # Long timeout covers the ~8-10 min silent tilelang-JIT + aiter-GEMM-tuning window.
-    # [
-    #     GLM_5_1_FP8,
-    #     4,
-    #     False,
-    #     False,
-    #     {
-    #         "args": [
-    #             "--reasoning-parser",
-    #             "glm45",
-    #             "--mem-fraction-static",
-    #             "0.85",
-    #         ],
-    #         "env": {"SGLANG_USE_AITER": "1"},
-    #         "server_ready_timeout": 1800,
-    #     },
-    # ],
 ]
 
 

--- a/tests/e2e/pd_mixed/sglang/matrix.py
+++ b/tests/e2e/pd_mixed/sglang/matrix.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import pytest
 
-from ...harness.matrix import DEEPSEEK_V4_PRO, GLM_5_1_FP8, GPT_OSS, KIMI_K26_MXFP4, expand_cases
+from ...harness.matrix import DEEPSEEK_V4_PRO, KIMI_K26_MXFP4, expand_cases
 
 # [model, tp, ep, dp_attn] (+ optional opts dict). A tuple/list on an axis
 # enumerates it (e.g. (True, False) runs both). MoE models can exercise ep.

--- a/tests/e2e/pd_mixed/sglang/matrix.py
+++ b/tests/e2e/pd_mixed/sglang/matrix.py
@@ -16,13 +16,13 @@ from ...harness.matrix import DEEPSEEK_V4_PRO, GLM_5_1_FP8, GPT_OSS, KIMI_K26_MX
 # enumerates it (e.g. (True, False) runs both). MoE models can exercise ep.
 CASES = [
     # gpt-oss-120b: tp2, ep on/off.
-    [
-        GPT_OSS,
-        2,
-        (True, False),
-        False,
-        {"env": {"SGLANG_USE_AITER": "1"}, "server_ready_timeout": 1800},
-    ],
+    # [
+    #     GPT_OSS,
+    #     2,
+    #     (True, False),
+    #     False,
+    #     {"env": {"SGLANG_USE_AITER": "1"}, "server_ready_timeout": 1800},
+    # ],
     [
         KIMI_K26_MXFP4,
         4,
@@ -94,22 +94,22 @@ CASES = [
     # auto-config. --reasoning-parser glm45 splits GLM reasoning_content; AITER on.
     # Verified 2026-07-23 single-node mix, temp=0: France->Paris/China->Beijing/2+2->4.
     # Long timeout covers the ~8-10 min silent tilelang-JIT + aiter-GEMM-tuning window.
-    [
-        GLM_5_1_FP8,
-        4,
-        False,
-        False,
-        {
-            "args": [
-                "--reasoning-parser",
-                "glm45",
-                "--mem-fraction-static",
-                "0.85",
-            ],
-            "env": {"SGLANG_USE_AITER": "1"},
-            "server_ready_timeout": 1800,
-        },
-    ],
+    # [
+    #     GLM_5_1_FP8,
+    #     4,
+    #     False,
+    #     False,
+    #     {
+    #         "args": [
+    #             "--reasoning-parser",
+    #             "glm45",
+    #             "--mem-fraction-static",
+    #             "0.85",
+    #         ],
+    #         "env": {"SGLANG_USE_AITER": "1"},
+    #         "server_ready_timeout": 1800,
+    #     },
+    # ],
 ]
 
 

--- a/tests/e2e/pd_mixed/sglang/matrix.py
+++ b/tests/e2e/pd_mixed/sglang/matrix.py
@@ -10,13 +10,14 @@ from __future__ import annotations
 
 import pytest
 
-from ...harness.matrix import GPT_OSS, KIMI_K26_MXFP4, expand_cases
+from ...harness.matrix import DEEPSEEK_V4_PRO, GLM_5_1_FP8, GPT_OSS, KIMI_K26_MXFP4, expand_cases
 
-# [model, tp, ep, dp_attn] (+ optional opts dict). A tuple/list on an axis
+# [enable, model, tp, ep, dp_attn] (+ optional opts dict). A tuple/list on an axis
 # enumerates it (e.g. (True, False) runs both). MoE models can exercise ep.
 CASES = [
     # gpt-oss-120b: tp2, ep on/off.
     [
+        True,
         GPT_OSS,
         2,
         (True, False),
@@ -24,6 +25,7 @@ CASES = [
         {"env": {"SGLANG_USE_AITER": "1"}, "server_ready_timeout": 1800},
     ],
     [
+        True,
         KIMI_K26_MXFP4,
         4,
         True,
@@ -36,6 +38,80 @@ CASES = [
                 "--model-loader-extra-config",
                 '{"enable_multithread_load": true, "num_threads": 8}',
             ],
+            "server_ready_timeout": 1800,
+        },
+    ],
+    # DeepSeek-V4-Pro (MoE, tp8): --attention-backend dsv4 selects the DSv4 sparse
+    # attention; the SGLANG_OPT_*/AITER env is its FP8 config. tp from the adapter.
+    [
+        False,
+        DEEPSEEK_V4_PRO,
+        8,
+        False,
+        False,
+        {
+            "args": [
+                "--attention-backend",
+                "dsv4",
+                "--page-size",
+                "256",
+                "--disable-radix-cache",
+                "--disable-shared-experts-fusion",
+                "--swa-full-tokens-ratio",
+                "0.15",
+                "--mem-fraction-static",
+                "0.90",
+                "--chunked-prefill-size",
+                "8192",
+                "--model-loader-extra-config",
+                '{"enable_multithread_load": true, "num_threads": 8}',
+            ],
+            "env": {
+                "SGLANG_USE_AITER": "1",
+                "AITER_BF16_FP8_MOE_BOUND": "0",
+                "SGLANG_OPT_FP8_WO_A_GEMM": "0",
+                "SGLANG_OPT_DEEPGEMM_HC_PRENORM": "0",
+                "SGLANG_OPT_USE_AITER_INDEXER": "1",
+                "SGLANG_OPT_USE_TOPK_V2": "0",
+                "SGLANG_FP8_PAGED_MQA_LOGITS_TORCH": "1",
+                "SGLANG_OPT_USE_FUSED_PAGED_COMPRESS": "1",
+                "SGLANG_HACK_FLASHMLA_BACKEND": "unified_kv_triton",
+                "SGLANG_OPT_USE_MULTI_STREAM_OVERLAP": "false",
+                "SGLANG_ROCM_USE_MULTI_STREAM": "false",
+                "SGLANG_OPT_USE_FUSED_COMPRESS": "true",
+                "SGLANG_OPT_USE_FUSED_COMPRESS_TRITON": "true",
+                "SGLANG_EAGER_INPUT_NO_COPY": "true",
+                "SGLANG_USE_ROCM700A": "0",
+                "SGLANG_OPT_USE_JIT_INDEXER_METADATA": "false",
+                "SGLANG_OPT_USE_TILELANG_INDEXER": "false",
+                "SGLANG_OPT_USE_TILELANG_MHC_PRE": "false",
+                "SGLANG_OPT_USE_TILELANG_MHC_POST": "false",
+            },
+            "server_ready_timeout": 2400,
+        },
+    ],
+    # GLM-5.1-FP8 (GlmMoeDsa = MLA + DSA lightning indexer, tp4). Minimal ON PURPOSE:
+    # SGLang routes GlmMoeDsaForCausalLM through the DeepSeek MLA+DSA path and
+    # auto-selects attention_backend=dsa / page_size=64 / tilelang / kv bf16 — do NOT
+    # force the DSv4 flags (--attention-backend dsv4, --page-size 256), they fight the
+    # auto-config. --reasoning-parser glm45 splits GLM reasoning_content; AITER on.
+    # Verified 2026-07-23 single-node mix, temp=0: France->Paris/China->Beijing/2+2->4.
+    # Long timeout covers the ~8-10 min silent tilelang-JIT + aiter-GEMM-tuning window.
+    [
+        False,
+        GLM_5_1_FP8,
+        4,
+        False,
+        False,
+        {
+            "args": [
+                "--reasoning-parser",
+                "glm45",
+                "--mem-fraction-static",
+                "0.85",
+                '{"enable_multithread_load": true, "num_threads": 8}',
+            ],
+            "env": {"SGLANG_USE_AITER": "1"},
             "server_ready_timeout": 1800,
         },
     ],

--- a/tests/e2e/pd_mixed/vllm/matrix.py
+++ b/tests/e2e/pd_mixed/vllm/matrix.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 
 import pytest
 
-from ...harness.matrix import KIMI_K26_MXFP4, QWEN3_8B, expand_cases
+from ...harness.matrix import DEEPSEEK_V4_PRO, GLM_5_1_FP8, KIMI_K26_MXFP4, QWEN3_8B, expand_cases
 
-# [model, tp, ep, dp_attn] (+ optional opts dict). Opts mirror the matching
-# InferenceX single_node/fixed_seq_len benchmarks.
+# [enable, model, tp, ep, dp_attn] (+ optional opts dict). Opts mirror the
+# matching InferenceX single_node/fixed_seq_len benchmarks.
 CASES = [
     [
+        True,
         QWEN3_8B,
         2,
         False,
@@ -26,6 +27,7 @@ CASES = [
         },
     ],
     [
+        True,
         KIMI_K26_MXFP4,
         4,
         False,
@@ -50,6 +52,87 @@ CASES = [
             # MXFP4 needs amd-quark; the vllm image already ships it, this is a
             # safety net mirroring the InferenceX recipe (no-op if present).
             "setup": ["pip install amd-quark"],
+            "server_ready_timeout": 1800,
+        },
+    ],
+    # DeepSeek-V4-Pro (MoE, tp8): DSv4 needs the deepseek_v4 tokenizer + reasoning
+    # parser; aiter MoE backend + fp8 KV are its config. tp from the adapter.
+    [
+        False,
+        DEEPSEEK_V4_PRO,
+        8,
+        False,
+        False,
+        {
+            "args": [
+                "--kv-cache-dtype",
+                "fp8",
+                "--moe-backend",
+                "aiter",
+                "--tokenizer-mode",
+                "deepseek_v4",
+                "--reasoning-parser",
+                "deepseek_v4",
+                "--no-enable-prefix-caching",
+                "--gpu-memory-utilization",
+                "0.90",
+                "--max-model-len",
+                "9472",
+                "--max-num-batched-tokens",
+                "8192",
+                "--max-num-seqs",
+                "128",
+                "--distributed-executor-backend",
+                "mp",
+                "--disable-hybrid-kv-cache-manager",
+                "--async-scheduling",
+                "--compilation-config",
+                '{"max_cudagraph_capture_size":128}',
+            ],
+            "env": {
+                "VLLM_USE_V1": "1",
+                "VLLM_ROCM_USE_AITER": "1",
+                "AITER_BF16_FP8_MOE_BOUND": "0",
+                "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS": "1",
+                "PYTHONHASHSEED": "0",
+            },
+            "server_ready_timeout": 2400,
+        },
+    ],
+    # GLM-5.1-FP8 (GlmMoeDsa = MLA + DSA lightning indexer, tp4). vLLM v0.25.1 serves
+    # it via the DeepSeek MLA path; fp8 KV + aiter (via env) + the glm45 reasoning
+    # parser is its config. Single-node mix uses NO kv-transfer connector (that's the
+    # pd_disag/vllm MoRIIO/Mooncake path). Verified 2026-07-23 single-node mix, temp=0
+    # (thinking disabled): France->Paris/China->Beijing/2+2->4.
+    [
+        False,
+        GLM_5_1_FP8,
+        4,
+        False,
+        False,
+        {
+            "args": [
+                "--kv-cache-dtype",
+                "fp8",
+                "--reasoning-parser",
+                "glm45",
+                "--no-enable-prefix-caching",
+                "--gpu-memory-utilization",
+                "0.85",
+                "--max-model-len",
+                "9472",
+                "--max-num-batched-tokens",
+                "8192",
+                "--distributed-executor-backend",
+                "mp",
+            ],
+            "env": {
+                "VLLM_USE_V1": "1",
+                "VLLM_ROCM_USE_AITER": "1",
+                "AITER_BF16_FP8_MOE_BOUND": "0",
+                "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS": "1",
+                "PYTHONHASHSEED": "0",
+            },
             "server_ready_timeout": 1800,
         },
     ],

--- a/tests/e2e/pd_mixed/vllm/matrix.py
+++ b/tests/e2e/pd_mixed/vllm/matrix.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import pytest
 
-from ...harness.matrix import DEEPSEEK_V4_PRO, GLM_5_1_FP8, KIMI_K26_MXFP4, QWEN3_8B, expand_cases
+from ...harness.matrix import DEEPSEEK_V4_PRO, KIMI_K26_MXFP4, expand_cases
 
 # [model, tp, ep, dp_attn] (+ optional opts dict). Opts mirror the matching
 # InferenceX single_node/fixed_seq_len benchmarks.

--- a/tests/e2e/pd_mixed/vllm/matrix.py
+++ b/tests/e2e/pd_mixed/vllm/matrix.py
@@ -10,21 +10,21 @@ from __future__ import annotations
 
 import pytest
 
-from ...harness.matrix import DEEPSEEK_V4_PRO, KIMI_K26_MXFP4, expand_cases
+from ...harness.matrix import KIMI_K26_MXFP4, QWEN3_8B, expand_cases
 
 # [model, tp, ep, dp_attn] (+ optional opts dict). Opts mirror the matching
 # InferenceX single_node/fixed_seq_len benchmarks.
 CASES = [
-    # [
-    #     QWEN3_8B,
-    #     2,
-    #     False,
-    #     False,
-    #     {
-    #         "args": ["--kv-cache-dtype", "fp8"],
-    #         "env": {"VLLM_ROCM_USE_AITER": "1"},
-    #     },
-    # ],
+    [
+        QWEN3_8B,
+        2,
+        False,
+        False,
+        {
+            "args": ["--kv-cache-dtype", "fp8"],
+            "env": {"VLLM_ROCM_USE_AITER": "1"},
+        },
+    ],
     [
         KIMI_K26_MXFP4,
         4,
@@ -53,85 +53,6 @@ CASES = [
             "server_ready_timeout": 1800,
         },
     ],
-    # DeepSeek-V4-Pro (MoE, tp8): DSv4 needs the deepseek_v4 tokenizer + reasoning
-    # parser; aiter MoE backend + fp8 KV are its config. tp from the adapter.
-    [
-        DEEPSEEK_V4_PRO,
-        8,
-        False,
-        False,
-        {
-            "args": [
-                "--kv-cache-dtype",
-                "fp8",
-                "--moe-backend",
-                "aiter",
-                "--tokenizer-mode",
-                "deepseek_v4",
-                "--reasoning-parser",
-                "deepseek_v4",
-                "--no-enable-prefix-caching",
-                "--gpu-memory-utilization",
-                "0.90",
-                "--max-model-len",
-                "9472",
-                "--max-num-batched-tokens",
-                "8192",
-                "--max-num-seqs",
-                "128",
-                "--distributed-executor-backend",
-                "mp",
-                "--disable-hybrid-kv-cache-manager",
-                "--async-scheduling",
-                "--compilation-config",
-                '{"max_cudagraph_capture_size":128}',
-            ],
-            "env": {
-                "VLLM_USE_V1": "1",
-                "VLLM_ROCM_USE_AITER": "1",
-                "AITER_BF16_FP8_MOE_BOUND": "0",
-                "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS": "1",
-                "PYTHONHASHSEED": "0",
-            },
-            "server_ready_timeout": 2400,
-        },
-    ],
-    # GLM-5.1-FP8 (GlmMoeDsa = MLA + DSA lightning indexer, tp4). vLLM v0.25.1 serves
-    # it via the DeepSeek MLA path; fp8 KV + aiter (via env) + the glm45 reasoning
-    # parser is its config. Single-node mix uses NO kv-transfer connector (that's the
-    # pd_disag/vllm MoRIIO/Mooncake path). Verified 2026-07-23 single-node mix, temp=0
-    # (thinking disabled): France->Paris/China->Beijing/2+2->4.
-    # [
-    #     GLM_5_1_FP8,
-    #     4,
-    #     False,
-    #     False,
-    #     {
-    #         "args": [
-    #             "--kv-cache-dtype",
-    #             "fp8",
-    #             "--reasoning-parser",
-    #             "glm45",
-    #             "--no-enable-prefix-caching",
-    #             "--gpu-memory-utilization",
-    #             "0.85",
-    #             "--max-model-len",
-    #             "9472",
-    #             "--max-num-batched-tokens",
-    #             "8192",
-    #             "--distributed-executor-backend",
-    #             "mp",
-    #         ],
-    #         "env": {
-    #             "VLLM_USE_V1": "1",
-    #             "VLLM_ROCM_USE_AITER": "1",
-    #             "AITER_BF16_FP8_MOE_BOUND": "0",
-    #             "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS": "1",
-    #             "PYTHONHASHSEED": "0",
-    #         },
-    #         "server_ready_timeout": 1800,
-    #     },
-    # ],
 ]
 
 

--- a/tests/e2e/pd_mixed/vllm/matrix.py
+++ b/tests/e2e/pd_mixed/vllm/matrix.py
@@ -15,16 +15,16 @@ from ...harness.matrix import DEEPSEEK_V4_PRO, GLM_5_1_FP8, KIMI_K26_MXFP4, QWEN
 # [model, tp, ep, dp_attn] (+ optional opts dict). Opts mirror the matching
 # InferenceX single_node/fixed_seq_len benchmarks.
 CASES = [
-    [
-        QWEN3_8B,
-        2,
-        False,
-        False,
-        {
-            "args": ["--kv-cache-dtype", "fp8"],
-            "env": {"VLLM_ROCM_USE_AITER": "1"},
-        },
-    ],
+    # [
+    #     QWEN3_8B,
+    #     2,
+    #     False,
+    #     False,
+    #     {
+    #         "args": ["--kv-cache-dtype", "fp8"],
+    #         "env": {"VLLM_ROCM_USE_AITER": "1"},
+    #     },
+    # ],
     [
         KIMI_K26_MXFP4,
         4,
@@ -101,37 +101,37 @@ CASES = [
     # parser is its config. Single-node mix uses NO kv-transfer connector (that's the
     # pd_disag/vllm MoRIIO/Mooncake path). Verified 2026-07-23 single-node mix, temp=0
     # (thinking disabled): France->Paris/China->Beijing/2+2->4.
-    [
-        GLM_5_1_FP8,
-        4,
-        False,
-        False,
-        {
-            "args": [
-                "--kv-cache-dtype",
-                "fp8",
-                "--reasoning-parser",
-                "glm45",
-                "--no-enable-prefix-caching",
-                "--gpu-memory-utilization",
-                "0.85",
-                "--max-model-len",
-                "9472",
-                "--max-num-batched-tokens",
-                "8192",
-                "--distributed-executor-backend",
-                "mp",
-            ],
-            "env": {
-                "VLLM_USE_V1": "1",
-                "VLLM_ROCM_USE_AITER": "1",
-                "AITER_BF16_FP8_MOE_BOUND": "0",
-                "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS": "1",
-                "PYTHONHASHSEED": "0",
-            },
-            "server_ready_timeout": 1800,
-        },
-    ],
+    # [
+    #     GLM_5_1_FP8,
+    #     4,
+    #     False,
+    #     False,
+    #     {
+    #         "args": [
+    #             "--kv-cache-dtype",
+    #             "fp8",
+    #             "--reasoning-parser",
+    #             "glm45",
+    #             "--no-enable-prefix-caching",
+    #             "--gpu-memory-utilization",
+    #             "0.85",
+    #             "--max-model-len",
+    #             "9472",
+    #             "--max-num-batched-tokens",
+    #             "8192",
+    #             "--distributed-executor-backend",
+    #             "mp",
+    #         ],
+    #         "env": {
+    #             "VLLM_USE_V1": "1",
+    #             "VLLM_ROCM_USE_AITER": "1",
+    #             "AITER_BF16_FP8_MOE_BOUND": "0",
+    #             "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS": "1",
+    #             "PYTHONHASHSEED": "0",
+    #         },
+    #         "server_ready_timeout": 1800,
+    #     },
+    # ],
 ]
 
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -159,6 +159,20 @@ _candidate_nodes() {
     printf '%s\n' "$run" | grep -qw -- "$n" || echo "$n"
   done
 }
+# Two free nodes, waiting for them rather than giving up: engines run in
+# parallel and the mixed tier shares the pool, so a pair is often only free
+# later. The CI job timeout is the real backstop. $1=exclude list.
+_wait_for_pair() {
+  local excl="$1" waited=0 every=30 limit="${INFERA_E2E_WAIT_NODES_TIMEOUT:-3600}" nodes
+  while :; do
+    nodes="$(_pick_idle_nodes 2 "$excl")"
+    [ "$(printf '%s\n' "$nodes" | sed '/^$/d' | wc -l)" -ge 2 ] && { printf '%s\n' "$nodes"; return 0; }
+    [ "$waited" -ge "$limit" ] && return 1
+    [ $((waited % 120)) -eq 0 ] &&
+      echo "[e2e disagg] fewer than 2 free nodes — waiting (${waited}s/${limit}s)" >&2
+    sleep "$every"; waited=$((waited + every))
+  done
+}
 # Print up to $1 free nodes (one per line), skipping the comma-separated exclude
 # list in $2. Used to place the PD-disagg node pair.
 _pick_idle_nodes() {
@@ -502,12 +516,12 @@ run_e2e_disagg() {
       if [ -n "${INFERA_E2E_NODES:-}" ] && [ "$attempt" -eq 1 ]; then
         n1="${INFERA_E2E_NODES%%,*}"; n2="${INFERA_E2E_NODES##*,}"
       else
-        nodes="$(_pick_idle_nodes 2 "$exclude")"
+        nodes="$(_wait_for_pair "$exclude")"
         n1="$(printf '%s\n' "$nodes" | sed -n 1p)"
         n2="$(printf '%s\n' "$nodes" | sed -n 2p)"
       fi
       if [ -z "$n1" ] || [ -z "$n2" ] || [ "$n1" = "$n2" ]; then
-        echo "[e2e disagg] WARNING: could not find 2 usable idle nodes in '$SLURM_PART' — skipping $e (set INFERA_E2E_SLURM_PARTITION to your cluster's partition)" >&2
+        echo "[e2e disagg] WARNING: no 2 free nodes in '$SLURM_PART' within ${INFERA_E2E_WAIT_NODES_TIMEOUT:-3600}s — skipping $e" >&2
         break
       fi
       echo "[e2e disagg] $e attempt $attempt/$max_attempts on nodes: $n1 (prefill), $n2 (decode)"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -547,9 +547,10 @@ run_e2e_disagg() {
 
   local rc=0 e prc out="$SCRATCH/.e2e-disag.out"
   local max_attempts=3 attempt exclude n1 n2 nodes ok
+  local races max_races="${INFERA_E2E_HOLD_RACE_MAX:-10}"
   for e in "${engines[@]}"; do
     echo "----- e2e disagg — tests/e2e/pd_disag/$e -----"
-    attempt=0; ok=0; exclude=""
+    attempt=0; ok=0; exclude=""; races=0
     while [ "$attempt" -lt "$max_attempts" ]; do
       attempt=$((attempt + 1))
       # A user-pinned pair (INFERA_E2E_NODES) wins on the first try; otherwise
@@ -565,12 +566,22 @@ run_e2e_disagg() {
         echo "[e2e disagg] WARNING: no 2 free nodes in '$SLURM_PART' within ${INFERA_E2E_WAIT_NODES_TIMEOUT:-6400}s — skipping $e" >&2
         break
       fi
-      # Lock the pair before using it; losing the race to another job just means
-      # picking a fresh pair, so it does not burn a real attempt.
+      # Lock the pair before using it. Losing the race to another job is not a
+      # node fault, so the pair must NOT join $exclude: with a small pool the
+      # engine would exclude every node and then starve on a fully idle cluster.
+      # Just re-pick — once the winner's holder is RUNNING, _candidate_nodes
+      # filters its nodes out by itself. Bounded so a pathological loser fails
+      # loudly instead of spinning until the CI job timeout.
       if ! _hold_pair "$n1,$n2"; then
-        echo "[e2e disagg] could not hold $n1,$n2 — trying another pair" >&2
-        exclude="${exclude:+$exclude,}$n1,$n2"; attempt=$((attempt - 1)); continue
+        races=$((races + 1))
+        if [ "$races" -ge "$max_races" ]; then
+          echo "[e2e disagg] lost the node-hold race $races times — giving up on $e" >&2
+          break
+        fi
+        echo "[e2e disagg] could not hold $n1,$n2 (race $races/$max_races) — re-picking in 30s" >&2
+        attempt=$((attempt - 1)); sleep 30; continue
       fi
+      races=0
       echo "[e2e disagg] $e attempt $attempt/$max_attempts on nodes: $n1 (prefill), $n2 (decode)"
       _DISAG_NODES="$n1,$n2"
       INFERA_E2E_NODES="$n1,$n2" INFERA_E2E_SLURM_PARTITION="$SLURM_PART" \

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -201,7 +201,7 @@ _hold_pair() {
 # parallel and the mixed tier shares the pool, so a pair is often only free
 # later. The CI job timeout is the real backstop. $1=exclude list.
 _wait_for_pair() {
-  local excl="$1" waited=0 every=30 limit="${INFERA_E2E_WAIT_NODES_TIMEOUT:-3600}" nodes
+  local excl="$1" waited=0 every=30 limit="${INFERA_E2E_WAIT_NODES_TIMEOUT:-6400}" nodes
   while :; do
     nodes="$(_pick_idle_nodes 2 "$excl")"
     [ "$(printf '%s\n' "$nodes" | sed '/^$/d' | wc -l)" -ge 2 ] && { printf '%s\n' "$nodes"; return 0; }
@@ -562,7 +562,7 @@ run_e2e_disagg() {
         n2="$(printf '%s\n' "$nodes" | sed -n 2p)"
       fi
       if [ -z "$n1" ] || [ -z "$n2" ] || [ "$n1" = "$n2" ]; then
-        echo "[e2e disagg] WARNING: no 2 free nodes in '$SLURM_PART' within ${INFERA_E2E_WAIT_NODES_TIMEOUT:-3600}s — skipping $e" >&2
+        echo "[e2e disagg] WARNING: no 2 free nodes in '$SLURM_PART' within ${INFERA_E2E_WAIT_NODES_TIMEOUT:-6400}s — skipping $e" >&2
         break
       fi
       # Lock the pair before using it; losing the race to another job just means

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -102,8 +102,16 @@ _wipe_disag_nodes() {
   done
   _DISAG_NODES=""
 }
-trap _cleanup_scratch EXIT
-trap '_wipe_disag_nodes; _cancel_dispatched; exit 130' INT TERM
+# SLURM job holding the PD pair's GPUs for the whole run (see _hold_pair).
+_HOLDER_JID=""
+_release_hold() {
+  [ -n "$_HOLDER_JID" ] || return 0
+  echo "[e2e disagg] releasing held nodes (scancel $_HOLDER_JID)" >&2
+  scancel "$_HOLDER_JID" >/dev/null 2>&1 || true
+  _HOLDER_JID=""
+}
+trap '_release_hold; _cleanup_scratch' EXIT
+trap '_wipe_disag_nodes; _release_hold; _cancel_dispatched; exit 130' INT TERM
 echo "[scratch] $SCRATCH  (worker logs: $E2E_LOG_DIR, kept)"
 
 # INFERA_E2E_MODEL_DIR: bind the model tree read-only at the same path + forward
@@ -159,6 +167,36 @@ _candidate_nodes() {
     printf '%s\n' "$run" | grep -qw -- "$n" || echo "$n"
   done
 }
+# Hold both PD nodes' GPUs for the whole run. Unlike the mixed tier, disagg's
+# per-step sruns leave the nodes idle in between, so SLURM hands one to another
+# job and their fixed ports (etcd 2379/2380, router 8000, ...) collide. A
+# --gres=gpu:8 batch job keeps them ours; our own no-gres steps co-schedule.
+# Sets _HOLDER_JID. $1=n1,n2
+_hold_pair() {
+  local pair="$1" script="$SCRATCH/hold.sh" jid st rs waited qos=() i
+  # A real script file, not --wrap: on Spur --wrap always NODE_FAILs at -N2.
+  printf '#!/bin/bash\nsleep %s\n' "${INFERA_E2E_HOLD_SLEEP:-10800}" > "$script"
+  for i in 1 2 3; do
+    jid=$(sbatch --parsable -N2 -n2 -w "$pair" --gres=gpu:8 -p "$SLURM_PART" \
+      -t "$SLURM_TIME" -J "infera-ci-hold-${INFERA_E2E_JOB_TAG:-local}" \
+      ${INFERA_E2E_RESERVATION:+--reservation="$INFERA_E2E_RESERVATION"} \
+      "${qos[@]}" "$script" 2>/dev/null) || continue
+    waited=0
+    while [ "$waited" -lt "$QOS_WAIT" ]; do
+      st=$(scontrol show job "$jid" 2>/dev/null | grep -oE 'JobState=[A-Z_]+' | cut -d= -f2)
+      rs=$(scontrol show job "$jid" 2>/dev/null | grep -oE 'Reason=[A-Za-z]+' | cut -d= -f2)
+      [ "$st" = RUNNING ] && { _HOLDER_JID="$jid"; return 0; }
+      case "$st" in NODE_FAIL | FAILED | CANCELLED) break ;; esac
+      sleep 5; waited=$((waited + 5))
+    done
+    # Read the reason BEFORE cancelling; the burst QoS is the way past a group
+    # node limit, and a launch failure is Spur being flaky — both just retry.
+    [ "${#qos[@]}" -eq 0 ] && [ "${rs#QOSGrp}" != "$rs" ] && qos=(-q "$QOS_FALLBACK")
+    scancel "$jid" >/dev/null 2>&1
+    echo "[e2e disagg] hold attempt $i on $pair not started (${st:-?}/${rs:-?}) — retrying" >&2
+  done
+  return 1
+}
 # Two free nodes, waiting for them rather than giving up: engines run in
 # parallel and the mixed tier shares the pool, so a pair is often only free
 # later. The CI job timeout is the real backstop. $1=exclude list.
@@ -176,12 +214,15 @@ _wait_for_pair() {
 # Print up to $1 free nodes (one per line), skipping the comma-separated exclude
 # list in $2. Used to place the PD-disagg node pair.
 _pick_idle_nodes() {
-  local count="$1" excl=",${2:-}," n out=()
+  local count="$1" excl=",${2:-}," n out=() all
+  # Collect the list first: breaking out of a `< <(...)` mid-stream leaves the
+  # producer writing to a closed pipe, which prints EPIPE noise on every call.
+  all="$(_candidate_nodes)"
   while read -r n; do
     [ -n "$n" ] || continue
     case "$excl" in *,"$n",*) continue ;; esac
     out+=("$n"); [ "${#out[@]}" -ge "$count" ] && break
-  done < <(_candidate_nodes)
+  done <<< "$all"
   printf '%s\n' "${out[@]-}"
 }
 # AMD GPU count on THIS host (one renderD* per GPU; PCI vendor 0x1002 == AMD).
@@ -524,6 +565,12 @@ run_e2e_disagg() {
         echo "[e2e disagg] WARNING: no 2 free nodes in '$SLURM_PART' within ${INFERA_E2E_WAIT_NODES_TIMEOUT:-3600}s — skipping $e" >&2
         break
       fi
+      # Lock the pair before using it; losing the race to another job just means
+      # picking a fresh pair, so it does not burn a real attempt.
+      if ! _hold_pair "$n1,$n2"; then
+        echo "[e2e disagg] could not hold $n1,$n2 — trying another pair" >&2
+        exclude="${exclude:+$exclude,}$n1,$n2"; attempt=$((attempt - 1)); continue
+      fi
       echo "[e2e disagg] $e attempt $attempt/$max_attempts on nodes: $n1 (prefill), $n2 (decode)"
       _DISAG_NODES="$n1,$n2"
       INFERA_E2E_NODES="$n1,$n2" INFERA_E2E_SLURM_PARTITION="$SLURM_PART" \
@@ -532,6 +579,7 @@ run_e2e_disagg() {
           "$REPO/tests/e2e/pd_disag/$e" 2>&1 | tee "$out"
       prc=${PIPESTATUS[0]}
       _DISAG_NODES=""   # pytest returned, so its fixtures already tore the stack down
+      _release_hold
       [ "$prc" -eq 0 ] && { ok=1; break; }
       if grep -qiE 'node failure|Cannot connect to the Docker daemon|could not resolve a routable IP|docker build .* failed' "$out"; then
         exclude="${exclude:+$exclude,}$n1,$n2"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -88,8 +88,22 @@ _cancel_dispatched() {
     [ -z "$(squeue -h -j "$csv" -o '%i' 2>/dev/null)" ] && return 0
   done
 }
+# Nodes the running PD-disagg attempt placed containers on. A killed run skips
+# pytest's fixture teardown, so without this a cancel leaves prefill+decode
+# engines holding both nodes' GPUs.
+_DISAG_NODES=""
+_wipe_disag_nodes() {
+  local n resv="${INFERA_E2E_RESERVATION:+--reservation=$INFERA_E2E_RESERVATION}"
+  for n in ${_DISAG_NODES//,/ }; do
+    echo "[cleanup] removing PD containers on $n" >&2
+    srun -N1 -n1 -p "$SLURM_PART" -w "$n" $resv ${INFERA_E2E_SRUN_EXTRA:-} \
+      bash -lc 'docker rm -f $(docker ps -aq --filter name=infera-e2e-) 2>/dev/null || true' \
+      >/dev/null 2>&1 || true
+  done
+  _DISAG_NODES=""
+}
 trap _cleanup_scratch EXIT
-trap '_cancel_dispatched; exit 130' INT TERM
+trap '_wipe_disag_nodes; _cancel_dispatched; exit 130' INT TERM
 echo "[scratch] $SCRATCH  (worker logs: $E2E_LOG_DIR, kept)"
 
 # INFERA_E2E_MODEL_DIR: bind the model tree read-only at the same path + forward
@@ -115,18 +129,45 @@ _default_partition() {
 }
 SLURM_PART="${INFERA_E2E_SLURM_PARTITION:-$(_default_partition)}"
 SLURM_PART="${SLURM_PART:-amd-spur}"
-SLURM_TIME="${INFERA_E2E_SLURM_TIME:-02:30:00}"
+SLURM_TIME="${INFERA_E2E_SLURM_TIME:-02:00:00}"
+# Burst QoS is a fallback: a dispatch queued this long on the group node limit is
+# resubmitted with it (see _watch_job / _dispatch_slurm), never used up front.
+QOS_FALLBACK="${INFERA_E2E_SLURM_QOS_FALLBACK:-amd-burst-qos}"
+QOS_WAIT="${INFERA_E2E_QOS_WAIT:-60}"
 
 _have_slurm() { command -v srun >/dev/null 2>&1; }
-# Print up to $1 idle nodes in the partition (one per line), skipping the
-# comma-separated exclude list in $2. Used to place the PD-disagg node pair.
+# The nodes reservation $1 covers, one per line ('' if it's gone/expired).
+# Spur ignores the NAME arg and dumps all reservations; match the exact block.
+_reservation_nodes() {
+  scontrol show reservation "$1" 2>/dev/null | awk -v r="ReservationName=$1" '
+    BEGIN{RS="";FS="\n"}
+    $1==r { for(i=1;i<=NF;i++) if($i ~ /Nodes=/){ n=$i; sub(/.*Nodes=/,"",n); sub(/[[:space:]].*/,"",n); print n; exit } }' \
+    | tr ',' '\n' | sed '/^$/d'
+}
+# Free nodes to place the PD-disagg pair on, one per line: the reservation's own
+# (a reserved node reads 'resv', never 'idle', so sinfo would miss it), else the
+# partition's idle ones.
+_candidate_nodes() {
+  local n run nodes=""
+  [ -n "${INFERA_E2E_RESERVATION:-}" ] && nodes="$(_reservation_nodes "$INFERA_E2E_RESERVATION")"
+  if [ -z "$nodes" ]; then
+    sinfo -h -N -p "$SLURM_PART" -t idle -o '%n' 2>/dev/null | awk 'NF && !seen[$0]++'
+    return
+  fi
+  run="$(squeue -h -t running -o '%N' 2>/dev/null)"
+  for n in $nodes; do
+    printf '%s\n' "$run" | grep -qw -- "$n" || echo "$n"
+  done
+}
+# Print up to $1 free nodes (one per line), skipping the comma-separated exclude
+# list in $2. Used to place the PD-disagg node pair.
 _pick_idle_nodes() {
   local count="$1" excl=",${2:-}," n out=()
   while read -r n; do
     [ -n "$n" ] || continue
     case "$excl" in *,"$n",*) continue ;; esac
     out+=("$n"); [ "${#out[@]}" -ge "$count" ] && break
-  done < <(sinfo -h -N -p "$SLURM_PART" -t idle -o '%n' 2>/dev/null | awk 'NF && !seen[$0]++')
+  done < <(_candidate_nodes)
   printf '%s\n' "${out[@]-}"
 }
 # AMD GPU count on THIS host (one renderD* per GPU; PCI vendor 0x1002 == AMD).
@@ -148,12 +189,8 @@ _local_eligible() { [ "$(_amd_gpu_count)" -ge 8 ] && command -v docker >/dev/nul
 _reservation_free() {
   local rname="$1" nodes run n free=0
   command -v scontrol >/dev/null 2>&1 || { echo -2; return; }
-  # Spur ignores the NAME arg and dumps all reservations; match the exact block.
-  nodes=$(scontrol show reservation "$rname" 2>/dev/null | awk -v r="ReservationName=$rname" '
-    BEGIN{RS="";FS="\n"}
-    $1==r { for(i=1;i<=NF;i++) if($i ~ /Nodes=/){ n=$i; sub(/.*Nodes=/,"",n); sub(/[[:space:]].*/,"",n); print n; exit } }')
+  nodes=$(_reservation_nodes "$rname")
   [ -n "$nodes" ] || { echo -1; return; }
-  nodes=$(printf '%s' "$nodes" | tr ',' ' ')
   run=$(squeue -h -t running -o '%N' 2>/dev/null)
   for n in $nodes; do
     printf '%s\n' "$run" | grep -qw -- "$n" || free=$((free + 1))
@@ -166,15 +203,31 @@ _spill_inflight() {
   squeue -h -u "$(id -un)" -o '%j' 2>/dev/null | grep -c -- 'spill' || true
 }
 
-_hold_watch() {
-  local out="$1" flag="$2" jid=""
+# Watch the dispatched job: report why it is still queued (a waiting job prints
+# NOTHING, so a CI run looks hung and gets cancelled), and cancel + flag the two
+# waits the caller can act on — a JobHoldMaxRequeue, and a group node limit still
+# unclear after $QOS_WAIT. $1=srun-out $2=hold-flag $3=qos-flag $4=label
+_watch_job() {
+  local out="$1" hold="$2" qos="$3" label="$4" jid="" state reason waited=0
+  local every="${INFERA_E2E_QUEUE_LOG_INTERVAL:-60}" next="${INFERA_E2E_QUEUE_LOG_INTERVAL:-60}"
   while sleep 5; do
-    [ -n "$jid" ] || jid=$(grep -oE 'srun: job [0-9]+' "$out" 2>/dev/null \
+    waited=$((waited + 5))
+    [ -n "$jid" ] || jid=$(grep -oE 'job (allocation )?[0-9]+' "$out" 2>/dev/null \
       | grep -oE '[0-9]+' | head -1)
     [ -n "$jid" ] || continue
-    case "$(squeue -h -j "$jid" -o '%T %r' 2>/dev/null)" in
-      PENDING*JobHoldMaxRequeue*) : > "$flag"; scancel "$jid" >/dev/null 2>&1; return ;;
-    esac
+    state=$(squeue -h -j "$jid" -o '%T' 2>/dev/null)
+    reason=$(squeue -h -j "$jid" -o '%r' 2>/dev/null)
+    [ "$state" = "PENDING" ] || continue
+    if [ "$reason" = "JobHoldMaxRequeue" ]; then
+      : > "$hold"; scancel "$jid" >/dev/null 2>&1; return
+    fi
+    if [ "$reason" = "QOSGrpNodeLimit" ] && [ "$waited" -ge "$QOS_WAIT" ]; then
+      : > "$qos"; scancel "$jid" >/dev/null 2>&1; return
+    fi
+    if [ "$waited" -ge "$next" ]; then
+      next=$((waited + every))
+      echo "[$label] still QUEUED on SLURM after ${waited}s — job $jid, reason=${reason:-unknown}" >&2
+    fi
   done
 }
 
@@ -201,6 +254,7 @@ _dispatch_slurm() {
 
   local prc=1 attempt=0 max_attempts=5 exclude="" ran
   local holdflag="$SCRATCH/.hold-$label" held=0 max_held="${INFERA_E2E_HOLD_MAX_RETRY:-30}"
+  local qosflag="$SCRATCH/.qos-$label" qos=()
   while [ "$attempt" -lt "$max_attempts" ]; do
     attempt=$((attempt + 1))
     local xflag=()
@@ -231,8 +285,11 @@ _dispatch_slurm() {
       fi
     fi
     echo "[$label] dispatch $attempt/$max_attempts to '$SLURM_PART' mode=$mode${exclude:+ exclude=$exclude} (remote: $*)"
+    echo "[$label] submitted to SLURM — the job now QUEUES until the scheduler frees a node," \
+         "which can take a while on a busy cluster. Nothing prints until it starts;" \
+         "queue status follows every ${INFERA_E2E_QUEUE_LOG_INTERVAL:-60}s."
     echo "[$label] streaming remote output below (live via $tailf):"
-    : > "$out"; [ -n "$logf" ] && : > "$logf"; rm -f "$holdflag"
+    : > "$out"; [ -n "$logf" ] && : > "$logf"; rm -f "$holdflag" "$qosflag"
     # stdbuf -oL line-buffers tail to our stdout; -F follows by name + retry
     # (tolerates the remote truncating on open, and polls over NFS).
     stdbuf -oL tail -n +1 -F "$tailf" 2>/dev/null &
@@ -247,10 +304,10 @@ _dispatch_slurm() {
     # job; `wait` is interrupted by the signal so the trap runs promptly.
     INFERA_E2E_LOCAL=1 \
       srun -N1 -p "$SLURM_PART" --gres=gpu:8 -t "$SLURM_TIME" \
-        -J "$jobname" "${xflag[@]}" "${resv[@]}" \
+        -J "$jobname" "${xflag[@]}" "${resv[@]}" "${qos[@]}" \
         "${remote[@]}" > "$out" 2>&1 &
     local srunpid=$!
-    _hold_watch "$out" "$holdflag" &
+    _watch_job "$out" "$holdflag" "$qosflag" "$label" &
     local holdpid=$!
     wait "$srunpid"; prc=$?
     kill "$holdpid" 2>/dev/null; wait "$holdpid" 2>/dev/null
@@ -267,6 +324,18 @@ _dispatch_slurm() {
       fi
       echo "[$label] job held (JobHoldMaxRequeue) — cancelled, retry $held/$max_held in 5s" >&2
       attempt=$((attempt - 1)); sleep 5; continue
+    fi
+    # Queued on the group node limit past $QOS_WAIT: the watchdog cancelled it —
+    # resubmit once on the burst QoS (not a real attempt); refused again = fail.
+    if [ -f "$qosflag" ]; then
+      prc=1
+      if [ "${#qos[@]}" -gt 0 ]; then
+        echo "[$label] still QOSGrpNodeLimit on --qos=$QOS_FALLBACK — giving up" >&2
+        break
+      fi
+      qos=(--qos="$QOS_FALLBACK")
+      echo "[$label] QOSGrpNodeLimit for ${QOS_WAIT}s — resubmitting with --qos=$QOS_FALLBACK" >&2
+      attempt=$((attempt - 1)); continue
     fi
     # Retry on transient faults. Docker errors are in $logf (shared) or $out
     # (local); "running on <node>" is always an srun banner in $out.
@@ -414,6 +483,13 @@ run_e2e_disagg() {
   python3 -c "import pytest, pytest_asyncio, httpx" >/dev/null 2>&1 \
     || { echo "[e2e disagg] WARNING: missing host deps (pytest/pytest-asyncio/httpx) — skipping" >&2; return 0; }
 
+  # An expired reservation is worse than none — every step's `srun --reservation`
+  # would fail. Drop it, as _dispatch_slurm does for the mixed tier.
+  if [ -n "${INFERA_E2E_RESERVATION:-}" ] && [ -z "$(_reservation_nodes "$INFERA_E2E_RESERVATION")" ]; then
+    echo "[e2e disagg] WARNING: reservation '$INFERA_E2E_RESERVATION' not found — falling back to open partition '$SLURM_PART'" >&2
+    unset INFERA_E2E_RESERVATION
+  fi
+
   local rc=0 e prc out="$SCRATCH/.e2e-disag.out"
   local max_attempts=3 attempt exclude n1 n2 nodes ok
   for e in "${engines[@]}"; do
@@ -435,11 +511,13 @@ run_e2e_disagg() {
         break
       fi
       echo "[e2e disagg] $e attempt $attempt/$max_attempts on nodes: $n1 (prefill), $n2 (decode)"
+      _DISAG_NODES="$n1,$n2"
       INFERA_E2E_NODES="$n1,$n2" INFERA_E2E_SLURM_PARTITION="$SLURM_PART" \
       PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 \
         python3 -m pytest -p no:cacheprovider -o addopts= -rfE -v -s \
           "$REPO/tests/e2e/pd_disag/$e" 2>&1 | tee "$out"
       prc=${PIPESTATUS[0]}
+      _DISAG_NODES=""   # pytest returned, so its fixtures already tore the stack down
       [ "$prc" -eq 0 ] && { ok=1; break; }
       if grep -qiE 'node failure|Cannot connect to the Docker daemon|could not resolve a routable IP|docker build .* failed' "$out"; then
         exclude="${exclude:+$exclude,}$n1,$n2"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -96,7 +96,11 @@ _wipe_disag_nodes() {
   local n resv="${INFERA_E2E_RESERVATION:+--reservation=$INFERA_E2E_RESERVATION}"
   for n in ${_DISAG_NODES//,/ }; do
     echo "[cleanup] removing PD containers on $n" >&2
+    # Name and timebox it like every other step: unnamed, SLURM calls it "bash"
+    # and leaves it UNLIMITED, so ci.yml's `infera-ci-`+run-id reclaim can neither
+    # see nor cancel it — and this runs on the very cancel that reclaim cleans up.
     srun -N1 -n1 -p "$SLURM_PART" -w "$n" $resv ${INFERA_E2E_SRUN_EXTRA:-} \
+      -J "infera-ci-wipe-${INFERA_E2E_JOB_TAG:-local}" -t 00:05:00 \
       bash -lc 'docker rm -f $(docker ps -aq --filter name=infera-e2e-) 2>/dev/null || true' \
       >/dev/null 2>&1 || true
   done

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -28,8 +28,8 @@ DF_VLLM="deploy/docker/Dockerfile.vllm"
 DF_SGLANG="deploy/docker/Dockerfile.sglang"
 DF_ATOM="deploy/docker/Dockerfile.atom"
 ETCD_IMG="quay.io/coreos/etcd:v3.5.14"
-# Every container we launch carries this prefix so a new run can wipe stragglers
-# a killed/cancelled prior run left on the same (reused) node.
+# On every container we launch, so a new run can wipe what a killed one left on
+# this (reused) node.
 CTR_PREFIX="infera-utest-"
 ETCD_CTR="${CTR_PREFIX}etcd"
 PIPDEPS='pip install -q pytest pytest-asyncio nats-py 2>/dev/null || true'
@@ -49,8 +49,8 @@ mkdir -p "$SCRATCH/hf"
 : > "$SCRATCH/failures.txt"
 chmod 666 "$SCRATCH/failures.txt" 2>/dev/null || true
 SCRATCH_FLAGS=(-v "$SCRATCH":/scratch -e HF_HOME=/scratch/hf)
-# Worker (engine) logs persist on the host at a fixed dir, mounted at /e2e-logs
-# in the container (the harness writes there when that mount exists).
+# Worker logs outlive the run at a fixed host dir; the harness writes there
+# whenever it finds the mount.
 E2E_LOG_DIR="/tmp/infera-e2e-logs"
 mkdir -p "$E2E_LOG_DIR"
 SCRATCH_FLAGS+=(-v "$E2E_LOG_DIR":/e2e-logs)
@@ -63,8 +63,8 @@ _cleanup_scratch() {
   rm -rf "$SCRATCH" 2>/dev/null || true
 }
 
-# On interrupt (Ctrl-C / CI SIGTERM) scancel the dispatched job: killing the srun
-# client does NOT stop the Spur job. Job id from $_CUR_DISPATCH_OUT, else job tag.
+# Killing the srun client does NOT stop the Spur job, so a Ctrl-C / CI SIGTERM
+# has to scancel it: job id from $_CUR_DISPATCH_OUT, else from the job tag.
 _CUR_DISPATCH_OUT=""
 _cancel_dispatched() {
   local jids="" i suf csv
@@ -89,16 +89,14 @@ _cancel_dispatched() {
   done
 }
 # Nodes the running PD-disagg attempt placed containers on. A killed run skips
-# pytest's fixture teardown, so without this a cancel leaves prefill+decode
-# engines holding both nodes' GPUs.
+# pytest's teardown, so without this a cancel leaves prefill+decode on the GPUs.
 _DISAG_NODES=""
 _wipe_disag_nodes() {
   local n resv="${INFERA_E2E_RESERVATION:+--reservation=$INFERA_E2E_RESERVATION}"
   for n in ${_DISAG_NODES//,/ }; do
     echo "[cleanup] removing PD containers on $n" >&2
-    # Name and timebox it like every other step: unnamed, SLURM calls it "bash"
-    # and leaves it UNLIMITED, so ci.yml's `infera-ci-`+run-id reclaim can neither
-    # see nor cancel it — and this runs on the very cancel that reclaim cleans up.
+    # Unnamed, SLURM would call this "bash" and leave it UNLIMITED — invisible to
+    # ci.yml's `infera-ci-`+run-id reclaim, on the very cancel that reclaim cleans up.
     srun -N1 -n1 -p "$SLURM_PART" -w "$n" $resv ${INFERA_E2E_SRUN_EXTRA:-} \
       -J "infera-ci-wipe-${INFERA_E2E_JOB_TAG:-local}" -t 00:05:00 \
       bash -lc 'docker rm -f $(docker ps -aq --filter name=infera-e2e-) 2>/dev/null || true' \
@@ -118,9 +116,8 @@ trap '_release_hold; _cleanup_scratch' EXIT
 trap '_wipe_disag_nodes; _release_hold; _cancel_dispatched; exit 130' INT TERM
 echo "[scratch] $SCRATCH  (worker logs: $E2E_LOG_DIR, kept)"
 
-# INFERA_E2E_MODEL_DIR: bind the model tree read-only at the same path + forward
-# the var. If absent here (lives on the compute node) just forward it; the remote
-# re-run mounts it.
+# Bind the model tree read-only at the same path. If it is absent here it lives
+# on the compute node, so just forward the var and let the remote re-run mount it.
 E2E_FLAGS=()
 if [ -n "${INFERA_E2E_MODEL_DIR:-}" ]; then
   if [ -d "$INFERA_E2E_MODEL_DIR" ]; then
@@ -132,9 +129,9 @@ if [ -n "${INFERA_E2E_MODEL_DIR:-}" ]; then
   fi
 fi
 
-# --- SLURM dispatch (Spur scheduler and stock SLURM) --------------------
-# Partition: honor INFERA_E2E_SLURM_PARTITION; else the cluster's default (the
-# one sinfo flags with '*'), so this works on amd-spur and stock SLURM alike.
+# --- SLURM dispatch (Spur scheduler and stock SLURM) -------------------------
+# Fall back to the cluster default partition (the one sinfo stars) so this works
+# on amd-spur and stock SLURM alike.
 _default_partition() {
   command -v sinfo >/dev/null 2>&1 || return 0
   sinfo -h -o '%P' 2>/dev/null | sed -n 's/\*$//p' | head -1
@@ -142,8 +139,8 @@ _default_partition() {
 SLURM_PART="${INFERA_E2E_SLURM_PARTITION:-$(_default_partition)}"
 SLURM_PART="${SLURM_PART:-amd-spur}"
 SLURM_TIME="${INFERA_E2E_SLURM_TIME:-02:00:00}"
-# Burst QoS is a fallback: a dispatch queued this long on the group node limit is
-# resubmitted with it (see _watch_job / _dispatch_slurm), never used up front.
+# Burst QoS is a fallback, never used up front: a dispatch queued this long on
+# the group node limit is resubmitted with it (see _watch_job / _dispatch_slurm).
 QOS_FALLBACK="${INFERA_E2E_SLURM_QOS_FALLBACK:-amd-burst-qos}"
 QOS_WAIT="${INFERA_E2E_QOS_WAIT:-30}"
 # _hold_pair's own window: its -N2 --gres=gpu:8 batch job needs longer to start
@@ -151,7 +148,7 @@ QOS_WAIT="${INFERA_E2E_QOS_WAIT:-30}"
 HOLD_WAIT="${INFERA_E2E_HOLD_WAIT:-60}"
 
 _have_slurm() { command -v srun >/dev/null 2>&1; }
-# The nodes reservation $1 covers, one per line ('' if it's gone/expired).
+# The nodes reservation $1 covers, one per line ('' if it is gone/expired).
 # Spur ignores the NAME arg and dumps all reservations; match the exact block.
 _reservation_nodes() {
   scontrol show reservation "$1" 2>/dev/null | awk -v r="ReservationName=$1" '
@@ -159,54 +156,43 @@ _reservation_nodes() {
     $1==r { for(i=1;i<=NF;i++) if($i ~ /Nodes=/){ n=$i; sub(/.*Nodes=/,"",n); sub(/[[:space:]].*/,"",n); print n; exit } }' \
     | tr ',' '\n' | sed '/^$/d'
 }
-# Free nodes to place the PD-disagg pair on, one per line: the reservation's own
-# (a reserved node reads 'resv', never 'idle', so sinfo would miss it), else the
+# Ask the NODE, not squeue: a multi-node job's %N is a compacted hostlist
+# (crsuse2-m2m-[090,183]) holding neither full name, and Spur has no `scontrol
+# show hostnames`. Unreadable => busy, never hand out what we cannot verify.
+_node_free() {
+  local alloc
+  alloc=$(scontrol show node "$1" 2>/dev/null | grep -oE 'CPUAlloc=[0-9]+' | head -1 | cut -d= -f2)
+  [ -n "$alloc" ] && [ "$alloc" -eq 0 ] 2>/dev/null
+}
+# Free nodes for the PD-disagg pair, one per line: the reservation's own (a
+# reserved node reads 'resv', never 'idle', so sinfo would miss it), else the
 # partition's idle ones.
 _candidate_nodes() {
-  local n run nodes=""
+  local n nodes=""
   [ -n "${INFERA_E2E_RESERVATION:-}" ] && nodes="$(_reservation_nodes "$INFERA_E2E_RESERVATION")"
   if [ -z "$nodes" ]; then
     sinfo -h -N -p "$SLURM_PART" -t idle -o '%n' 2>/dev/null | awk 'NF && !seen[$0]++'
     return
   fi
-  run="$(squeue -h -t running -o '%N' 2>/dev/null)"
   for n in $nodes; do
-    printf '%s\n' "$run" | grep -qw -- "$n" || echo "$n"
+    _node_free "$n" && echo "$n"
   done
 }
-# Hold both PD nodes' GPUs for the whole run. Unlike the mixed tier, disagg's
-# per-step sruns leave the nodes idle in between, so SLURM hands one to another
-# job and their fixed ports (etcd 2379/2380, router 8000, ...) collide. A
-# --gres=gpu:8 batch job keeps them ours; our own no-gres steps co-schedule.
-# Sets _HOLDER_JID. $1=n1,n2
-_hold_pair() {
-  local pair="$1" script="$SCRATCH/hold.sh" jid st rs waited qos=() i
-  # A real script file, not --wrap: on Spur --wrap always NODE_FAILs at -N2.
-  printf '#!/bin/bash\nsleep %s\n' "${INFERA_E2E_HOLD_SLEEP:-10800}" > "$script"
-  for i in 1 2 3; do
-    jid=$(sbatch --parsable -N2 -n2 -w "$pair" --gres=gpu:8 -p "$SLURM_PART" \
-      -t "$SLURM_TIME" -J "infera-ci-hold-${INFERA_E2E_JOB_TAG:-local}" \
-      ${INFERA_E2E_RESERVATION:+--reservation="$INFERA_E2E_RESERVATION"} \
-      "${qos[@]}" "$script" 2>/dev/null) || continue
-    waited=0
-    while [ "$waited" -lt "$HOLD_WAIT" ]; do
-      st=$(scontrol show job "$jid" 2>/dev/null | grep -oE 'JobState=[A-Z_]+' | cut -d= -f2)
-      rs=$(scontrol show job "$jid" 2>/dev/null | grep -oE 'Reason=[A-Za-z]+' | cut -d= -f2)
-      [ "$st" = RUNNING ] && { _HOLDER_JID="$jid"; return 0; }
-      case "$st" in NODE_FAIL | FAILED | CANCELLED) break ;; esac
-      sleep 5; waited=$((waited + 5))
-    done
-    # Read the reason BEFORE cancelling; the burst QoS is the way past a group
-    # node limit, and a launch failure is Spur being flaky — both just retry.
-    [ "${#qos[@]}" -eq 0 ] && [ "${rs#QOSGrp}" != "$rs" ] && qos=(-q "$QOS_FALLBACK")
-    scancel "$jid" >/dev/null 2>&1
-    echo "[e2e disagg] hold attempt $i on $pair not started (${st:-?}/${rs:-?}) — retrying" >&2
-  done
-  return 1
+# Up to $1 free nodes, skipping the comma-separated exclude list in $2. Collect
+# before filtering: breaking out of a `< <(...)` mid-stream prints EPIPE noise.
+_pick_idle_nodes() {
+  local count="$1" excl=",${2:-}," n out=() all
+  all="$(_candidate_nodes)"
+  while read -r n; do
+    [ -n "$n" ] || continue
+    case "$excl" in *,"$n",*) continue ;; esac
+    out+=("$n"); [ "${#out[@]}" -ge "$count" ] && break
+  done <<< "$all"
+  printf '%s\n' "${out[@]-}"
 }
-# Two free nodes, waiting for them rather than giving up: engines run in
-# parallel and the mixed tier shares the pool, so a pair is often only free
-# later. The CI job timeout is the real backstop. $1=exclude list.
+# Wait for two free nodes rather than give up: engines run in parallel and the
+# mixed tier shares the pool, so a pair is often only free later. The CI job
+# timeout is the real backstop. $1=exclude list.
 _wait_for_pair() {
   local excl="$1" waited=0 every=30 limit="${INFERA_E2E_WAIT_NODES_TIMEOUT:-6400}" nodes
   while :; do
@@ -218,21 +204,52 @@ _wait_for_pair() {
     sleep "$every"; waited=$((waited + every))
   done
 }
-# Print up to $1 free nodes (one per line), skipping the comma-separated exclude
-# list in $2. Used to place the PD-disagg node pair.
-_pick_idle_nodes() {
-  local count="$1" excl=",${2:-}," n out=() all
-  # Collect the list first: breaking out of a `< <(...)` mid-stream leaves the
-  # producer writing to a closed pipe, which prints EPIPE noise on every call.
-  all="$(_candidate_nodes)"
-  while read -r n; do
-    [ -n "$n" ] || continue
-    case "$excl" in *,"$n",*) continue ;; esac
-    out+=("$n"); [ "${#out[@]}" -ge "$count" ] && break
-  done <<< "$all"
-  printf '%s\n' "${out[@]-}"
+# A running pair holder other than $1, on the same nodes and submitted earlier.
+_rival_holder() {
+  local self="$1" mine
+  mine=$(squeue -h -j "$self" -o '%N' 2>/dev/null)
+  [ -n "$mine" ] || return 0
+  squeue -h -t running -o '%i %j %N' 2>/dev/null | awk -v self="$self" -v mine="$mine" '
+    $2 ~ /^infera-ci-hold-/ && $3 == mine && $1 + 0 < self + 0 { print $1; exit }'
 }
-# AMD GPU count on THIS host (one renderD* per GPU; PCI vendor 0x1002 == AMD).
+# Hold both PD nodes' GPUs for the whole run: disagg's per-step sruns leave them
+# idle in between, so SLURM would hand one out and the fixed ports (etcd 2379,
+# router 8000, ...) collide. Our own no-gres steps co-schedule. Sets _HOLDER_JID.
+_hold_pair() {
+  local pair="$1" script="$SCRATCH/hold.sh" jid st rs waited qos=() i other
+  # A real script file, not --wrap: on Spur --wrap always NODE_FAILs at -N2.
+  printf '#!/bin/bash\nsleep %s\n' "${INFERA_E2E_HOLD_SLEEP:-10800}" > "$script"
+  for i in 1 2 3; do
+    jid=$(sbatch --parsable -N2 -n2 -w "$pair" --gres=gpu:8 -p "$SLURM_PART" \
+      -t "$SLURM_TIME" -J "infera-ci-hold-${INFERA_E2E_JOB_TAG:-local}" \
+      ${INFERA_E2E_RESERVATION:+--reservation="$INFERA_E2E_RESERVATION"} \
+      "${qos[@]}" "$script" 2>/dev/null) || continue
+    waited=0
+    while [ "$waited" -lt "$HOLD_WAIT" ]; do
+      st=$(scontrol show job "$jid" 2>/dev/null | grep -oE 'JobState=[A-Z_]+' | cut -d= -f2)
+      rs=$(scontrol show job "$jid" 2>/dev/null | grep -oE 'Reason=[A-Za-z]+' | cut -d= -f2)
+      if [ "$st" = RUNNING ]; then
+        # --gres does fence the pair, but two engines can submit in the same
+        # instant, before either holder exists to be seen. Lower job id keeps it
+        # and the other yields, so they cannot both back off and re-collide.
+        other=$(_rival_holder "$jid")
+        [ -z "$other" ] && { _HOLDER_JID="$jid"; return 0; }
+        scancel "$jid" >/dev/null 2>&1
+        echo "[e2e disagg] holder $jid started on $pair but $other holds it too — yielding" >&2
+        return 1
+      fi
+      case "$st" in NODE_FAIL | FAILED | CANCELLED) break ;; esac
+      sleep 5; waited=$((waited + 5))
+    done
+    # Read the reason BEFORE cancelling; the burst QoS is the way past a group
+    # node limit, and a launch failure is Spur being flaky — both just retry.
+    [ "${#qos[@]}" -eq 0 ] && [ "${rs#QOSGrp}" != "$rs" ] && qos=(-q "$QOS_FALLBACK")
+    scancel "$jid" >/dev/null 2>&1
+    echo "[e2e disagg] hold attempt $i on $pair not started (${st:-?}/${rs:-?}) — retrying" >&2
+  done
+  return 1
+}
+# One renderD* per GPU; PCI vendor 0x1002 == AMD.
 _amd_gpu_count() {
   local n=0 d
   for d in /sys/class/drm/renderD*/device/vendor; do
@@ -240,42 +257,37 @@ _amd_gpu_count() {
   done
   echo "$n"
 }
-
-# --- shared local-vs-SLURM decision (used by unit / engine / e2e-mixed) -------
-# THIS host can run a containerized GPU tier in place iff it has docker + >=8 AMD
-# GPUs. INFERA_E2E_LOCAL=1 (set by _dispatch_slurm on the remote) forces in-place.
+# Shared by unit / engine / e2e-mixed. INFERA_E2E_LOCAL=1 (set by _dispatch_slurm
+# on the remote) forces in-place.
 _local_eligible() { [ "$(_amd_gpu_count)" -ge 8 ] && command -v docker >/dev/null 2>&1; }
 
-# Reservation free-node count (spill helper; Spur has no srun --immediate).
-# Prints free count, -1 if reservation gone/expired, -2 if scontrol unavailable.
+# Spill helper (Spur has no srun --immediate): free count, -1 if the reservation
+# is gone/expired, -2 if scontrol is unavailable.
 _reservation_free() {
-  local rname="$1" nodes run n free=0
+  local rname="$1" nodes n free=0
   command -v scontrol >/dev/null 2>&1 || { echo -2; return; }
   nodes=$(_reservation_nodes "$rname")
   [ -n "$nodes" ] || { echo -1; return; }
-  run=$(squeue -h -t running -o '%N' 2>/dev/null)
   for n in $nodes; do
-    printf '%s\n' "$run" | grep -qw -- "$n" || free=$((free + 1))
+    _node_free "$n" && free=$((free + 1))
   done
   echo "$free"
 }
-# Count in-flight 'spill'-marked jobs to cap borrowed nodes at INFERA_E2E_SPILL_MAX.
-# Best-effort: concurrent dispatchers can race the cap.
+# Caps borrowed nodes at INFERA_E2E_SPILL_MAX; concurrent dispatchers can race it.
 _spill_inflight() {
   squeue -h -u "$(id -un)" -o '%j' 2>/dev/null | grep -c -- 'spill' || true
 }
 
-# Watch the dispatched job: report why it is still queued (a waiting job prints
-# NOTHING, so a CI run looks hung and gets cancelled), and cancel + flag the two
-# waits the caller can act on — a JobHoldMaxRequeue, and a group node limit still
-# unclear after $QOS_WAIT. $1=srun-out $2=hold-flag $3=qos-flag $4=label
+# Report why the dispatch is still queued (a waiting job prints NOTHING, so a CI
+# run looks hung and gets cancelled), and cancel + flag the two waits the caller
+# can act on. $1=srun-out $2=hold-flag $3=qos-flag $4=label
 _watch_job() {
   local out="$1" hold="$2" qos="$3" label="$4" jid="" state reason waited=0
   local every="${INFERA_E2E_QUEUE_LOG_INTERVAL:-60}" next="${INFERA_E2E_QUEUE_LOG_INTERVAL:-60}"
   while sleep 5; do
     waited=$((waited + 5))
-    # Match both srun banners: "Pending job allocation N" while queued (the only
-    # one printed for a job that never starts) and "job N running on ...".
+    # Both srun banners: "Pending job allocation N" (the only one a job that
+    # never starts prints) and "job N running on ...".
     [ -n "$jid" ] || jid=$(grep -oE 'job (allocation )?[0-9]+' "$out" 2>/dev/null \
       | grep -oE '[0-9]+' | head -1)
     [ -n "$jid" ] || continue
@@ -301,9 +313,9 @@ _dispatch_slurm() {
     echo "[$label] WARNING: no SLURM (srun) — skipping" >&2
     return 0
   fi
-  # $out: srun's own client banners/errors (job id, "running on <node>", ...).
+  # srun's own client banners/errors (job id, "running on <node>", ...).
   local out="$SCRATCH/.dispatch-$label.out"
-  _CUR_DISPATCH_OUT="$out"   # let the INT/TERM trap scancel this job if aborted
+  _CUR_DISPATCH_OUT="$out"
 
   # CI (buffered srun) -> remote writes to a SHARED-NFS file we `tail -F`; local ->
   # srun forwards to $out. INFERA_DISPATCH_LOGDIR forces the shared path.
@@ -323,9 +335,9 @@ _dispatch_slurm() {
     attempt=$((attempt + 1))
     local xflag=()
     [ -n "$exclude" ] && xflag=(-x "$exclude")
-    # Reservation policy: use it while it has free nodes; when full, spill to the
-    # open partition up to INFERA_E2E_SPILL_MAX borrowed nodes (else queue on it);
-    # if it's gone, drop --reservation (a stale one PENDs forever on Spur).
+    # Use the reservation while it has free nodes; when full, spill to the open
+    # partition up to INFERA_E2E_SPILL_MAX borrowed nodes (else queue on it); if
+    # it is gone, drop --reservation (a stale one PENDs forever on Spur).
     local resv=() jobname="infera-ci-${label}${INFERA_E2E_JOB_TAG:+-$INFERA_E2E_JOB_TAG}" mode="open"
     if [ -n "${INFERA_E2E_RESERVATION:-}" ]; then
       local rfree smax inflight
@@ -354,12 +366,10 @@ _dispatch_slurm() {
          "queue status follows every ${INFERA_E2E_QUEUE_LOG_INTERVAL:-60}s."
     echo "[$label] streaming remote output below (live via $tailf):"
     : > "$out"; [ -n "$logf" ] && : > "$logf"; rm -f "$holdflag" "$qosflag"
-    # stdbuf -oL line-buffers tail to our stdout; -F follows by name + retry
-    # (tolerates the remote truncating on open, and polls over NFS).
+    # -F follows by name + retries, tolerating the remote truncating on open.
     stdbuf -oL tail -n +1 -F "$tailf" 2>/dev/null &
     local tailpid=$!
-    # Shared mode: the remote redirects its own fd1/fd2 to $logf (NFS) before
-    # exec'ing so output lands there live; local mode: srun forwards it to $out.
+    # Shared mode: the remote points its own fd1/fd2 at $logf (NFS) before exec'ing.
     local remote=(bash "$SCRIPT" "$@")
     [ "$shared" -eq 1 ] && \
       remote=(bash -c 'lf="$1"; shift; exec >"$lf" 2>&1; exec bash "$@"' _ "$logf" "$SCRIPT" "$@")
@@ -401,8 +411,8 @@ _dispatch_slurm() {
       echo "[$label] QOSGrpNodeLimit for ${QOS_WAIT}s — resubmitting with --qos=$QOS_FALLBACK" >&2
       attempt=$((attempt - 1)); continue
     fi
-    # Retry on transient faults. Docker errors are in $logf (shared) or $out
-    # (local); "running on <node>" is always an srun banner in $out.
+    # Docker errors land in $logf (shared) or $out (local); "running on <node>"
+    # is always an srun banner in $out.
     ran="$(sed -n 's/.*running on \([A-Za-z0-9._-]*\).*/\1/p' "$out" | tail -1)"
     if grep -qiE 'node failure|Cannot connect to the Docker daemon' "$out" ${logf:+"$logf"} 2>/dev/null; then
       [ -n "$ran" ] && exclude="${exclude:+$exclude,}$ran"
@@ -414,15 +424,13 @@ _dispatch_slurm() {
     fi
     break  # genuine test/build failure
   done
-  # Shared mode only: prune logs older than 10 days (INFERA_DISPATCH_LOG_TTL_MIN).
   [ "$shared" -eq 1 ] && find "$logdir" -maxdepth 1 -type f -name '*.log' \
     -mmin "+${INFERA_DISPATCH_LOG_TTL_MIN:-14400}" -delete 2>/dev/null
   return "$prc"
 }
 
-# docker build the engine image. --network=host so RUN steps (pip) resolve DNS
-# via the host resolver (these nodes list "nameserver 127.0.0.1" first, which a
-# default bridge build netns can't reach). Layer cache makes a no-op build fast.
+# --network=host so RUN steps (pip) resolve DNS via the host resolver: these
+# nodes list "nameserver 127.0.0.1" first, unreachable from a bridge build netns.
 build_image() {
   local df="$1" img="$2"
   echo "[build] $img <- $df"
@@ -438,8 +446,8 @@ run_unit() {
     "$PIPDEPS; python3 -m pytest -p no:cacheprovider -o addopts= -q -rfE tests/unit 2>&1 | stdbuf -oL tee /scratch/.unit.out; rc=\${PIPESTATUS[0]}; grep -aE '^(FAILED|ERROR) ' /scratch/.unit.out 2>/dev/null | sed 's/^/[unit] /' >> /scratch/failures.txt; exit \$rc"
 }
 
-# tests/engine one file at a time so a single ROCm/HIP native crash can't abort
-# the run. Each image runs only its own subtree. $1=Dockerfile $2=image $3=scope.
+# One file at a time so a single ROCm/HIP native crash cannot abort the run.
+# $1=Dockerfile $2=image $3=scope.
 run_engine() {
   local df="$1" img="$2" scope="${3:-tests/engine}"
   echo "===== engine in $img — $scope (per-file, crash-isolated) ====="
@@ -453,8 +461,7 @@ run_engine() {
       rc=0
       for f in $(find "$INFERA_TEST_SCOPE" -name "test_*.py" | sort); do
         echo "----- pytest $f -----"
-        # Stream pytest output live (so CI shows real test progress) AND keep a
-        # copy for the crash/summary/failure classification below.
+        # tee: stream live for CI, keep a copy for the classification below.
         $PYT "$f" 2>&1 | stdbuf -oL tee /scratch/.engine_f.out; code=${PIPESTATUS[0]}
         out=$(cat /scratch/.engine_f.out)
         case $code in
@@ -476,20 +483,19 @@ run_engine() {
       exit $rc'
 }
 
-# Run one engine's PD-mixed suite in its own image against the shared etcd.
+# One engine's PD-mixed suite in its own image against the shared etcd. Verbose:
+# -s keeps worker stdout live, -v names each test.
 run_e2e_engine() {
   local img="$1" testpath="$2"
   echo "----- e2e in $img — $testpath -----"
-  # Verbose: pytest capture off (-s, live worker stdout) + per-test names (-v).
   docker run --rm --name "${CTR_PREFIX}e2e" --network host "${GPU_FLAGS[@]}" "${SCRATCH_FLAGS[@]}" "${E2E_FLAGS[@]}" \
     -e PYTHONDONTWRITEBYTECODE=1 -e PYTHONUNBUFFERED=1 \
     -v "$REPO":/workspace:ro -w /workspace --entrypoint bash "$img" -lc \
     "$PIPDEPS; python3 -m pytest -p no:cacheprovider -o addopts= -rfE -v -s $testpath 2>&1 | stdbuf -oL tee /scratch/.e2e.out; rc=\${PIPESTATUS[0]}; grep -aE '^(FAILED|ERROR) ' /scratch/.e2e.out 2>/dev/null | sed 's|^|[e2e $img] |' >> /scratch/failures.txt; exit \$rc"
 }
 
-# PD-mixed: run in place when eligible, else dispatch to one SLURM node. Locally:
-# build each engine image, start a temp etcd, run each engine's suite against it.
-# $@ = engines.
+# Run in place when eligible, else dispatch the whole tier to one SLURM node.
+# Locally: build each image, start a temp etcd, run each engine against it.
 run_e2e_mixed() {
   local engines=("$@")
   echo "===== e2e PD-mixed (etcd + real workers, GPU): ${engines[*]} ====="
@@ -534,9 +540,9 @@ run_e2e_mixed() {
   return "$rc"
 }
 
-# PD-disaggregated e2e (cross-node): a pytest orchestrator here drives
-# etcd/router/prefill/decode on TWO idle nodes (via INFERA_E2E_NODES + srun; see
-# harness/launcher.py). A bad node is excluded and a fresh pair tried. $@=engines.
+# Cross-node: a pytest orchestrator here drives etcd/router/prefill/decode on TWO
+# idle nodes (INFERA_E2E_NODES + srun; see harness/launcher.py). A bad node is
+# excluded and a fresh pair tried.
 run_e2e_disagg() {
   local engines=("$@")
   echo "===== e2e PD-disaggregated (cross-node, 2 nodes): ${engines[*]} ====="
@@ -562,8 +568,7 @@ run_e2e_disagg() {
     attempt=0; ok=0; exclude=""; races=0
     while [ "$attempt" -lt "$max_attempts" ]; do
       attempt=$((attempt + 1))
-      # A user-pinned pair (INFERA_E2E_NODES) wins on the first try; otherwise
-      # pick two idle nodes, skipping any excluded after a bad attempt.
+      # A user-pinned pair (INFERA_E2E_NODES) wins on the first try.
       if [ -n "${INFERA_E2E_NODES:-}" ] && [ "$attempt" -eq 1 ]; then
         n1="${INFERA_E2E_NODES%%,*}"; n2="${INFERA_E2E_NODES##*,}"
       else
@@ -575,12 +580,9 @@ run_e2e_disagg() {
         echo "[e2e disagg] WARNING: no 2 free nodes in '$SLURM_PART' within ${INFERA_E2E_WAIT_NODES_TIMEOUT:-6400}s — skipping $e" >&2
         break
       fi
-      # Lock the pair before using it. Losing the race to another job is not a
-      # node fault, so the pair must NOT join $exclude: with a small pool the
-      # engine would exclude every node and then starve on a fully idle cluster.
-      # Just re-pick — once the winner's holder is RUNNING, _candidate_nodes
-      # filters its nodes out by itself. Bounded so a pathological loser fails
-      # loudly instead of spinning until the CI job timeout.
+      # Losing the race is not a node fault, so the pair must NOT join $exclude:
+      # with a small pool the engine would exclude every node and then starve on
+      # an idle cluster. Bounded so a pathological loser fails loudly instead.
       if ! _hold_pair "$n1,$n2"; then
         races=$((races + 1))
         if [ "$races" -ge "$max_races" ]; then
@@ -640,9 +642,7 @@ run_e2e() {
   return "$rc"
 }
 
-# unit / engine tiers, gated by the SAME local-vs-SLURM decision as e2e-mixed:
-# run in place when eligible (or already the dispatched remote), else hand the
-# whole tier to a SLURM node via the shared dispatcher.
+# Gated by the SAME local-vs-SLURM decision as e2e-mixed.
 unit_tier() {
   if [ -n "${INFERA_E2E_LOCAL:-}" ] || _local_eligible; then run_unit
   else echo "[unit] no docker/GPU here — dispatching via srun"; _dispatch_slurm unit unit; fi
@@ -658,9 +658,8 @@ engine_tier() {
   fi
 }
 
-# On a container host (dispatched node or local-eligible box) wipe stale
-# infera-utest-* containers a killed/cancelled prior run left behind, so leaked
-# GPU/etcd containers can't OOM or clash with this run (reserved nodes are reused).
+# Reserved nodes get reused, so wipe what a killed run left behind before its
+# leaked GPU/etcd containers can OOM or clash with this one.
 if command -v docker >/dev/null 2>&1 && { [ -n "${INFERA_E2E_LOCAL:-}" ] || _local_eligible; }; then
   docker ps -aq --filter "name=^${CTR_PREFIX}" 2>/dev/null | xargs -r docker rm -f >/dev/null 2>&1 || true
 fi


### PR DESCRIPTION
# Enable PD-disaggregation e2e on dma-buf-only RoCE fabrics (crusoe), for all 3 engines

## Summary

PD-disaggregated e2e could not run on the crusoe `amd-spur` cluster: every engine's
prefill worker died while registering its KV pool for RDMA. This enables it for
**vLLM, SGLang and ATOM**, verifies the KV really moves over GPU Direct RDMA, and
wires it into CI as a new `e2e-disag` job.

```
tests/run_tests.sh e2e disag          # all three engines, ~12 min
tests/run_tests.sh e2e vllm disag     # one engine
```

## Root cause

These nodes load no `ib_peer_mem`, so a bare `ibv_reg_mr()` on a device pointer
cannot pin VRAM. Measured directly with Mooncake's `TransferEngine`:

| image | dma-buf compiled in | `register_memory(VRAM)` |
|---|---|---|
| vLLM (before) | no | `rc=-202` FAIL |
| ATOM (before) | no (base image's old Mooncake) | `rc=-202` FAIL |
| SGLang | yes | `rc=0` OK |

`build_mooncake_rocm.sh` dropped the dma-buf registration path in #154 (it exhausts
a KFD resource at high util on ib_peer_mem fabrics → HIP-209). That is the right
default there, but on a dma-buf-only fabric it is the *only* path that works.

Two further findings:

- **Rail** — with dma-buf the ionic rail dies registering a production-sized KV pool
  (prefill worker killed during KV-cache init at `gpu-memory-utilization 0.9`). The
  flat mlx5 rail works; its routable GID is **index 3** (0 and 1 are link-local),
  unlike ionic's index 1.
- **ATOM silently fell back to TCP** — it names its own Mooncake NIC and guesses the
  MI300X `rdma<N>`. No such device here → `Found 0 HCAs` → TcpTransport. The case
  still *passed* all correctness probes; only the log showed it (and it ran 2.4x
  slower: 589s over TCP vs 247s over RDMA).

## Changes

### Image build — dma-buf is opt-in, default behaviour unchanged

- Restore the B.1 CMake patch (`rdma_transport_dmabuf_cmake.diff`) that propagates
  `USE_HIP_DMABUF` to the `rdma_transport` object lib, where `rdma_context.cpp`
  actually calls `ibv_reg_dmabuf_mr`. Gated behind a new `MOONCAKE_HIP_DMABUF`
  build ARG, **default 0**.
- `Dockerfile.atom`: build Mooncake from the same pinned ref vLLM uses, but *only*
  when `MOONCAKE_HIP_DMABUF=1`; at the default the base image's Mooncake is
  untouched. Entrypoint switched to the host-libionic injector (see below).
- `build_mooncake_rocm.sh`: asserts the dma-buf symbols actually landed in the
  built `.so`, so a CMake define that fails to reach the target is a loud build
  failure rather than a silent fallback.

Verified equivalent at the default: a `MOONCAKE_HIP_DMABUF=0` build still reports
`bare ibv_reg_mr, needs ib_peer_mem`, applies B.2/B.3 only, and produces a `.so`
with **0** dma-buf symbols — byte-for-byte the pre-existing behaviour.

### Harness — fabric config is per-run, not per-engine

New cluster-level knobs, so no engine adapter or matrix row carries site specifics:

| env | purpose |
|---|---|
| `INFERA_E2E_BUILD_ARGS` | `K=V,K=V` → `docker build --build-arg` |
| `INFERA_E2E_WORKER_ENV` | `K=V,K=V` merged into every PD worker |
| `INFERA_E2E_GID_INDEX` | RoCE GID index (default 1) |
| `INFERA_E2E_SRUN_EXTRA` / `INFERA_E2E_RESERVATION` | extra `srun` flags |

Also:
- A build-arg'd image gets its **own tag** (`…-mooncake_hip_dmabuf1`), so the
  mixed/unit/engine tiers building the plain tag on the same nodes can't clobber it
  (they run as concurrent CI jobs).
- `cluster.srun_argv()` is now the single place scheduler flags are assembled;
  `launcher._srun` and the topology probes shared duplicated (and divergent) copies.
- `_has_libionic` probes **on the node** instead of on the orchestrator, which is a
  login box with no ionic stack — the mount was being dropped everywhere.
- ATOM's `ib_device` defaults to the rail the cluster pinned via `MC_TE_FILTERS`.
- Dropped the now-unused `shell_entrypoint` plumbing (all three images share one
  entrypoint contract).

### New: the test asserts RDMA, not just correctness

`assert_rdma_kv_transport()` fails a case whose worker logs show a TCP transport or
`Found 0 HCAs`. A TCP fallback still delivers the KV and still passes every
correctness probe, so nothing else distinguishes it. This is what caught ATOM.

```
[e2e disagg transport] prefill @ node-a: rdma
[e2e disagg transport] decode  @ node-b: rdma
```

### Scheduler robustness in `run_tests.sh`

- **QoS fallback.** Dispatches start on the cluster's default QoS; if a job sits in
  `QOSGrpNodeLimit` for 60s the watchdog cancels it and resubmits once with
  `--qos=amd-burst-qos`. Refused again → fail. Applies to `unit` / `engine` /
  `e2e mixed`; the disag tier does the equivalent with a one-shot probe before the
  stack comes up.
- **Queue visibility.** A queued job printed *nothing*, so a CI run looked hung and
  got cancelled. It now reports `still QUEUED on SLURM after Ns — job N, reason=…`
  every 60s.
- **Fixed a dead watchdog.** The job-id regex only matched `srun: job N running on …`,
  never `Pending job allocation N` — so the `JobHoldMaxRequeue` retry could never
  fire, since that state only exists while pending.
- Reservation-aware node picking (a reserved node reads `resv`, never `idle`, so
  `sinfo` alone returned nodes outside the pool), fallback to the open partition
  when the reservation has expired, and removal of leftover PD containers on
  Ctrl-C / CI cancel (pytest's fixture teardown does not run when killed).

### Test matrix

One case per engine: `gpt-oss-120b`, TP2 prefill + TP2 decode, Mooncake, production
memory utilisation (0.9). The vLLM `GLM-5.1-FP8` MoRIIO case and its adapter
plumbing are removed — see below.

### CI

New `e2e-disag` job (matrix: vllm, sglang, atom) with its own `run_e2e_disag`
dispatch input. The existing `run_e2e` input is renamed `run_e2e_mixed` for symmetry
— **update any `gh workflow run -f run_e2e=…` invocations.**

## Verification

All on crusoe `amd-spur`, 2 nodes, via `tests/run_tests.sh`:

| engine | case | result | time |
|---|---|---|---|
| sglang | gpt-oss-120b tp2 | PASS, `rdma` both sides | 294s |
| vllm | gpt-oss-120b tp2 | PASS, `rdma` both sides | 189s |
| atom | gpt-oss-120b tp2 | PASS, `rdma` both sides | 232s |

Both `e2e disag` (all three) and `e2e vllm disag` (single engine) end in
`RESULT: PASS`. Worker logs confirm `installTransport, type=rdma` on `mlx5_0` at
GID index 3. The QoS fallback was exercised against a real `QOSGrpNodeLimit`:
resubmission on `amd-burst-qos` started within seconds while default-QoS jobs stayed
queued.

## Backward compatibility

- `MOONCAKE_HIP_DMABUF` defaults to 0 — ib_peer_mem fabrics keep bare `ibv_reg_mr`,
  verified by rebuilding and diffing the resulting Mooncake `.so`.
- `run_e2e_mixed` / `run_unit` / `run_engine` are untouched; `pd_mixed` imports none
  of the modified harness modules.
- ATOM's entrypoint changed from `/bin/bash` to the host-libionic injector, which is
  required for RDMA (its container libionic is ABI-mismatched, so libibverbs
  enumerates 0 devices). The injector now execs bash when handed a leading flag, so
  `docker run <img> -c '…'` keeps working; `docker run <img> python3 …` now works
  too. Verified on all three images.
- The changed `COPY`/`RUN` lines invalidate the docker layer cache, so the first
  build after merge rebuilds the Mooncake layer once per node (~4-5 min).

## Known limitations

- **MoRIIO PD cannot run on this fabric.** `libmori_io` registers KV with bare
  `ibv_reg_mr` and ships no dma-buf path, so `RegisterRdmaMemoryRegion` returns
  `EINVAL` and the prefill worker dies mid-request. Pinning `MORI_RDMA_DEVICES`
  fixes an earlier `std::bad_cast` but not this. The GLM-5.1-FP8 MoRIIO case is
  therefore removed rather than skipped; restore it from history once MoRI-IO can
  register through dma-buf.
- The disag tier has no spill-to-open-partition path (unlike `_dispatch_slurm`); if
  the reservation is full it skips rather than borrowing nodes.
- On a build failure the disag retry excludes *both* nodes of the pair, which can
  exhaust a small reservation.