### PR TITLE
fix(ci): make "Cancel workflow" actually stop GPU jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,8 +152,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+      # exec, so run_tests.sh IS the step's entry process: on cancel the runner
+      # signals only that one pid, and a wrapping bash would not forward it, so
+      # the script's INT/TERM trap (scancel of the dispatched job) never ran.
       - name: engine tests
-        run: bash tests/run_tests.sh engine
+        run: exec bash tests/run_tests.sh engine
       - name: reclaim this job's SLURM jobs (on cancel/failure)
         if: always() && (cancelled() || failure())
         run: |
@@ -172,12 +175,15 @@ jobs:
     # Run on PRs into main (pre-merge; pull_request already filters base=main), so
     # the merge is validated BEFORE landing and not re-run on the main push after.
     # Also on manual dispatch when run_e2e is checked. Skipped for docs-only PRs.
-    # Gated behind lint: run only if lint did not fail. `always()` + result check
-    # (instead of a plain success dependency) is needed so e2e still runs when lint
-    # is *skipped* as a duplicate (pre_check), but is held back when lint fails.
+    # Gated behind lint: run only if lint did not fail. `!cancelled()` + result
+    # check (instead of a plain success dependency) is needed so e2e still runs
+    # when lint is *skipped* as a duplicate (pre_check), but is held back when
+    # lint fails. NOT `always()`: on cancel the server re-evaluates job-level
+    # `if`, and `always()` evaluates true, so the job is never cancelled — it
+    # keeps (or even starts) burning GPU nodes after "Cancel workflow".
     needs: [lint, changes]
     if: >-
-      always() &&
+      !cancelled() &&
       needs.changes.outputs.code == 'true' &&
       needs.lint.result != 'failure' && needs.lint.result != 'cancelled' &&
       (github.event_name == 'pull_request' ||
@@ -201,8 +207,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+      # exec: see the engine job — keeps run_tests.sh's INT/TERM trap reachable.
       - name: e2e ${{ matrix.engine }} mixed
-        run: bash tests/run_tests.sh e2e ${{ matrix.engine }} mixed
+        run: exec bash tests/run_tests.sh e2e ${{ matrix.engine }} mixed
       - name: reclaim this job's SLURM jobs (on cancel/failure)
         if: always() && (cancelled() || failure())
         run: |


### PR DESCRIPTION
Two defects made a cancel a no-op on the self-hosted runners:

- e2e-mixed used always() in its job-level if. On cancel the server re-evaluates job-level conditions and always() is true, so the job was never cancelled -- queued matrix legs even got dispatched after the cancel and ran to completion on the reserved nodes. !cancelled() keeps the "run even when lint was skipped as a duplicate" intent while letting the job be cancelled.

- The tiers were launched as `bash tests/run_tests.sh ...`, so the step's entry process was a wrapper bash. The runner signals only that pid, and a non-interactive bash waiting on a foreground child neither forwards nor acts on it, so run_tests.sh was SIGKILLed with its INT/TERM trap never firing and the dispatched SLURM job never scancelled. exec makes run_tests.sh the entry process, so the trap runs within a second.

# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
