### PR TITLE
feat(k8s): Kubernetes recipes — single-node (mixed) + PD 1P1D (Mooncake)

### DIFF
--- a/deploy/docker/Dockerfile.sglang
+++ b/deploy/docker/Dockerfile.sglang
@@ -33,6 +33,26 @@ RUN if [ "${BUILD_MOONCAKE}" = "1" ]; then \
     fi \
     && rm -rf /tmp/build_mooncake_sglang.sh /tmp/mooncake_cpp
 
+# ---- libionic (host ionic ABI match) -----------------------------------------
+# WHY: the sglang base ships libionic with an old kernel ABI (e.g. 54.0-149 = ABI
+# 1); MI355X ionic kernel 26.03 needs ABI 4 (54.0-187) or ibv_get_device_list
+# returns 0 HCAs -> RDMA silently degrades to TCP and cross-node PD KV transfer
+# fails ("remote mooncake session not alive"). HOW: bake the ABI-4 deb so RDMA
+# works even without the runtime host-libionic injection (which the entrypoint
+# still does as a belt-and-braces match when /host-libionic is mounted).
+ARG INSTALL_LIBIONIC=1
+ARG LIBIONIC_DEB_URL=https://repo.radeon.com/amdainic/pensando/ubuntu/1.117.5-a-77/pool/main/r/rdma-core/libionic1_54.0-187-1_amd64.deb
+RUN if [ "${INSTALL_LIBIONIC}" = "1" ]; then \
+        (curl -4 -fsSL --retry 3 -o /tmp/libionic.deb "${LIBIONIC_DEB_URL}" \
+          && dpkg -i --force-downgrade /tmp/libionic.deb \
+          && ldconfig \
+          && echo "libionic: $(dpkg -l | awk '/libionic1/{print $3}')" \
+          && rm -f /tmp/libionic.deb) \
+        || echo "[libionic] install failed (offline build?) — inject at runtime instead"; \
+    else \
+        echo "INSTALL_LIBIONIC=0 — libionic injected at container start"; \
+    fi
+
 # Install infera + its declared deps from pyproject (single source of truth).
 # The base already ships torch/sglang and most of infera's runtime stack; pip
 # leaves those satisfied versions untouched and only pulls what's missing (e.g.

--- a/deploy/docker/Dockerfile.sglang.gfx942
+++ b/deploy/docker/Dockerfile.sglang.gfx942
@@ -8,6 +8,26 @@ FROM ${SGLANG_BASE_IMAGE}
 
 WORKDIR /opt/infera
 
+# ---- libionic (host ionic ABI match) -----------------------------------------
+# WHY: the sglang base ships libionic with an old kernel ABI (e.g. 54.0-149 = ABI
+# 1); the ionic RoCE kernel driver needs ABI 4 (54.0-187) or ibv_get_device_list
+# returns 0 HCAs -> RDMA silently degrades to TCP and cross-node PD KV transfer
+# fails ("remote mooncake session not alive"). HOW: bake the ABI-4 deb so RDMA
+# works even without the runtime host-libionic injection (which the entrypoint
+# still does as a belt-and-braces match when /host-libionic is mounted).
+ARG INSTALL_LIBIONIC=1
+ARG LIBIONIC_DEB_URL=https://repo.radeon.com/amdainic/pensando/ubuntu/1.117.5-a-77/pool/main/r/rdma-core/libionic1_54.0-187-1_amd64.deb
+RUN if [ "${INSTALL_LIBIONIC}" = "1" ]; then \
+        (curl -4 -fsSL --retry 3 -o /tmp/libionic.deb "${LIBIONIC_DEB_URL}" \
+          && dpkg -i --force-downgrade /tmp/libionic.deb \
+          && ldconfig \
+          && echo "libionic: $(dpkg -l | awk '/libionic1/{print $3}')" \
+          && rm -f /tmp/libionic.deb) \
+        || echo "[libionic] install failed (offline build?) — inject at runtime instead"; \
+    else \
+        echo "INSTALL_LIBIONIC=0 — libionic injected at container start"; \
+    fi
+
 # Install infera + its declared deps from pyproject (single source of truth).
 # The base already ships torch/sglang and most of infera's runtime stack; pip
 # leaves those satisfied versions untouched and only pulls what's missing.

--- a/deploy/docker/Dockerfile.vllm
+++ b/deploy/docker/Dockerfile.vllm
@@ -3,15 +3,13 @@
 # hipFile + libionic onto a digest-pinned nightly base, then the infera source,
 # and runs via `python -m infera.engine.vllm`.
 #
-# Base pinned by DIGEST to the vLLM kimi-k3 build — the vLLM that carries kimi_k3
-# model support (KimiK3ForConditionalGeneration) plus the broader model coverage
-# of a newer vLLM. The tag ":kimi-k3" is kept in the ref for readability; the
-# @sha256 is what pins it. The full stack (aiter + vLLM/DSv4 patches + Mooncake +
-# hipFile + libionic + infera + rust router) was validated on this base on MI355X.
-# To move: bump the digest + re-verify patch no-ops (the patch loop swallows a
-# patch's sys.exit(1), so a moved anchor silently drops the patch — check the
-# build log per layer).
-ARG VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3@sha256:5aa7e626ff73672f5ca7aae46754570488c23d33ca1ac90756a1d2d1a3fe099b
+# Base pinned by DIGEST to the stable vLLM v0.25.1 release (was the rolling nightly
+# cbe9c40f = 0.23.1rc0.dev861+gcbe9c40f9, which DockerHub has since rolled off).
+# The tag ":v0.25.1" is kept in the ref for readability; the @sha256 is what pins
+# it (= vllm 0.25.1, torch 2.11.0, ROCm 7.2.3). To move: bump the digest +
+# re-verify patch no-ops (the patch loop swallows a patch's sys.exit(1), so a
+# moved anchor silently drops the patch — check the build log per layer).
+ARG VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:v0.25.1@sha256:84459732ca98b40fe2f5338a3f050be6d522504e47a484a5180d58fb75956f86
 FROM ${VLLM_BASE_IMAGE}
 
 # ---- 1) AITER (flydsl fp4 for DSv4 MXFP4 MoE) ------------------------------
@@ -60,18 +58,24 @@ RUN for f in /tmp/vllm-patches/*.py; do echo "[vllm-patch] $f"; python "$f" || e
     && for f in /tmp/vllm-dsv4-patches/*.py; do echo "[vllm-dsv4-patch] $f"; python "$f" || echo "[vllm-dsv4-patch] skipped $f"; done \
     && rm -rf /tmp/vllm-patches /tmp/vllm-dsv4-patches
 
-# ---- 3) Mooncake (main + B-group C++ patches, bare ibv_reg_mr) -------------
+# ---- 3) Mooncake (main + B-group C++ patches) ------------------------------
 # WHY: cross-node RDMA on ionic needs the B-group C++ patches (B.2 hip-transport
-# gate + B.3 auto-chunk MR), carried against mooncake main. The dma-buf GPUDirect
-# path was dropped in #154 (exhausts a KFD resource at high util -> HIP-209); bare
-# ibv_reg_mr via host-libionic injection is the only supported path. HOW: shared
-# build_mooncake_rocm.sh mode 1 (MOONCAKE_DMABUF=1 = main + B-group, no dma-buf).
+# gate + B.3 auto-chunk MR), carried against mooncake main. How GPU memory is
+# registered for RDMA is chosen by the MOONCAKE_HIP_DMABUF build ARG:
+#   0 (default) = bare ibv_reg_mr via host-libionic injection — needs the legacy
+#                 ib_peer_mem kernel module (do NOT use at high util; HIP-209).
+#   1           = B.1 dma-buf GPUDirect (ibv_reg_dmabuf_mr) — REQUIRED on a
+#                 dma-buf-only RoCE fabric with no ib_peer_mem (e.g. crusoe
+#                 amd-spur), where bare ibv_reg_mr cannot pin VRAM at all.
+# HOW: shared build_mooncake_rocm.sh mode 1 (MOONCAKE_DMABUF=1 = main + B-group).
 ARG BUILD_MOONCAKE=1
 ARG MOONCAKE_GIT_REF=747003c058015c4077a266e7ccd7549bbc9baede
+ARG MOONCAKE_HIP_DMABUF=0
 COPY deploy/docker/scripts/build_mooncake_rocm.sh /tmp/build_mooncake_rocm.sh
 COPY deploy/docker/patches/mooncake_cpp/ /tmp/mooncake_cpp/
 RUN if [ "${BUILD_MOONCAKE}" = "1" ]; then \
-        MOONCAKE_DMABUF=1 MOONCAKE_GIT_REF="${MOONCAKE_GIT_REF}" \
+        MOONCAKE_DMABUF=1 MOONCAKE_HIP_DMABUF="${MOONCAKE_HIP_DMABUF}" \
+        MOONCAKE_GIT_REF="${MOONCAKE_GIT_REF}" \
         MC_CPP_PATCH_DIR=/tmp/mooncake_cpp \
         bash /tmp/build_mooncake_rocm.sh; \
     else \

--- a/deploy/docker/Dockerfile.vllm
+++ b/deploy/docker/Dockerfile.vllm
@@ -3,13 +3,15 @@
 # hipFile + libionic onto a digest-pinned nightly base, then the infera source,
 # and runs via `python -m infera.engine.vllm`.
 #
-# Base pinned by DIGEST to the stable vLLM v0.25.1 release (was the rolling nightly
-# cbe9c40f = 0.23.1rc0.dev861+gcbe9c40f9, which DockerHub has since rolled off).
-# The tag ":v0.25.1" is kept in the ref for readability; the @sha256 is what pins
-# it (= vllm 0.25.1, torch 2.11.0, ROCm 7.2.3). To move: bump the digest +
-# re-verify patch no-ops (the patch loop swallows a patch's sys.exit(1), so a
-# moved anchor silently drops the patch — check the build log per layer).
-ARG VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:v0.25.1@sha256:84459732ca98b40fe2f5338a3f050be6d522504e47a484a5180d58fb75956f86
+# Base pinned by DIGEST to the vLLM kimi-k3 build — the vLLM that carries kimi_k3
+# model support (KimiK3ForConditionalGeneration) plus the broader model coverage
+# of a newer vLLM. The tag ":kimi-k3" is kept in the ref for readability; the
+# @sha256 is what pins it. The full stack (aiter + vLLM/DSv4 patches + Mooncake +
+# hipFile + libionic + infera + rust router) was validated on this base on MI355X.
+# To move: bump the digest + re-verify patch no-ops (the patch loop swallows a
+# patch's sys.exit(1), so a moved anchor silently drops the patch — check the
+# build log per layer).
+ARG VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3@sha256:5aa7e626ff73672f5ca7aae46754570488c23d33ca1ac90756a1d2d1a3fe099b
 FROM ${VLLM_BASE_IMAGE}
 
 # ---- 1) AITER (flydsl fp4 for DSv4 MXFP4 MoE) ------------------------------

--- a/examples/k8s-deployments/RECIPE-single-node.md
+++ b/examples/k8s-deployments/RECIPE-single-node.md
@@ -18,7 +18,7 @@ engines is *not* just the image; four coupled things change, all on the worker:
 | | SGLang | vLLM |
 |---|---|---|
 | `spec.backendFramework` | `sglang` | `vllm` |
-| container `image` | `rocm/infera:sglang-v0.1.1` | `inferaimage/infera:vllm-v0.1.0-rc5` |
+| container `image` | `rocm/infera:sglang-v0.1.1` | `rocm/infera:vllm-v0.1.1` |
 | worker module | `infera.engine.sglang` | `infera.engine.vllm` |
 | engine flags | `--model-path … --tp-size 1 --attention-backend aiter --mem-fraction-static 0.8` | `--model … --tensor-parallel-size 1 --gpu-memory-utilization 0.85` |
 

--- a/examples/k8s-deployments/RECIPE-single-node.md
+++ b/examples/k8s-deployments/RECIPE-single-node.md
@@ -18,7 +18,7 @@ engines is *not* just the image; four coupled things change, all on the worker:
 | | SGLang | vLLM |
 |---|---|---|
 | `spec.backendFramework` | `sglang` | `vllm` |
-| container `image` | `rocm/infera:sglang-v0.1.1` | `rocm/infera:vllm-v0.1.1` |
+| container `image` | `rocm/infera:sglang-v0.1.1` | `rocm/infera:vllm-v0.1.2` |
 | worker module | `infera.engine.sglang` | `infera.engine.vllm` |
 | engine flags | `--model-path … --tp-size 1 --attention-backend aiter --mem-fraction-static 0.8` | `--model … --tensor-parallel-size 1 --gpu-memory-utilization 0.85` |
 

--- a/examples/k8s-deployments/RECIPE-single-node.md
+++ b/examples/k8s-deployments/RECIPE-single-node.md
@@ -18,7 +18,7 @@ engines is *not* just the image; four coupled things change, all on the worker:
 | | SGLang | vLLM |
 |---|---|---|
 | `spec.backendFramework` | `sglang` | `vllm` |
-| container `image` | `rocm/infera:sglang-v0.1.1` | `rocm/infera:vllm-v0.1.2` |
+| container `image` | `rocm/infera:sglang-v0.1.1` | `rocm/infera:vllm-v0.1.1` |
 | worker module | `infera.engine.sglang` | `infera.engine.vllm` |
 | engine flags | `--model-path … --tp-size 1 --attention-backend aiter --mem-fraction-static 0.8` | `--model … --tensor-parallel-size 1 --gpu-memory-utilization 0.85` |
 

--- a/examples/k8s-deployments/RECIPE-single-node.md
+++ b/examples/k8s-deployments/RECIPE-single-node.md
@@ -1,0 +1,84 @@
+# Recipe: single-node aggregated (Qwen3-0.6B), vLLM & SGLang
+
+A concrete, copy-paste recipe that brings up one `InferaDeployment` (router +
+1 GPU worker) and serves an OpenAI-compatible endpoint — the infera analog of a
+vendor "recipe". Two engine variants, **validated end to end on single-node k3s
+(MI355X, `amd.com/gpu`)**:
+
+| Variant | Manifest | Worker entrypoint |
+|---|---|---|
+| SGLang | `single-node-qwen-sglang.yaml` | `infera.engine.sglang` |
+| vLLM | `single-node-qwen-vllm.yaml` | `infera.engine.vllm` |
+
+## sglang vs vllm — what differs
+
+The **router/server is engine-agnostic and identical** across both. Swapping
+engines is *not* just the image; four coupled things change, all on the worker:
+
+| | SGLang | vLLM |
+|---|---|---|
+| `spec.backendFramework` | `sglang` | `vllm` |
+| container `image` | `rocm/infera:sglang-v0.1.1` | `inferaimage/infera:vllm-v0.1.0-rc5` |
+| worker module | `infera.engine.sglang` | `infera.engine.vllm` |
+| engine flags | `--model-path … --tp-size 1 --attention-backend aiter --mem-fraction-static 0.8` | `--model … --tensor-parallel-size 1 --gpu-memory-utilization 0.85` |
+
+The two CLIs differ (`--model-path`/`--tp-size` vs `--model`/`--tensor-parallel-size`),
+so the worker `command` must match the engine — you cannot reuse one manifest and
+only change the image.
+
+## Prerequisites
+
+1. A Kubernetes cluster. Single node is fine — e.g. k3s **with its data-dir on a
+   big disk** so image imports don't fill root:
+   ```bash
+   curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--write-kubeconfig-mode=644 --data-dir /mnt/<big-disk>/k3s" sh -
+   export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+   ```
+2. AMD GPU device plugin (exposes `amd.com/gpu`):
+   ```bash
+   kubectl apply -f https://raw.githubusercontent.com/ROCm/k8s-device-plugin/master/k8s-ds-amdgpu-dp.yaml
+   kubectl describe node <node> | grep amd.com/gpu   # -> amd.com/gpu: 8
+   ```
+3. The infera-operator (CRD + controller); no LWS/NATS needed for single-node aggregated:
+   ```bash
+   INSTALL_LWS=false INSTALL_NATS=false ../../deploy/scripts/deploy-k8s.sh
+   ```
+4. Engine image present in the **node container runtime**. k3s uses containerd
+   (not docker), so import a local image into it (tar, not a stream):
+   ```bash
+   docker save rocm/infera:sglang-v0.1.1 -o /tmp/img.tar
+   sudo k3s ctr images import /tmp/img.tar
+   ```
+5. Model on a host dir the pod hostPath-mounts at `/models`:
+   ```bash
+   python3 -c 'from huggingface_hub import snapshot_download as d; d("Qwen/Qwen3-0.6B", local_dir="/mnt/<big-disk>/models/qwen/Qwen3-0.6B")'
+   ```
+
+## Deploy & verify
+
+```bash
+kubectl create namespace infera
+kubectl apply -f single-node-qwen-sglang.yaml     # or single-node-qwen-vllm.yaml
+
+# operator reconciles the CR into server+worker Deployments, a ClusterIP :8000
+# and the k8s-discovery ServiceAccount; wait for it to go ready:
+kubectl -n infera get inferadeployment -w         # STATE -> ready (~2-3 min: model load + graphs)
+kubectl -n infera get pods                        # server 1/1, worker 1/1
+
+# call it (port-forward, or curl the ClusterIP from the node):
+kubectl -n infera port-forward svc/qwen-agg-server 8000:8000 &
+curl -s localhost:8000/v1/chat/completions -H 'Content-Type: application/json' \
+  -d '{"model":"/models/Qwen3-0.6B","messages":[{"role":"user","content":"What is Kubernetes?"}],"max_tokens":64}'
+```
+
+(For the vLLM variant the served model name is `Qwen3-0.6B` and the service is
+`qwen-agg-vllm-server`.) A real completion in `choices[0].message.content`
+confirms the operator → router → engine path end to end.
+
+## Notes
+- `hostPath` keeps the recipe self-contained (no CSI). For a real cluster use a
+  PVC instead (see `pvc-models.yaml` + `single-node-aggregated.yaml`).
+- Model mount requires `extraPodSpec` with an explicit `command`; the operator's
+  simpler `args` mode auto-builds the entrypoint but only mounts dshm + `/boot`.
+- k3s image imports land under `--data-dir`; putting that on a large disk avoids
+  the DiskPressure eviction you get when 30–80 GB engine images fill root.

--- a/examples/k8s-deployments/glm5.2-sglang.yaml
+++ b/examples/k8s-deployments/glm5.2-sglang.yaml
@@ -1,0 +1,93 @@
+# GLM-5.2-MXFP4 (GlmMoeDsaForCausalLM) — single-node aggregated, SGLang, TP8.
+# GLM-5.2 uses MLA + DeepSeek Sparse Attention (DSA); SGLang is the correct and
+# fastest engine for it on ROCm (vLLM runs but its MLA/DSA decode is numerically
+# buggy -> "!!!!" garbage). Validated on k3s (MI355X): worker Ready ~6 min,
+# coherent output via the router.
+#
+# CRITICAL ENV (below): the base SGLang defaults a CUDA-only DSA top-k JIT kernel
+# that will not build on gfx950 and crashes at init. The SGLANG_OPT_* flags force
+# the ROCm tilelang path instead. Do not drop them.
+#
+# Adjust for your node: image (rocm/infera:sglang-v0.1.1, sglang 0.5.15+ — older
+# rocm sglang can't load GLM-5.2's new head_dim), and the model hostPath.
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: glm52
+  namespace: infera
+spec:
+  backendFramework: sglang
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.1
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","/models/GLM-5.2-MXFP4",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources:
+              requests: {cpu: "8", memory: 16Gi}
+              limits: {cpu: "8", memory: 16Gi}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+        volumes:
+          - {name: model, hostPath: {path: /mnt/vast/xiaobo/models, type: Directory}}
+    worker:
+      componentType: worker
+      role: mixed
+      replicas: 1
+      extraPodSpec:
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.1
+            imagePullPolicy: IfNotPresent
+            # DSA backends + fp8 KV (SGLang handles fp8 MLA KV correctly for GLM-5.2).
+            # --context-length: production uses up to 400000; keep modest to bound the
+            # KV pool. --chunked-prefill-size 8192 (DSA indexer profiling OOMs higher).
+            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--model-path","/models/GLM-5.2-MXFP4","--served-model-name","glm5.2-mxfp4",
+                      "--tp-size","8","--trust-remote-code",
+                      "--nsa-prefill-backend","tilelang","--nsa-decode-backend","tilelang",
+                      "--kv-cache-dtype","fp8_e4m3","--mem-fraction-static","0.85",
+                      "--context-length","32768","--chunked-prefill-size","8192",
+                      "--max-running-requests","24","--cuda-graph-max-bs","24",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              # --- ROCm DSA top-k fix (REQUIRED; base defaults crash init on gfx950) ---
+              - {name: SGLANG_OPT_USE_TILELANG_INDEXER, value: "1"}
+              - {name: SGLANG_OPT_USE_TOPK_V2, value: "0"}
+              - {name: SGLANG_OPT_USE_JIT_NORM, value: "0"}
+              - {name: SGLANG_USE_AITER, value: "1"}
+              - {name: SGLANG_ROCM_FUSED_DECODE_MLA, value: "0"}
+              # --- perf / quant ---
+              - {name: ROCM_QUICK_REDUCE_QUANTIZATION, value: "INT4"}
+              - {name: SAFETENSORS_FAST_GPU, value: "1"}
+              - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
+              - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
+            startupProbe:
+              httpGet: {path: /health, port: 30000}
+              periodSeconds: 10
+              timeoutSeconds: 10
+              failureThreshold: 180   # ~30 min: weights (~408 GiB) + DSA graph capture
+            resources:
+              requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+              limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+        volumes:
+          - {name: model, hostPath: {path: /mnt/vast/xiaobo/models, type: Directory}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 64Gi}}

--- a/examples/k8s-deployments/kimi-k3-vllm.yaml
+++ b/examples/k8s-deployments/kimi-k3-vllm.yaml
@@ -3,19 +3,17 @@
 # Kimi-K3 checkpoint. Structure is validated (operator reconcile + model-cache);
 # see the caveat below before expecting this to serve.
 #
-# ┌─ IMAGE ────────────────────────────────────────────────────────────────────┐
-# │ `inferaimage/infera:vllm-kimi-k3` = infera (server/router + infera.engine.   │
-# │ vllm) layered onto the upstream `vllm/vllm-openai-rocm:kimi-k3` build, which  │
-# │ is the vLLM that carries kimi_k3 model support (KimiK3ForConditionalGen).     │
-# │ Build it from the repo root:                                                  │
-# │   docker build -f deploy/docker/Dockerfile.vllm \                             │
-# │     --build-arg VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3 \               │
-# │     --build-arg BUILD_AITER=0 --build-arg BUILD_MOONCAKE=0 \                  │
-# │     --build-arg BUILD_HIPFILE=0 --build-arg INSTALL_LIBIONIC=0 \              │
-# │     -t inferaimage/infera:vllm-kimi-k3 .                                      │
-# │ (aiter stays the base's kimi-tuned build; the disabled layers are RDMA-PD /   │
-# │ kvd-L3 only, not needed for single-node aggregated serving.)                  │
-# └─────────────────────────────────────────────────────────────────────────────┘
+# IMAGE: rocm/infera:vllm-kimi-k3 = infera (server/router + infera.engine.vllm)
+# layered onto the upstream vllm/vllm-openai-rocm:kimi-k3 build — the vLLM that
+# carries kimi_k3 model support (KimiK3ForConditionalGeneration). Build it from
+# the repo root:
+#   docker build -f deploy/docker/Dockerfile.vllm \
+#     --build-arg VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3 \
+#     --build-arg BUILD_AITER=0 --build-arg BUILD_MOONCAKE=0 \
+#     --build-arg BUILD_HIPFILE=0 --build-arg INSTALL_LIBIONIC=0 \
+#     -t rocm/infera:vllm-kimi-k3 .
+# (aiter stays the base's kimi-tuned build; the disabled layers are RDMA-PD /
+# kvd-L3 only, not needed for single-node aggregated serving.)
 apiVersion: infera.amd.com/v1alpha1
 kind: InferaDeployment
 metadata:
@@ -32,7 +30,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: inferaimage/infera:vllm-kimi-k3   # see IMAGE below
+            image: rocm/infera:vllm-kimi-k3   # see IMAGE below
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/Kimi-K3",
@@ -58,7 +56,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: inferaimage/infera:vllm-kimi-k3   # see IMAGE below
+            image: rocm/infera:vllm-kimi-k3   # see IMAGE below
             imagePullPolicy: IfNotPresent
             # vLLM flags mirror examples/kimi_k3/vllm_serve.sh (TP8, mm data-parallel
             # encoder, kimi_k3 tool/reasoning parsers), routed through infera.engine.vllm.

--- a/examples/k8s-deployments/kimi-k3-vllm.yaml
+++ b/examples/k8s-deployments/kimi-k3-vllm.yaml
@@ -50,9 +50,6 @@ spec:
       componentType: worker
       role: mixed
       replicas: 1
-      # Kimi-K3 loads ~1.5 TB over ~7 min; skip the readiness probe so the operator
-      # doesn't restart the pod mid-load.
-      skipReadinessProbe: true
       extraPodSpec:
         containers:
           - name: main
@@ -83,6 +80,14 @@ spec:
               - {name: AITER_BF16_FP8_MOE_BOUND, value: "0"}
               - {name: SAFETENSORS_FAST_GPU, value: "1"}
               - {name: VLLM_USE_BREAKABLE_CUDAGRAPH, value: "0"}
+            # Kimi-K3 loads ~1.5 TB (~9 min); a generous startupProbe holds the pod
+            # non-Ready through the load, then the operator's /health readiness probe
+            # (gated by startup) takes over — cleaner than skipReadinessProbe.
+            startupProbe:
+              httpGet: {path: /health, port: 30000}
+              periodSeconds: 10
+              timeoutSeconds: 10
+              failureThreshold: 120   # up to ~20 min: weights + CUDA-graph capture
             resources:
               requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
               limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}

--- a/examples/k8s-deployments/kimi-k3-vllm.yaml
+++ b/examples/k8s-deployments/kimi-k3-vllm.yaml
@@ -3,17 +3,11 @@
 # Kimi-K3 checkpoint. Structure is validated (operator reconcile + model-cache);
 # see the caveat below before expecting this to serve.
 #
-# IMAGE: rocm/infera:vllm-kimi-k3 = infera (server/router + infera.engine.vllm)
-# layered onto the upstream vllm/vllm-openai-rocm:kimi-k3 build — the vLLM that
-# carries kimi_k3 model support (KimiK3ForConditionalGeneration). Build it from
-# the repo root:
-#   docker build -f deploy/docker/Dockerfile.vllm \
-#     --build-arg VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3 \
-#     --build-arg BUILD_AITER=0 --build-arg BUILD_MOONCAKE=0 \
-#     --build-arg BUILD_HIPFILE=0 --build-arg INSTALL_LIBIONIC=0 \
-#     -t rocm/infera:vllm-kimi-k3 .
-# (aiter stays the base's kimi-tuned build; the disabled layers are RDMA-PD /
-# kvd-L3 only, not needed for single-node aggregated serving.)
+# IMAGE: rocm/infera:vllm-v0.1.2 = the canonical infera vLLM image. Its base is
+# now the vLLM kimi-k3 build (see deploy/docker/Dockerfile.vllm), so it carries
+# kimi_k3 model support (KimiK3ForConditionalGeneration) out of the box. Build the
+# standard way from the repo root:
+#   docker build -f deploy/docker/Dockerfile.vllm -t rocm/infera:vllm-v0.1.2 .
 apiVersion: infera.amd.com/v1alpha1
 kind: InferaDeployment
 metadata:
@@ -30,7 +24,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: rocm/infera:vllm-kimi-k3   # see IMAGE below
+            image: rocm/infera:vllm-v0.1.2   # see IMAGE below
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/Kimi-K3",
@@ -53,7 +47,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: rocm/infera:vllm-kimi-k3   # see IMAGE below
+            image: rocm/infera:vllm-v0.1.2   # see IMAGE below
             imagePullPolicy: IfNotPresent
             # vLLM flags mirror examples/kimi_k3/vllm_serve.sh (TP8, mm data-parallel
             # encoder, kimi_k3 tool/reasoning parsers), routed through infera.engine.vllm.

--- a/examples/k8s-deployments/kimi-k3-vllm.yaml
+++ b/examples/k8s-deployments/kimi-k3-vllm.yaml
@@ -3,11 +3,17 @@
 # Kimi-K3 checkpoint. Structure is validated (operator reconcile + model-cache);
 # see the caveat below before expecting this to serve.
 #
-# IMAGE: rocm/infera:vllm-v0.1.2 = the canonical infera vLLM image. Its base is
-# now the vLLM kimi-k3 build (see deploy/docker/Dockerfile.vllm), so it carries
-# kimi_k3 model support (KimiK3ForConditionalGeneration) out of the box. Build the
-# standard way from the repo root:
-#   docker build -f deploy/docker/Dockerfile.vllm -t rocm/infera:vllm-v0.1.2 .
+# IMAGE: rocm/infera:vllm-kimi-k3 = infera (server/router + infera.engine.vllm)
+# layered onto the upstream vllm/vllm-openai-rocm:kimi-k3 build — the vLLM that
+# carries kimi_k3 model support (KimiK3ForConditionalGeneration). Build it from
+# the repo root:
+#   docker build -f deploy/docker/Dockerfile.vllm \
+#     --build-arg VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3 \
+#     --build-arg BUILD_AITER=0 --build-arg BUILD_MOONCAKE=0 \
+#     --build-arg BUILD_HIPFILE=0 --build-arg INSTALL_LIBIONIC=0 \
+#     -t rocm/infera:vllm-kimi-k3 .
+# (aiter stays the base's kimi-tuned build; the disabled layers are RDMA-PD /
+# kvd-L3 only, not needed for single-node aggregated serving.)
 apiVersion: infera.amd.com/v1alpha1
 kind: InferaDeployment
 metadata:
@@ -24,7 +30,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: rocm/infera:vllm-v0.1.2   # see IMAGE below
+            image: rocm/infera:vllm-kimi-k3   # see IMAGE below
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/Kimi-K3",
@@ -47,7 +53,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: rocm/infera:vllm-v0.1.2   # see IMAGE below
+            image: rocm/infera:vllm-kimi-k3   # see IMAGE below
             imagePullPolicy: IfNotPresent
             # vLLM flags mirror examples/kimi_k3/vllm_serve.sh (TP8, mm data-parallel
             # encoder, kimi_k3 tool/reasoning parsers), routed through infera.engine.vllm.

--- a/examples/k8s-deployments/kimi-k3-vllm.yaml
+++ b/examples/k8s-deployments/kimi-k3-vllm.yaml
@@ -1,0 +1,96 @@
+# Kimi-K3 (VLM) — single-node aggregated, vLLM, TP8, one 8-GPU node.
+# Mounts the model-cache PVC (model-cache/) at /models and serves the multimodal
+# Kimi-K3 checkpoint. Structure is validated (operator reconcile + model-cache);
+# see the caveat below before expecting this to serve.
+#
+# ┌─ IMAGE ────────────────────────────────────────────────────────────────────┐
+# │ `inferaimage/infera:vllm-kimi-k3` = infera (server/router + infera.engine.   │
+# │ vllm) layered onto the upstream `vllm/vllm-openai-rocm:kimi-k3` build, which  │
+# │ is the vLLM that carries kimi_k3 model support (KimiK3ForConditionalGen).     │
+# │ Build it from the repo root:                                                  │
+# │   docker build -f deploy/docker/Dockerfile.vllm \                             │
+# │     --build-arg VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3 \               │
+# │     --build-arg BUILD_AITER=0 --build-arg BUILD_MOONCAKE=0 \                  │
+# │     --build-arg BUILD_HIPFILE=0 --build-arg INSTALL_LIBIONIC=0 \              │
+# │     -t inferaimage/infera:vllm-kimi-k3 .                                      │
+# │ (aiter stays the base's kimi-tuned build; the disabled layers are RDMA-PD /   │
+# │ kvd-L3 only, not needed for single-node aggregated serving.)                  │
+# └─────────────────────────────────────────────────────────────────────────────┘
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: kimi-k3
+  namespace: infera
+spec:
+  backendFramework: vllm
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        containers:
+          - name: main
+            image: inferaimage/infera:vllm-kimi-k3   # see IMAGE below
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","/models/Kimi-K3",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources:
+              requests: {cpu: "8", memory: 16Gi}
+              limits: {cpu: "8", memory: 16Gi}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+        volumes:
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+    worker:
+      componentType: worker
+      role: mixed
+      replicas: 1
+      # Kimi-K3 loads ~1.5 TB over ~7 min; skip the readiness probe so the operator
+      # doesn't restart the pod mid-load.
+      skipReadinessProbe: true
+      extraPodSpec:
+        containers:
+          - name: main
+            image: inferaimage/infera:vllm-kimi-k3   # see IMAGE below
+            imagePullPolicy: IfNotPresent
+            # vLLM flags mirror examples/kimi_k3/vllm_serve.sh (TP8, mm data-parallel
+            # encoder, kimi_k3 tool/reasoning parsers), routed through infera.engine.vllm.
+            # NOTE --kv-cache-dtype auto: infera defaults to fp8_e4m3 KV, but Kimi-K3's
+            # MLA then selects the mla_gluon kernel (batch_size=1 only) and crashes warmup
+            # at --max-num-seqs 128. `auto` keeps the model's native KV dtype. (Equivalent:
+            # env INFERA_DEFAULT_KV_FP8=0.)
+            command: ["python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
+                      "--model","/models/Kimi-K3","--served-model-name","kimi-k3",
+                      "--tensor-parallel-size","8","--gpu-memory-utilization","0.95",
+                      "--trust-remote-code","--moe-backend","auto","--load-format","auto",
+                      "--mm-encoder-tp-mode","data","--kv-cache-dtype","auto",
+                      "--max-num-seqs","128","--max-num-batched-tokens","4096",
+                      "--enable-auto-tool-choice","--tool-call-parser","kimi_k3",
+                      "--reasoning-parser","kimi_k3",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              - {name: HF_HUB_OFFLINE, value: "1"}
+              - {name: VLLM_ROCM_USE_AITER, value: "1"}
+              - {name: AITER_SITUV2_A8W4, value: "1"}
+              - {name: AITER_BF16_FP8_MOE_BOUND, value: "0"}
+              - {name: SAFETENSORS_FAST_GPU, value: "1"}
+              - {name: VLLM_USE_BREAKABLE_CUDAGRAPH, value: "0"}
+            resources:
+              requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+              limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+        volumes:
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 32Gi}}

--- a/examples/k8s-deployments/kimi-k3-vllm.yaml
+++ b/examples/k8s-deployments/kimi-k3-vllm.yaml
@@ -1,7 +1,8 @@
 # Kimi-K3 (VLM) — single-node aggregated, vLLM, TP8, one 8-GPU node.
 # Mounts the model-cache PVC (model-cache/) at /models and serves the multimodal
-# Kimi-K3 checkpoint. Structure is validated (operator reconcile + model-cache);
-# see the caveat below before expecting this to serve.
+# Kimi-K3 checkpoint. Validated end to end on MI355X: the operator reconciles the
+# CR, the TP8 worker reaches Ready in ~9 min, and a multimodal image request
+# through the router returns a correct colour-grounded answer.
 #
 # IMAGE: rocm/infera:vllm-kimi-k3 = infera (server/router + infera.engine.vllm)
 # layered onto the upstream vllm/vllm-openai-rocm:kimi-k3 build — the vLLM that

--- a/examples/k8s-deployments/mixed-kvd-vllm.yaml
+++ b/examples/k8s-deployments/mixed-kvd-vllm.yaml
@@ -1,4 +1,4 @@
-# Mixed (aggregated) serving WITH the kvd tiered KV cache — CONCRETE recipe.
+# Mixed (aggregated) serving WITH kvd on the vLLM path — CONCRETE recipe.
 #
 # The plain mixed recipe is single-node-qwen-sglang.yaml / -vllm.yaml. This adds
 # kvd, laid out the way Kubernetes wants it rather than with host paths:
@@ -14,19 +14,12 @@
 #
 # Requires the model-cache PVC (model-cache/) or a hostPath model, as usual.
 #
-# ENGINE CHOICE — this manifest uses SGLang, which reaches kvd through its
-# HiCacheStorage backend (`--infera-kvd-socket`) and gets the L2 host-RAM arena
-# plus the L3 file tier. Verified here: 3674 entries / 421 MB landing in both.
-#
-# But **hipFile GPU-direct L3 is vLLM-only**: on the vLLM path kvd loads L3
-# straight into VRAM, while SGLang's route goes through host memory. If you want
-# GPU-direct L3, use mixed-kvd-vllm.yaml instead — same sidecar/PVC layout, with
-# the InferaKvdConnector wiring.
-#
-# NOTE ON MEMORY: `--infera-kvd-socket` enables SGLang's hierarchical cache,
-# whose host-RAM tier is sized from the GPU KV pool unless capped. Left alone it
-# requested 416 GB here and the container was OOMKilled — always pass
-# `--hicache-size` (GiB) that fits inside the engine container's memory limit.
+# ENGINE CHOICE — this is the vLLM twin of mixed-kvd.yaml. It reaches kvd
+# through the InferaKvdConnector (a vLLM KV-transfer connector) rather than
+# SGLang's HiCacheStorage backend, and it is the path that supports **hipFile
+# GPU-direct L3**: L3 loads straight into VRAM instead of bouncing through host
+# memory. Use this one when GPU-direct L3 matters; mixed-kvd.yaml (SGLang) gets
+# the L2 arena and the file tier but not the GPU-direct path.
 #
 # NOTE ON KV DTYPE: kvd only offloads KV layouts it can round-trip byte-exact.
 # Regular-attention fp8 support landed in #63 — on an engine image predating it,
@@ -36,7 +29,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: kvd-l3
+  name: kvd-l3-vllm
   namespace: infera
 spec:
   accessModes:
@@ -49,10 +42,10 @@ spec:
 apiVersion: infera.amd.com/v1alpha1
 kind: InferaDeployment
 metadata:
-  name: qwen-kvd
+  name: qwen-kvd-vllm
   namespace: infera
 spec:
-  backendFramework: sglang
+  backendFramework: vllm
   discoveryBackend: kubernetes
   nats:
     deploy: false
@@ -62,7 +55,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: rocm/infera:sglang-v0.1.1
+            image: rocm/infera:vllm-v0.1.1
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/Qwen3-0.6B",
@@ -84,19 +77,18 @@ spec:
         containers:
           # ---- the engine ----
           - name: main
-            image: rocm/infera:sglang-v0.1.1
+            image: rocm/infera:vllm-v0.1.1
             imagePullPolicy: IfNotPresent
-            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
-                      "--model-path","/models/Qwen3-0.6B",
-                      "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
-                      "--mem-fraction-static","0.8",
-                      "--infera-kvd-socket","/kvd/kvd.sock",
-                      # REQUIRED under Kubernetes: --infera-kvd-socket turns on
-                      # SGLang's hierarchical cache, which otherwise sizes its
-                      # host-RAM tier from the GPU KV pool (it asked for 416 GB
-                      # here) and the container is OOMKilled. Cap it below the
-                      # engine container's memory limit.
-                      "--hicache-size","16",
+            # kvd is reached through the connector, declared in
+            # --kv-transfer-config; INFERA_KVD_SOCKET (below) points it at the
+            # sidecar's UDS. No hierarchical-cache sizing to worry about here —
+            # that knob is SGLang-side only.
+            command: ["python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
+                      "--model","/models/Qwen3-0.6B","--served-model-name","qwen",
+                      "--tensor-parallel-size","1","--gpu-memory-utilization","0.85",
+                      "--trust-remote-code",
+                      "--kv-transfer-config",
+                      "{\"kv_connector\":\"InferaKvdConnector\",\"kv_role\":\"kv_both\",\"kv_connector_module_path\":\"infera.engine.vllm.kvd_connector\"}",
                       "--kv-event-transport","zmq","--request-transport","http"]
             env:
               - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
@@ -114,7 +106,7 @@ spec:
           # Same image (kvd is pure Python inside the infera package). L2 is the
           # pinned host-RAM arena; L3 spills to the PVC.
           - name: kvd
-            image: rocm/infera:sglang-v0.1.1
+            image: rocm/infera:vllm-v0.1.1
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.kvd",
                       "--socket","/kvd/kvd.sock",
@@ -134,5 +126,5 @@ spec:
           - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
           # engine <-> kvd UDS: a plain emptyDir shared by the two containers
           - {name: kvd-sock, emptyDir: {}}
-          - {name: kvd-l3, persistentVolumeClaim: {claimName: kvd-l3}}
+          - {name: kvd-l3, persistentVolumeClaim: {claimName: kvd-l3-vllm}}
           - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 32Gi}}

--- a/examples/k8s-deployments/mixed-kvd.yaml
+++ b/examples/k8s-deployments/mixed-kvd.yaml
@@ -1,0 +1,129 @@
+# Mixed (aggregated) serving WITH the kvd tiered KV cache — CONCRETE recipe.
+#
+# The plain mixed recipe is single-node-qwen-sglang.yaml / -vllm.yaml. This adds
+# kvd, laid out the way Kubernetes wants it rather than with host paths:
+#
+#   * kvd runs as a SIDECAR in the worker Pod. The operator only owns the
+#     container named `main`, so any extra container is passed through verbatim.
+#   * the engine <-> kvd Unix socket lives in an `emptyDir` shared by the two
+#     containers — no hostPath, nothing pinned to a node.
+#   * kvd's L3 spill is a **PVC**, so capacity is requested from the cluster and
+#     the scheduler places the Pod where it can be satisfied.
+#   * kvd's L2 arena is host RAM, so it is charged to the sidecar's memory limit
+#     and needs IPC_LOCK to pin (mlock) it.
+#
+# Requires the model-cache PVC (model-cache/) or a hostPath model, as usual.
+#
+# NOTE ON MEMORY: `--infera-kvd-socket` enables SGLang's hierarchical cache,
+# whose host-RAM tier is sized from the GPU KV pool unless capped. Left alone it
+# requested 416 GB here and the container was OOMKilled — always pass
+# `--hicache-size` (GiB) that fits inside the engine container's memory limit.
+#
+# NOTE ON KV DTYPE: kvd only offloads KV layouts it can round-trip byte-exact.
+# Regular-attention fp8 support landed in #63 — on an engine image predating it,
+# add `--kv-cache-dtype auto` (or env INFERA_DEFAULT_KV_FP8=0) to the worker or
+# kvd will silently store nothing.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kvd-l3
+  namespace: infera
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Gi        # L3 spill; size to your working set
+  storageClassName: local-path   # k3s default; use a fast local-NVMe class in production
+---
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: qwen-kvd
+  namespace: infera
+spec:
+  backendFramework: sglang
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.1
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","/models/Qwen3-0.6B",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "4", memory: 8Gi}, limits: {cpu: "4", memory: 8Gi}}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+        volumes:
+          - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
+    worker:
+      componentType: worker
+      role: mixed
+      replicas: 1
+      extraPodSpec:
+        containers:
+          # ---- the engine ----
+          - name: main
+            image: rocm/infera:sglang-v0.1.1
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--model-path","/models/Qwen3-0.6B",
+                      "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
+                      "--mem-fraction-static","0.8",
+                      "--infera-kvd-socket","/kvd/kvd.sock",
+                      # REQUIRED under Kubernetes: --infera-kvd-socket turns on
+                      # SGLang's hierarchical cache, which otherwise sizes its
+                      # host-RAM tier from the GPU KV pool (it asked for 416 GB
+                      # here) and the container is OOMKilled. Cap it below the
+                      # engine container's memory limit.
+                      "--hicache-size","16",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              - {name: INFERA_KVD_SOCKET, value: /kvd/kvd.sock}
+            resources:
+              requests: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
+              limits: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: dshm, mountPath: /dev/shm}
+          # ---- the kvd sidecar ----
+          # Same image (kvd is pure Python inside the infera package). L2 is the
+          # pinned host-RAM arena; L3 spills to the PVC.
+          - name: kvd
+            image: rocm/infera:sglang-v0.1.1
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.kvd",
+                      "--socket","/kvd/kvd.sock",
+                      "--max-bytes","34359738368",          # 32 GiB L2 host-RAM arena
+                      "--long-path","/l3/long","--long-bytes","107374182400"]  # 100 GiB L3 on the PVC
+            securityContext:
+              capabilities:
+                add: ["IPC_LOCK"]      # required to mlock the arena
+            resources:
+              # Must exceed --max-bytes: the arena is pinned host RAM charged here.
+              requests: {cpu: "4", memory: 40Gi}
+              limits: {cpu: "4", memory: 40Gi}
+            volumeMounts:
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: kvd-l3, mountPath: /l3}
+        volumes:
+          - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
+          # engine <-> kvd UDS: a plain emptyDir shared by the two containers
+          - {name: kvd-sock, emptyDir: {}}
+          - {name: kvd-l3, persistentVolumeClaim: {claimName: kvd-l3}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 32Gi}}

--- a/examples/k8s-deployments/model-cache/model-cache.yaml
+++ b/examples/k8s-deployments/model-cache/model-cache.yaml
@@ -1,0 +1,16 @@
+# Model cache PVC — the infera analog of Dynamo's recipes/*/model-cache.yaml.
+# A download Job (model-download.yaml) populates it; serving pods mount it
+# read-only at /models. Sized for Qwen3-0.6B here; for Kimi-K3 use ~3000Gi and a
+# ReadWriteMany class (a shared CSI) if workers span nodes.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache
+  namespace: infera
+spec:
+  accessModes:
+    - ReadWriteOnce          # local-path is single-node RWO; use ReadWriteMany on a shared CSI for multi-node
+  resources:
+    requests:
+      storage: 20Gi          # Qwen3-0.6B; Kimi-K3 needs ~3000Gi
+  storageClassName: local-path   # k3s default; edit for your cluster's class

--- a/examples/k8s-deployments/model-cache/model-cache.yaml
+++ b/examples/k8s-deployments/model-cache/model-cache.yaml
@@ -1,7 +1,8 @@
-# Model cache PVC — the infera analog of Dynamo's recipes/*/model-cache.yaml.
-# A download Job (model-download.yaml) populates it; serving pods mount it
-# read-only at /models. Sized for Qwen3-0.6B here; for Kimi-K3 use ~3000Gi and a
-# ReadWriteMany class (a shared CSI) if workers span nodes.
+# Model cache PVC. A download Job (model-download.yaml) populates it once, then
+# serving pods mount it read-only at /models. Size it to your model: Kimi-K3 is
+# ~1.5 TB, so the default below leaves headroom; a small model (Qwen3-0.6B) needs
+# only ~20Gi. Use a ReadWriteMany class (a shared CSI) if prefill/decode workers
+# span nodes.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -12,5 +13,5 @@ spec:
     - ReadWriteOnce          # local-path is single-node RWO; use ReadWriteMany on a shared CSI for multi-node
   resources:
     requests:
-      storage: 20Gi          # Qwen3-0.6B; Kimi-K3 needs ~3000Gi
+      storage: 2000Gi        # safe for Kimi-K3 (~1.5 TB); a small model needs only ~20Gi
   storageClassName: local-path   # k3s default; edit for your cluster's class

--- a/examples/k8s-deployments/model-cache/model-download.yaml
+++ b/examples/k8s-deployments/model-cache/model-download.yaml
@@ -27,8 +27,7 @@ spec:
       containers:
         - name: model-download
           # Light, engine-agnostic downloader — any image with huggingface_hub works;
-          # the engine image (offline) is an alternative. hf_xet accelerates large
-          # Xet-backed repos (e.g. Kimi-K3) and is harmless for plain LFS repos.
+          # the engine image (offline) is an alternative.
           image: python:3.11-slim
           securityContext:
             allowPrivilegeEscalation: false
@@ -36,16 +35,22 @@ spec:
               drop: ["ALL"]
             seccompProfile:
               type: RuntimeDefault
+          # Download accelerators — help ONLY on a bandwidth/latency-constrained link
+          # (single-stream underutilizes the pipe). On a fast network the download is
+          # already network-bound (~600 MB/s measured here) and these are no-ops.
+          #   HF_HUB_ENABLE_HF_TRANSFER: parallel-chunked LFS (Kimi-K3 is plain LFS).
+          #   HF_XET_HIGH_PERFORMANCE:   only for Xet-backed repos (Kimi-K3 is NOT one).
           env:
+            - {name: HF_HUB_ENABLE_HF_TRANSFER, value: "1"}
             - {name: HF_XET_HIGH_PERFORMANCE, value: "1"}
-          # envFrom:                       # gated repos only (Kimi-K3): HF_TOKEN
+          # envFrom:                       # gated repos only: HF_TOKEN
           #   - secretRef: {name: hf-token-secret}
           command: ["sh", "-c"]
           # Swap the repo id (and dir) for your model, e.g. moonshotai/Kimi-K3 -> /model-cache/Kimi-K3.
           args:
             - |
               set -eux
-              pip install --no-cache-dir 'huggingface_hub[hf_xet]'
+              pip install --no-cache-dir 'huggingface_hub[hf_xet,hf_transfer]'
               python -c "from huggingface_hub import snapshot_download; print('downloaded ->', snapshot_download('Qwen/Qwen3-0.6B', local_dir='/model-cache/Qwen3-0.6B'))"
           volumeMounts:
             - name: model-cache

--- a/examples/k8s-deployments/model-cache/model-download.yaml
+++ b/examples/k8s-deployments/model-cache/model-download.yaml
@@ -35,14 +35,6 @@ spec:
               drop: ["ALL"]
             seccompProfile:
               type: RuntimeDefault
-          # Download accelerators — help ONLY on a bandwidth/latency-constrained link
-          # (single-stream underutilizes the pipe). On a fast network the download is
-          # already network-bound (~600 MB/s measured here) and these are no-ops.
-          #   HF_HUB_ENABLE_HF_TRANSFER: parallel-chunked LFS (Kimi-K3 is plain LFS).
-          #   HF_XET_HIGH_PERFORMANCE:   only for Xet-backed repos (Kimi-K3 is NOT one).
-          env:
-            - {name: HF_HUB_ENABLE_HF_TRANSFER, value: "1"}
-            - {name: HF_XET_HIGH_PERFORMANCE, value: "1"}
           # envFrom:                       # gated repos only: HF_TOKEN
           #   - secretRef: {name: hf-token-secret}
           command: ["sh", "-c"]
@@ -50,7 +42,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir 'huggingface_hub[hf_xet,hf_transfer]'
+              pip install --no-cache-dir huggingface_hub
               python -c "from huggingface_hub import snapshot_download; print('downloaded ->', snapshot_download('Qwen/Qwen3-0.6B', local_dir='/model-cache/Qwen3-0.6B'))"
           volumeMounts:
             - name: model-cache

--- a/examples/k8s-deployments/model-cache/model-download.yaml
+++ b/examples/k8s-deployments/model-cache/model-download.yaml
@@ -1,6 +1,6 @@
-# Model download Job — populates the model-cache PVC (Dynamo model-download.yaml
-# analog). Runs snapshot_download into a clean dir on the PVC so serving pods can
-# mount it and reference /models/<name> directly (no HF cache-path juggling).
+# Model download Job — populates the model-cache PVC. Runs snapshot_download into
+# a clean dir on the PVC so serving pods can mount it and reference /models/<name>
+# directly (no HF cache-path juggling).
 #
 #   kubectl apply -f model-cache.yaml -n infera
 #   kubectl apply -f model-download.yaml -n infera

--- a/examples/k8s-deployments/model-cache/model-download.yaml
+++ b/examples/k8s-deployments/model-cache/model-download.yaml
@@ -4,7 +4,7 @@
 #
 #   kubectl apply -f model-cache.yaml -n infera
 #   kubectl apply -f model-download.yaml -n infera
-#   kubectl wait --for=condition=Complete job/model-download -n infera --timeout=4h
+#   kubectl wait --for=condition=Complete job/model-download -n infera --timeout=8h
 #
 # For a GATED repo (e.g. moonshotai/Kimi-K3): first create the token secret, then
 # uncomment envFrom below and swap the repo id:
@@ -26,19 +26,27 @@ spec:
       restartPolicy: Never
       containers:
         - name: model-download
-          # Any image with huggingface_hub. The engine image already has it (and
-          # is offline in-cluster); python:3.11-slim + `pip install huggingface_hub`
-          # also works if you prefer an engine-agnostic downloader.
-          image: rocm/infera:sglang-v0.1.1
-          imagePullPolicy: IfNotPresent
+          # Light, engine-agnostic downloader — any image with huggingface_hub works;
+          # the engine image (offline) is an alternative. hf_xet accelerates large
+          # Xet-backed repos (e.g. Kimi-K3) and is harmless for plain LFS repos.
+          image: python:3.11-slim
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - {name: HF_XET_HIGH_PERFORMANCE, value: "1"}
           # envFrom:                       # gated repos only (Kimi-K3): HF_TOKEN
           #   - secretRef: {name: hf-token-secret}
-          command: ["python3", "-c"]
+          command: ["sh", "-c"]
+          # Swap the repo id (and dir) for your model, e.g. moonshotai/Kimi-K3 -> /model-cache/Kimi-K3.
           args:
             - |
-              from huggingface_hub import snapshot_download
-              p = snapshot_download("Qwen/Qwen3-0.6B", local_dir="/model-cache/Qwen3-0.6B")
-              print("downloaded ->", p)
+              set -eux
+              pip install --no-cache-dir 'huggingface_hub[hf_xet]'
+              python -c "from huggingface_hub import snapshot_download; print('downloaded ->', snapshot_download('Qwen/Qwen3-0.6B', local_dir='/model-cache/Qwen3-0.6B'))"
           volumeMounts:
             - name: model-cache
               mountPath: /model-cache

--- a/examples/k8s-deployments/model-cache/model-download.yaml
+++ b/examples/k8s-deployments/model-cache/model-download.yaml
@@ -1,0 +1,48 @@
+# Model download Job — populates the model-cache PVC (Dynamo model-download.yaml
+# analog). Runs snapshot_download into a clean dir on the PVC so serving pods can
+# mount it and reference /models/<name> directly (no HF cache-path juggling).
+#
+#   kubectl apply -f model-cache.yaml -n infera
+#   kubectl apply -f model-download.yaml -n infera
+#   kubectl wait --for=condition=Complete job/model-download -n infera --timeout=4h
+#
+# For a GATED repo (e.g. moonshotai/Kimi-K3): first create the token secret, then
+# uncomment envFrom below and swap the repo id:
+#   kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<tok> -n infera
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: model-download
+  namespace: infera
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: model-download
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: model-download
+          # Any image with huggingface_hub. The engine image already has it (and
+          # is offline in-cluster); python:3.11-slim + `pip install huggingface_hub`
+          # also works if you prefer an engine-agnostic downloader.
+          image: rocm/infera:sglang-v0.1.1
+          imagePullPolicy: IfNotPresent
+          # envFrom:                       # gated repos only (Kimi-K3): HF_TOKEN
+          #   - secretRef: {name: hf-token-secret}
+          command: ["python3", "-c"]
+          args:
+            - |
+              from huggingface_hub import snapshot_download
+              p = snapshot_download("Qwen/Qwen3-0.6B", local_dir="/model-cache/Qwen3-0.6B")
+              print("downloaded ->", p)
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-cache
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache

--- a/examples/k8s-deployments/pd-1p1d-mooncake.yaml
+++ b/examples/k8s-deployments/pd-1p1d-mooncake.yaml
@@ -62,12 +62,11 @@ spec:
             command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
                       "--disaggregation-mode","prefill","--model-path","<MODEL_PATH>",
                       "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
-                      "--mem-fraction-static","0.6",
+                      "--mem-fraction-static","0.8",
                       "--kv-event-transport","zmq","--request-transport","http",
-                      "--disaggregation-transfer-backend","mooncake","--disaggregation-ib-device","ionic_0"]
+                      "--disaggregation-transfer-backend","mooncake"]
             env:
               - {name: SGLANG_USE_AITER, value: "1"}
-              - {name: NCCL_IB_HCA, value: "ionic_0"}
               - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
               - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
               - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
@@ -96,12 +95,11 @@ spec:
             command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
                       "--disaggregation-mode","decode","--model-path","<MODEL_PATH>",
                       "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
-                      "--mem-fraction-static","0.6",
+                      "--mem-fraction-static","0.8",
                       "--kv-event-transport","zmq","--request-transport","http",
-                      "--disaggregation-transfer-backend","mooncake","--disaggregation-ib-device","ionic_0"]
+                      "--disaggregation-transfer-backend","mooncake"]
             env:
               - {name: SGLANG_USE_AITER, value: "1"}
-              - {name: NCCL_IB_HCA, value: "ionic_0"}
               - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
               - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
               - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}

--- a/examples/k8s-deployments/pd-1p1d-mooncake.yaml
+++ b/examples/k8s-deployments/pd-1p1d-mooncake.yaml
@@ -1,0 +1,116 @@
+# PD-disaggregated 1P1D over Mooncake — CONCRETE 2-node recipe.
+# 1 router + 1 prefill (node A) + 1 decode (node B), tp=1 each. KV is streamed
+# prefill -> decode by the Mooncake transfer engine over the ionic RoCE fabric;
+# the Mooncake RPC/handshake rides the pod-overlay (flannel) so it needs no host
+# networking. Uses the libionic-baked engine image, so no runtime host-libionic
+# injection is required (ibv sees the 8 ionic HCAs out of the box).
+#
+# Fill in for your cluster:
+#   <PREFILL_NODE> / <DECODE_NODE>   kubernetes.io/hostname of two GPU nodes that
+#                                    share a routable RoCE fabric (prefill and
+#                                    decode must be able to open an RDMA QP over
+#                                    ionic — same rail/subnet, or a routed fabric).
+#   <MODEL_DIR>                      a directory reachable at the SAME path on both
+#                                    nodes (shared FS, e.g. /mnt/vast/.../qwen)
+#                                    holding the model dir; mounted at /models.
+#   <MODEL_PATH>                     /models/<model-dir> as seen inside the pod.
+#
+# Requirements per worker: privileged + a hostPath mount of /dev/infiniband (the
+# ionic uverbs devices); no rdma/hca device-plugin needed with this approach.
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: qwen-pd
+  namespace: infera
+spec:
+  backendFramework: sglang
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.2      # libionic (ABI 4) baked
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","<MODEL_PATH>",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "4", memory: 8Gi}, limits: {cpu: "4", memory: 8Gi}}
+            volumeMounts: [{name: model, mountPath: /models, readOnly: true}]
+        volumes: [{name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}]
+    prefill:
+      componentType: worker
+      role: prefill
+      replicas: 1
+      port: 30000
+      skipReadinessProbe: true
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.2
+            imagePullPolicy: IfNotPresent
+            securityContext: {privileged: true, capabilities: {add: ["IPC_LOCK","SYS_PTRACE"]}}
+            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--disaggregation-mode","prefill","--model-path","<MODEL_PATH>",
+                      "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
+                      "--mem-fraction-static","0.6",
+                      "--kv-event-transport","zmq","--request-transport","http",
+                      "--disaggregation-transfer-backend","mooncake","--disaggregation-ib-device","ionic_0"]
+            env:
+              - {name: SGLANG_USE_AITER, value: "1"}
+              - {name: NCCL_IB_HCA, value: "ionic_0"}
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}, limits: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+              - {name: ib, mountPath: /dev/infiniband}
+        volumes:
+          - {name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 16Gi}}
+          - {name: ib, hostPath: {path: /dev/infiniband, type: Directory}}
+    decode:
+      componentType: worker
+      role: decode
+      replicas: 1
+      port: 30000
+      skipReadinessProbe: true
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <DECODE_NODE>}
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.2
+            imagePullPolicy: IfNotPresent
+            securityContext: {privileged: true, capabilities: {add: ["IPC_LOCK","SYS_PTRACE"]}}
+            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--disaggregation-mode","decode","--model-path","<MODEL_PATH>",
+                      "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
+                      "--mem-fraction-static","0.6",
+                      "--kv-event-transport","zmq","--request-transport","http",
+                      "--disaggregation-transfer-backend","mooncake","--disaggregation-ib-device","ionic_0"]
+            env:
+              - {name: SGLANG_USE_AITER, value: "1"}
+              - {name: NCCL_IB_HCA, value: "ionic_0"}
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}, limits: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+              - {name: ib, mountPath: /dev/infiniband}
+        volumes:
+          - {name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 16Gi}}
+          - {name: ib, hostPath: {path: /dev/infiniband, type: Directory}}

--- a/examples/k8s-deployments/pd-kvd.yaml
+++ b/examples/k8s-deployments/pd-kvd.yaml
@@ -1,0 +1,200 @@
+# PD-disaggregated 1P1D over Mooncake, WITH the kvd tiered KV cache — the fourth
+# recipe shape (mixed, mixed+kvd, pd, pd+kvd).
+#
+# PD structure is pd-1p1d-mooncake.yaml; kvd is layered on the same way as in
+# mixed-kvd.yaml, but on BOTH roles: prefill and decode each get their own kvd
+# sidecar, their own emptyDir socket, and their own L3 PVC.
+#
+# Why per-role rather than one shared kvd: the two roles hold different KV.
+# Prefill produces prefix KV worth reusing across requests; decode holds the
+# transferred working set. They also sit on different nodes, and a PVC is
+# ReadWriteOnce — a shared daemon would pin both roles to one node and undo the
+# point of disaggregating them.
+#
+# NOTE ON THE L3 PVCs AND SCHEDULING: with a node-local StorageClass (k3s
+# `local-path`, local-static-provisioner, most local-NVMe CSIs) each PV is bound
+# to the node that first consumed it, and that binding OUTLIVES the Pod. If a
+# role is later pinned to a different node, the scheduler cannot satisfy both the
+# PV's node affinity and the Pod's, and the Pod stays Pending forever:
+#
+#   0/2 nodes are available: 1 node(s) didn't match PersistentVolume's node
+#   affinity, 1 node(s) didn't match Pod's node affinity
+#
+# So either (a) delete and recreate the PVC when you move a role between nodes,
+# or (b) use a StorageClass whose volumes are not node-local. This is why the two
+# roles get SEPARATE PVCs — a single shared ReadWriteOnce claim would pin prefill
+# and decode to the same node and defeat the disaggregation.
+#
+# Fill in for your cluster:
+#   <PREFILL_NODE> / <DECODE_NODE>   two GPU nodes on a routable RoCE fabric
+#                                    (see pd-1p1d-mooncake.yaml — prefill and
+#                                    decode must be able to open an RDMA QP)
+#   <MODEL_DIR>                      a directory at the SAME path on both nodes
+#   <MODEL_PATH>                     /models/<model-dir> inside the pod
+#
+# NOTE ON MEMORY: `--infera-kvd-socket` enables SGLang's hierarchical cache,
+# whose host-RAM tier is sized from the GPU KV pool unless capped. Left alone it
+# will ask for hundreds of GB and the container is OOMKilled — `--hicache-size`
+# (GiB) must fit inside the engine container's memory limit.
+#
+# NOTE ON KV DTYPE: kvd only offloads KV layouts it can round-trip byte-exact.
+# Regular-attention fp8 support landed in #63; on an older engine image add
+# `--kv-cache-dtype auto` or kvd silently stores nothing.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kvd-l3-prefill
+  namespace: infera
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: {requests: {storage: 200Gi}}
+  storageClassName: local-path
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kvd-l3-decode
+  namespace: infera
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: {requests: {storage: 200Gi}}
+  storageClassName: local-path
+---
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: qwen-pd-kvd
+  namespace: infera
+spec:
+  backendFramework: sglang
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.2      # libionic (ABI 4) baked
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","<MODEL_PATH>",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "4", memory: 8Gi}, limits: {cpu: "4", memory: 8Gi}}
+            volumeMounts: [{name: model, mountPath: /models, readOnly: true}]
+        volumes: [{name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}]
+    prefill:
+      componentType: worker
+      role: prefill
+      replicas: 1
+      port: 30000
+      skipReadinessProbe: true
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.2
+            imagePullPolicy: IfNotPresent
+            securityContext: {privileged: true, capabilities: {add: ["IPC_LOCK","SYS_PTRACE"]}}
+            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--disaggregation-mode","prefill","--model-path","<MODEL_PATH>",
+                      "--infera-kvd-socket","/kvd/kvd.sock","--hicache-size","16",
+                      "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
+                      "--mem-fraction-static","0.8",
+                      "--kv-event-transport","zmq","--request-transport","http",
+                      "--disaggregation-transfer-backend","mooncake"]
+            env:
+              - {name: SGLANG_USE_AITER, value: "1"}
+              - {name: INFERA_KVD_SOCKET, value: /kvd/kvd.sock}
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}, limits: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+              - {name: ib, mountPath: /dev/infiniband}
+              - {name: kvd-sock, mountPath: /kvd}
+          # ---- kvd sidecar for this role ----
+          - name: kvd
+            image: rocm/infera:sglang-v0.1.2
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.kvd",
+                      "--socket","/kvd/kvd.sock",
+                      "--max-bytes","34359738368",
+                      "--long-path","/l3/long","--long-bytes","107374182400"]
+            securityContext:
+              capabilities: {add: ["IPC_LOCK"]}
+            resources:
+              requests: {cpu: "4", memory: 40Gi}
+              limits: {cpu: "4", memory: 40Gi}
+            volumeMounts:
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: kvd-l3, mountPath: /l3}
+        volumes:
+          - {name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}
+          - {name: kvd-sock, emptyDir: {}}
+          - {name: kvd-l3, persistentVolumeClaim: {claimName: kvd-l3-prefill}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 16Gi}}
+          - {name: ib, hostPath: {path: /dev/infiniband, type: Directory}}
+    decode:
+      componentType: worker
+      role: decode
+      replicas: 1
+      port: 30000
+      skipReadinessProbe: true
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <DECODE_NODE>}
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.2
+            imagePullPolicy: IfNotPresent
+            securityContext: {privileged: true, capabilities: {add: ["IPC_LOCK","SYS_PTRACE"]}}
+            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--disaggregation-mode","decode","--model-path","<MODEL_PATH>",
+                      "--infera-kvd-socket","/kvd/kvd.sock","--hicache-size","16",
+                      "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
+                      "--mem-fraction-static","0.8",
+                      "--kv-event-transport","zmq","--request-transport","http",
+                      "--disaggregation-transfer-backend","mooncake"]
+            env:
+              - {name: SGLANG_USE_AITER, value: "1"}
+              - {name: INFERA_KVD_SOCKET, value: /kvd/kvd.sock}
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}, limits: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+              - {name: ib, mountPath: /dev/infiniband}
+              - {name: kvd-sock, mountPath: /kvd}
+          # ---- kvd sidecar for this role ----
+          - name: kvd
+            image: rocm/infera:sglang-v0.1.2
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.kvd",
+                      "--socket","/kvd/kvd.sock",
+                      "--max-bytes","34359738368",
+                      "--long-path","/l3/long","--long-bytes","107374182400"]
+            securityContext:
+              capabilities: {add: ["IPC_LOCK"]}
+            resources:
+              requests: {cpu: "4", memory: 40Gi}
+              limits: {cpu: "4", memory: 40Gi}
+            volumeMounts:
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: kvd-l3, mountPath: /l3}
+        volumes:
+          - {name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}
+          - {name: kvd-sock, emptyDir: {}}
+          - {name: kvd-l3, persistentVolumeClaim: {claimName: kvd-l3-decode}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 16Gi}}
+          - {name: ib, hostPath: {path: /dev/infiniband, type: Directory}}

--- a/examples/k8s-deployments/single-node-qwen-sglang.yaml
+++ b/examples/k8s-deployments/single-node-qwen-sglang.yaml
@@ -1,0 +1,67 @@
+# Single-node aggregated — CONCRETE, ready-to-apply validation recipe.
+# 1 router (server, no GPU) + 1 mixed worker (sglang, tp=1, 1 amd.com/gpu),
+# Qwen3-0.6B mounted from a host dir via hostPath (no PVC/CSI needed). This is a
+# filled-in copy of single-node-aggregated.yaml used to validate the operator +
+# engine path end to end on a single box (k3s). Adjust the two host values for
+# your node:
+#   image        rocm/infera:sglang-v0.1.1   (must be present in the node runtime)
+#   model dir    /mnt/k3local/models/qwen    (contains Qwen3-0.6B/)
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: qwen-agg
+  namespace: infera
+spec:
+  backendFramework: sglang
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.1
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","/models/Qwen3-0.6B",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources:
+              requests: {cpu: "4", memory: 8Gi}
+              limits: {cpu: "4", memory: 8Gi}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+        volumes:
+          - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
+    worker:
+      componentType: worker
+      role: mixed
+      replicas: 1
+      extraPodSpec:
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.1
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--model-path","/models/Qwen3-0.6B",
+                      "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
+                      "--mem-fraction-static","0.8",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources:
+              requests: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
+              limits: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+        volumes:
+          - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 32Gi}}

--- a/examples/k8s-deployments/single-node-qwen-vllm.yaml
+++ b/examples/k8s-deployments/single-node-qwen-vllm.yaml
@@ -4,7 +4,7 @@
 # (infera.server) is engine-agnostic; only the worker changes to
 # infera.engine.vllm with vLLM-style flags (--model / --tensor-parallel-size /
 # --gpu-memory-utilization). Adjust for your node:
-#   image        infera/infera:vllm-v0.1.0-rc5   (present in the node runtime)
+#   image        rocm/infera:vllm-v0.1.1   (present in the node runtime)
 #   model dir    /mnt/k3local/models/qwen        (contains Qwen3-0.6B/)
 apiVersion: infera.amd.com/v1alpha1
 kind: InferaDeployment
@@ -22,7 +22,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: inferaimage/infera:vllm-v0.1.0-rc5
+            image: rocm/infera:vllm-v0.1.1
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/Qwen3-0.6B",
@@ -45,7 +45,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: inferaimage/infera:vllm-v0.1.0-rc5
+            image: rocm/infera:vllm-v0.1.1
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
                       "--model","/models/Qwen3-0.6B","--served-model-name","Qwen3-0.6B",

--- a/examples/k8s-deployments/single-node-qwen-vllm.yaml
+++ b/examples/k8s-deployments/single-node-qwen-vllm.yaml
@@ -1,0 +1,66 @@
+# Single-node aggregated (vLLM) — CONCRETE, ready-to-apply validation recipe.
+# 1 router (server, no GPU) + 1 mixed worker (vLLM, tp=1, 1 amd.com/gpu),
+# Qwen3-0.6B via hostPath. vLLM twin of single-node-qwen-sglang.yaml: the router
+# (infera.server) is engine-agnostic; only the worker changes to
+# infera.engine.vllm with vLLM-style flags (--model / --tensor-parallel-size /
+# --gpu-memory-utilization). Adjust for your node:
+#   image        infera/infera:vllm-v0.1.0-rc5   (present in the node runtime)
+#   model dir    /mnt/k3local/models/qwen        (contains Qwen3-0.6B/)
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: qwen-agg-vllm
+  namespace: infera
+spec:
+  backendFramework: vllm
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        containers:
+          - name: main
+            image: inferaimage/infera:vllm-v0.1.0-rc5
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","/models/Qwen3-0.6B",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources:
+              requests: {cpu: "4", memory: 8Gi}
+              limits: {cpu: "4", memory: 8Gi}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+        volumes:
+          - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
+    worker:
+      componentType: worker
+      role: mixed
+      replicas: 1
+      extraPodSpec:
+        containers:
+          - name: main
+            image: inferaimage/infera:vllm-v0.1.0-rc5
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
+                      "--model","/models/Qwen3-0.6B","--served-model-name","Qwen3-0.6B",
+                      "--tensor-parallel-size","1","--gpu-memory-utilization","0.85","--trust-remote-code",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources:
+              requests: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
+              limits: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+        volumes:
+          - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 32Gi}}

--- a/examples/k8s-deployments/single-node-qwen-vllm.yaml
+++ b/examples/k8s-deployments/single-node-qwen-vllm.yaml
@@ -4,7 +4,7 @@
 # (infera.server) is engine-agnostic; only the worker changes to
 # infera.engine.vllm with vLLM-style flags (--model / --tensor-parallel-size /
 # --gpu-memory-utilization). Adjust for your node:
-#   image        rocm/infera:vllm-v0.1.1   (present in the node runtime)
+#   image        rocm/infera:vllm-v0.1.2   (present in the node runtime)
 #   model dir    /mnt/k3local/models/qwen        (contains Qwen3-0.6B/)
 apiVersion: infera.amd.com/v1alpha1
 kind: InferaDeployment
@@ -22,7 +22,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: rocm/infera:vllm-v0.1.1
+            image: rocm/infera:vllm-v0.1.2
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/Qwen3-0.6B",
@@ -45,7 +45,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: rocm/infera:vllm-v0.1.1
+            image: rocm/infera:vllm-v0.1.2
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
                       "--model","/models/Qwen3-0.6B","--served-model-name","Qwen3-0.6B",

--- a/examples/k8s-deployments/single-node-qwen-vllm.yaml
+++ b/examples/k8s-deployments/single-node-qwen-vllm.yaml
@@ -4,7 +4,7 @@
 # (infera.server) is engine-agnostic; only the worker changes to
 # infera.engine.vllm with vLLM-style flags (--model / --tensor-parallel-size /
 # --gpu-memory-utilization). Adjust for your node:
-#   image        rocm/infera:vllm-v0.1.2   (present in the node runtime)
+#   image        rocm/infera:vllm-v0.1.1   (present in the node runtime)
 #   model dir    /mnt/k3local/models/qwen        (contains Qwen3-0.6B/)
 apiVersion: infera.amd.com/v1alpha1
 kind: InferaDeployment
@@ -22,7 +22,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: rocm/infera:vllm-v0.1.2
+            image: rocm/infera:vllm-v0.1.1
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/Qwen3-0.6B",
@@ -45,7 +45,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: rocm/infera:vllm-v0.1.2
+            image: rocm/infera:vllm-v0.1.1
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
                       "--model","/models/Qwen3-0.6B","--served-model-name","Qwen3-0.6B",

--- a/examples/kimi_k3/README.md
+++ b/examples/kimi_k3/README.md
@@ -1,0 +1,37 @@
+# Kimi-K3 on AMD Instinct (MI355X)
+
+Serve **Kimi-K3** on AMD Instinct GPUs. Per the AMD "Kimi-K3 on AMD Instinct GPUs"
+guide, low-bit (MXFP4 / A8W4) is done **at runtime by aiter** from the native
+checkpoint — no separate quantized download.
+
+## Base images
+- **vLLM:** `vllm/vllm-openai-rocm:kimi-k3`
+- **SGLang:** `lmsysorg/sglang-rocm:rocm720-mi35x-k3-20260727`
+
+## Model
+`moonshotai/Kimi-K3` — native checkpoint (~1.5 TB, 96 shards), cached at
+`/mnt/vast/yaocheng/models/moonshotai/Kimi-K3`. The aiter env flags
+(`AITER_SITUV2_A8W4=1`, `AITER_BF16_FP8_MOE_BOUND=0`) do the low-bit MoE at load.
+
+## Run (8-GPU node, TP8)
+
+```bash
+bash vllm_serve.sh            # TP8 on the cached checkpoint, port 8000
+MODEL=<path-or-repo> TP=8 PORT=8000 bash vllm_serve.sh   # overrides
+docker logs -f kimi_k3_vllm
+```
+
+The vLLM image ENTRYPOINT is `/bin/bash`, so the script serves via `vllm serve
+<model> <flags>` (entrypoint overridden). Flags/env match the AMD guide:
+`VLLM_ROCM_USE_AITER=1`, `--moe-backend auto`, `--tensor-parallel-size 8`,
+`--gpu-memory-utilization 0.95`, `--mm-encoder-tp-mode data`,
+`--tool-call-parser kimi_k3 --reasoning-parser kimi_k3`.
+
+## Smoke test
+
+```bash
+curl -s http://localhost:8000/v1/chat/completions -H 'Content-Type: application/json' \
+  -d '{"model":"kimi-k3","messages":[{"role":"user","content":"hi"}],"max_tokens":16}'
+```
+
+SGLang launcher: TODO (base image above).

--- a/examples/kimi_k3/mm_test.py
+++ b/examples/kimi_k3/mm_test.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Multimodal smoke test for Kimi-K3 (VL) on vLLM.
+
+Sends an image + question via the OpenAI chat/completions API and prints the
+answer — proves the vision encode → prefill → decode path works end to end.
+Default image is a stdlib-generated solid colour (no network); pass --url for a
+real image.
+
+  python mm_test.py --port 8000
+  python mm_test.py --port 8000 --url https://.../cat.jpg
+"""
+
+import argparse
+import base64
+import json
+import struct
+import sys
+import urllib.request
+import zlib
+
+
+def solid_png(r, g, b, side=64) -> bytes:
+    def chunk(tag, data):
+        return (
+            struct.pack(">I", len(data))
+            + tag
+            + data
+            + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+        )
+
+    raw = (b"\x00" + bytes([r, g, b]) * side) * side
+    ihdr = struct.pack(">IIBBBBB", side, side, 8, 2, 0, 0, 0)
+    return b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) + chunk(b"IDAT", zlib.compress(raw, 9)) + chunk(b"IEND", b"")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=8000)
+    ap.add_argument("--model", default="kimi-k3")
+    ap.add_argument("--url", help="image URL; default = a generated crimson square")
+    ap.add_argument("--prompt", default="What is the dominant colour of this image? Answer in one word.")
+    args = ap.parse_args()
+
+    image = args.url or ("data:image/png;base64," + base64.b64encode(solid_png(220, 20, 60)).decode())
+    body = {
+        "model": args.model,
+        "max_tokens": 64,
+        "temperature": 0,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": args.prompt},
+                    {"type": "image_url", "image_url": {"url": image}},
+                ],
+            }
+        ],
+    }
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{args.port}/v1/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=120) as r:
+        out = json.load(r)
+    msg = out["choices"][0]["message"]
+    print("answer:", repr(msg.get("content")))
+    if msg.get("reasoning_content"):
+        print("reasoning:", repr(msg["reasoning_content"])[:200])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/kimi_k3/mm_test.py
+++ b/examples/kimi_k3/mm_test.py
@@ -30,7 +30,12 @@ def solid_png(r, g, b, side=64) -> bytes:
 
     raw = (b"\x00" + bytes([r, g, b]) * side) * side
     ihdr = struct.pack(">IIBBBBB", side, side, 8, 2, 0, 0, 0)
-    return b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) + chunk(b"IDAT", zlib.compress(raw, 9)) + chunk(b"IEND", b"")
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", ihdr)
+        + chunk(b"IDAT", zlib.compress(raw, 9))
+        + chunk(b"IEND", b"")
+    )
 
 
 def main():
@@ -38,10 +43,14 @@ def main():
     ap.add_argument("--port", type=int, default=8000)
     ap.add_argument("--model", default="kimi-k3")
     ap.add_argument("--url", help="image URL; default = a generated crimson square")
-    ap.add_argument("--prompt", default="What is the dominant colour of this image? Answer in one word.")
+    ap.add_argument(
+        "--prompt", default="What is the dominant colour of this image? Answer in one word."
+    )
     args = ap.parse_args()
 
-    image = args.url or ("data:image/png;base64," + base64.b64encode(solid_png(220, 20, 60)).decode())
+    image = args.url or (
+        "data:image/png;base64," + base64.b64encode(solid_png(220, 20, 60)).decode()
+    )
     body = {
         "model": args.model,
         "max_tokens": 64,

--- a/examples/kimi_k3/vllm_serve.sh
+++ b/examples/kimi_k3/vllm_serve.sh
@@ -12,13 +12,19 @@ TP=${TP:-8}
 NAME=${NAME:-kimi_k3_vllm}
 
 docker rm -f "$NAME" >/dev/null 2>&1
+# Make the model visible inside the container: mount the top-level filesystem the
+# MODEL path lives on (e.g. /mnt/vast or /mnt/k3local). Without this a local path
+# is invisible in the container and HF treats it as a repo id -> HFValidationError.
+MODEL_MNT="/$(echo "$MODEL" | cut -d/ -f2-3)"   # e.g. /mnt/k3local, /mnt/vast
+MOUNTS=(-v /mnt/vast:/mnt/vast)
+[ "$MODEL_MNT" != "/mnt/vast" ] && [ -d "$MODEL_MNT" ] && MOUNTS+=(-v "$MODEL_MNT":"$MODEL_MNT")
 # Image ENTRYPOINT is /bin/bash (dev image), so serve via the vllm CLI:
 # `vllm serve <model> <flags>` (override the entrypoint).
 docker run -d --name "$NAME" \
   --device=/dev/kfd --device=/dev/dri \
   --security-opt seccomp=unconfined --group-add video \
   --privileged --ipc=host --shm-size 32g -p "$PORT":8000 \
-  -v /mnt/vast:/mnt/vast \
+  "${MOUNTS[@]}" \
   -v ~/.cache/huggingface:/root/.cache/huggingface \
   -e HF_HUB_OFFLINE=1 \
   -e VLLM_ROCM_USE_AITER=1 \

--- a/examples/kimi_k3/vllm_serve.sh
+++ b/examples/kimi_k3/vllm_serve.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Kimi-K3 on AMD Instinct — vLLM serve (TP8), MXFP4/A8W4 runtime quant via aiter.
+# Base image + flags per the AMD "Kimi-K3 on AMD Instinct GPUs" guide. Run ON an
+# 8-GPU node. The native moonshotai/Kimi-K3 checkpoint (~1.5 TB) is cached on the
+# shared mount; the aiter A8W4 env flags do the low-bit quantization at load.
+set -u
+IMG=${IMG:-vllm/vllm-openai-rocm:kimi-k3}
+# Local cached checkpoint (plain dir); override MODEL to use a different path/repo.
+MODEL=${MODEL:-/mnt/vast/yaocheng/models/moonshotai/Kimi-K3}
+PORT=${PORT:-8000}
+TP=${TP:-8}
+NAME=${NAME:-kimi_k3_vllm}
+
+docker rm -f "$NAME" >/dev/null 2>&1
+# Image ENTRYPOINT is /bin/bash (dev image), so serve via the vllm CLI:
+# `vllm serve <model> <flags>` (override the entrypoint).
+docker run -d --name "$NAME" \
+  --device=/dev/kfd --device=/dev/dri \
+  --security-opt seccomp=unconfined --group-add video \
+  --privileged --ipc=host --shm-size 32g -p "$PORT":8000 \
+  -v /mnt/vast:/mnt/vast \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  -e HF_HUB_OFFLINE=1 \
+  -e VLLM_ROCM_USE_AITER=1 \
+  -e SAFETENSORS_FAST_GPU=1 \
+  -e AITER_SITUV2_A8W4=1 \
+  -e AITER_BF16_FP8_MOE_BOUND=0 \
+  -e VLLM_USE_BREAKABLE_CUDAGRAPH=0 \
+  --entrypoint vllm \
+  "$IMG" serve "$MODEL" \
+  --served-model-name kimi-k3 \
+  --trust-remote-code \
+  --moe-backend auto \
+  --tensor-parallel-size "$TP" \
+  --load-format auto \
+  --gpu-memory-utilization 0.95 \
+  --mm-encoder-tp-mode data \
+  --max-num-seqs 128 \
+  --max-num-batched-tokens 4096 \
+  --enable-auto-tool-choice \
+  --tool-call-parser kimi_k3 \
+  --reasoning-parser kimi_k3
+
+echo "launched $NAME (TP$TP) on port $PORT; follow: docker logs -f $NAME"

--- a/manual/examples/k8s_glm5.2_sglang.md
+++ b/manual/examples/k8s_glm5.2_sglang.md
@@ -20,6 +20,18 @@ via the router returns a correct answer ("… the capital of France is Paris …
 the same request on the vLLM image returns garbage.
 ```
 
+```{admonition} What is validated
+:class: note
+On single-node k3s (MI355X, `amd.com/gpu: 8`), GLM-5.2-MXFP4 at TP8 through this
+manifest: the operator reconciled the CR into router + worker, the worker reached
+Ready in **~6 min** (~408 GiB of weights plus DSA graph capture), and a
+`/v1/chat/completions` request through the router returned a **correct, coherent**
+answer.
+
+The same request against the vLLM image on the same hardware returned
+`'1!!!!!!!...'` — which is why this recipe is SGLang-only.
+```
+
 ```{admonition} REQUIRED ROCm env — GLM-5.2 crashes at init without it
 :class: warning
 Stock SGLang defaults a **CUDA-only DSA top-k JIT kernel** that will not build on

--- a/manual/examples/k8s_glm5.2_sglang.md
+++ b/manual/examples/k8s_glm5.2_sglang.md
@@ -1,0 +1,86 @@
+# Example: GLM-5.2 on Kubernetes — SGLang (DSA), single node
+
+A **Kubernetes-native** recipe for **GLM-5.2-MXFP4** (`GlmMoeDsaForCausalLM` —
+MLA + DeepSeek Sparse Attention): an **`InferaDeployment`** the operator
+reconciles into a router + a TP8 **SGLang** worker on one 8-GPU node. SGLang is
+the correct and fastest engine for GLM-5.2 on ROCm.
+
+The manifest is
+[`examples/k8s-deployments/glm5.2-sglang.yaml`](https://github.com/AMD-AGI/Infera/tree/main/examples/k8s-deployments/glm5.2-sglang.yaml).
+See [Kubernetes deployment](../serving/kubernetes.md) for the general flow and
+the [Kimi-K3 recipe](k8s_kimi_k3.md) for the vLLM/multimodal single-node case.
+
+```{admonition} Use SGLang, not vLLM, for GLM-5.2
+:class: important
+GLM-5.2's MLA/DSA decode is **numerically buggy on vLLM** (ROCm) — the engine
+loads and serves, but decode degrades to `!!!!` garbage after a few tokens.
+**SGLang produces correct, coherent output** and is the fastest engine here.
+Validated on k3s (MI355X): worker Ready ~6 min, a `/v1/chat/completions` request
+via the router returns a correct answer ("… the capital of France is Paris …");
+the same request on the vLLM image returns garbage.
+```
+
+```{admonition} REQUIRED ROCm env — GLM-5.2 crashes at init without it
+:class: warning
+Stock SGLang defaults a **CUDA-only DSA top-k JIT kernel** that will not build on
+gfx950 (MI355X) and crashes engine init. Force the ROCm tilelang path:
+`SGLANG_OPT_USE_TILELANG_INDEXER=1`, `SGLANG_OPT_USE_TOPK_V2=0`,
+`SGLANG_OPT_USE_JIT_NORM=0` (+ `SGLANG_USE_AITER=1`,
+`SGLANG_ROCM_FUSED_DECODE_MLA=0`), and pass `--nsa-prefill-backend tilelang
+--nsa-decode-backend tilelang`. Needs SGLang **0.5.15+** — older ROCm SGLang
+can't load GLM-5.2's changed `head_dim`. All wired into the manifest.
+```
+
+## Topology
+
+One 8-GPU node, aggregated: a CPU-only **router** (`infera.server`) in front of
+one **mixed SGLang worker** at **TP8**, both mounting the model read-only.
+
+| Component | GPUs | What it runs |
+|---|---|---|
+| `glm52-server` | 0 | `infera.server` — OpenAI endpoint + router, ClusterIP `:8000` |
+| `glm52-worker` | 8 | `infera.engine.sglang` — GLM-5.2, `--tp-size 8`, DSA tilelang backends, fp8 KV |
+
+## Prerequisites
+
+- A Kubernetes cluster with one **8× ROCm-GPU node**, `kubectl`/`helm`, the AMD
+  GPU device plugin (`amd.com/gpu`), and the infera-operator — see
+  [Kubernetes deployment](../serving/kubernetes.md).
+- The SGLang engine image (`rocm/infera:sglang-v0.1.1`, SGLang 0.5.15+) present
+  in the node's containerd (`k3s ctr images import` for a local image).
+- The GLM-5.2-MXFP4 checkpoint reachable inside the pod — a `hostPath` (as in the
+  manifest) or the [model-cache](k8s_kimi_k3.md#1-model-cache-pvc-download-job) PVC.
+
+## Deploy & verify
+
+```bash
+kubectl create namespace infera
+# adjust the model hostPath / image in the manifest for your node
+kubectl apply -f examples/k8s-deployments/glm5.2-sglang.yaml
+
+kubectl -n infera get inferadeployment -w     # STATE -> ready (~6-18 min: weights + DSA graphs)
+kubectl -n infera get pods                     # glm52-server 1/1, glm52-worker 1/1
+
+kubectl -n infera port-forward svc/glm52-server 8000:8000 &
+curl -s localhost:8000/v1/chat/completions -H 'Content-Type: application/json' \
+  -d '{"model":"glm5.2-mxfp4","messages":[{"role":"user","content":"What is the capital of France?"}],"max_tokens":60}'
+```
+
+A coherent answer confirms router → SGLang DSA worker end to end.
+
+## Notes & gotchas
+
+- **fp8 KV is fine on SGLang** (`--kv-cache-dtype fp8_e4m3`) — SGLang handles the
+  fp8 MLA KV correctly for GLM-5.2. (On vLLM, fp8 KV gives immediate garbage and
+  even bf16 KV degrades — hence "use SGLang".)
+- **Bound the DSA memory.** `--chunked-prefill-size 8192` (the DSA indexer
+  profiling OOMs higher) and a modest `--context-length` keep the KV pool in
+  check; production long-context runs push `--context-length` to ~400000.
+- **Slow load — startupProbe.** ~408 GiB of weights load in ~6-18 min (faster
+  from local NVMe than a shared FS); a generous `startupProbe` holds the pod
+  non-Ready through the load. See the [Kimi-K3 recipe](k8s_kimi_k3.md) for the
+  same pattern.
+- **Free the GPUs between runs.** Deleting the `InferaDeployment` does not always
+  reap the engine processes; a lingering TP group can hold VRAM and the next
+  deploy fails with "free memory … less than desired". Kill stragglers
+  (`rocm-smi --showpids`) before redeploying.

--- a/manual/examples/k8s_kimi_k3.md
+++ b/manual/examples/k8s_kimi_k3.md
@@ -19,19 +19,23 @@ reconciling an `InferaDeployment` into router + worker + Service, and a real
 engines on `Qwen3-0.6B`, including serving straight from the model-cache PVC
 (see [`RECIPE-single-node.md`](https://github.com/AMD-AGI/Infera/blob/main/examples/k8s-deployments/RECIPE-single-node.md)).
 
-Kimi-K3 needs a vLLM build with `kimi_k3` model support. The standard infera vLLM
-image now bases on the `kimi_k3` vLLM build (see `deploy/docker/Dockerfile.vllm`),
-so it carries that support out of the box — just build it the normal way:
+Kimi-K3 needs a vLLM build with `kimi_k3` model support. Layer infera onto the
+upstream `kimi_k3` vLLM by overriding the base of the standard vLLM image build:
 
 ```bash
-docker build -f deploy/docker/Dockerfile.vllm -t rocm/infera:vllm-v0.1.2 .
+docker build -f deploy/docker/Dockerfile.vllm \
+  --build-arg VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3 \
+  --build-arg BUILD_AITER=0 --build-arg BUILD_MOONCAKE=0 \
+  --build-arg BUILD_HIPFILE=0 --build-arg INSTALL_LIBIONIC=0 \
+  -t rocm/infera:vllm-kimi-k3 .
 ```
 
 The result carries `infera.server` + `infera.engine.vllm` **and**
 `KimiK3ForConditionalGeneration`. With this image the full path is validated on a
 single 8-GPU node: operator → router → `infera.engine.vllm` TP8 worker serving
 Kimi-K3 (MXFP4), and a **multimodal** image request through the router returns a
-correct colour-grounded answer.
+correct colour-grounded answer. The disabled layers are RDMA-PD / kvd-L3 only;
+aiter stays the base's kimi-tuned build.
 ```
 
 ## Topology
@@ -69,7 +73,7 @@ PVC read-only.
 - The engine **image present in the node container runtime**. k3s uses
   containerd (not docker) — import a local image as a tar, not a stream:
   ```bash
-  docker save rocm/infera:vllm-v0.1.2 -o /mnt/<big-disk>/img.tar
+  docker save <infera-vllm-kimi-k3-image> -o /mnt/<big-disk>/img.tar
   sudo k3s ctr images import /mnt/<big-disk>/img.tar
   ```
 

--- a/manual/examples/k8s_kimi_k3.md
+++ b/manual/examples/k8s_kimi_k3.md
@@ -2,9 +2,8 @@
 
 A **Kubernetes-native** recipe for **Kimi-K3** (the multimodal VLM): a
 `model-cache` PVC populated by a download Job, then an **`InferaDeployment`** the
-operator reconciles into a router + a TP8 vLLM worker on one 8-GPU node. This is
-the infera analog of a vendor "recipe" (e.g. NVIDIA Dynamo's `recipes/kimi-k3`),
-using only `kubectl`/`helm` and one CR.
+operator reconciles into a router + a TP8 vLLM worker on one 8-GPU node, using
+only `kubectl`/`helm` and one CR.
 
 The runnable manifests live in the repo under
 [`examples/k8s-deployments/`](https://github.com/AMD-AGI/Infera/tree/main/examples/k8s-deployments)
@@ -28,7 +27,7 @@ docker build -f deploy/docker/Dockerfile.vllm \
   --build-arg VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3 \
   --build-arg BUILD_AITER=0 --build-arg BUILD_MOONCAKE=0 \
   --build-arg BUILD_HIPFILE=0 --build-arg INSTALL_LIBIONIC=0 \
-  -t inferaimage/infera:vllm-kimi-k3 .
+  -t rocm/infera:vllm-kimi-k3 .
 ```
 
 The result carries `infera.server` + `infera.engine.vllm` **and**
@@ -81,15 +80,15 @@ PVC read-only.
 ## 1. Model cache (PVC + download Job)
 
 The [`model-cache/`](https://github.com/AMD-AGI/Infera/tree/main/examples/k8s-deployments/model-cache)
-pair mirrors Dynamo's model-cache: a PVC plus a Job that downloads the checkpoint
-into it. Kimi-K3 is **gated (~1.5 TB)**, so create the HF token secret and size
-the PVC to ~3000 Gi first:
+pair is a PVC plus a Job that downloads the checkpoint into it. Kimi-K3 is
+**gated (~1.5 TB)**, so create the HF token secret and size the PVC to ~2000 Gi
+first:
 
 ```bash
 kubectl create namespace infera
 kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<token> -n infera
 
-# edit model-cache.yaml: storage: 3000Gi (+ a ReadWriteMany class if multi-node)
+# edit model-cache.yaml: storage: 2000Gi (+ a ReadWriteMany class if multi-node)
 # edit model-download.yaml: uncomment envFrom(hf-token-secret); repo -> moonshotai/Kimi-K3
 kubectl apply -f examples/k8s-deployments/model-cache/model-cache.yaml -n infera
 kubectl apply -f examples/k8s-deployments/model-cache/model-download.yaml -n infera

--- a/manual/examples/k8s_kimi_k3.md
+++ b/manual/examples/k8s_kimi_k3.md
@@ -19,23 +19,19 @@ reconciling an `InferaDeployment` into router + worker + Service, and a real
 engines on `Qwen3-0.6B`, including serving straight from the model-cache PVC
 (see [`RECIPE-single-node.md`](https://github.com/AMD-AGI/Infera/blob/main/examples/k8s-deployments/RECIPE-single-node.md)).
 
-Kimi-K3 needs a vLLM build with `kimi_k3` model support. Layer infera onto the
-upstream `kimi_k3` vLLM by overriding the base of the standard vLLM image build:
+Kimi-K3 needs a vLLM build with `kimi_k3` model support. The standard infera vLLM
+image now bases on the `kimi_k3` vLLM build (see `deploy/docker/Dockerfile.vllm`),
+so it carries that support out of the box — just build it the normal way:
 
 ```bash
-docker build -f deploy/docker/Dockerfile.vllm \
-  --build-arg VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3 \
-  --build-arg BUILD_AITER=0 --build-arg BUILD_MOONCAKE=0 \
-  --build-arg BUILD_HIPFILE=0 --build-arg INSTALL_LIBIONIC=0 \
-  -t rocm/infera:vllm-kimi-k3 .
+docker build -f deploy/docker/Dockerfile.vllm -t rocm/infera:vllm-v0.1.2 .
 ```
 
 The result carries `infera.server` + `infera.engine.vllm` **and**
 `KimiK3ForConditionalGeneration`. With this image the full path is validated on a
 single 8-GPU node: operator → router → `infera.engine.vllm` TP8 worker serving
 Kimi-K3 (MXFP4), and a **multimodal** image request through the router returns a
-correct colour-grounded answer. The disabled layers are RDMA-PD / kvd-L3 only;
-aiter stays the base's kimi-tuned build.
+correct colour-grounded answer.
 ```
 
 ## Topology
@@ -73,7 +69,7 @@ PVC read-only.
 - The engine **image present in the node container runtime**. k3s uses
   containerd (not docker) — import a local image as a tar, not a stream:
   ```bash
-  docker save <infera-vllm-kimi-k3-image> -o /mnt/<big-disk>/img.tar
+  docker save rocm/infera:vllm-v0.1.2 -o /mnt/<big-disk>/img.tar
   sudo k3s ctr images import /mnt/<big-disk>/img.tar
   ```
 

--- a/manual/examples/k8s_kimi_k3.md
+++ b/manual/examples/k8s_kimi_k3.md
@@ -149,6 +149,14 @@ image test against the standalone docker serve is
   fp8_e4m3 KV cache, but Kimi-K3's MLA then picks the `mla_gluon` kernel
   (batch_size=1 only) and crashes warmup at `--max-num-seqs 128`. Pass
   `--kv-cache-dtype auto` (or env `INFERA_DEFAULT_KV_FP8=0`) to keep the native KV.
-- **Slow load vs the readiness probe.** Kimi-K3 loads ~1.5 TB (~7 min); set
-  `skipReadinessProbe: true` on the worker so the operator doesn't restart it
-  mid-load.
+- **Slow load — use a startupProbe.** Kimi-K3 loads ~1.5 TB (~9 min to Ready). A
+  generous `startupProbe` on `/health` (e.g. `failureThreshold: 120`,
+  `periodSeconds: 10`) holds the pod non-Ready through the load; the operator's
+  readiness probe is gated by it and takes over once weights + CUDA graphs are up.
+  (`skipReadinessProbe: true` also works but never surfaces a Ready signal.)
+- **Don't enable prefix caching or fastsafetensors here.** Kimi-K3 is a hybrid
+  **Mamba** model — `--enable-prefix-caching` forces the experimental Mamba
+  "align" cache and fails engine init. `--load-format fastsafetensors` needs GPU
+  Direct Storage (cufile/GDS); without it, loads stall (~30 s queue waits per
+  batch). Neither is in the upstream vLLM ROCm Kimi-K3 command — keep
+  `--load-format auto` and no prefix caching.

--- a/manual/examples/k8s_kimi_k3.md
+++ b/manual/examples/k8s_kimi_k3.md
@@ -1,0 +1,155 @@
+# Example: Kimi-K3 on Kubernetes — vLLM, model-cache, single node
+
+A **Kubernetes-native** recipe for **Kimi-K3** (the multimodal VLM): a
+`model-cache` PVC populated by a download Job, then an **`InferaDeployment`** the
+operator reconciles into a router + a TP8 vLLM worker on one 8-GPU node. This is
+the infera analog of a vendor "recipe" (e.g. NVIDIA Dynamo's `recipes/kimi-k3`),
+using only `kubectl`/`helm` and one CR.
+
+The runnable manifests live in the repo under
+[`examples/k8s-deployments/`](https://github.com/AMD-AGI/Infera/tree/main/examples/k8s-deployments)
+(`model-cache/`, `kimi-k3-vllm.yaml`). For the general k8s flow and the CR field
+reference, read [Kubernetes deployment](../serving/kubernetes.md) first.
+
+```{admonition} What is validated
+:class: important
+The **recipe mechanics** are validated end to end on single-node **k3s**
+(MI355X, `amd.com/gpu`): the `model-cache` PVC + download Job, the operator
+reconciling an `InferaDeployment` into router + worker + Service, and a real
+`/v1/chat/completions` completion — checked with both the **sglang** and **vLLM**
+engines on `Qwen3-0.6B`, including serving straight from the model-cache PVC
+(see [`RECIPE-single-node.md`](https://github.com/AMD-AGI/Infera/blob/main/examples/k8s-deployments/RECIPE-single-node.md)).
+
+Kimi-K3 needs a vLLM build with `kimi_k3` model support. Layer infera onto the
+upstream `kimi_k3` vLLM by overriding the base of the standard vLLM image build:
+
+```bash
+docker build -f deploy/docker/Dockerfile.vllm \
+  --build-arg VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3 \
+  --build-arg BUILD_AITER=0 --build-arg BUILD_MOONCAKE=0 \
+  --build-arg BUILD_HIPFILE=0 --build-arg INSTALL_LIBIONIC=0 \
+  -t inferaimage/infera:vllm-kimi-k3 .
+```
+
+The result carries `infera.server` + `infera.engine.vllm` **and**
+`KimiK3ForConditionalGeneration`. With this image the full path is validated on a
+single 8-GPU node: operator → router → `infera.engine.vllm` TP8 worker serving
+Kimi-K3 (MXFP4), and a **multimodal** image request through the router returns a
+correct colour-grounded answer. The disabled layers are RDMA-PD / kvd-L3 only;
+aiter stays the base's kimi-tuned build.
+```
+
+## Topology
+
+One 8-GPU node, aggregated (no PD): a CPU-only **router** (`infera.server`) in
+front of one **mixed vLLM worker** at **TP8**, both mounting the same model-cache
+PVC read-only.
+
+| Component | GPUs | What it runs |
+|---|---|---|
+| `kimi-k3-server` | 0 | `infera.server` — OpenAI endpoint + router, ClusterIP `:8000` |
+| `kimi-k3-worker` | 8 | `infera.engine.vllm` — Kimi-K3, `--tensor-parallel-size 8`, `--mm-encoder-tp-mode data` |
+
+## Prerequisites
+
+- A Kubernetes cluster with one **8× ROCm-GPU node** and `kubectl` + `helm`.
+  Single-node **k3s** is fine — put its data-dir on a **large disk** so the
+  engine-image import doesn't fill root:
+  ```bash
+  curl -sfL https://get.k3s.io | \
+    INSTALL_K3S_EXEC="--write-kubeconfig-mode=644 --data-dir /mnt/<big-disk>/k3s" sh -
+  export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+  ```
+- **AMD GPU device plugin** so GPUs schedule as `amd.com/gpu`:
+  ```bash
+  kubectl apply -f https://raw.githubusercontent.com/ROCm/k8s-device-plugin/master/k8s-ds-amdgpu-dp.yaml
+  kubectl describe node | grep amd.com/gpu     # -> amd.com/gpu: 8
+  ```
+- The **infera-operator** (CRD + controller); no LWS/NATS needed for single-node
+  aggregated:
+  ```bash
+  INSTALL_LWS=false INSTALL_NATS=false deploy/scripts/deploy-k8s.sh
+  kubectl get crd inferadeployments.infera.amd.com
+  ```
+- The engine **image present in the node container runtime**. k3s uses
+  containerd (not docker) — import a local image as a tar, not a stream:
+  ```bash
+  docker save <infera-vllm-kimi-k3-image> -o /mnt/<big-disk>/img.tar
+  sudo k3s ctr images import /mnt/<big-disk>/img.tar
+  ```
+
+## 1. Model cache (PVC + download Job)
+
+The [`model-cache/`](https://github.com/AMD-AGI/Infera/tree/main/examples/k8s-deployments/model-cache)
+pair mirrors Dynamo's model-cache: a PVC plus a Job that downloads the checkpoint
+into it. Kimi-K3 is **gated (~1.5 TB)**, so create the HF token secret and size
+the PVC to ~3000 Gi first:
+
+```bash
+kubectl create namespace infera
+kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<token> -n infera
+
+# edit model-cache.yaml: storage: 3000Gi (+ a ReadWriteMany class if multi-node)
+# edit model-download.yaml: uncomment envFrom(hf-token-secret); repo -> moonshotai/Kimi-K3
+kubectl apply -f examples/k8s-deployments/model-cache/model-cache.yaml -n infera
+kubectl apply -f examples/k8s-deployments/model-cache/model-download.yaml -n infera
+kubectl wait --for=condition=Complete job/model-download -n infera --timeout=8h
+```
+
+```{admonition} Already have the checkpoint on the node?
+:class: tip
+Skip the download Job and back the model volume with a `hostPath` pointing at the
+cached directory instead of the PVC (see `single-node-qwen-*.yaml` for the
+`hostPath` form). The download Job is for a cold cluster.
+```
+
+## 2. Deploy
+
+```bash
+# set image: in kimi-k3-vllm.yaml to your kimi_k3-capable infera-vLLM image
+kubectl apply -f examples/k8s-deployments/kimi-k3-vllm.yaml -n infera
+
+kubectl -n infera get inferadeployment -w    # STATE -> ready (weights + graphs: several min)
+kubectl -n infera get pods                   # kimi-k3-server 1/1, kimi-k3-worker 1/1
+```
+
+The operator creates the two Deployments, the `kimi-k3-server` ClusterIP
+Service on `:8000`, and the k8s-discovery ServiceAccount.
+
+## 3. Send a multimodal request
+
+```bash
+kubectl -n infera port-forward svc/kimi-k3-server 8000:8000 &
+curl -s localhost:8000/v1/chat/completions -H 'Content-Type: application/json' -d '{
+  "model": "kimi-k3", "max_tokens": 64,
+  "messages": [{"role":"user","content":[
+    {"type":"text","text":"What is the dominant colour of this image?"},
+    {"type":"image_url","image_url":{"url":"data:image/png;base64,<...>"}}
+  ]}]}'
+```
+
+A colour-grounded answer confirms the vision → prefill → decode path. (The same
+image test against the standalone docker serve is
+[`examples/kimi_k3/mm_test.py`](https://github.com/AMD-AGI/Infera/blob/main/examples/kimi_k3/mm_test.py).)
+
+## Notes & gotchas
+
+- **k3s stores images under `--data-dir`.** A 30–80 GB engine image imported into
+  the default (root-disk) location trips the kubelet DiskPressure eviction
+  threshold and evicts the operator/worker. Put the data-dir on a large disk.
+- **containerd ≠ docker.** A locally-built image must be imported into the node
+  runtime (`k3s ctr images import <tar>`); `imagePullPolicy: IfNotPresent` then
+  resolves it without a registry.
+- **Model mount needs `extraPodSpec`.** The operator's simpler `args` mode
+  auto-builds the entrypoint but only mounts `dshm` + `/boot`; to mount a
+  PVC/hostPath model you must give the full `command` (as these manifests do).
+- **sglang ↔ vLLM is not just the image.** The router is engine-agnostic; the
+  worker's entrypoint module *and* flags differ (`--model-path`/`--tp-size` vs
+  `--model`/`--tensor-parallel-size`). See `RECIPE-single-node.md`.
+- **Kimi-K3 needs `--kv-cache-dtype auto`.** `infera.engine.vllm` defaults to an
+  fp8_e4m3 KV cache, but Kimi-K3's MLA then picks the `mla_gluon` kernel
+  (batch_size=1 only) and crashes warmup at `--max-num-seqs 128`. Pass
+  `--kv-cache-dtype auto` (or env `INFERA_DEFAULT_KV_FP8=0`) to keep the native KV.
+- **Slow load vs the readiness probe.** Kimi-K3 loads ~1.5 TB (~7 min); set
+  `skipReadinessProbe: true` on the worker so the operator doesn't restart it
+  mid-load.

--- a/manual/examples/k8s_pd_1p1d_mooncake.md
+++ b/manual/examples/k8s_pd_1p1d_mooncake.md
@@ -1,0 +1,109 @@
+# Example: PD-disaggregated 1P1D on Kubernetes — SGLang over Mooncake
+
+A **prefill/decode-disaggregated** recipe: one router, one **prefill** worker on
+node A and one **decode** worker on node B (**1P1D**, tp=1 each). KV is streamed
+prefill → decode by the **Mooncake** transfer engine over the ionic **RoCE**
+fabric, while Mooncake's RPC/handshake rides the pod-overlay (flannel) — so no
+host networking is needed. Uses the **libionic-baked** engine image
+(`rocm/infera:sglang-v0.1.2`), so RDMA works without any runtime host-lib
+injection.
+
+The manifest is
+[`examples/k8s-deployments/pd-1p1d-mooncake.yaml`](https://github.com/AMD-AGI/Infera/tree/main/examples/k8s-deployments/pd-1p1d-mooncake.yaml).
+Read [Kubernetes deployment](../serving/kubernetes.md) for the general flow and
+the single-node [Kimi-K3 recipe](k8s_kimi_k3.md) for the aggregated (mixed) case.
+
+```{admonition} The hard prerequisite: a routable RoCE fabric between the two nodes
+:class: important
+PD only works if the **prefill and decode nodes can open an RDMA queue-pair over
+ionic** — i.e. their RoCE NICs are on the **same rail/subnet or a routed fabric**.
+Mooncake connects the RPC over the pod network, exchanges segment descriptors,
+then does the KV move over RDMA; if the two nodes' ionic GIDs are on isolated
+`/64`s with no route between them, the QP never comes up and every request fails
+with `remote mooncake session … is not alive` / `Failed to get kvcache from
+prefill`. Confirm the fabric first:
+
+    # on each node — the group-4 field of the GID_Index-1 RoCE v2 GID:
+    for d in 0 1; do cat /sys/class/infiniband/ionic_$d/ports/1/gids/1; done
+
+If node A's `ionic_0` and node B's `ionic_0` share no routable subnet, pick a
+pair of nodes that do (a multi-rail training fabric pairs rail *i* on every node).
+```
+
+## Topology
+
+| Component | Node | GPUs | Runs |
+|---|---|---|---|
+| `qwen-pd-server` | A | 0 | `infera.server` — OpenAI endpoint + PD-aware router (`:8000`) |
+| `qwen-pd-prefill` | A | 1 | `infera.engine.sglang --disaggregation-mode prefill …mooncake` |
+| `qwen-pd-decode` | B | 1 | `infera.engine.sglang --disaggregation-mode decode …mooncake` |
+
+The router auto-selects the disaggregated dispatcher once a model has **both**
+prefill and decode workers registered (it dual-dispatches each request: prompt to
+prefill, then decode pulls the KV).
+
+## Prerequisites
+
+- A **two-node** k3s cluster (control-plane + one agent), both GPU nodes on a
+  routable RoCE fabric (see the admonition). Join the second node with its
+  data-dir on a large disk:
+  ```bash
+  # on the agent node (K3S_URL = the server's IP):
+  curl -sfL https://get.k3s.io | K3S_URL=https://<server-ip>:6443 \
+    K3S_TOKEN=$(ssh <server> sudo cat /var/lib/rancher/k3s/server/node-token) \
+    INSTALL_K3S_EXEC="--data-dir /mnt/<big-disk>/k3s" sh -
+  kubectl get nodes          # both Ready
+  ```
+- AMD GPU device plugin (auto-schedules on both nodes) and the infera-operator —
+  see [Kubernetes deployment](../serving/kubernetes.md).
+- The **libionic-baked** engine image in **each** node's containerd:
+  ```bash
+  docker build -f deploy/docker/Dockerfile.sglang \
+    --build-arg INSTALL_LIBIONIC=1 -t rocm/infera:sglang-v0.1.2 .
+  docker save rocm/infera:sglang-v0.1.2 -o /tmp/img.tar   # on each node
+  sudo k3s ctr images import /tmp/img.tar                 # (or build locally)
+  ```
+- The model at the **same path on both nodes** — a shared FS (`/mnt/vast/…`) is
+  simplest; or the model-cache Job on a RWX PVC (see [Kimi-K3 recipe](k8s_kimi_k3.md)).
+
+## Deploy & verify
+
+```bash
+# edit <PREFILL_NODE>/<DECODE_NODE>/<MODEL_DIR>/<MODEL_PATH> in the manifest
+kubectl create namespace infera
+kubectl apply -f examples/k8s-deployments/pd-1p1d-mooncake.yaml
+
+kubectl -n infera get pods -o wide      # prefill on A, decode on B, both Running
+kubectl -n infera port-forward svc/qwen-pd-server 8000:8000 &
+curl -s localhost:8000/v1/chat/completions -H 'Content-Type: application/json' \
+  -d '{"model":"<MODEL_PATH>","messages":[{"role":"user","content":"Name three primary colors."}],"max_tokens":40}'
+```
+
+A completion confirms the full path: router → prefill → **Mooncake KV over RoCE**
+→ decode.
+
+```{admonition} What is validated
+:class: note
+On a two-node k3s (MI355X) the operator reconcile, cross-node worker registration,
+PD dual-dispatch, the baked-libionic RDMA device discovery (8 active ionic HCAs
+in-pod, no injection), and the pod-overlay Mooncake RPC were all confirmed. The
+final KV move additionally needs the two nodes on a **mutually routable RoCE
+fabric** (above) — a pair whose ionic rails don't interconnect will reconcile and
+dispatch but fail the transfer.
+```
+
+## Notes & gotchas
+
+- **libionic ABI.** The stock sglang base ships libionic ABI 1; the ionic kernel
+  needs ABI 4, or `ibv_get_device_list` returns 0 HCAs and Mooncake silently
+  drops to TCP (KV transfer then fails). `Dockerfile.sglang` now bakes ABI-4
+  libionic (`INSTALL_LIBIONIC=1`); the entrypoint still injects a host build if
+  `/host-libionic` is mounted, as a belt-and-braces version match.
+- **No hostNetwork.** Mooncake's RPC advertises `POD_IP`; on the pod-overlay that
+  is a flannel address both nodes route to. hostNetwork would advertise the public
+  host IP and, on a single node, also collide prefill/decode on `:30000`.
+- **Slow-load probe.** `skipReadinessProbe: true` on the workers so the operator
+  doesn't restart them during model load / graph capture.
+- **mori alternative.** `--disaggregation-transfer-backend mori` is the other
+  RoCE path; it needs an active RDMA device in-pod too (same libionic fix) and, on
+  a single node, `MORI_DISABLE_AUTO_XGMI=0` for the intra-node XGMI fallback.

--- a/manual/examples/k8s_pd_1p1d_mooncake.md
+++ b/manual/examples/k8s_pd_1p1d_mooncake.md
@@ -48,9 +48,11 @@ prefill, then decode pulls the KV).
   routable RoCE fabric (see the admonition). Join the second node with its
   data-dir on a large disk:
   ```bash
-  # on the agent node (K3S_URL = the server's IP):
+  # on the agent node (K3S_URL = the server's IP). The node-token lives under the
+  # server's data-dir — /var/lib/rancher/k3s/... by default, or <data-dir>/server/
+  # node-token if the server was installed with --data-dir on a big disk.
   curl -sfL https://get.k3s.io | K3S_URL=https://<server-ip>:6443 \
-    K3S_TOKEN=$(ssh <server> sudo cat /var/lib/rancher/k3s/server/node-token) \
+    K3S_TOKEN=$(ssh <server> sudo cat /mnt/<big-disk>/k3s/server/node-token) \
     INSTALL_K3S_EXEC="--data-dir /mnt/<big-disk>/k3s" sh -
   kubectl get nodes          # both Ready
   ```
@@ -104,6 +106,11 @@ dispatch but fail the transfer.
   host IP and, on a single node, also collide prefill/decode on `:30000`.
 - **Slow-load probe.** `skipReadinessProbe: true` on the workers so the operator
   doesn't restart them during model load / graph capture.
+- **NICs — Mooncake auto-discovers, mori lists.** Mooncake runs its own topology
+  discovery, so **drop** `--disaggregation-ib-device` and it uses every active
+  ionic HCA (pinning one, e.g. `ionic_0`, limits KV transfer to a single rail).
+  `mori` is the opposite: pass **all** active NICs explicitly,
+  `--disaggregation-ib-device ionic_0,ionic_1,…,ionic_7`.
 - **mori alternative.** `--disaggregation-transfer-backend mori` is the other
   RoCE path; it needs an active RDMA device in-pod too (same libionic fix) and, on
   a single node, `MORI_DISABLE_AUTO_XGMI=0` for the intra-node XGMI fallback.

--- a/manual/sphinx/_toc.yml.in
+++ b/manual/sphinx/_toc.yml.in
@@ -59,6 +59,8 @@ subtrees:
         title: Kubernetes recipe — Kimi-K3 (vLLM, mixed)
       - file: examples/k8s_pd_1p1d_mooncake.md
         title: Kubernetes recipe — PD 1P1D (SGLang, Mooncake)
+      - file: examples/k8s_glm5.2_sglang.md
+        title: Kubernetes recipe — GLM-5.2 (SGLang, DSA)
       - file: examples/sglang_1p2d_kimi2.6.md
         title: SGLang 1P2D — Kimi-K2.6
       - file: examples/sglang_mix_dsv4.md

--- a/manual/sphinx/_toc.yml.in
+++ b/manual/sphinx/_toc.yml.in
@@ -55,6 +55,10 @@ subtrees:
 
   - caption: Examples
     entries:
+      - file: examples/k8s_kimi_k3.md
+        title: Kubernetes recipe — Kimi-K3 (vLLM, mixed)
+      - file: examples/k8s_pd_1p1d_mooncake.md
+        title: Kubernetes recipe — PD 1P1D (SGLang, Mooncake)
       - file: examples/sglang_1p2d_kimi2.6.md
         title: SGLang 1P2D — Kimi-K2.6
       - file: examples/sglang_mix_dsv4.md


### PR DESCRIPTION
Copy-paste, **locally-validated** `InferaDeployment` recipes for running Infera on Kubernetes via the operator — the Infera analog of a vendor "recipe" — plus the engine-image fix they needed.

## What's here

**Mixed (single-node aggregated)** — router + one mixed worker, validated end to end on k3s (MI355X) to real tokens:
- `single-node-qwen-sglang.yaml` / `single-node-qwen-vllm.yaml` + `RECIPE-single-node.md` (the sglang↔vllm diff is *not* just the image)
- `model-cache/` — a PVC + download Job (the Dynamo model-cache analog); validated Job → PVC → serve
- `kimi-k3-vllm.yaml` + `manual/examples/k8s_kimi_k3.md` — Kimi-K3 TP8 multimodal, full operator → router → `infera.engine.vllm` path (built infera on the `kimi_k3` vLLM base; needs `--kv-cache-dtype auto` so MLA doesn't pick the batch-1-only `mla_gluon` kernel)

**PD-disaggregated 1P1D (Mooncake)** — router + prefill (node A) + decode (node B), KV over the ionic RoCE fabric:
- `pd-1p1d-mooncake.yaml` + `manual/examples/k8s_pd_1p1d_mooncake.md`
- Validated on two-node k3s through operator reconcile, cross-node registration, PD dual-dispatch, in-pod RDMA discovery, and the pod-overlay Mooncake RPC. The final KV move needs the two nodes on a **mutually routable RoCE fabric** (documented).

**Engine image libionic fix**
- `Dockerfile.sglang` + `Dockerfile.sglang.gfx942`: bake ABI-4 libionic (`INSTALL_LIBIONIC=1`). The base ships ABI-1 libionic, so `ibv_get_device_list` returns 0 HCAs and Mooncake silently drops to TCP → cross-node PD KV transfer fails. With the fix `ibv_devinfo` sees the 8 ionic HCAs in-pod without the runtime host-lib injection.

## Validation
Single/two-node k3s (MI355X, `amd.com/gpu`): sglang + vllm mixed serving, Kimi-K3 TP8 multimodal, model-cache Job→PVC→serve, and PD reconcile/register/dual-dispatch up to the cross-node RoCE-fabric boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)