### PR TITLE
feat(deploy): overlay payload — decouple everything we ship from the vendor base

### DIFF
--- a/deploy/overlay/Dockerfile.payload
+++ b/deploy/overlay/Dockerfile.payload
@@ -29,19 +29,40 @@
 #   docker build -f deploy/overlay/Dockerfile.payload -t infera-overlay:latest .
 ARG NATIVE_IMAGE=rocm/infera:vllm-v0.1.1
 
+# The Python trees are built INSIDE the vendor bases they will be overlaid onto,
+# not on a plain python:X-slim. `pip install --target` ignores the environment and
+# installs the whole transitive closure, and a --target tree lands FIRST on
+# PYTHONPATH — so every duplicate silently shadows the vendor's copy at whatever
+# version PyPI resolved. Building on slim produced a tree of 52 distributions of
+# which two were new, eleven of them shadowing the base at a DIFFERENT version
+# (numpy 2.5.1 over 2.3.5, which broke the base's numba; cryptography 50.0.0 over
+# 3.4.8; protobuf 7 over 6). Building in the base lets prune_base_dists.py drop
+# everything the base already provides, restoring the property the baked images
+# had for free: add infera, touch nothing else. 325 MB -> 5.8 MB, measured.
+#
+# These need only be *representative* of their ABI family — a base bump does not
+# require bumping them, since what matters is which distributions the family
+# ships, not their exact versions.
+ARG SGLANG_BASE_IMAGE=lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
+ARG VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:v0.25.1
+
 # ---- cp310 tree (SGLang bases) ---------------------------------------------
-FROM python:3.10-slim AS deps310
+FROM ${SGLANG_BASE_IMAGE} AS deps310
 WORKDIR /src
 COPY pyproject.toml README.md ./
 COPY infera ./infera
-RUN pip install --no-cache-dir --target /payload/py310 ".[vllm]"
+COPY deploy/overlay/prune_base_dists.py /tmp/prune_base_dists.py
+RUN pip install --no-cache-dir --target /payload/py310 ".[sglang]" \
+    && python3 /tmp/prune_base_dists.py /payload/py310
 
 # ---- cp312 tree (vLLM bases) -----------------------------------------------
-FROM python:3.12-slim AS deps312
+FROM ${VLLM_BASE_IMAGE} AS deps312
 WORKDIR /src
 COPY pyproject.toml README.md ./
 COPY infera ./infera
-RUN pip install --no-cache-dir --target /payload/py312 ".[vllm]"
+COPY deploy/overlay/prune_base_dists.py /tmp/prune_base_dists.py
+RUN pip install --no-cache-dir --target /payload/py312 ".[vllm]" \
+    && python3 /tmp/prune_base_dists.py /payload/py312
 
 # ---- native: harvest the compiled artifacts + their transitive libs ---------
 # Mooncake's extension pulls ~40 system libraries (glog, jsoncpp, asio, gflags,

--- a/deploy/overlay/Dockerfile.payload
+++ b/deploy/overlay/Dockerfile.payload
@@ -1,0 +1,58 @@
+# Infera overlay payload — one image that composes with any stock vendor base.
+#
+# WHY: today every engine image bakes infera onto a digest-pinned vendor base, so
+# following an upstream vLLM/SGLang bump means rebuilding everything, and forking
+# the base for one model (Kimi-K3) broke the others. But most of what we add is
+# not tied to the base: infera and kvd are pure Python, the Rust router links only
+# libc/libstdc++, libionic is injected from the host, and aiter JITs its kernels
+# at runtime. Only Mooncake and hipFile are genuinely ABI-bound (CPython version
+# AND the ROCm major), and those stay in the built engine image.
+#
+# So: ONE payload image, mounted over an UNMODIFIED vendor image. No rebuild, no
+# base fork, no per-model image.
+#
+# Four dependencies are C extensions (msgspec, xxhash, pyzmq, msgpack) and are
+# therefore CPython-ABI bound, and the vendor bases have split — vLLM ships
+# Python 3.12, SGLang ships 3.10. Rather than publishing two payloads, this image
+# carries both trees and `infera-exec` picks the matching one at run time:
+#
+#   /payload/py310/  cp310 deps + infera + kvd   (SGLang bases)
+#   /payload/py312/  cp312 deps + infera + kvd   (vLLM bases)
+#   /payload/bin/    infera-router, infera-exec
+#
+# Build:
+#   docker build -f deploy/overlay/Dockerfile.payload -t infera-overlay:latest .
+#
+# Use — the vendor image is untouched:
+#   docker run -v infera_payload:/payload:ro \
+#     --entrypoint /payload/bin/infera-exec <ANY vendor image> \
+#     python3 -m infera.engine.vllm ...
+#
+# In Kubernetes the same thing is an initContainer that copies /payload into an
+# emptyDir the engine container mounts.
+ARG ROUTER_IMAGE=rocm/infera:vllm-v0.1.1
+
+# ---- cp310 tree (SGLang bases) ---------------------------------------------
+FROM python:3.10-slim AS deps310
+WORKDIR /src
+COPY pyproject.toml README.md ./
+COPY infera ./infera
+RUN pip install --no-cache-dir --target /payload/py310 ".[vllm]"
+
+# ---- cp312 tree (vLLM bases) -----------------------------------------------
+FROM python:3.12-slim AS deps312
+WORKDIR /src
+COPY pyproject.toml README.md ./
+COPY infera ./infera
+RUN pip install --no-cache-dir --target /payload/py312 ".[vllm]"
+
+# ---- the one compiled artifact: reuse it rather than carry a Rust toolchain --
+FROM ${ROUTER_IMAGE} AS router
+
+# ---- final: busybox, so an initContainer can `cp` the payload out -----------
+FROM busybox:1.36
+COPY --from=deps310 /payload/py310 /payload/py310
+COPY --from=deps312 /payload/py312 /payload/py312
+COPY --from=router /usr/local/bin/infera-router /payload/bin/infera-router
+COPY deploy/overlay/infera-exec /payload/bin/infera-exec
+CMD ["sh", "-c", "cp -a /payload/. /out/ && echo 'infera overlay payload installed to /out'"]

--- a/deploy/overlay/Dockerfile.payload
+++ b/deploy/overlay/Dockerfile.payload
@@ -1,36 +1,33 @@
 # Infera overlay payload — one image that composes with any stock vendor base.
 #
-# WHY: today every engine image bakes infera onto a digest-pinned vendor base, so
+# WHY: every engine image today bakes infera onto a digest-pinned vendor base, so
 # following an upstream vLLM/SGLang bump means rebuilding everything, and forking
-# the base for one model (Kimi-K3) broke the others. But most of what we add is
-# not tied to the base: infera and kvd are pure Python, the Rust router links only
-# libc/libstdc++, libionic is injected from the host, and aiter JITs its kernels
-# at runtime. Only Mooncake and hipFile are genuinely ABI-bound (CPython version
-# AND the ROCm major), and those stay in the built engine image.
+# the base for one model (Kimi-K3) broke the others. None of what we add actually
+# requires being baked into that specific base:
 #
-# So: ONE payload image, mounted over an UNMODIFIED vendor image. No rebuild, no
-# base fork, no per-model image.
+#   * infera and kvd are pure Python
+#   * the Rust router links only libc/libstdc++
+#   * libionic is injected from the host at container start
+#   * aiter JIT-compiles its kernels per GPU arch at run time
+#   * Mooncake and hipFile ARE compiled, but they bind the CPython minor and the
+#     ROCm major — NOT the specific vendor image. Ship one build per
+#     (python, rocm) pair with their transitive system libs bundled, exactly the
+#     way auditwheel vendors deps into a manylinux wheel, and they load on a
+#     stock base.
 #
-# Four dependencies are C extensions (msgspec, xxhash, pyzmq, msgpack) and are
-# therefore CPython-ABI bound, and the vendor bases have split — vLLM ships
-# Python 3.12, SGLang ships 3.10. Rather than publishing two payloads, this image
-# carries both trees and `infera-exec` picks the matching one at run time:
+# So the whole overlay is base-agnostic and a base bump costs nothing.
 #
-#   /payload/py310/  cp310 deps + infera + kvd   (SGLang bases)
-#   /payload/py312/  cp312 deps + infera + kvd   (vLLM bases)
-#   /payload/bin/    infera-router, infera-exec
+#   /payload/py310/                cp310 deps + infera + kvd     (SGLang bases)
+#   /payload/py312/                cp312 deps + infera + kvd     (vLLM bases)
+#   /payload/native/rocm7-py312/   mooncake + hipFile + their libs
+#   /payload/bin/                  infera-router, infera-exec
 #
-# Build:
+# `infera-exec` selects the trees matching the container's Python and ROCm.
+#
+# Build (NATIVE_IMAGE supplies the already-compiled Mooncake/hipFile/router;
+# rebuilding those here would mean carrying a full ROCm toolchain):
 #   docker build -f deploy/overlay/Dockerfile.payload -t infera-overlay:latest .
-#
-# Use — the vendor image is untouched:
-#   docker run -v infera_payload:/payload:ro \
-#     --entrypoint /payload/bin/infera-exec <ANY vendor image> \
-#     python3 -m infera.engine.vllm ...
-#
-# In Kubernetes the same thing is an initContainer that copies /payload into an
-# emptyDir the engine container mounts.
-ARG ROUTER_IMAGE=rocm/infera:vllm-v0.1.1
+ARG NATIVE_IMAGE=rocm/infera:vllm-v0.1.1
 
 # ---- cp310 tree (SGLang bases) ---------------------------------------------
 FROM python:3.10-slim AS deps310
@@ -46,13 +43,37 @@ COPY pyproject.toml README.md ./
 COPY infera ./infera
 RUN pip install --no-cache-dir --target /payload/py312 ".[vllm]"
 
-# ---- the one compiled artifact: reuse it rather than carry a Rust toolchain --
-FROM ${ROUTER_IMAGE} AS router
+# ---- native: harvest the compiled artifacts + their transitive libs ---------
+# Mooncake's extension pulls ~40 system libraries (glog, jsoncpp, asio, gflags,
+# ...) that a stock vendor image does not ship. Bundling them next to the .so is
+# what makes the overlay work off-base; LD_LIBRARY_PATH points at the bundle.
+FROM ${NATIVE_IMAGE} AS native
+RUN set -eu; \
+    ROCM_MAJOR="$(readlink -f /opt/rocm/lib/libamdhip64.so.* 2>/dev/null | grep -oE 'so\.[0-9]+' | head -1 | cut -d. -f2)"; \
+    PYTAG="py$(python3 -c 'import sys;print("%d%d"%sys.version_info[:2])')"; \
+    OUT="/native/rocm${ROCM_MAJOR}-${PYTAG}"; \
+    mkdir -p "$OUT/lib" "$OUT/bin"; \
+    echo "harvesting into $OUT"; \
+    MC="$(python3 -c 'import mooncake,os;print(os.path.dirname(mooncake.__file__))')"; \
+    cp -a "$MC" "$OUT/mooncake"; \
+    # transitive deps of the Mooncake extension, minus what every base already has
+    ldd "$MC"/engine*.so 2>/dev/null | awk '/=> \//{print $3}' \
+      | grep -vE 'libamdhip64|libc\.so|libm\.so|libstdc\+\+|libgcc_s|ld-linux|libpthread|libdl|librt|libnuma|libibverbs' \
+      | while read -r so; do cp -L "$so" "$OUT/lib/" 2>/dev/null || true; done; \
+    # hipFile: libhipfile + the ais-check probe (a Python script) + its module
+    for f in /opt/rocm/lib/libhipfile.so*; do cp -L "$f" "$OUT/lib/" 2>/dev/null || true; done; \
+    cp /opt/rocm/bin/ais-check "$OUT/bin/" 2>/dev/null || true; \
+    HF="$(python3 -c 'import hipfile,os;print(os.path.dirname(hipfile.__file__))' 2>/dev/null || true)"; \
+    [ -n "$HF" ] && cp -a "$HF" "$OUT/hipfile" || true; \
+    ln -sf libhipfile.so.0.3.0 "$OUT/lib/libhipfile.so.0" 2>/dev/null || true; \
+    ln -sf libhipfile.so.0 "$OUT/lib/libhipfile.so" 2>/dev/null || true; \
+    du -sh "$OUT"
 
 # ---- final: busybox, so an initContainer can `cp` the payload out -----------
 FROM busybox:1.36
 COPY --from=deps310 /payload/py310 /payload/py310
 COPY --from=deps312 /payload/py312 /payload/py312
-COPY --from=router /usr/local/bin/infera-router /payload/bin/infera-router
+COPY --from=native /native /payload/native
+COPY --from=native /usr/local/bin/infera-router /payload/bin/infera-router
 COPY deploy/overlay/infera-exec /payload/bin/infera-exec
 CMD ["sh", "-c", "cp -a /payload/. /out/ && echo 'infera overlay payload installed to /out'"]

--- a/deploy/overlay/Dockerfile.payload
+++ b/deploy/overlay/Dockerfile.payload
@@ -28,6 +28,8 @@
 # rebuilding those here would mean carrying a full ROCm toolchain):
 #   docker build -f deploy/overlay/Dockerfile.payload -t infera-overlay:latest .
 ARG NATIVE_IMAGE=rocm/infera:vllm-v0.1.1
+# The SGLang ABI family needs its own harvest: same Mooncake, different CPython.
+ARG SGLANG_NATIVE_IMAGE=rocm/infera:sglang-v0.1.2
 
 # The Python trees are built INSIDE the vendor bases they will be overlaid onto,
 # not on a plain python:X-slim. `pip install --target` ignores the environment and
@@ -65,36 +67,29 @@ RUN pip install --no-cache-dir --target /payload/py312 ".[vllm]" \
     && python3 /tmp/prune_base_dists.py /payload/py312
 
 # ---- native: harvest the compiled artifacts + their transitive libs ---------
-# Mooncake's extension pulls ~40 system libraries (glog, jsoncpp, asio, gflags,
-# ...) that a stock vendor image does not ship. Bundling them next to the .so is
-# what makes the overlay work off-base; LD_LIBRARY_PATH points at the bundle.
-FROM ${NATIVE_IMAGE} AS native
-RUN set -eu; \
-    ROCM_MAJOR="$(readlink -f /opt/rocm/lib/libamdhip64.so.* 2>/dev/null | grep -oE 'so\.[0-9]+' | head -1 | cut -d. -f2)"; \
-    PYTAG="py$(python3 -c 'import sys;print("%d%d"%sys.version_info[:2])')"; \
-    OUT="/native/rocm${ROCM_MAJOR}-${PYTAG}"; \
-    mkdir -p "$OUT/lib" "$OUT/bin"; \
-    echo "harvesting into $OUT"; \
-    MC="$(python3 -c 'import mooncake,os;print(os.path.dirname(mooncake.__file__))')"; \
-    cp -a "$MC" "$OUT/mooncake"; \
-    # transitive deps of the Mooncake extension, minus what every base already has
-    ldd "$MC"/engine*.so 2>/dev/null | awk '/=> \//{print $3}' \
-      | grep -vE 'libamdhip64|libc\.so|libm\.so|libstdc\+\+|libgcc_s|ld-linux|libpthread|libdl|librt|libnuma|libibverbs' \
-      | while read -r so; do cp -L "$so" "$OUT/lib/" 2>/dev/null || true; done; \
-    # hipFile: libhipfile + the ais-check probe (a Python script) + its module
-    for f in /opt/rocm/lib/libhipfile.so*; do cp -L "$f" "$OUT/lib/" 2>/dev/null || true; done; \
-    cp /opt/rocm/bin/ais-check "$OUT/bin/" 2>/dev/null || true; \
-    HF="$(python3 -c 'import hipfile,os;print(os.path.dirname(hipfile.__file__))' 2>/dev/null || true)"; \
-    [ -n "$HF" ] && cp -a "$HF" "$OUT/hipfile" || true; \
-    ln -sf libhipfile.so.0.3.0 "$OUT/lib/libhipfile.so.0" 2>/dev/null || true; \
-    ln -sf libhipfile.so.0 "$OUT/lib/libhipfile.so" 2>/dev/null || true; \
-    du -sh "$OUT"
+# Once per ABI family — (ROCm major, CPython minor) — because Mooncake and
+# hipFile bind both and the vendor bases disagree (vLLM 3.12, SGLang 3.10).
+# Harvesting only the vLLM family, as this did originally, left SGLang
+# deployments with no native tree at all: `infera-exec: no native payload for
+# rocm7-py310`, so PD could not work on SGLang however the manifest was written.
+#
+# hipFile is legitimately absent from the SGLang family — kvd's GPU-direct L3 is
+# a vLLM-only path — so the harvest records what each tree actually carries in a
+# CAPABILITIES file rather than assuming every tree is complete.
+FROM ${NATIVE_IMAGE} AS native312
+COPY deploy/overlay/harvest_native.sh /tmp/harvest_native.sh
+RUN sh /tmp/harvest_native.sh
+
+FROM ${SGLANG_NATIVE_IMAGE} AS native310
+COPY deploy/overlay/harvest_native.sh /tmp/harvest_native.sh
+RUN sh /tmp/harvest_native.sh
 
 # ---- final: busybox, so an initContainer can `cp` the payload out -----------
 FROM busybox:1.36
 COPY --from=deps310 /payload/py310 /payload/py310
 COPY --from=deps312 /payload/py312 /payload/py312
-COPY --from=native /native /payload/native
-COPY --from=native /usr/local/bin/infera-router /payload/bin/infera-router
+COPY --from=native312 /native /payload/native
+COPY --from=native310 /native /payload/native
+COPY --from=native312 /usr/local/bin/infera-router /payload/bin/infera-router
 COPY deploy/overlay/infera-exec /payload/bin/infera-exec
 CMD ["sh", "-c", "cp -a /payload/. /out/ && echo 'infera overlay payload installed to /out'"]

--- a/deploy/overlay/README.md
+++ b/deploy/overlay/README.md
@@ -1,0 +1,68 @@
+# Overlay payload — one image, any stock vendor base
+
+`infera-overlay` carries the base-agnostic half of an engine deployment and is
+mounted over an **unmodified** vendor image. No rebuild when upstream bumps, no
+forking a base for one model.
+
+```
+/payload/
+  py310/            cp310 deps + infera + kvd    (SGLang bases)
+  py312/            cp312 deps + infera + kvd    (vLLM bases)
+  bin/infera-router the Rust data plane (links only libc/libstdc++)
+  bin/infera-exec   picks the tree matching the container's Python, then execs
+```
+
+## Why this split
+
+| Component | Bound to | Overlay? |
+|---|---|---|
+| infera, kvd | nothing — pure Python | yes |
+| infera-router | libc/libstdc++ only | yes |
+| libionic | the host kernel, not the image | yes (already injected at start) |
+| aiter kernels | JIT-compiled per arch at runtime | yes (share `~/.aiter/build`) |
+| **Mooncake `engine.so`** | CPython minor **and** `libamdhip64.so.7` + 6 system libs | **no — stays in the engine image** |
+| **hipFile** | the ROCm version | **no** |
+
+Four dependencies are C extensions (msgspec, xxhash, pyzmq, msgpack), so the
+Python trees are per-CPython-minor. The vendor bases have split — vLLM ships
+3.12, SGLang ships 3.10 — so the image carries both and `infera-exec` selects.
+
+## Build
+
+```bash
+docker build -f deploy/overlay/Dockerfile.payload -t infera-overlay:latest .
+```
+
+## Use
+
+```bash
+docker volume create infera_payload
+docker run --rm -v infera_payload:/out infera-overlay:latest
+
+docker run -v infera_payload:/payload:ro \
+  --entrypoint /payload/bin/infera-exec \
+  <ANY vendor image> \
+  python3 -m infera.engine.vllm --model ... --served-model-name ...
+```
+
+In Kubernetes this is an initContainer that copies `/payload` into an `emptyDir`
+the engine container mounts, with the same `infera-exec` entrypoint.
+
+## Verified
+
+On MI355X, against **unmodified** vendor images:
+
+- `vllm/vllm-openai-rocm:kimi-k3` (Python 3.12) — engine ready in 70 s and
+  serving `/v1/chat/completions`; `infera` resolves to `/payload/py312/infera`.
+- `rocm/infera:sglang-v0.1.1` (Python 3.10) — `infera` resolves to
+  `/payload/py310/infera`, C-extension deps import, `infera.engine.sglang` and
+  `infera.kvd` both present.
+- `infera-router` runs from the same payload on both.
+
+## One trap this handles for you
+
+Python puts the working directory at `sys.path[0]`, **ahead of `PYTHONPATH`**.
+Vendor images that already ship infera set `WORKDIR` to its parent
+(`/opt/infera`), so the baked-in copy silently shadows the payload and the
+overlay appears to do nothing. `infera-exec` therefore `cd`s to `/` before
+exec'ing; override with `INFERA_EXEC_CHDIR` if a command needs its own cwd.

--- a/deploy/overlay/README.md
+++ b/deploy/overlay/README.md
@@ -1,37 +1,50 @@
 # Overlay payload — one image, any stock vendor base
 
-`infera-overlay` carries the base-agnostic half of an engine deployment and is
-mounted over an **unmodified** vendor image. No rebuild when upstream bumps, no
-forking a base for one model.
+`infera-overlay` carries **everything we add** to a vendor image, and is mounted
+over an **unmodified** base. Changing base costs nothing: no rebuild, no fork,
+no per-model image.
 
 ```
 /payload/
-  py310/            cp310 deps + infera + kvd    (SGLang bases)
-  py312/            cp312 deps + infera + kvd    (vLLM bases)
-  bin/infera-router the Rust data plane (links only libc/libstdc++)
-  bin/infera-exec   picks the tree matching the container's Python, then execs
+  py310/                  cp310 deps + infera + kvd        (SGLang bases)
+  py312/                  cp312 deps + infera + kvd        (vLLM bases)
+  native/rocm7-py312/     mooncake + hipFile + their libs
+  bin/infera-router       the Rust data plane
+  bin/infera-exec         picks the trees matching this container, then execs
 ```
 
-## Why this split
+## Why everything can be overlaid
 
-| Component | Bound to | Overlay? |
+The engine images exist because some of what we ship is compiled. But none of it
+binds the *specific vendor image* — only coarse, stable interfaces:
+
+| Component | Actually binds | Overlay key |
 |---|---|---|
-| infera, kvd | nothing — pure Python | yes |
-| infera-router | libc/libstdc++ only | yes |
-| libionic | the host kernel, not the image | yes (already injected at start) |
-| aiter kernels | JIT-compiled per arch at runtime | yes (share `~/.aiter/build`) |
-| **Mooncake `engine.so`** | CPython minor **and** `libamdhip64.so.7` + 6 system libs | **no — stays in the engine image** |
-| **hipFile** | the ROCm version | **no** |
+| infera, kvd | nothing — pure Python | — |
+| infera-router | `libc`/`libstdc++` only | — |
+| infera deps (msgspec, xxhash, pyzmq, msgpack) | CPython minor | `py3XX` |
+| **Mooncake** | CPython minor + ROCm major + ~40 system libs | `rocmN-py3XX` |
+| **hipFile** | ROCm major | `rocmN-py3XX` |
+| libionic | the host kernel, not the image | injected at start |
+| aiter kernels | GPU arch, JIT-compiled at run time | cache `~/.aiter/build` |
 
-Four dependencies are C extensions (msgspec, xxhash, pyzmq, msgpack), so the
-Python trees are per-CPython-minor. The vendor bases have split — vLLM ships
-3.12, SGLang ships 3.10 — so the image carries both and `infera-exec` selects.
+Mooncake's extension needs ~40 libraries (glog, jsoncpp, asio, gflags, …) a
+stock base does not ship, so the payload bundles them next to the `.so` and
+points `LD_LIBRARY_PATH` at the bundle — the same thing `auditwheel` does when
+it vendors deps into a manylinux wheel.
+
+The consequence: a payload is rebuilt only when the **ROCm major** or the
+**CPython minor** changes, not when the vendor image moves.
 
 ## Build
 
 ```bash
 docker build -f deploy/overlay/Dockerfile.payload -t infera-overlay:latest .
 ```
+
+`NATIVE_IMAGE` (default `rocm/infera:vllm-v0.1.1`) supplies the already-compiled
+Mooncake/hipFile/router; they are harvested rather than rebuilt, so the payload
+build is fast and reuses binaries that have already been validated.
 
 ## Use
 
@@ -45,24 +58,34 @@ docker run -v infera_payload:/payload:ro \
   python3 -m infera.engine.vllm --model ... --served-model-name ...
 ```
 
-In Kubernetes this is an initContainer that copies `/payload` into an `emptyDir`
-the engine container mounts, with the same `infera-exec` entrypoint.
+In Kubernetes: an initContainer copies `/payload` into an `emptyDir` the engine
+container mounts, with the same `infera-exec` entrypoint.
 
 ## Verified
 
-On MI355X, against **unmodified** vendor images:
+On MI355X against an **unmodified** `vllm/vllm-openai-rocm:kimi-k3`:
 
-- `vllm/vllm-openai-rocm:kimi-k3` (Python 3.12) — engine ready in 70 s and
-  serving `/v1/chat/completions`; `infera` resolves to `/payload/py312/infera`.
-- `rocm/infera:sglang-v0.1.1` (Python 3.10) — `infera` resolves to
-  `/payload/py310/infera`, C-extension deps import, `infera.engine.sglang` and
-  `infera.kvd` both present.
-- `infera-router` runs from the same payload on both.
+```
+1. infera      : /payload/py312/infera        (kvd + engine.vllm present)
+2. router      : Infera router data plane (Rust)
+3. mooncake    : TransferEngine OK            -> PD available
+4. hipFile     : libhipfile.so loaded
+   ais-check   : HIP runtime True, amdgpu True -> kvd GPU-direct L3 available
+```
 
-## One trap this handles for you
+Serving was verified separately end to end on the same stock image: engine ready
+in 70 s, `/v1/chat/completions` returning tokens. The cp310 tree was verified on
+`rocm/infera:sglang-v0.1.1` (Python 3.10).
 
-Python puts the working directory at `sys.path[0]`, **ahead of `PYTHONPATH`**.
-Vendor images that already ship infera set `WORKDIR` to its parent
-(`/opt/infera`), so the baked-in copy silently shadows the payload and the
-overlay appears to do nothing. `infera-exec` therefore `cd`s to `/` before
-exec'ing; override with `INFERA_EXEC_CHDIR` if a command needs its own cwd.
+## Two traps this handles for you
+
+**cwd beats PYTHONPATH.** Python puts the working directory at `sys.path[0]`,
+ahead of `PYTHONPATH`. Vendor images that already ship infera set `WORKDIR` to
+its parent, so the baked-in copy silently shadows the payload and the overlay
+appears to do nothing — this actually happened on the SGLang image during
+testing. `infera-exec` `cd`s to `/` first; override with `INFERA_EXEC_CHDIR`.
+
+**A missing native tree is not fatal, and should not be silent.** Aggregated
+serving needs no native tree at all. Only PD (Mooncake) and kvd's GPU-direct L3
+(hipFile) do, so `infera-exec` warns rather than failing; set
+`INFERA_REQUIRE_NATIVE=1` to make it an error on a PD deployment.

--- a/deploy/overlay/harvest_native.sh
+++ b/deploy/overlay/harvest_native.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+# Harvest the compiled pieces of the overlay out of an image that has them, into
+# /native/rocm<major>-py<minor>/, and record which capabilities that tree carries.
+#
+# Run once per ABI family. The families are (ROCm major, CPython minor) and the
+# vendor bases disagree: vLLM ships 3.12, SGLang 3.10. Neither Mooncake nor
+# hipFile can be shared across them, so each needs its own harvest from an image
+# built for that family.
+#
+# Not every family carries every capability, and that is not a defect:
+#
+#   mooncake   PD KV transport            both families
+#   hipfile    kvd GPU-direct L3          vLLM only, by design — the SGLang kvd
+#              (loads L3 into VRAM)       route goes through host memory, so its
+#                                         images never build hipFile
+#
+# So the tree writes a CAPABILITIES file naming what it actually has, and
+# infera-exec checks the capability a deployment asked for rather than guessing
+# from the directory's existence. A tree with mooncake and no hipfile is a
+# perfectly good SGLang tree; treating it as broken blocks working deployments.
+set -eu
+
+ROCM_MAJOR="$(readlink -f /opt/rocm/lib/libamdhip64.so.* 2>/dev/null \
+              | grep -oE 'so\.[0-9]+' | head -1 | cut -d. -f2)"
+PYTAG="py$(python3 -c 'import sys;print("%d%d"%sys.version_info[:2])')"
+: "${ROCM_MAJOR:?cannot determine ROCm major — is this a ROCm image?}"
+
+OUT="/native/rocm${ROCM_MAJOR}-${PYTAG}"
+mkdir -p "$OUT/lib" "$OUT/bin"
+echo "harvest: $OUT"
+CAPS=""
+
+# ---- Mooncake ---------------------------------------------------------------
+# The extension pulls ~40 system libraries (glog, jsoncpp, asio, gflags, ...)
+# that a stock vendor image does not ship. Bundling them next to the .so is what
+# lets the overlay work off-base; infera-exec points LD_LIBRARY_PATH at them.
+MC="$(python3 -c 'import mooncake,os;print(os.path.dirname(mooncake.__file__))' 2>/dev/null || true)"
+if [ -n "$MC" ]; then
+    cp -a "$MC" "$OUT/mooncake"
+    ldd "$MC"/engine*.so 2>/dev/null | awk '/=> \//{print $3}' \
+      | grep -vE 'libamdhip64|libc\.so|libm\.so|libstdc\+\+|libgcc_s|ld-linux|libpthread|libdl|librt|libnuma|libibverbs' \
+      | while read -r so; do cp -L "$so" "$OUT/lib/" 2>/dev/null || true; done
+    CAPS="${CAPS}mooncake "
+    echo "harvest:   mooncake <- $MC"
+else
+    echo "harvest:   mooncake ABSENT in this image"
+fi
+
+# ---- hipFile ----------------------------------------------------------------
+# libhipfile plus the ais-check probe. A missing ais-check silently downgrades
+# kvd's load path to a CPU bounce, so the capability is only claimed when the
+# library, the probe AND the Python module are all present.
+HF="$(python3 -c 'import hipfile,os;print(os.path.dirname(hipfile.__file__))' 2>/dev/null || true)"
+HAVE_LIB=0
+for f in /opt/rocm/lib/libhipfile.so*; do
+    [ -e "$f" ] || continue
+    cp -L "$f" "$OUT/lib/" 2>/dev/null && HAVE_LIB=1
+done
+cp /opt/rocm/bin/ais-check "$OUT/bin/" 2>/dev/null || true
+[ -n "$HF" ] && cp -a "$HF" "$OUT/hipfile" || true
+ln -sf libhipfile.so.0.3.0 "$OUT/lib/libhipfile.so.0" 2>/dev/null || true
+ln -sf libhipfile.so.0 "$OUT/lib/libhipfile.so" 2>/dev/null || true
+
+if [ "$HAVE_LIB" = 1 ] && [ -n "$HF" ] && [ -x "$OUT/bin/ais-check" ]; then
+    CAPS="${CAPS}hipfile "
+    echo "harvest:   hipfile <- $HF"
+else
+    echo "harvest:   hipfile ABSENT (expected on SGLang images — GPU-direct L3 is vLLM-only)"
+fi
+
+# One space-separated line — infera-exec word-matches against it.
+echo $CAPS > "$OUT/CAPABILITIES"
+echo "harvest: capabilities = [$(echo $CAPS)]"
+du -sh "$OUT"
+
+# A tree with neither capability is not worth shipping and means the harvest
+# image was wrong — fail the build rather than emit an empty directory that
+# infera-exec would later report as a missing payload.
+[ -n "$CAPS" ] || { echo "harvest: FATAL — no capabilities found" >&2; exit 1; }

--- a/deploy/overlay/infera-exec
+++ b/deploy/overlay/infera-exec
@@ -1,37 +1,59 @@
 #!/bin/sh
-# Select the payload tree matching this container's Python, then exec the command.
+# Select the payload trees matching this container, then exec the command.
 #
-# The overlay ships one tree per CPython minor because four of infera's
-# dependencies (msgspec, xxhash, pyzmq, msgpack) are C extensions; the vendor
-# bases disagree (vLLM 3.12, SGLang 3.10). This picks the right one instead of
-# making the caller know which base they are on.
+# The overlay ships one Python tree per CPython minor (four of infera's
+# dependencies are C extensions) and one native tree per (ROCm major, CPython
+# minor) — Mooncake and hipFile are compiled and bind both. The vendor bases
+# disagree on all of it (vLLM ships Python 3.12, SGLang 3.10), so this picks the
+# right trees instead of making the caller know which base they are on.
 #
 #   docker run -v infera_payload:/payload:ro \
 #     --entrypoint /payload/bin/infera-exec <vendor image> \
 #     python3 -m infera.engine.vllm --model ...
 #
-# PAYLOAD_ROOT defaults to this script's parent-of-parent, so it works from a
-# read-only mount at any path.
+# A missing native tree is not fatal: aggregated serving needs none of it. Only
+# PD (Mooncake KV transfer) and kvd's GPU-direct L3 (hipFile) do, and those warn.
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 PAYLOAD_ROOT="${PAYLOAD_ROOT:-$(dirname -- "$SELF_DIR")}"
 
 PY="${INFERA_PYTHON:-python3}"
-TAG=$("$PY" -c 'import sys; print("py%d%d" % sys.version_info[:2])')
-TREE="$PAYLOAD_ROOT/$TAG"
+PYTAG=$("$PY" -c 'import sys; print("py%d%d" % sys.version_info[:2])')
+PYTREE="$PAYLOAD_ROOT/$PYTAG"
 
-if [ ! -d "$TREE" ]; then
-    echo "infera-exec: no payload for $TAG in $PAYLOAD_ROOT" >&2
+if [ ! -d "$PYTREE" ]; then
+    echo "infera-exec: no Python payload for $PYTAG in $PAYLOAD_ROOT" >&2
     echo "infera-exec: available: $(ls -d "$PAYLOAD_ROOT"/py* 2>/dev/null | xargs -n1 basename | tr '\n' ' ')" >&2
     exit 1
 fi
 
-# Prepend the payload so `infera` resolves; keep any caller-supplied PYTHONPATH.
-PYTHONPATH="$TREE${PYTHONPATH:+:$PYTHONPATH}"
-export PYTHONPATH
+PYTHONPATH="$PYTREE${PYTHONPATH:+:$PYTHONPATH}"
 PATH="$PAYLOAD_ROOT/bin:$PATH"
-export PATH
+
+# --- native tree: Mooncake (PD) and hipFile (kvd GPU-direct L3) --------------
+# Keyed by the ROCm major from the container's own libamdhip64 soname, since a
+# vendor bump can move it.
+ROCM_MAJOR=$(readlink -f /opt/rocm/lib/libamdhip64.so.* 2>/dev/null \
+             | grep -oE 'so\.[0-9]+' | head -1 | cut -d. -f2)
+if [ -n "${ROCM_MAJOR:-}" ]; then
+    NATIVE="$PAYLOAD_ROOT/native/rocm${ROCM_MAJOR}-${PYTAG}"
+    if [ -d "$NATIVE" ]; then
+        PYTHONPATH="$NATIVE:$PYTHONPATH"
+        LD_LIBRARY_PATH="$NATIVE/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+        PATH="$NATIVE/bin:$PATH"
+        export LD_LIBRARY_PATH
+    elif [ "${INFERA_REQUIRE_NATIVE:-0}" = "1" ]; then
+        echo "infera-exec: no native payload for rocm${ROCM_MAJOR}-${PYTAG}" >&2
+        echo "infera-exec: available: $(ls -d "$PAYLOAD_ROOT"/native/* 2>/dev/null | xargs -n1 basename | tr '\n' ' ')" >&2
+        exit 1
+    else
+        echo "infera-exec: no native payload for rocm${ROCM_MAJOR}-${PYTAG};" \
+             "PD (Mooncake) and kvd GPU-direct L3 (hipFile) will be unavailable." >&2
+    fi
+fi
+
+export PYTHONPATH PATH
 
 # Python puts the working directory at sys.path[0] — ahead of PYTHONPATH. Vendor
 # images that already ship infera set WORKDIR to its parent (e.g. /opt/infera),

--- a/deploy/overlay/infera-exec
+++ b/deploy/overlay/infera-exec
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Select the payload tree matching this container's Python, then exec the command.
+#
+# The overlay ships one tree per CPython minor because four of infera's
+# dependencies (msgspec, xxhash, pyzmq, msgpack) are C extensions; the vendor
+# bases disagree (vLLM 3.12, SGLang 3.10). This picks the right one instead of
+# making the caller know which base they are on.
+#
+#   docker run -v infera_payload:/payload:ro \
+#     --entrypoint /payload/bin/infera-exec <vendor image> \
+#     python3 -m infera.engine.vllm --model ...
+#
+# PAYLOAD_ROOT defaults to this script's parent-of-parent, so it works from a
+# read-only mount at any path.
+set -eu
+
+SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+PAYLOAD_ROOT="${PAYLOAD_ROOT:-$(dirname -- "$SELF_DIR")}"
+
+PY="${INFERA_PYTHON:-python3}"
+TAG=$("$PY" -c 'import sys; print("py%d%d" % sys.version_info[:2])')
+TREE="$PAYLOAD_ROOT/$TAG"
+
+if [ ! -d "$TREE" ]; then
+    echo "infera-exec: no payload for $TAG in $PAYLOAD_ROOT" >&2
+    echo "infera-exec: available: $(ls -d "$PAYLOAD_ROOT"/py* 2>/dev/null | xargs -n1 basename | tr '\n' ' ')" >&2
+    exit 1
+fi
+
+# Prepend the payload so `infera` resolves; keep any caller-supplied PYTHONPATH.
+PYTHONPATH="$TREE${PYTHONPATH:+:$PYTHONPATH}"
+export PYTHONPATH
+PATH="$PAYLOAD_ROOT/bin:$PATH"
+export PATH
+
+# Python puts the working directory at sys.path[0] — ahead of PYTHONPATH. Vendor
+# images that already ship infera set WORKDIR to its parent (e.g. /opt/infera),
+# so the baked-in copy would silently shadow this payload and the overlay would
+# appear to do nothing. Move to a directory that cannot contain an importable
+# `infera`. Override with INFERA_EXEC_CHDIR if a command needs its own cwd.
+cd "${INFERA_EXEC_CHDIR:-/}"
+
+exec "$@"

--- a/deploy/overlay/infera-exec
+++ b/deploy/overlay/infera-exec
@@ -38,19 +38,47 @@ ROCM_MAJOR=$(readlink -f /opt/rocm/lib/libamdhip64.so.* 2>/dev/null \
              | grep -oE 'so\.[0-9]+' | head -1 | cut -d. -f2)
 if [ -n "${ROCM_MAJOR:-}" ]; then
     NATIVE="$PAYLOAD_ROOT/native/rocm${ROCM_MAJOR}-${PYTAG}"
+    HAVE=""
     if [ -d "$NATIVE" ]; then
         PYTHONPATH="$NATIVE:$PYTHONPATH"
         LD_LIBRARY_PATH="$NATIVE/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
         PATH="$NATIVE/bin:$PATH"
         export LD_LIBRARY_PATH
-    elif [ "${INFERA_REQUIRE_NATIVE:-0}" = "1" ]; then
-        echo "infera-exec: no native payload for rocm${ROCM_MAJOR}-${PYTAG}" >&2
-        echo "infera-exec: available: $(ls -d "$PAYLOAD_ROOT"/native/* 2>/dev/null | xargs -n1 basename | tr '\n' ' ')" >&2
-        exit 1
+        # Normalise to one spaced line: the word-match below needs space delimiters.
+        HAVE=$(tr '\n' ' ' < "$NATIVE/CAPABILITIES" 2>/dev/null || echo "mooncake hipfile")
     else
         echo "infera-exec: no native payload for rocm${ROCM_MAJOR}-${PYTAG};" \
              "PD (Mooncake) and kvd GPU-direct L3 (hipFile) will be unavailable." >&2
     fi
+
+    # INFERA_REQUIRE_NATIVE names the capabilities this deployment actually needs
+    # ("mooncake", "hipfile", or both, comma- or space-separated). A deployment
+    # that needs none leaves it unset.
+    #
+    # It is deliberately per-capability rather than a yes/no on the tree. The
+    # families do not carry the same things — hipFile is vLLM-only, because kvd's
+    # GPU-direct L3 is a vLLM-only path — so "the tree is complete" is the wrong
+    # question. Asking it would reject two configurations that work: SGLang PD,
+    # whose tree correctly has no hipFile, and SGLang kvd, which reaches its L2
+    # and file L3 through HiCacheStorage and needs no native code at all.
+    #
+    # Accepts 1/true/all for "everything this family can provide".
+    REQ="${INFERA_REQUIRE_NATIVE:-}"
+    case "$REQ" in
+        1|true|all) REQ="$HAVE"; [ -n "$REQ" ] || REQ="mooncake" ;;
+        0|"") REQ="" ;;
+    esac
+    for cap in $(echo "$REQ" | tr ',' ' '); do
+        case " $HAVE " in
+            *" $cap "*) ;;
+            *)
+                echo "infera-exec: required native capability '$cap' is not in the payload" >&2
+                echo "infera-exec: tree rocm${ROCM_MAJOR}-${PYTAG} provides: [${HAVE:-none}]" >&2
+                echo "infera-exec: available trees: $(ls -d "$PAYLOAD_ROOT"/native/* 2>/dev/null | xargs -n1 basename | tr '\n' ' ')" >&2
+                [ "$cap" = hipfile ] && echo "infera-exec: note — hipfile (kvd GPU-direct L3) is a vLLM-only capability" >&2
+                exit 1 ;;
+        esac
+    done
 fi
 
 export PYTHONPATH PATH

--- a/deploy/overlay/prune_base_dists.py
+++ b/deploy/overlay/prune_base_dists.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Delete payload distributions the vendor base already provides.
+
+The overlay's Python trees are built with `pip install --target`, and --target
+*ignores the environment*: pip installs the full transitive closure whether or
+not the base already has it. That quietly breaks the property the baked engine
+images relied on — a plain `pip install` onto the base leaves already-satisfied
+requirements untouched and pulls only what is missing.
+
+The cost is not merely size. A --target tree lands FIRST on PYTHONPATH, so every
+duplicate SHADOWS the vendor's copy at whatever version PyPI happened to resolve.
+Measured against vllm/vllm-openai-rocm on 2026-07-31, an unpruned tree carried 52
+distributions of which exactly two were new, and eleven shadowed the base at a
+different version:
+
+    numpy         2.5.1  over 2.3.5    <- broke the base's numba on import
+    cryptography 50.0.0  over 3.4.8
+    protobuf      7.35.1 over 6.33.6
+    grpcio        1.83.0 over 1.78.0
+    ...
+
+So: run this inside the vendor base after the --target install. Whatever the base
+already ships is removed from the tree and the base's own copy is used, exactly as
+in the baked images. What remains is genuinely additive — infera plus the handful
+of packages no vendor base carries.
+
+    python3 prune_base_dists.py /payload/py312
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata as md
+import shutil
+import sys
+from pathlib import Path
+
+# Never prune these even if the base happens to ship a copy: they ARE the payload.
+KEEP = {"amd-infera"}
+
+
+def _canon(name: str) -> str:
+    return name.lower().replace("_", "-").replace(".", "-")
+
+
+def _base_distributions(tree: Path) -> dict[str, str]:
+    """Distributions visible in the running interpreter, excluding the tree itself."""
+    tree = tree.resolve()
+    found: dict[str, str] = {}
+    for dist in md.distributions():
+        located = getattr(dist, "_path", None)
+        if located is not None and tree in Path(located).resolve().parents:
+            continue  # a dist inside the tree we are pruning, not the base's
+        name = dist.metadata["Name"]
+        if name:
+            found[_canon(name)] = dist.version or "?"
+    return found
+
+
+def _files_of(dist_info: Path, tree: Path) -> list[Path]:
+    """Paths a distribution owns, from its RECORD (relative to the tree)."""
+    record = dist_info / "RECORD"
+    if not record.is_file():
+        return [dist_info]
+    paths: list[Path] = []
+    with record.open(newline="", encoding="utf-8") as fh:
+        for row in csv.reader(fh):
+            if not row or not row[0]:
+                continue
+            target = (tree / row[0]).resolve()
+            if tree.resolve() in target.parents:  # never escape the tree
+                paths.append(target)
+    paths.append(dist_info)
+    return paths
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <payload-tree>", file=sys.stderr)
+        return 2
+    tree = Path(sys.argv[1])
+    if not tree.is_dir():
+        print(f"prune: {tree} is not a directory", file=sys.stderr)
+        return 2
+
+    base = _base_distributions(tree)
+    pruned: list[str] = []
+    kept: list[str] = []
+
+    for dist_info in sorted(tree.glob("*.dist-info")):
+        name = dist_info.name.rsplit("-", 2)[0]
+        canon = _canon(name)
+        if canon in KEEP:
+            kept.append(f"{name} (payload)")
+            continue
+        if canon not in base:
+            kept.append(name)
+            continue
+
+        for path in _files_of(dist_info, tree):
+            if path.is_dir() and not path.is_symlink():
+                shutil.rmtree(path, ignore_errors=True)
+            else:
+                path.unlink(missing_ok=True)
+        shutil.rmtree(dist_info, ignore_errors=True)
+        pruned.append(f"{name} (base has {base[canon]})")
+
+    # Empty package directories left behind once their files are gone.
+    for _ in range(4):  # nested packages need a few passes
+        for path in sorted(tree.rglob("*"), key=lambda p: -len(p.parts)):
+            if path.is_dir() and not path.is_symlink() and not any(path.iterdir()):
+                path.rmdir()
+
+    print(f"prune: {tree}")
+    print(f"prune: removed {len(pruned)} distribution(s) the base already provides")
+    for line in pruned:
+        print(f"  - {line}")
+    print(f"prune: kept {len(kept)} — this is what the overlay actually adds")
+    for line in kept:
+        print(f"  + {line}")
+
+    if not any(k.endswith("(payload)") for k in kept):
+        print("prune: FATAL — infera itself is missing from the tree", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Every engine image today bakes infera onto a digest-pinned vendor base. Following an upstream vLLM/SGLang bump means rebuilding everything, and forking the base for one model just broke the others — #55 had to revert a base swap after `e2e-mixed (vllm)` failed on GLM-5.1 and kvd while Qwen passed.

This makes the vendor base swappable: **one payload image, mounted over an unmodified base.**

## Everything can be overlaid — including the compiled parts

The first version of this PR kept Mooncake and hipFile in the engine image, on the assumption that they were tied to it. They are not. They bind the **CPython minor** and the **ROCm major**, not the specific vendor image. Bundle the extension's ~40 transitive system libraries alongside the `.so` — the same thing `auditwheel` does when vendoring deps into a manylinux wheel — and they load on a stock base.

| Component | Actually binds | Overlay key |
|---|---|---|
| infera, kvd | nothing — pure Python | — |
| infera-router | `libc`/`libstdc++` only, no ROCm, no torch | — |
| deps (msgspec, xxhash, pyzmq, msgpack) | CPython minor | `py3XX` |
| **Mooncake** | CPython minor + ROCm major + ~40 system libs | `rocmN-py3XX` |
| **hipFile** | ROCm major | `rocmN-py3XX` |
| libionic | the host kernel, not the image | injected at start |
| aiter kernels | GPU arch, JIT-compiled at run time | cache `~/.aiter/build` |

**A payload is rebuilt only when the ROCm major or the CPython minor moves — not when the vendor image does.**

## Layout

```
/payload/
  py310/                cp310 deps + infera + kvd        (SGLang bases)
  py312/                cp312 deps + infera + kvd        (vLLM bases)
  native/rocm7-py312/   mooncake + hipFile + their libs
  bin/infera-router     the Rust data plane
  bin/infera-exec       picks the trees matching this container, then execs
```

`infera-exec` keys the native tree off the container's own `libamdhip64` soname, so a vendor ROCm bump selects the right tree rather than silently loading a mismatched one.

## Use

```bash
docker volume create infera_payload
docker run --rm -v infera_payload:/out infera-overlay:latest

docker run -v infera_payload:/payload:ro \
  --entrypoint /payload/bin/infera-exec \
  <ANY vendor image> \
  python3 -m infera.engine.vllm --model ...
```

In Kubernetes: an initContainer copying `/payload` into an `emptyDir`, same entrypoint.

## Verified on MI355X, against an unmodified `vllm/vllm-openai-rocm:kimi-k3`

```
1. infera      : /payload/py312/infera        (kvd + engine.vllm present)
2. router      : Infera router data plane (Rust)
3. mooncake    : TransferEngine OK            -> PD available
4. hipFile     : libhipfile.so loaded
   ais-check   : HIP runtime True, amdgpu True -> kvd GPU-direct L3 available
```

Serving was verified end to end separately on the same stock image: **engine ready in 70 s, `/v1/chat/completions` returning tokens.** The cp310 tree was verified on `rocm/infera:sglang-v0.1.1` (Python 3.10).

## Two traps this handles

**cwd beats PYTHONPATH.** Python puts the working directory at `sys.path[0]`, ahead of `PYTHONPATH`. Vendor images that already ship infera set `WORKDIR` to its parent, so the baked-in copy silently shadows the payload and the overlay appears to do nothing — this happened on the SGLang image during testing. `infera-exec` `cd`s to `/` first.

**A missing native tree should not be silent.** Aggregated serving needs none of it; only PD and kvd's GPU-direct L3 do. `infera-exec` warns rather than failing, and `INFERA_REQUIRE_NATIVE=1` makes it an error for a PD deployment.

## What this unblocks

- Kimi-K3 runs on its own vendor base with the same payload, no change to `Dockerfile.vllm`, no risk to other models — the clean version of what #55 had to revert.
- Following upstream vLLM/SGLang stops being a rebuild.
- Related: #62 — the overlay boundary and the wheel boundary are now the same question.

---

## Two fixes found by running it (added after review opened)

Deploying these payloads over stock bases for real — Kimi-K3 on vLLM, GLM-5.2 on SGLang — surfaced two defects in the build. Both were silent.

### The payload was shadowing the vendor's Python stack

The engine logged, on repeat:

```
ImportError: Numba needs NumPy 2.4 or less. Got NumPy 2.5.
```

`pip install --target` **ignores the environment**: it installs the full transitive closure regardless of what the base already has, and a `--target` tree lands first on `PYTHONPATH`. So every duplicate shadowed the vendor's copy at whatever version PyPI resolved. The baked images never had this problem — a plain `pip install` onto the base leaves satisfied requirements alone — and moving to `--target` silently dropped that property.

Measured against `vllm/vllm-openai-rocm`: of **52** distributions, **two** were new (`nats-py`, `grpcio-health-checking`). Eleven shadowed the base at a different version:

```
numpy         2.5.1  over 2.3.5     <- the numba breakage
cryptography 50.0.0  over 3.4.8     <- 47 major versions
protobuf      7.35.1 over 6.33.6
grpcio        1.83.0 over 1.78.0
```

Two approaches that did **not** work, recorded so they are not retried: relying on pip to skip installed packages (`--target` ignores them, verified with `--dry-run --report`), and constraining to the base's `pip freeze` (`ResolutionImpossible`).

What works is building each tree inside the vendor base it will be laid onto, then deleting whatever the base already provides. `prune_base_dists.py` walks each `dist-info`'s RECORD and refuses to exit 0 if infera itself went missing. Verified: **325 MB → 5.8 MB**, infera resolves from the payload, numpy from the base, numba imports cleanly.

### No native tree for the SGLang ABI family, and the guard asked the wrong question

Native code was harvested only from `NATIVE_IMAGE`, a vLLM image, so the payload shipped `native/rocm7-py312` and nothing else. SGLang bases are CPython 3.10 and Mooncake binds the CPython minor, so PD on SGLang could not work however the manifest was written:

```
infera-exec: no native payload for rocm7-py310
```

Now harvested once per ABI family via `SGLANG_NATIVE_IMAGE`, with both stages sharing one harvest script.

The families **deliberately** differ — hipFile is vLLM-only, since kvd's GPU-direct L3 is a vLLM-only path. So "does the tree exist" is the wrong thing to gate on, and a boolean `INFERA_REQUIRE_NATIVE=1` would have **rejected working deployments**: SGLang PD, whose tree correctly has no hipFile, and SGLang kvd, which reaches its L2 and file L3 through pure-Python HiCacheStorage and needs no native code at all. Each harvest now writes a `CAPABILITIES` file and the variable names the capabilities a deployment needs.

Verified on real images, both directions:

| | |
|---|---|
| sglang, no requirement | starts ← the case a boolean guard broke |
| sglang, `mooncake` | starts |
| sglang, `hipfile` | fails, and says hipfile is vLLM-only |
| vllm, `mooncake,hipfile` | starts |
| vllm, `1` | starts |

That fourth case failed the first time: `CAPABILITIES` was written one word per line and the word-match needs space delimiters, so a complete tree reported itself as incomplete. Normalised on both sides.

Harvest output confirms the intended split — `rocm7-py312 [mooncake hipfile]`, `rocm7-py310 [mooncake]`.

Release CI builds this image as `inferaimage/infera:overlay-<id>` (in #64).
