### PR TITLE
sglang DSA: enable PD + DP-attention + EAGLE MTP on GLM-5.2 / gfx950 (3 patches, rebased onto main)

### DIFF
--- a/deploy/docker/Dockerfile.sglang
+++ b/deploy/docker/Dockerfile.sglang
@@ -1,6 +1,11 @@
 # Infera SGLang engine image: layers the infera source onto the ROCm SGLang
 # base and sets an entrypoint that injects the host's libionic before exec'ing
 # the command.
+#
+# ⚠️ The base tag is PINNED and must stay pinned: the GLM-5.2 DSA patches near
+# the end of this file are context diffs applied at --fuzz=0 against this exact
+# sglang commit. Bumping the base fails the build there rather than silently
+# mis-applying. Build with APPLY_SGLANG_DSA_PATCHES=0 if you need a newer base.
 ARG SGLANG_BASE_IMAGE=lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
 FROM ${SGLANG_BASE_IMAGE}
 
@@ -71,6 +76,28 @@ RUN pip install --no-cache-dir ".[sglang]"
 COPY deploy/docker/patches/sglang/ /tmp/sglang-patches/
 RUN for f in /tmp/sglang-patches/*.py; do echo "[sglang-patch] $f"; python "$f" || echo "[sglang-patch] skipped $f"; done \
     && rm -rf /tmp/sglang-patches
+
+# ---- GLM-5.2 DSA patch set (PD + DP-attention + EAGLE MTP on gfx950) --------
+# WHAT: three patches that together make PD + DP-attention + EAGLE MTP work for
+# GLM-5.2; without them it crashes on the first batch or deadlocks the DP group.
+# Per-patch rationale and upstream linkage: patches/sglang_dsa/README.md.
+#
+# MUST stay after the loop above -- that supplies the nextn eh_proj prerequisite,
+# which the script asserts. Unlike that loop these are context diffs at --fuzz=0
+# against the pinned base, so a base bump FAILS here instead of mis-applying.
+#
+# The script also verifies each patch reached the BYTECODE, not just the source:
+# a stale __pycache__ silently reverts a patch and has voided an experiment here.
+# APPLY_SGLANG_DSA_PATCHES=0 builds a stock engine to A/B against.
+ARG APPLY_SGLANG_DSA_PATCHES=1
+COPY deploy/docker/patches/sglang_dsa/ /tmp/sglang_dsa/
+COPY deploy/docker/scripts/apply_sglang_dsa_patches.sh /tmp/apply_sglang_dsa_patches.sh
+RUN if [ "${APPLY_SGLANG_DSA_PATCHES}" = "1" ]; then \
+        PATCH_DIR=/tmp/sglang_dsa bash /tmp/apply_sglang_dsa_patches.sh; \
+    else \
+        echo "APPLY_SGLANG_DSA_PATCHES=0 — stock sglang, GLM-5.2 PD+DPA+MTP will NOT work"; \
+    fi \
+    && rm -rf /tmp/apply_sglang_dsa_patches.sh /tmp/sglang_dsa
 
 # ---- Rust router (multi-core data plane; --router-backend rust) ----
 # The ROCm base ships cargo; use it (install a minimal toolchain only if

--- a/deploy/docker/patch.upstream.status.md
+++ b/deploy/docker/patch.upstream.status.md
@@ -1,0 +1,128 @@
+# Patch ↔ upstream status
+
+Every patch under `deploy/docker/patches/`, and where it stands relative to the
+project it patches. Kept here so "why do we still carry this?" has one answer
+per row, and so a patch that upstream has since merged gets dropped instead of
+quietly outliving its reason.
+
+**Verified with `gh` on 2026-08-01.** State drifts; re-check before relying on a
+row. `gh search` matches titles and bodies, **not diff content**, so "no upstream
+PR" means "none found by search", not "none exists".
+
+Column meanings:
+
+- **ours?** — was the upstream PR opened by a contributor of this repo?
+  `yes` = us; `no` = a third party; `—` = no PR.
+- **PR state** — of the upstream PR named in the same row.
+
+## sglang — `patches/sglang_dsa/` (baked by `Dockerfile.sglang`, `APPLY_SGLANG_DSA_PATCHES=1`)
+
+| patch | fixes | upstream issue | upstream PR | ours? | PR state |
+|---|---|---|---|---|---|
+| `sglang_dsa/dsa_indexer_hip_dp_padded_rows.diff` | HIP/aiter paged-MQA sizes its output from DP-padded rows while `lengths` is sized to real rows → `Expected lengths.size(0) == B` | none found | [sglang#33059](https://github.com/sgl-project/sglang/pull/33059) | **yes** (`dorado269`) | OPEN, `REVIEW_REQUIRED` |
+| ″ (same bug class, other platform) | — | none found | [sglang#32762](https://github.com/sgl-project/sglang/pull/32762) `[NPU] Fix DSA eager padding mismatch` — our diff is written in its shape | no (`stellaxcpeng`) | OPEN |
+| `sglang_dsa/dsa_backend_dp_sync_and_page_table_rows.diff` (2a) | `seq_lens.max().item()` is a host sync on a branch only *some* DP ranks take → DP collectives desync → deadlock | none found | none found | — | — |
+| `sglang_dsa/dsa_backend_dp_sync_and_page_table_rows.diff` (2b) | page table has one row per **request**, top-k one per **token** under MTP → `assert page_table.shape[0] == topk_indices.shape[0]` | none found | [sglang#32209](https://github.com/sgl-project/sglang/pull/32209) solves the same row mismatch by **trimming q/top-k**; porting that half here fails at conc=32 and is unresolved | no (`HZY-Wade`) | OPEN, `REVIEW_REQUIRED` |
+| `sglang_dsa/draft_cuda_graph_dp_vote.diff` | draft graph/eager choice is per-rank and diverges on the PD decode leg → group deadlock | [sglang#32527](https://github.com/sgl-project/sglang/issues/32527) (independent report, 8× Blackwell) | [sglang#32209](https://github.com/sgl-project/sglang/pull/32209) — same defect, same strategy; **this diff adopts its placement** | no (`HZY-Wade`) | OPEN, `REVIEW_REQUIRED` |
+
+Prerequisite for the set, applied earlier in the same Dockerfile and **asserted**
+by `scripts/apply_sglang_dsa_patches.sh`:
+
+| patch | fixes | upstream issue | upstream PR | ours? | PR state |
+|---|---|---|---|---|---|
+| `sglang/patch_glm52_nextn_quark_exclude.py` | GLM-5.2 MTP `eh_proj` is bf16 but the quark-exclude check probes the bare layer prefix → draft weight-load dies `3072 vs 6144` | none found | [sglang#30265](https://github.com/sgl-project/sglang/pull/30265) `[AMD] Fix GLM-5.2 MTP Quark excludes` — a **superset** (dedicated `GlmMoeDsaForCausalLMNextN`); ours is a narrow backport | no (`wangjiaxin99`) | **MERGED** 2026-07-08 |
+
+> Our base `v0.5.15.post1` (`0b3bb0c`) predates #30265 — the release line was cut
+> without it. **Drop this patch** when the base sglang carries #30265; the anchor
+> disappears and the script no-ops.
+
+Background, already present in the base and **not** patched by us:
+[sglang#30378](https://github.com/sgl-project/sglang/pull/30378) /
+[#30427](https://github.com/sgl-project/sglang/pull/30427) (MERGED) clamp padded-row
+seq_lens **values**; our patch 01 fixes the HIP-side row **count**.
+[#30839](https://github.com/sgl-project/sglang/pull/30839) /
+[#31083](https://github.com/sgl-project/sglang/pull/31083) (MERGED 2026-07-14)
+introduced the guard patch 04 repairs — so that deadlock is a regression in this
+baseline, not a legacy wart.
+[#32722](https://github.com/sgl-project/sglang/pull/32722) (OPEN) adds a test for
+PD + DP-attention + MTP, i.e. **no CI covers this topology today**.
+
+## Mooncake C++ — `patches/mooncake_cpp/` (built by `Dockerfile.sglang`, `Dockerfile.vllm`, `Dockerfile.atom`)
+
+Pinned to Mooncake `main @ 747003c`; `git apply` fails loudly on ref drift.
+
+| patch | fixes | upstream issue | upstream PR | ours? | PR state |
+|---|---|---|---|---|---|
+| `mooncake_cpp/rdma_auto_chunk_mr_2017.diff` | buffers over the device `max_mr_size` are silently truncated by `ibv_reg_mr` while `BufferDesc.length` advertises the full size → `IBV_WC_REM_ACCESS_ERR` past the boundary | [Mooncake#2017](https://github.com/kvcache-ai/Mooncake/issues/2017) | [Mooncake#2644](https://github.com/kvcache-ai/Mooncake/pull/2644) | **yes** (`jiejingzhangamd`) | **MERGED** 2026-07-28 |
+| `mooncake_cpp/rdma_transport_dmabuf_cmake.diff` | `USE_HIP_DMABUF` is defined only on the `transfer_engine` target, so the `ibv_reg_dmabuf_mr` branch compiles **out** of `rdma_transport` — where it is actually called → GPU buffers fall back to bare `ibv_reg_mr`, which cannot pin VRAM without `ib_peer_mem` | none found | none found | — | — |
+| `mooncake_cpp/transfer_engine_impl.diff` | `installTransport("hip")` runs unconditionally, so GPU buffers become intra-node HIP IPC segments a cross-node peer cannot open (`Corrupted segment descriptor hipbuffer`) | none found | none found | — | — |
+
+> #2644 is merged upstream but **not** in the pinned `747003c` tree, so the local
+> diff is still applied. Drop it when the pin advances past the merge.
+
+## vLLM — `patches/vllm/` (baked by `Dockerfile.vllm`)
+
+| patch | fixes | upstream issue | upstream PR | ours? | PR state |
+|---|---|---|---|---|---|
+| `vllm/patch_defer_kv_register.py` | registering the Mooncake KV pool before warmup trips a decode-boot crash at high util (`compile_or_warm_up_model` returns None → `AttributeError: 'NoneType' … language_model`); defer to the end of warmup | none found | none found | — | — |
+| `vllm/patch_moriio_pagelen.py` | MoRIIO MLA derives per-block transfer size/stride from tensor **shape**, so block-scaled fp8 MLA + DSA transfers the wrong geometry → PD output is wrong while direct prefill is correct | none found | none found | — | — |
+| `vllm/patch_moriio_write.py` | in WRITE (push) mode the decode addresses **itself** (`is_producer=True`), the consumer handler asserts, the notify thread dies and the request hangs | `AMD-AGI/Infera#67` | fixed on vLLM `main` / `v0.22.1rc0` **source**, but no AMD ROCm image ships it | no | n/a (source-only) |
+| `vllm/patch_sched_guard.py` | decode EngineCore dies on `assert req_id in self.requests` when a KV-xfer-finished event arrives for an already-removed request | `AMD-AGI/Infera#69` | none found | — | — |
+| `vllm/patch_vllm_mooncake_blocksize.py` | backends that force a kernel block size of 1 make the connector index logical pages at kernel granularity → RDMA moves empty rows, decode attends over zeros | none found | none found | — | — |
+| `vllm/patch_vllm_mooncake_prom_metrics.py` | `MooncakeConnector` lacks `build_prom_metrics`, so `MultiKVConnectorPromMetrics.observe` asserts and kills the engine under `MultiConnector` | none found | internal PR #178 (the sibling fix for `InferaKvdConnector`) | **yes** | **MERGED** |
+
+> The `AMD-AGI/Infera#NN` references above are quoted verbatim from the patches'
+> own docstrings, which is the citation form this repo already uses. They resolve
+> against an internal tracker, so treat a `404` as expected rather than as a
+> stale number.
+
+## vLLM DSv4 — `patches/vllm-dsv4/` (baked by `Dockerfile.vllm`)
+
+| patch | fixes | upstream issue | upstream PR | ours? | PR state |
+|---|---|---|---|---|---|
+| `vllm-dsv4/patch_aiter_flydsl_moe_memref_bufres.py` | aiter 0.1.16's `fx.ptrtoint` rejects flydsl memrefs → `MLIRError` in the 2-stage MoE GEMM (Kimi-K2.6 int4 W4A16) | none found | none found | — | — |
+| `vllm-dsv4/patch_moriio_dsv4_hybrid_blocksize.py` | a global `block_size` equality check kills the prefill worker at KV registration, though DSv4 registers per-layer caches with different block sizes and offsets already use the per-layer map | none found | none found | — | — |
+| `vllm-dsv4/patch_moriio_dsv4_noncontig_register.py` | `register_torch_tensor` rejects DSv4's 576B-aligned non-contiguous fp8_ds_mla KV view, and `.contiguous()` would detach from the buffer the forward writes into | none found | none found | — | — |
+| `vllm-dsv4/patch_moriio_dsv4_sparse_backend.py` | the generic ROCm selector returns `ROCM_AITER_MLA_SPARSE` (no `fp8_ds_mla`) and raises, killing the prefill worker, though `backend_name` is only a P/D handshake tag | none found | none found | — | — |
+
+### `patches/vllm-dsv4/legacy/` — archival, **not executed by any Dockerfile**
+
+Kept for provenance; both are no-ops on the current verified stack
+(vLLM `0.23.1rc1.dev748`, `amd-aiter 0.1.16.post2`).
+
+| patch | fixes | upstream issue | upstream PR | ours? | PR state |
+|---|---|---|---|---|---|
+| `vllm-dsv4/legacy/patch_dsv4_aiter_moe.py` | DSv4 MXFP4 MoE gate-mode plumbing, before aiter carried it | none found | [aiter#3123](https://github.com/ROCm/aiter/pull/3123) `[MoE] Align Swiglu MXFP4 fused quant paths` | no (`XiaobingSuper`) | **MERGED** 2026-05-12 |
+| `vllm-dsv4/legacy/patch_dsv4_mhc_aiter.py` + `.diff` | `mhc_pre_gemm_sqrsum_kernel` store race → EngineCore dies | none found | [aiter#3033](https://github.com/ROCm/aiter/pull/3033) `Fix sqrsum store race condition` | no (`kkHuang-amd`) | **MERGED** 2026-05-06 |
+
+## ATOM — `patches/atom/` (baked by `Dockerfile.atom`)
+
+ATOM is an internal engine; there is no public upstream to file against.
+
+| patch | fixes | upstream issue | upstream PR | ours? | PR state |
+|---|---|---|---|---|---|
+| `atom/patch_gdn_pd_state_transfer.py` | hybrid GDN models never transfer the GatedDeltaNet recurrent state in PD, so decode starts from a zero state and cannot recall prompt context (5/5 mixed vs 0/5 PD) | n/a — internal engine | n/a | — | — |
+| `atom/patch_minimax_m2_qknorm_rope.py` | stock `minimax_m2.py` fails to load: `get_rope()` rejects `dtype=`, and the TP fused QK-norm kernel needs a batch guard | n/a | n/a | — | — |
+| `atom/patch_mooncake_consumer_slot.py` | `UnboundLocalError: consumer_staging_pool_idx` crashes the decode worker on the first PD request for models with slot state but no `slot_regions` | n/a | n/a | — | — |
+
+## hipFile — `patches/hipfile_async/` (baked by `Dockerfile.vllm`)
+
+| patch | fixes | upstream issue | upstream PR | ours? | PR state |
+|---|---|---|---|---|---|
+| `hipfile_async/hipfile_async.patch` (+ `file_async_fragment.py`, `patch_hipfile_async.sh`) | the ROCm hipFile binding exposes no async API; adds `write_async`/`read_async`, `Stream`, `supports_async()`. Cython stack-locals passed as `&local` die before the driver dereferences them → `bytes_done` reads 0 and intermittent `HipFileException 5022`, so the wrapper calls `libhipfile.so` via ctypes with heap-allocated slots | none found | none found | — | — |
+
+## Not patches
+
+Every file under `patches/` is covered above except these, which carry no fix of
+their own: `mooncake_cpp/apply_mooncake_cpp_patches.sh` (applies the three
+Mooncake diffs), `sglang_dsa/README.md` and `vllm-dsv4/legacy/README.md`.
+
+## Maintenance
+
+A row is ready to delete when its upstream PR is **merged and present in the
+pinned base**. Merged-but-not-in-base still needs the local patch — the two
+`MERGED` rows above (sglang#30265, Mooncake#2644) are exactly that case.
+
+When adding a patch, add its row here in the same commit, and put the full
+argument — evidence, alternatives, how it differs from our own upstream PR — in
+the patch's own header. This table is the index, not the record.

--- a/deploy/docker/patches/sglang_dsa/README.md
+++ b/deploy/docker/patches/sglang_dsa/README.md
@@ -1,0 +1,164 @@
+# sglang DSA patches
+
+Three patches that together make **PD disaggregation + DP-attention + EAGLE MTP**
+work for GLM-5.2 on gfx950. Without them the combination crashes on the first
+batch or deadlocks the whole DP group under concurrency.
+
+They apply to the sglang tree bundled in the ROCm engine images
+(`lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x`, an editable checkout at
+`/sgl-workspace/sglang`).
+
+| # | patch | fixes |
+|---|---|---|
+| 01 | `dsa_indexer_hip_dp_padded_rows.diff` | HIP/aiter paged-MQA sizes its output from **DP-padded** rows while `lengths` is sized to **real** rows → `Expected lengths.size(0) == B` |
+| 02 | `dsa_backend_dp_sync_and_page_table_rows.diff` | (a) a host sync on a branch only *some* DP ranks take → collectives desync → deadlock; (b) page table has one row per **request**, top-k one per **token** under MTP → assert |
+| 04 | `draft_cuda_graph_dp_vote.diff` | the draft graph/eager choice is made **per rank** from rank-dependent inputs and diverges on the PD decode leg → deadlock |
+
+**Each patch's own header is the record**: what it fixes, why, how it was
+established, the upstream issue / third-party PR / our own PR, how it differs
+from our own upstream PR, and whether the IndexShare workaround substitutes for
+it. Read the `.diff` before changing it.
+
+Upstream linkage for these and every other patch in the repo is indexed in
+[`deploy/docker/patch.upstream.status.md`](../../patch.upstream.status.md).
+
+## Applying
+
+`Dockerfile.sglang` applies them at build time by default
+(`APPLY_SGLANG_DSA_PATCHES=1`) via `deploy/docker/scripts/apply_sglang_dsa_patches.sh`.
+Set `APPLY_SGLANG_DSA_PATCHES=0` for a stock engine to A/B against.
+
+Prefer the script over patching by hand: it also verifies each patch reached the
+**bytecode**, not just the source. A stale `__pycache__` entry silently reverts a
+patch and has already invalidated a full experiment here — the source showed the
+fix, the runtime did not have it.
+
+By hand, against sglang `0b3bb0cbe31873994c9f989fddfe2f87ca839fdd` (v0.5.15.post1):
+
+```bash
+cd /sgl-workspace/sglang
+for d in dsa_indexer_hip_dp_padded_rows.diff \
+         dsa_backend_dp_sync_and_page_table_rows.diff \
+         draft_cuda_graph_dp_vote.diff; do
+  patch -p1 --fuzz=0 < "$d"
+done
+```
+
+`--fuzz=0` is deliberate: these target one pinned commit, and a fuzzy apply that
+"succeeds" against a different base is worse than a clean failure. The base image
+tag is pinned for the same reason — bumping it fails the build here rather than
+mis-applying silently. Note that `patch --dry-run` and `git apply --check` **fuzz
+by default**, and a hand-written diff in this series once silently dropped a hunk
+while still "passing".
+
+### Prerequisite
+
+`deploy/docker/patches/sglang/patch_glm52_nextn_quark_exclude.py` (a backport of
+sglang #30265) must run **first** — GLM-5.2 MTP cannot load its draft weights
+without it, dying with a `3072 vs 6144` shape mismatch. `Dockerfile.sglang` runs
+that loop before this one, and `apply_sglang_dsa_patches.sh` **asserts** the edit
+rather than assuming it: that script is idempotent, so a missing anchor would
+print `skipped`, exit 0, and surface only at runtime.
+
+An earlier revision of this directory carried the same edit as a fourth diff.
+Keeping both would have been worse than redundant — main's loop runs first, so
+our context diff would then fail at `--fuzz=0` against an already-edited anchor.
+
+## Validation
+
+2 × 8×MI355X (gfx950), ROCm 7.2.0, sglang 0.5.15.post1, GLM-5.2-MXFP4, PD over
+mooncake/mlx5 + dma-buf, `--dp-size 8 --enable-dp-attention --ep-size 8` + EAGLE
+MTP(3,1,4), **draft CUDA graph enabled**.
+
+Final run (2026-07-31), from an image built by `Dockerfile.sglang` on this branch
+with patches applied **at build time** — nothing patched in the running container:
+
+| Check | Target | Result |
+|---|---|---|
+| Build-time bytecode verification, both nodes | all markers | **8/8 + prereq + patch2a** |
+| 4-prompt correctness probe | 4/4, `acc_len` > 1 | **4/4**, 2.00–3.43 |
+| conc=32 × 512 tok | 32/32 | **32/32** |
+| conc=128 × 512 tok, ×2 | 128/128 | **128/128**, **128/128** |
+| `Traceback` / `KVTransferError`, either leg | 0 | **0 / 0** |
+| DP ranks serving | 8 | **8**, every run, 0 retries |
+
+Cumulative across the earlier arms with the fixes: **2540/2540**, versus **0/4**
+with patch 04 reverted (same nodes, same image, deadlock at 120 s on request 1).
+Draft-graph replay was measured at **97.1 %** (777/800 calls, identical on all 8
+ranks) — that counter is the point, because forcing the draft path eager passes
+every functional test while disabling the feature under test.
+
+Raw measurements are held in internal reproduction kits, one per arm: the run
+above, the draft-graph fix with its differential control, the IndexShare-off
+workaround arm, and the failed #32209 port. Ask the patch author for access.
+
+### What this validation does NOT establish
+
+* **The image built from this branch after the rebase was not re-run.** `main`
+  has since added a `libionic` layer (`eb7da57`) that the measured image did not
+  carry. It is orthogonal to these patches — RDMA ABI matching, not DSA — but it
+  is a difference between what was measured and what this branch now builds.
+* Draft-graph replay was not re-measured on the final image (it needs an added
+  probe, i.e. a different image); 97.1 % is from the immediately preceding build
+  of the same patch set. No differential control was re-run either — each patch's
+  necessity is established in the kits above.
+* Performance was not measured against the DPA-only baseline.
+* All runs used `--disable-custom-all-reduce` (required on gfx942/gfx950 for
+  EAGLE), so the custom all-reduce path is unexercised.
+* Context 32768, short prompts, 512-token outputs, one hardware configuration.
+  Long-context and 400k-context configs are untested.
+* A seventh occurrence of the padded-vs-real-rows crash family was seen **once**
+  in 500+ requests during an earlier session, on a machine already carrying the
+  `dsa_indexer` fix. It did not recur in 2540 requests here, but at that rate
+  absence is not evidence.
+
+### One earlier caveat, withdrawn
+
+> ~~"about 2 % of responses under concurrency are degenerate"~~ — **falsified;
+> this was a test-harness error, not an engine bug.** The harness posted raw
+> prompts to `/generate`, skipping GLM-5.2's chat template (so the model was
+> doing base-LM completion), and forced `temperature=0` over the model's own
+> recommended `1.0 / 0.95`. Degenerate repetition under greedy decoding is
+> expected (Holtzman et al. 2019). With the template applied and the model's own
+> sampling: **0/128 degenerate at conc=128 on both MXFP4 and FP8** — and the
+> official FP8 build reproduced the "failure" under the wrong config exactly as
+> MXFP4 did, so quantization was never implicated either.
+>
+> The related note about `eagle_utils.py:620` forcing `argmax` on HIP stands as a
+> code observation, but it is confined to the spec-decode verify path and does
+> not discard user sampling params for the request as a whole — that
+> over-generalization is withdrawn.
+
+## A configuration-only alternative to part of this set
+
+Turning GLM-5.2's MTP **IndexShare** off avoids the same deadlock without patch
+04 or the page-table half of patch 02:
+
+```
+--json-model-override-args '{"index_share_for_mtp_iteration":false}'
+```
+
+It works because IndexShare is the *source* of the rank divergence — remove the
+seed and the guard term stops diverging, so no vote is needed.
+
+| patch | substituted by IndexShare-off? |
+|---|---|
+| 01 `dsa_indexer_hip_dp_padded_rows` | **No** — independent bug, present regardless |
+| 02a `dsa_backend` DP host-sync | **No** — a host sync is invisible to the graph/eager decision either mechanism changes |
+| 02b `dsa_backend` page-table rows | **Yes**, in effect — the arm ran without it and passed |
+| 04 `draft_cuda_graph_dp_vote` | **Yes** — this is what it targets |
+| nextn `eh_proj` (the prerequisite) | **No** — weight-load bug, unrelated |
+
+Measured with 02b and 04 asserted **absent from the bytecode**: 4/4, 32/32 twice,
+64/64, zero tracebacks, accept length 2.98–3.01 — no measurable cost. Two
+conditions are easy to miss: MTP must be on the **prefill** leg too (otherwise the
+seed never reaches decode and the setting is untested rather than tested), and
+that arm was taken to conc=64, not 128.
+
+**Why the patches remain the default.** The override is nearly free only because
+IndexShare's consumer is currently disabled under PD by
+`should_use_dsa_fused_topk`. Upstream PR #31477 exists to remove that limitation;
+once it lands the override starts costing (~3 % TPOT, reported internally —
+second-hand, not measured by us). Checked with `gh` on 2026-08-01: #31477 is
+**open**, `REVIEW_REQUIRED`, unmerged. A good answer today if IndexShare is not
+wanted, a dated one if it is.

--- a/deploy/docker/patches/sglang_dsa/draft_cuda_graph_dp_vote.diff
+++ b/deploy/docker/patches/sglang_dsa/draft_cuda_graph_dp_vote.diff
@@ -1,0 +1,342 @@
+PATCH 04 -- draft CUDA graph, group-wide DP vote
+================================================================================
+WHAT   `EagleDraftWorker.draft()` decides PER RANK whether to replay the draft
+       CUDA graph or run the multi-step draft eagerly.  The two paths do not
+       issue the same host-side collective sequence, and two of the guard's four
+       terms are rank-dependent by construction:
+         * `not forward_batch.forward_mode.is_idle()` -- occupancy differs per
+           rank every step;
+         * `draft_input.dsa_topk_indices is None` -- on the PD DECODE leg this is
+           seeded from RDMA-shipped per-request payloads
+           (eagle_disaggregation.py:54-59), so it is a function of which requests
+           a rank happens to hold.
+       Make the choice a GROUP decision: one more int64 slot in the MLP-sync
+       all-gather the scheduler ALREADY performs, min()-reduced so any rank
+       needing eager takes the whole group eager.  Inactive ranks contribute 1
+       (permissive) and can never drag the group into eager on their own.
+WHY    Without it the first routed request hard-deadlocks on the PD decode leg.
+       Single-node MIX never hangs: with no disaggregation the top-k seed is
+       produced locally by identical code on every rank, so term 4 never flips
+       asymmetrically.
+
+UPSTREAM STATUS  (queried with `gh`, 2026-08-01 -- all OPEN, none merged)
+--------------------------------------------------------------------------------
+issue            #32527  "[BUG] EAGLE + DP Attention + PD Disaggregation:
+                 Deadlock when index_share_for_mtp_iteration is enabled for
+                 GLM-5.2" (Xavier1994, OPEN).  SAME defect, reported
+                 independently on 8x Blackwell / GLM-5.2-FP8 on 2026-07-27, two
+                 days before we fixed it, with the same analysis.  It proposes a
+                 THIRD strategy: a dummy all-zeros seed so term 4 is always false.
+third-party PR   #32209  "Fix PD decode hang with DP attention and GLM-5.2 MTP"
+                 (HZY-Wade, OPEN, REVIEW_REQUIRED).  SAME defect, SAME strategy.
+                 This diff adopts its placement verbatim.
+                 #32722  "[RED regression] Test GLM-5.2 PD + DP attention + MTP"
+                 (IvanShan177, OPEN) -- a test for this topology.  Its existence
+                 proves NO CI covers it today, which is why the family survives.
+                 #32196  "[PD] Keep EAGLE DP graph and token metadata consistent"
+                 (weireweire, OPEN) -- adjacent, different site.
+                 #30839 / #31083 (both MERGED 2026-07-14, cherry-picked to
+                 release/v0.5.15) INTRODUCED the guard -- so this deadlock is a
+                 regression in our baseline, not a legacy wart.
+own PR           NONE.  #32209 already carries this fix upstream and is better
+                 placed; opening a competing PR would be noise.  The right move
+                 is to converge on it, which this diff does.
+
+THIS PATCH vs UPSTREAM #32209 (the PR we would otherwise have opened)
+--------------------------------------------------------------------------------
+Same idea, same placement, same slot semantics.  Ours is a SUBSET, adapted:
+
+  scope      #32209 also ships a `_forward_trtllm` decode trim, a CUDA idle
+             short-circuit in `forward_cuda`, and an eager draft-output slice.
+             We take only the vote.  Its decode-trim half is the one that fails
+             reproducibly here -- see the note in patch 02's header.
+  base       Ours applies to v0.5.15.post1 (`0b3bb0c`); #32209 targets `main`.
+  default    #32209 defaults `can_run_dp_draft_cuda_graph` to False, ours to
+             True.  Its scheduler sets the value on every DP path; on this base
+             the field can reach a non-DP forward unset, where False would refuse
+             the graph outright.  Permissive-by-default matches
+             `can_cuda_graph`'s treatment of idle ranks.
+  local-only The GLM52_P4V2 markers -- the build script greps them out of the
+             BYTECODE to prove the patch landed.  Stripped if ever upstreamed.
+  KNOWN GAP  #32209 also adds a default `requires_dp_attention_eager_forward`
+             returning False on `BaseSpecWorker`.  We do NOT.  Consequence: only
+             the EAGLE worker family is covered -- EAGLEWorkerV2 and its
+             subclasses StandaloneWorkerV2 / FrozenKVMTPWorkerV2.  The workers
+             that inherit BaseSpecWorker directly (MultiLayerEagleWorkerV2,
+             DFlashWorkerV2, NGRAMWorker) have no such method and BaseSpecWorker
+             has no __getattr__, so those spec algorithms would raise
+             AttributeError at the decode.py call site on every PD decode step.
+             Deliberate: this branch only ships EAGLE, and adding the base method
+             would be an unvalidated change to a file the measured image never
+             touched.  Anyone enabling another spec algorithm with PD must add it.
+
+WHY V2, NOT V1
+--------------------------------------------------------------------------------
+Two placements were implemented and both were MEASURED:
+
+  v1 (superseded)  a 1-element gloo all-reduce inside draft()
+                   -> one extra collective per draft call, 98.4% graph usage.
+  v2 (this diff)   one more slot in the existing MLP-sync all-gather
+                   -> zero extra collectives, 97.1% graph usage.
+
+v2 also separates the DRAFT-graph vote from the generic `can_cuda_graph` vote,
+so target-verify and draft-extend graphs are not collateral damage -- #32209
+reports that folding them together cost 9.7% of decode batches their generic
+graph replay.  v1 additionally had to use `get_tp_group()`, not
+`get_attention_tp_group()`: under DPA8 on tp8 the attention TP group is
+attn_tp_size = tp/dp = 1 rank wide, so voting on it is a no-op.  v2 rides the
+scheduler's existing gather and never faces that choice.
+v1's diff is preserved with its full evidence in the internal reproduction kits.
+
+TWO DETAILS THAT WOULD MAKE THIS SILENTLY INERT
+--------------------------------------------------------------------------------
+1. Under overlap scheduling the draft input resolves AFTER the scheduler-side
+   vote, so `dsa_topk_indices` is stale and must not be read directly.  The
+   predicate consults `future_dsa_topk_indices_available` -- exactly "will term 4
+   hold once resolved" (set at scheduler.py:3314, consumed at
+   overlap_utils.py:271).  An earlier revision wrongly assumed that attribute was
+   absent and required eager whenever `future_indices` was set; overlap
+   scheduling sets it on EVERY decode iteration, so the draft graph was refused
+   100% of the time (measured 0.0%, 200/200 calls) -- degrading this patch into
+   the "just disable the draft graph" workaround while passing every test.
+2. Removing only the `not is_idle()` term does NOT work: it fixes the busy-rank
+   iteration and breaks the idle-rank one, which matches the observed symptom of
+   the failure moving earlier, into warmup.
+
+MECHANISM VERIFIED, NOT JUST OUTCOME
+--------------------------------------------------------------------------------
+Over 2992 iterations with all 8 ranks logging: the LOCAL decision still diverges
+38 times (the defect is real and latent, not masked by timing), the ACTED-ON
+decision diverges 0 times, and the vote changed some rank's mind 190 times --
+each one an averted deadlock.  Same-node differential control, only this diff
+reverted: 0/4, deadlock, 120 s timeout on request 1.
+A green stress result alone cannot distinguish this fix from forcing the draft
+path eager -- both pass every functional test.  The graph-usage counter can.
+
+ALTERNATIVE TO THIS PATCH: turn GLM-5.2 MTP IndexShare off
+--------------------------------------------------------------------------------
+    --json-model-override-args '{"index_share_for_mtp_iteration":false}'
+
+Rather than making the decision uniform, this removes what makes it diverge: no
+seed, no divergence, no vote.  Measured on 2 x 8 MI355X with this patch and 02b
+BOTH asserted absent from the bytecode: 4/4, 32/32 twice, 64/64, zero tracebacks,
+accept length 2.98-3.01 -- no measurable cost.  It substitutes for THIS patch and
+for 02b; NOT for 01, NOT for the nextn eh_proj fix, NOT for 02a.
+Two conditions easy to miss: MTP must be on the PREFILL leg too (else the seed
+never reaches decode and the setting is untested rather than tested), and that
+arm was taken to conc=64, not 128.
+WHY IT IS NOT THE DEFAULT: it is nearly free only because IndexShare's consumer
+is currently disabled under PD by `should_use_dsa_fused_topk`.  Upstream #31477
+("[Spec][PD] Enable fused TopK for GLM-5.2 MTP IndexShare", HanHan009527) exists
+to remove that limitation; once it lands the override starts costing (~3% TPOT,
+reported internally -- second-hand, not measured by us).  Checked with `gh`
+2026-08-01: #31477 is OPEN, REVIEW_REQUIRED, unmerged.  So: a good answer today
+if IndexShare is not wanted, a dated one if it is.
+The full arm, with anti-marker verification, is in the internal kits.
+
+diff --git a/python/sglang/srt/disaggregation/decode.py b/python/sglang/srt/disaggregation/decode.py
+index 2164cad..b1e9e0e 100644
+--- a/python/sglang/srt/disaggregation/decode.py
++++ b/python/sglang/srt/disaggregation/decode.py
+@@ -1905,6 +1905,14 @@ class SchedulerDisaggregationDecodeMixin:
+             self.running_batch = self.update_running_batch(self.running_batch)
+             ret = self.running_batch if not self.running_batch.is_empty() else None
+ 
++        # GLM52_P4V2: record this rank's eager-draft request on the batch, so the
++        # MLP-sync all-gather spreads it. Must precede maybe_prepare_mlp_sync_batch
++        # -- that IS the collective. Upstream #32209 places it at this same line.
++        if ret is not None and getattr(self, "draft_worker", None) is not None:
++            ret.force_disable_draft_cuda_graph = (
++                self.draft_worker.requires_dp_attention_eager_forward(ret)
++            )
++
+         ret = self.dp_attn_adapter.maybe_prepare_mlp_sync_batch(ret)
+         if ret:
+             set_schedule_time_batch(ret)
+diff --git a/python/sglang/srt/managers/schedule_batch.py b/python/sglang/srt/managers/schedule_batch.py
+index 55c88af..23687c1 100644
+--- a/python/sglang/srt/managers/schedule_batch.py
++++ b/python/sglang/srt/managers/schedule_batch.py
+@@ -1782,6 +1782,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+     is_extend_in_batch: bool = False
+     all_extend_in_batch: bool = False  # plumbing for downstream forks (PR #19639)
+     can_run_dp_cuda_graph: bool = False
++    can_run_dp_draft_cuda_graph: bool = True  # GLM52_P4V2
++    # GLM52_P4V2: rank-local request for an eager draft step; the MLP-sync
++    # all-gather turns it into the group-wide can_run_dp_draft_cuda_graph.
++    force_disable_draft_cuda_graph: bool = False
+     can_run_dp_breakable_cuda_graph: bool = False
+     tbo_split_seq_index: Optional[int] = None
+ 
+@@ -2852,6 +2856,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+             global_num_tokens=self.global_num_tokens,
+             global_num_tokens_for_logprob=self.global_num_tokens_for_logprob,
+             can_run_dp_cuda_graph=self.can_run_dp_cuda_graph,
++            can_run_dp_draft_cuda_graph=self.can_run_dp_draft_cuda_graph,  # GLM52_P4V2
++            force_disable_draft_cuda_graph=self.force_disable_draft_cuda_graph,
+             can_run_dp_breakable_cuda_graph=self.can_run_dp_breakable_cuda_graph,
+             is_extend_in_batch=self.is_extend_in_batch,
+             all_extend_in_batch=self.all_extend_in_batch,
+diff --git a/python/sglang/srt/managers/scheduler_components/dp_attn.py b/python/sglang/srt/managers/scheduler_components/dp_attn.py
+index b473a11..ff0ef42 100644
+--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
++++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
+@@ -37,6 +37,9 @@ class MLPSyncBatchInfo:
+     num_tokens: int
+     num_tokens_for_logprob: int
+     can_cuda_graph: bool
++    # GLM52_P4V2: slot 7 of the gathered tensor. min()-reduced like
++    # can_cuda_graph, so ANY rank needing eager takes the whole group eager.
++    can_draft_cuda_graph: bool
+     is_extend_in_batch: bool
+     local_can_run_tbo: bool
+     local_forward_mode: int
+@@ -60,6 +63,7 @@ class MLPSyncBatchInfo:
+                 int(self.local_can_run_tbo),
+                 self.local_forward_mode,
+                 int(self.can_run_breakable_cuda_graph),
++                int(self.can_draft_cuda_graph),  # GLM52_P4V2
+             ],
+             device=device,
+             dtype=dtype,
+@@ -75,6 +79,8 @@ class MLPSyncBatchInfo:
+                 1,  # local_can_run_tbo
+                 ForwardMode.IDLE.value,  # local_forward_mode
+                 0,  # can_run_breakable_cuda_graph
++                1,  # can_draft_cuda_graph -- GLM52_P4V2, permissive: an
++                    # inactive rank must not drag the group into eager.
+             ],
+             device=device,
+             dtype=dtype,
+@@ -82,8 +88,9 @@ class MLPSyncBatchInfo:
+ 
+     def all_gather(self, device, group: torch.distributed.ProcessGroup):
+         local_info_tensor = self._get_local_tensor(device=device)
++        # GLM52_P4V2: 7 -> 8 slots (can_draft_cuda_graph appended).
+         global_info_tensor = torch.empty(
+-            (self.dp_size, self.tp_size * self.cp_size, 7),
++            (self.dp_size, self.tp_size * self.cp_size, 8),
+             dtype=torch.int64,
+             device=device,
+         )
+@@ -99,7 +106,9 @@ class MLPSyncBatchInfo:
+             tp_active_ranks = get_tp_group().active_ranks
+ 
+         # Set fallback values for inactive ranks
+-        tp_info = global_info_tensor.view(self.dp_size * self.tp_size * self.cp_size, 7)
++        tp_info = global_info_tensor.view(  # GLM52_P4V2: 7 -> 8
++            self.dp_size * self.tp_size * self.cp_size, 8
++        )
+         tp_info[tp_active_ranks == 0] = self._get_fallback_tensor(device=device)
+ 
+         tp0_info = global_info_tensor[:, 0, :]
+@@ -111,6 +120,8 @@ class MLPSyncBatchInfo:
+         self.can_cuda_graph = bool(tp0_info[:, 2].min().item())
+         self.is_extend_in_batch = bool(tp0_info[:, 3].max().item())
+         self.can_run_breakable_cuda_graph = bool(tp0_info[:, 6].min().item())
++        # GLM52_P4V2: min() -- one rank needing eager takes the whole group.
++        self.can_draft_cuda_graph = bool(tp0_info[:, 7].min().item())
+         if _ENABLE_METRICS_DP_ATTENTION:
+             self.dp_cooperation_info = DPCooperationInfo.create(tp0_info[:, 5].tolist())
+ 
+@@ -137,6 +148,7 @@ def _update_gather_batch(
+ 
+     # Check forward mode for cuda graph
+     batch.can_run_dp_cuda_graph = mlp_sync_info.can_cuda_graph
++    batch.can_run_dp_draft_cuda_graph = mlp_sync_info.can_draft_cuda_graph  # GLM52_P4V2
+     batch.can_run_dp_breakable_cuda_graph = mlp_sync_info.can_run_breakable_cuda_graph
+ 
+ 
+@@ -189,6 +201,13 @@ def prepare_mlp_sync_batch_raw(
+         and local_batch.forward_mode in (ForwardMode.EXTEND, ForwardMode.MIXED)
+         and not disable_cuda_graph
+     )
++    # GLM52_P4V2: rank-local answer set by the scheduler just before this call.
++    # Default True (permissive) when the batch is None or the attribute is
++    # absent, matching can_cuda_graph's treatment of idle ranks.
++    can_draft_cuda_graph = not (
++        local_batch is not None
++        and getattr(local_batch, "force_disable_draft_cuda_graph", False)
++    )
+ 
+     is_extend_in_batch = local_batch.forward_mode.is_extend() if local_batch else False
+     if local_batch is not None:
+@@ -214,6 +233,7 @@ def prepare_mlp_sync_batch_raw(
+         num_tokens=num_tokens,
+         num_tokens_for_logprob=num_tokens_for_logprob,
+         can_cuda_graph=can_cuda_graph,
++        can_draft_cuda_graph=can_draft_cuda_graph,  # GLM52_P4V2
+         is_extend_in_batch=is_extend_in_batch,
+         local_can_run_tbo=local_can_run_tbo,
+         local_forward_mode=local_forward_mode,
+diff --git a/python/sglang/srt/model_executor/forward_batch_info.py b/python/sglang/srt/model_executor/forward_batch_info.py
+index 031ab4f..09c43f6 100644
+--- a/python/sglang/srt/model_executor/forward_batch_info.py
++++ b/python/sglang/srt/model_executor/forward_batch_info.py
+@@ -389,6 +389,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
+     # Mirrors ScheduleBatch.all_extend_in_batch; kept for downstream forks.
+     all_extend_in_batch: bool = False
+     can_run_dp_cuda_graph: bool = False
++    can_run_dp_draft_cuda_graph: bool = True  # GLM52_P4V2
+     can_run_dp_breakable_cuda_graph: bool = False
+     global_forward_mode: Optional[ForwardMode] = None
+ 
+@@ -704,6 +705,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
+             is_extend_in_batch=batch.is_extend_in_batch,
+             all_extend_in_batch=batch.all_extend_in_batch,
+             can_run_dp_cuda_graph=batch.can_run_dp_cuda_graph,
++            can_run_dp_draft_cuda_graph=batch.can_run_dp_draft_cuda_graph,  # GLM52_P4V2
+             can_run_dp_breakable_cuda_graph=batch.can_run_dp_breakable_cuda_graph,
+             global_forward_mode=batch.global_forward_mode,
+             is_prefill_only=batch.is_prefill_only,
+diff --git a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+index 7cf1291..f60254f 100644
+--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
++++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+@@ -305,7 +305,13 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
+         )
+ 
+         if self.require_mlp_sync:
+-            is_bs_supported = is_bs_supported and forward_batch.can_run_dp_cuda_graph
++            # GLM52_P4V2: the group-wide draft-graph gate the scheduler
++            # all-gathered. Without it the choice stays rank-local and deadlocks.
++            is_bs_supported = (
++                is_bs_supported
++                and forward_batch.can_run_dp_cuda_graph
++                and forward_batch.can_run_dp_draft_cuda_graph
++            )
+ 
+         return is_bs_supported
+ 
+diff --git a/python/sglang/srt/speculative/eagle_worker_v2.py b/python/sglang/srt/speculative/eagle_worker_v2.py
+index baa3674..d726ac4 100644
+--- a/python/sglang/srt/speculative/eagle_worker_v2.py
++++ b/python/sglang/srt/speculative/eagle_worker_v2.py
+@@ -1105,6 +1105,27 @@ class EAGLEWorkerV2(BaseSpecWorker):
+         # draft_extend, which runs on the draft runner.
+         return self._draft_worker.draft_runner
+ 
++    def requires_dp_attention_eager_forward(self, batch) -> bool:
++        """GLM52_P4V2: does THIS rank need the draft step to run eagerly?
++
++        Rank-local half of upstream #32209's vote; the scheduler min()-reduces it
++        over its existing MLP-sync all-gather, adding no collective. Condition is
++        guard term 4 of `draft()`. Full account in the patch header.
++        """
++        if not self._draft_worker.seed_dsa_topk_from_draft_extend:
++            return False
++
++        draft_input = batch.spec_info
++        if draft_input is None:
++            return False
++
++        # Overlap resolves the draft input AFTER this vote, so dsa_topk_indices
++        # is stale; read #32209's flag instead. Substituting `future_indices is
++        # not None` refuses the graph 100% of the time -- see the patch header.
++        if getattr(draft_input, "future_indices", None) is not None:
++            return not draft_input.future_dsa_topk_indices_available
++        return getattr(draft_input, "dsa_topk_indices", None) is None
++
+     @property
+     def spec_v2_attn_backends(self) -> tuple:
+         # Every attn backend a spec_v2 forward touches; consumed by

--- a/deploy/docker/patches/sglang_dsa/dsa_backend_dp_sync_and_page_table_rows.diff
+++ b/deploy/docker/patches/sglang_dsa/dsa_backend_dp_sync_and_page_table_rows.diff
@@ -1,0 +1,181 @@
+PATCH 02 -- dsa_backend DP host-sync (2a) + page-table rows (2b)
+================================================================================
+Two independent fixes in one file, both needed for PD disaggregation with MTP on
+the decode leg.
+
+WHAT 2a  `max_seqlen_k = int(forward_batch.seq_lens.max().item())` is a blocking
+         D2H sync sitting on a branch only SOME DP ranks take (idle peers keep
+         their host mirror and take the cheap arm), so the DP collectives
+         desynchronize and the group deadlocks.  Replaced with the sync-free
+         `self.req_to_token.shape[1]`.  Two further unconditional `.cpu()` syncs
+         on the same branch are removed (2a2) -- with 2a alone the hang persists.
+WHY 2a   Over-allocating page-table columns is safe: the table is only indexed
+         THROUGH top-k, which masks per row by cache_seqlens, so extra columns
+         get -inf and are never selected.  Verified by walking every consumer.
+         The sync-free idiom is established in-tree three times
+         (triton_backend.py:704-708, trtllm_mha_backend.py:555-559, and DSA's own
+         graph path at dsa_backend.py:689-695).
+         2a2's removals are dead for DRAFT_EXTEND_V2, which is not is_extend()
+         (ForwardMode.is_extend, include_draft_extend_v2 defaults False), so every
+         consumer is unreachable: extend_prefix_lens_cpu is read only inside the
+         is_extend() arm; seq_lens_sum at the is_extend()-gated capacity check and
+         the Blackwell+EXTEND heuristic; indexer_seq_lens_cpu is captured ABOVE
+         this block and is already None here; _cal_indexer_k_start_end and
+         dsa_indexer's k-only path both open with is_extend_without_speculative().
+         base_spec_worker.prepare_for_draft_extend already supplies the mirror
+         this branch does need (extend_seq_lens_cpu), for this exact reason.
+
+WHAT 2b  `metadata.page_table_1` is one row per REQUEST; `topk_indices` has just
+         been padded to `q.shape[0]`, one row per TOKEN.  Equal for plain decode,
+         unequal under MTP -- `transform_index_page_table_decode_fast` then trips
+         `assert page_table.shape[0] == topk_indices.shape[0]` and every rank dies.
+WHY 2b   Expanding by repeat_interleave reproduces the token-major layout.  Rows
+         `_pad_topk_indices` added hold all -1 and the triton kernel masks them
+         (`valid_topk_mask = mask & (loaded_topk_indices >= 0)`), so only the row
+         COUNT has to match.  Applied at BOTH decode call sites -- the traceback
+         named only the first, but the second pairs the same unpadded page table
+         with a padded topk_indices.  The prefill sibling solves this with an
+         explicit `output_num_tokens`; the decode entry point has no equivalent.
+
+UPSTREAM STATUS  (queried with `gh`, 2026-08-01)
+--------------------------------------------------------------------------------
+issue            NONE for either half.
+third-party PR   NONE for either half.  Per-diff greps: #31683 does not touch
+                 this file's max_seqlen_k path at all; #32209 / #32196 vote on
+                 GRAPH CAPTURE, which a host-side sync is invisible to; merged
+                 #29798 ("avoid DSA indexer CPU seq lens fallback") repaired the
+                 GLOBAL eager path -- batches over --cuda-graph-max-bs, entered
+                 by all ranks together -- and never anticipated per-rank
+                 asymmetric entry.
+                 Weaker than it sounds: `gh search` matches titles and bodies,
+                 not diff content, so an upstream PR could touch either site
+                 without naming it.
+own PR           NONE.  Not upstreamed.  2a's evidence is runtime-state, not a
+                 revert, so it is harder to present upstream than patch 01 was;
+                 2b's upstream counterpart would be #32209's other half, which we
+                 could not make work here (see below).
+
+HOW 2a WAS ESTABLISHED
+--------------------------------------------------------------------------------
+Not by reverting the fix -- by observing the divergence.  A py-spy dump caught a
+BUSY rank blocked inside dsa_backend on `.max().item()` while IDLE peers had
+already advanced into the next collective.  After the fix no rank appears in
+dsa_backend in a dump again and PD warmup passes on all 8 ranks.  2a2 was forced
+by experiment, not by reading: with 2a applied and 2a2 not, the hang persists.
+
+A NEGATIVE RESULT WORTH RECORDING
+--------------------------------------------------------------------------------
+#32209's other half reconciles the same decode row counts by TRIMMING q/top-k
+where 2b EXPANDS the page table.  It looks like an obvious convergence and is
+not: porting it onto this HIP/tilelang path fails reproducibly at conc=32 (0/32
+across seven runs, three node pairs, a rebuilt image).  Seventeen candidate
+causes were instrumented and eliminated; the root cause is NOT identified.  The
+reproduction kit is held internally.  Until that is understood, 2b keeps its
+own form.
+
+RELATION TO THE INDEXSHARE WORKAROUND
+--------------------------------------------------------------------------------
+    --json-model-override-args '{"index_share_for_mtp_iteration":false}'
+
+Substitutes for 2b, NOT for 2a.  An arm with the override, and with 2b and 04
+both asserted ABSENT from the bytecode, passed 4/4, 32/32 twice and 64/64 on
+2 x 8 MI355X.  2a was NOT reverted in that arm, so it says nothing about 2a
+either way -- and a host-side sync is invisible to the graph/eager decision the
+override acts on.  See the header of draft_cuda_graph_dp_vote.diff for the cost
+of the override and the #31477 status check.
+
+diff --git a/python/sglang/srt/layers/attention/dsa_backend.py b/python/sglang/srt/layers/attention/dsa_backend.py
+index 75aa41d..59edf19 100644
+--- a/python/sglang/srt/layers/attention/dsa_backend.py
++++ b/python/sglang/srt/layers/attention/dsa_backend.py
+@@ -141,6 +141,29 @@ def _to_2d_context_lens(seqlens_32: torch.Tensor, batch_size: int) -> torch.Tens
+ global_workspace_buffer = None
+ 
+ 
++def _glm52_match_page_table_rows(page_table, topk_indices):
++    """GLM52_BUG2B: give page_table one row per TOKEN, matching topk_indices.
++
++    page_table_1 is per-REQUEST, topk_indices per-TOKEN -- equal for plain decode,
++    not under MTP, where decode then trips `assert page_table.shape[0] ==
++    topk_indices.shape[0]`. Padded rows are masked, so only the COUNT matters.
++    """
++    if topk_indices is None or page_table is None:
++        return page_table
++    n_topk = topk_indices.shape[0]
++    n_rows = page_table.shape[0]
++    if n_rows == n_topk:
++        return page_table
++    if n_rows > 0 and n_topk % n_rows == 0:
++        return page_table.repeat_interleave(n_topk // n_rows, dim=0)
++    # Non-integral ratio: trim or edge-pad so the shapes agree. Any row reached
++    # only through padded (-1) topk entries is masked, so its content is moot.
++    if n_rows > n_topk:
++        return page_table[:n_topk]
++    pad = page_table[-1:].expand(n_topk - n_rows, -1)
++    return torch.cat([page_table, pad], dim=0)
++
++
+ @dataclass(frozen=True)
+ class DSAFlashMLAMetadata:
+     """Metadata only needed by FlashMLA"""
+@@ -740,10 +763,10 @@ class DeepseekSparseAttnBackend(
+                 forward_batch.seq_lens_cpu.max().item() + draft_token_num
+             )
+         else:
+-            # needs_cpu_seq_lens=False nulls the host mirror for spec-v2 relay
+-            # batches; graph replay uses the static page-table width, so only this
+-            # eager (e.g. over-capture-bs) fallback needs a length here.
+-            max_seqlen_k = int(forward_batch.seq_lens.max().item()) + draft_token_num
++            # GLM52_BUG2A: BEFORE `seq_lens.max().item()`, a D2H sync on a branch
++            # only SOME DP ranks take -> collectives desync -> deadlock. AFTER the
++            # static width, the sync-free idiom _graph_page_table_width() uses.
++            max_seqlen_k = self.req_to_token.shape[1]
+         # [b, max_seqlen_k]
+         page_table = self.req_to_token_pool.req_to_token[
+             forward_batch.req_pool_indices, :max_seqlen_k
+@@ -803,19 +826,13 @@ class DeepseekSparseAttnBackend(
+                 page_table, repeats=self.speculative_num_draft_tokens, dim=0
+             )
+         elif forward_batch.forward_mode.is_draft_extend_v2():
+-            if forward_batch.extend_prefix_lens_cpu is None:
+-                assert forward_batch.extend_prefix_lens is not None
+-                forward_batch.extend_prefix_lens_cpu = (
+-                    forward_batch.extend_prefix_lens.cpu().tolist()
+-                )
+-            if forward_batch.seq_lens_cpu is None:
+-                forward_batch.seq_lens_cpu = forward_batch.seq_lens.cpu()
+-                forward_batch.seq_lens_sum = int(forward_batch.seq_lens_cpu.sum())
++            # GLM52_BUG2A2: BEFORE two more D2H syncs sat here on the same
++            # divergent branch, so 2A alone left the deadlock. AFTER removed --
++            # dead for DRAFT_EXTEND_V2; per-consumer walk in the patch header.
+             assert (
+                 forward_batch.extend_seq_lens_cpu is not None
+                 and forward_batch.extend_seq_lens is not None
+-                and forward_batch.extend_prefix_lens_cpu is not None
+-            ), "All of them must not be None"
++            ), "extend_seq_lens{,_cpu} must not be None for DRAFT_EXTEND_V2"
+ 
+             extend_seq_lens_cpu = forward_batch.extend_seq_lens_cpu
+             assert forward_batch.extend_seq_lens is not None
+@@ -2134,7 +2151,9 @@ class DeepseekSparseAttnBackend(
+             page_table_1 = self._get_fused_topk_page_table(topk_indices)
+         else:
+             page_table_1 = transform_index_page_table_decode(
+-                page_table=metadata.page_table_1,
++                page_table=_glm52_match_page_table_rows(
++                    metadata.page_table_1, topk_indices
++                ),
+                 topk_indices=topk_indices,
+                 page_size=1,
+             )
+@@ -2704,7 +2723,9 @@ class DeepseekSparseAttnBackend(
+             if topk_indices is not None:
+                 topk_indices = self._pad_topk_indices(topk_indices, q.shape[0])
+             page_table_1 = transform_index_page_table_decode(
+-                page_table=metadata.page_table_1,
++                page_table=_glm52_match_page_table_rows(
++                    metadata.page_table_1, topk_indices
++                ),
+                 topk_indices=topk_indices,
+                 page_size=1,
+             )

--- a/deploy/docker/patches/sglang_dsa/dsa_indexer_hip_dp_padded_rows.diff
+++ b/deploy/docker/patches/sglang_dsa/dsa_indexer_hip_dp_padded_rows.diff
@@ -1,0 +1,161 @@
+PATCH 01 -- dsa_indexer HIP/aiter DP-padded rows
+================================================================================
+WHAT   The aiter (HIP) paged-MQA branch sizes its `logits` output from the
+       DP-PADDED row count while `lengths` is sized to the REAL count, so top-k
+       dies with "Expected lengths.size(0) == B to be true, but got false".
+       Slice q/weights to the real count (the contract every CUDA backend
+       already honours), then restore the padding after topk_transform.
+WHY    Without it, DP-attention + EAGLE MTP for GLM-5.2 DSA on gfx950 crashes on
+       the very first batch.  CUDA was never affected: those backends take
+       `q_offset=` and slice internally.  ROCm-specific.
+
+UPSTREAM STATUS  (queried with `gh`, 2026-08-01 -- all OPEN, none merged)
+--------------------------------------------------------------------------------
+issue            NONE.  No upstream issue reports this.  Searched sgl-project/
+                 sglang for "Expected lengths.size", "DSA padding DP attention"
+                 and the GLM-5.2 MTP crash text: no match.  Weak evidence --
+                 `gh search` matches titles and bodies, not diff content.
+third-party PR   #32762  "[NPU] Fix DSA eager padding mismatch in PD MTP
+                 warm-up" (stellaxcpeng, OPEN).  SAME BUG CLASS on a different
+                 platform, and this diff is written in its shape: one boolean
+                 gates both trim and restore, and the returned row count is
+                 asserted before the padding is re-attached.  It does not touch
+                 the aiter branch, so it does not fix HIP.
+                 #31683  "[ROCm][MI35X] Enable GLM-5.2-MXFP4 MTP" (long10024070,
+                 OPEN).  ADJACENT, NOT THE SAME FIX -- same function, but it
+                 widens forward_cuda's guard from `seq_lens.numel() == 0` to
+                 `is_idle() or ...`.  Different symptom; verified against its diff.
+                 #30378 / #30427 (both MERGED, in this base) clamp padded-row
+                 seq_lens VALUES in triton_ops/pad.py.  This fixes the HIP-side
+                 row COUNT -- a different defect in the same area.
+own PR           #33059  "Fix DSA indexer aiter (HIP) padding mismatch under
+                 DP-attention" (dorado269, OPEN, REVIEW_REQUIRED, against main,
+                 1 file +16/-4, fork dorado269/sglang).  CI is red only at
+                 `pr-gate`, which blocks on a missing `run-ci` label, not on code.
+
+THIS PATCH vs OUR OWN PR #33059
+--------------------------------------------------------------------------------
+Same defect, same two edits.  They differ deliberately:
+
+  base       here: v0.5.15.post1 (`0b3bb0c`), the pinned engine base.
+             #33059: sglang `main`, whose `_get_topk_paged` has drifted (added
+             cutedsl / dg_native branches and `_mask_init_and_local_tokens`).
+  form       here: explicit `_p1v2_trim` / `_p1v2_real` / `_p1v2_padded` locals
+             with a post-kernel row-count ASSERT, following #32762's shape.
+             #33059: the minimal `q_fp8[:q_offset]` / `weights[:q_offset]` slice
+             and a plain `if q_offset < q_fp8.shape[0]` restore.
+  local-only Stripped for upstream: the `GLM52_P1V2` markers (the build script
+             greps them out of the BYTECODE to prove the patch landed), the
+             `_p1v2_*` naming, and the whole `SGLANG_DEBUG_DSA_ROWS` logging
+             block.  All three are scaffolding for this repo's verification
+             loop and carry no upstream value.
+  trade-off  The upstream form is smaller and easier to review.  Ours fails
+             LOUDER: on a shape drift the assert crashes instead of silently
+             returning a short tensor.  Prefer upstream's once it merges and the
+             base carries it -- then delete this diff.
+  validation Ours: 4/4 probe, conc=64 1k/1k 256/256, plus 2540/2540 in the PD
+             set.  #33059's port to `main` was NOT re-run on hardware; CI or a
+             maintainer run is its confirmation.
+
+RELATION TO THE INDEXSHARE WORKAROUND
+--------------------------------------------------------------------------------
+NOT substituted.  `--json-model-override-args
+'{"index_share_for_mtp_iteration":false}'` removes the rank divergence that
+patch 04 and patch 02b address, but this is an independent bug -- present
+regardless of IndexShare, and the arm that validated the override had THIS
+patch applied.
+
+diff --git a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+index 59b2256..0bacbdb 100644
+--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
++++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+@@ -5,6 +5,8 @@ import logging
+ from abc import ABC, abstractmethod
+ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+ 
++import os
++
+ import torch
+ from einops import rearrange
+ 
+@@ -57,6 +59,9 @@ logger = logging.getLogger(__name__)
+ global _use_multi_stream
+ _is_cuda = is_cuda()
+ _is_hip = is_hip()
++# Set SGLANG_DEBUG_DSA_ROWS=1 to log the indexer row bookkeeping (padded vs real).
++_DSA_DEBUG_ROWS = os.environ.get("SGLANG_DEBUG_DSA_ROWS", "0") == "1"
++
+ _is_npu = is_npu()
+ 
+ if not _is_npu:
+@@ -902,11 +907,45 @@ class Indexer(MultiPlatformOp):
+         assert len(weights.shape) == 3
+         weights = weights.squeeze(2)
+ 
++        # GLM52_P1V2: bound before the branch so the restore gates on the same
++        # boolean. Only aiter sets it; the CUDA branches slice internally.
++        _p1v2_trim = False
++        _p1v2_real = q_offset
++        _p1v2_padded = q_fp8.shape[0]
+         if self.paged_mqa_logits_backend.is_aiter():
++            # WHY: DP-attention pads q_fp8 past `lengths` and aiter (unlike CUDA)
++            # sizes logits from q_fp8.shape[0] -> "Expected lengths.size(0) == B".
++            # HOW: slice to the real count -- the contract CUDA already honours.
++
++            # Trim at _p1v2_real == 0 too: q_fp8[:0] is what a DP-idle rank should
++            # pass. An earlier `0 < q_offset` bound asserted on exactly those ranks.
++            _p1v2_trim = _p1v2_real < _p1v2_padded
++            _q_mqa, _w_mqa = q_fp8, weights
++            if _p1v2_trim:
++                _q_mqa = q_fp8[:_p1v2_real]
++                _w_mqa = weights[:_p1v2_real]
++            if _DSA_DEBUG_ROWS:
++                # Cross-check against the padding bookkeeping #32762 keys off.
++                # Logged, not asserted: it has never been measured to agree with
++                # q_offset on the MTP draft-extend path.
++                _p1v2_ntnp = getattr(forward_batch, "_original_num_tokens", None)
++                if _p1v2_ntnp is None:
++                    _p1v2_ntnp = forward_batch.num_token_non_padded_cpu
++                logger.info(
++                    "[dsa-rows] mode=%s q_fp8=%s q_offset=%s ntnp=%s agree=%s "
++                    "lengths=%s -> mqa_q=%s",
++                    forward_batch.forward_mode,
++                    tuple(q_fp8.shape),
++                    _p1v2_real,
++                    _p1v2_ntnp,
++                    _p1v2_ntnp == _p1v2_real,
++                    tuple(metadata.get_seqlens_expanded().shape),
++                    tuple(_q_mqa.shape),
++                )
+             logits = aiter_paged_mqa_logits(
+-                q_fp8,
++                _q_mqa,
+                 kv_cache_fp8,
+-                weights,
++                _w_mqa,
+                 seqlens_32,
+                 block_tables,
+                 max_seq_len,
+@@ -961,11 +1000,18 @@ class Indexer(MultiPlatformOp):
+ 
+         # NOTE(dark): logits should be cleaned in topk_transform
+         topk_result = metadata.topk_transform(logits, self.index_topk)
+-        # Restore possible padding exist in the hidden states.
+-        if not _is_hip and q_offset < q_fp8.shape[0]:
+-            pad_len = q_fp8.shape[0] - q_offset
++        # GLM52_P1V2: restore the trimmed padding -- gate on the SAME boolean and
++        # assert the row count. BEFORE, a re-derived condition skipped the restore
++        # on a shape drift, returning a short tensor instead of crashing.
++        if _p1v2_trim:
++            assert topk_result.shape[0] == _p1v2_real, (
++                "GLM52_P1V2: paged-MQA top-k returned "
++                f"{topk_result.shape[0]} rows for {_p1v2_real} trimmed query "
++                f"rows (padded={_p1v2_padded}); refusing to pad a mis-shaped "
++                "result."
++            )
+             padding = torch.full(
+-                (pad_len, topk_result.shape[1]),
++                (_p1v2_padded - _p1v2_real, topk_result.shape[1]),
+                 -1,
+                 dtype=topk_result.dtype,
+                 device=topk_result.device,

--- a/deploy/docker/scripts/apply_sglang_dsa_patches.sh
+++ b/deploy/docker/scripts/apply_sglang_dsa_patches.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Apply the GLM-5.2 DSA patch set to the sglang checkout in an engine image, and
+# prove every patch reached the BYTECODE.
+#
+# Used by Dockerfile.sglang at build time, and runnable by hand inside a
+# container for iteration.
+#
+# DEPENDENCY: the GLM-5.2 nextn eh_proj quark-exclude fix is NOT in this set --
+# deploy/docker/patches/sglang/patch_glm52_nextn_quark_exclude.py already carries
+# it, and Dockerfile.sglang runs that loop BEFORE this script.  It is a hard
+# prerequisite (without it GLM-5.2 MTP dies at draft weight-load with a
+# 3072-vs-6144 shape error), so we ASSERT it below rather than assume it.
+#
+# WHY BYTECODE VERIFICATION.  Python caches compiled modules in __pycache__ keyed
+# on the source mtime.  A patch script that restores a backup with shutil.copy2
+# preserves the original mtime, so the edited .py can match a stale .pyc and
+# CPython silently runs the UNPATCHED bytecode.  This has already invalidated a
+# full experiment here -- the source showed the fix, the runtime did not have it.
+# So we drop __pycache__ and re-verify against freshly compiled bytecode.
+#
+# Verification greps for IDENTIFIERS, never for `#` comment markers: the compiler
+# discards comments, so a comment marker reads as a false negative.
+set -euo pipefail
+
+SGLANG_DIR="${SGLANG_DIR:-/sgl-workspace/sglang}"
+PATCH_DIR="${PATCH_DIR:-/tmp/sglang_dsa}"
+SRT="$SGLANG_DIR/python/sglang/srt"
+
+# Applied in this order.  Order is not significant -- the three touch disjoint
+# files, except that 02 carries both patch 2a and 2b in one diff.
+PATCHES=(
+  dsa_indexer_hip_dp_padded_rows.diff
+  dsa_backend_dp_sync_and_page_table_rows.diff
+  draft_cuda_graph_dp_vote.diff
+)
+
+# module basename : identifier that must be present in the compiled bytecode
+MARKERS=(
+  "dsa_indexer.py:_p1v2_trim"
+  "dsa_backend.py:_glm52_match_page_table_rows"
+  "dp_attn.py:can_draft_cuda_graph"
+  "eagle_worker_v2.py:requires_dp_attention_eager_forward"
+  "eagle_draft_cuda_graph_runner.py:can_run_dp_draft_cuda_graph"
+  "forward_batch_info.py:can_run_dp_draft_cuda_graph"
+  "schedule_batch.py:force_disable_draft_cuda_graph"
+  "decode.py:force_disable_draft_cuda_graph"
+)
+
+echo "=== sglang DSA patches: applying to $SGLANG_DIR ==="
+cd "$SGLANG_DIR"
+for p in "${PATCHES[@]}"; do
+  echo "  --- $p"
+  # --fuzz=0: these target a pinned sglang commit.  A fuzzy apply that "succeeds"
+  # against a different base is worse than a clean failure.
+  patch -p1 --fuzz=0 < "$PATCH_DIR/$p"
+done
+
+echo "=== dropping __pycache__ so verification cannot read a stale .pyc ==="
+find "$SGLANG_DIR/python/sglang/srt" -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+
+echo "=== verifying every patch reached the bytecode ==="
+fail=0
+
+# PREREQUISITE, not one of our patches: patch_glm52_nextn_quark_exclude.py (run
+# earlier by Dockerfile.sglang) must have made the nextn eh_proj edit.  Asserted
+# here because GLM-5.2 MTP cannot load its draft weights without it, and because
+# a silent "skipped" from that idempotent script would otherwise go unnoticed
+# until the engine crashed at runtime.  The marker is a literal inside an
+# f-string, so this is a SOURCE check -- the f-string is split across bytecode
+# constants and does not appear whole in the .pyc.
+n3=$(grep -c 'num_hidden_layers}.eh_proj' "$SRT/models/deepseek_nextn.py" || true)
+echo "  PREREQ nextn eh_proj      -> src=$n3 (want 1)"
+[ "$n3" -eq 1 ] || { echo "  ^ run deploy/docker/patches/sglang/ first" >&2; fail=1; }
+
+# Patch 2a changes an expression and introduces no new identifier, and the same
+# expression already appears on two pre-existing graph-capture paths -- so
+# counting it gives 3, not 1.  Key off the unique comment the patch adds.  This
+# is a SOURCE check by necessity; bytecode cannot show it.
+n2a=$(grep -cF 'GLM52_BUG2A: BEFORE `seq_lens.max().item()`' \
+      "$SRT/layers/attention/dsa_backend.py" || true)
+echo "  patch2a max_seqlen_k      -> src=$n2a (want 1)"
+[ "$n2a" -eq 1 ] || fail=1
+
+for spec in "${MARKERS[@]}"; do
+  f="${spec%%:*}"; m="${spec#*:}"
+  p=$(find "$SRT" -name "$f" | head -1)
+  if [ -z "$p" ]; then echo "  MISSING MODULE $f"; fail=1; continue; fi
+  d=$(dirname "$p"); b=$(basename "$p" .py)
+  rm -f "$d/__pycache__/$b."*.pyc
+  python3 -c "import py_compile; py_compile.compile('$p', doraise=True)"
+  pyc=$(ls "$d/__pycache__/$b."*.pyc 2>/dev/null | head -1)
+  n=$(strings "$pyc" | grep -c "$m" || true)
+  printf "  %-42s -> pyc=%s (want >0)\n" "$f :: $m" "$n"
+  [ "$n" -gt 0 ] || fail=1
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "SGLANG DSA PATCH VERIFICATION FAILED" >&2
+  exit 1
+fi
+echo "=== all sglang DSA patches verified in bytecode ==="


### PR DESCRIPTION
Enables PD disaggregation + DP-attention + EAGLE MTP for GLM-5.2-MXFP4 on gfx950. Without these the combination crashes on the first batch or deadlocks the whole DP group under concurrency.

Supersedes #34, which was branched from `cf85272`. `main` has since moved 29 commits ahead and absorbed three of the things that branch carried; this one is rebased onto `8692fb4` with those dropped. See "Relationship to #34" below.

## The patches

| # | file | what it fixes | shape |
|---|---|---|---|
| 1 | `dsa_indexer_hip_dp_padded_rows.diff` | HIP/aiter paged-MQA sizes its output from **DP-padded** rows while `lengths` is sized to **real** rows → `Expected lengths.size(0) == B` | upstream [#32762](https://github.com/sgl-project/sglang/pull/32762) (NPU, same bug class): one boolean gates both trim and restore, post-kernel row count asserted before padding is restored |
| 2 | `dsa_backend_dp_sync_and_page_table_rows.diff` | (a) `seq_lens.max().item()` is a host sync on a branch only *some* DP ranks take → collectives desynchronize; (b) page table has one row per **request**, top-k one per **token** under MTP → assert | ours; no upstream counterpart found |
| 4 | `draft_cuda_graph_dp_vote.diff` | the draft graph/eager choice is made **per rank** from rank-dependent inputs and diverges on the PD decode leg → deadlock | upstream [#32209](https://github.com/sgl-project/sglang/pull/32209): the vote rides the MLP-sync all-gather the scheduler already performs — **zero** extra collectives |

Applied at build time by `Dockerfile.sglang`, defaulting **on** (`APPLY_SGLANG_DSA_PATCHES=1`). Build with `=0` for a stock engine to A/B.

The apply script verifies every patch reached the **bytecode**, not just the source: a stale `__pycache__` entry silently reverts a patch and has already invalidated one full experiment on this stack.

## Validation

Image built from `Dockerfile.sglang` independently on each of two nodes; **nothing patched in the running container**. 2 × 8×MI355X (gfx950), GLM-5.2-MXFP4, PD + `--dp-size 8 --enable-dp-attention --ep-size 8` + EAGLE MTP with the draft CUDA graph **enabled**, mooncake RDMA over mlx5 + dma-buf.

| Check | Target | Result |
|---|---|---|
| Build-time bytecode verification, both nodes | all markers | **8/8 + prereq + patch2a** |
| 4-prompt correctness probe | 4/4, `acc_len` > 1 | **4/4**, 2.00–3.43 |
| conc=32 × 512 tok | 32/32 | **32/32** |
| conc=128 × 512 tok | 128/128 | **128/128** |
| conc=128 × 512, repeat | — | **128/128** |
| `Traceback` / `KVTransferError`, either leg | 0 | **0 / 0** |
| DP ranks serving | 8 | **8** every run, 0 retries |

The **draft CUDA graph was measured in use at 92.0 %, identical on all 8 ranks**, on the immediately preceding build of this patch set. That measurement needs an added probe (a different image) so it is not part of the run above — but it is the criterion that matters: forcing the draft path eager passes every functional test while disabling the feature under test, so a green stress result alone cannot distinguish a fix from that workaround. Uniformity across ranks is the property patch 4 exists to produce.

## Relationship to #34

#34 carried four patches and two Dockerfiles. Rebasing onto current `main` applied with **zero conflicts**, which was misleading — the branch only *added* files, so git had nothing to compare against changes `main` made to the same problems in different files. Three overlapped:

- **`deepseek_nextn_glm52_mtp_bf16.diff`** — `main`'s `patch_glm52_nextn_quark_exclude.py` (0d8d0ff) makes the identical edit: same file, same line, same resulting value. Keeping both would have been *actively broken*, not merely redundant: `main`'s loop runs first, so our context diff would then fail at `--fuzz=0` against an already-edited anchor. Dropped; `apply_sglang_dsa_patches.sh` now **asserts** it as a prerequisite, because that script is idempotent and a silent skip would surface only at runtime as GLM-5.2 dying at draft weight-load.
- **`build_mooncake_dmabuf.sh`** — `main`'s `build_mooncake_sglang.sh` is a strict superset (same logic line for line, plus a HIP-transport gate check and build-tree cleanup). Dropped.
- **`Dockerfile.sglang.dmabuf`** — `main`'s `Dockerfile.sglang` now compiles the dma-buf branch in and selects it at runtime via `MOONCAKE_DISABLE_HIP_DMABUF`, which is exactly how these runs drove it (`=0`). Dropped; the DSA layer moved into `Dockerfile.sglang`.

Net: 8 files / 1181 lines → 6 files / 1048 lines, one modified file instead of two new Dockerfiles and a duplicated build script.

## There is a configuration-only alternative to part of this set

Turning GLM-5.2 MTP **IndexShare** off avoids the same deadlock without patch 4 or patch 2's page-table half:

```
--json-model-override-args '{"index_share_for_mtp_iteration":false}'
```

It works because IndexShare is the *source* of the divergence: the guard term `dsa_topk_indices is None` is seeded on the PD decode leg from RDMA-shipped per-request payloads, so it is a function of which requests each rank happens to hold.

| patch | substituted? |
|---|---|
| 1 | **No** — independent bug, present regardless |
| 2a DP host-sync | **No** — a host sync is invisible to the graph/eager decision either mechanism changes |
| 2b page-table rows | **Yes**, in effect |
| nextn `eh_proj` | **No** — weight-load bug |
| 4 | **Yes** — this is what it targets |

Measured with 2b and 4 asserted absent from the bytecode: 4/4, 32/32 ×2, 64/64, accept length 2.98–3.01 (no measurable cost). It needs MTP on the **prefill** leg too, and that arm ran conc=64, not 128.

Not adopted as the default because it is nearly free only while IndexShare's consumer stays disabled under PD by `should_use_dsa_fused_topk`. Upstream [#31477](https://github.com/sgl-project/sglang/pull/31477) removes that limitation; once it lands the override starts costing (~3 % TPOT, reported by AMD's llying — second-hand, not measured by us). Checked with `gh` on 2026-07-31: open, `REVIEW_REQUIRED`, unmerged.

Each diff header records where it stands relative to this, so the choice is visible at the point of use.

## What this does not establish

- **No differential control was run in this validation.** Necessity is established in the earlier reproduction kits — patch 4's same-node revert control (0/4, deadlock) among them.
- **Patch 2 has no revert-style control** — its case was made from runtime state instead: a py-spy dump caught a *busy* rank blocked inside `dsa_backend` on `.max().item()` while *idle* peers had already advanced into the next collective, and after the fix no rank appears there in a dump again, with PD warmup passing on all 8 ranks. Its second half was forced *by experiment* — with the `max_seqlen_k` change alone, the hang persists. A revert control would still be a cheap addition.
- **No performance comparison** against a DPA-only baseline. Patch 4 adds no collective (that was the point of adopting #32209's placement), but no throughput comparison was run.
- **One configuration**: context 32768, short prompts, 512-token outputs, `--disable-custom-all-reduce` (required — the aiter custom all-reduce kernel deadlocks on gfx942/gfx950 during EAGLE verify), MTP on the decode leg only. With prefill MTP off, the rank-split case patch 4 is designed for has not been exercised.

## Base image pinning

The base tag stays pinned. These are context diffs applied at `--fuzz=0` against sglang `0b3bb0cbe31873994c9f989fddfe2f87ca839fdd`; a base bump fails the build at the patch step rather than mis-applying silently. That is intended behaviour. Build with `APPLY_SGLANG_DSA_PATCHES=0` if you need a newer base.

Reproduction kits (raw per-request jsonl, both server logs, the build log, and cold-start instructions) live in the `infera.yihou.glm5.2.mxfp4` workspace; the one for this run is `glm52.mxfp4.spur.mooncake.packup_20260731_main_converged`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

