### PR TITLE
feat(recipes): per-model Kubernetes recipes for GLM-5.2 and Kimi-K3, on stock vendor images

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,52 @@
+# Repository conventions
+
+## DCO sign-off is required on every commit
+
+This repository enforces the [Developer Certificate of Origin](https://developercertificate.org/).
+CI blocks any PR containing a commit without a `Signed-off-by:` trailer, so an
+unsigned commit is a broken PR, not a style nit.
+
+Commit with `-s`, always:
+
+```bash
+git commit -s -m "..."
+git commit -s -F -   # when writing a longer message from a heredoc
+```
+
+That appends a trailer matching `user.name` / `user.email`:
+
+```
+Signed-off-by: Zhang, Jiejing <jiejing.zhang@amd.com>
+```
+
+**Sign off as the repository's configured identity** (`git config user.name` /
+`user.email`). The DCO is an assertion about the *right to submit* the code, so
+it must name the human submitting it — never a bot or assistant identity.
+
+### Fixing commits that are already missing it
+
+Sign off a range without disturbing commits that already carry the trailer —
+rebasing from a point that includes signed commits appends duplicates:
+
+```bash
+git rebase --signoff <last-already-signed-commit>
+git push --force-with-lease origin <branch>
+```
+
+Pick `<last-already-signed-commit>` as the newest commit that already has the
+trailer. Check what you are about to touch first:
+
+```bash
+git log --format='%h %s | %(trailers:key=Signed-off-by,valueonly)' origin/main..HEAD
+```
+
+Cherry-picks do **not** inherit the trailer — `git cherry-pick -s`, or sign off
+afterwards. This is the easiest way to reintroduce the problem on a second branch
+after fixing it on the first.
+
+## Related trailers
+
+`Signed-off-by` is the DCO assertion and is mandatory. `Co-Authored-By` is
+separate, is not a substitute, and some upstreams reject assistant co-author
+trailers outright — when contributing to a third-party repository (e.g. ROCm/aiter),
+do not add them.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -13,15 +13,31 @@ git commit -s -m "..."
 git commit -s -F -   # when writing a longer message from a heredoc
 ```
 
-That appends a trailer matching `user.name` / `user.email`:
+That appends a trailer built from **your own** `user.name` / `user.email`:
 
 ```
-Signed-off-by: Zhang, Jiejing <jiejing.zhang@amd.com>
+Signed-off-by: Your Name <you@example.com>
 ```
 
-**Sign off as the repository's configured identity** (`git config user.name` /
-`user.email`). The DCO is an assertion about the *right to submit* the code, so
-it must name the human submitting it — never a bot or assistant identity.
+**Sign off as yourself.** The DCO is an assertion that *you* have the right to
+submit this code, so the trailer must name the person making the commit. Never
+copy a colleague's line from an existing commit, and never use a bot or assistant
+identity — contributors here sign off under several different addresses, and the
+trailer has to match the commit's actual author.
+
+Check what `-s` will produce before your first commit in a fresh clone or
+container, where git may have inherited a default from the environment:
+
+```bash
+git config user.name && git config user.email
+```
+
+If those are empty or wrong, set them (add `--global` outside a container):
+
+```bash
+git config user.name "Your Name"
+git config user.email "you@example.com"
+```
 
 ### Fixing commits that are already missing it
 

--- a/.github/scripts/build_test_push.sh
+++ b/.github/scripts/build_test_push.sh
@@ -3,19 +3,23 @@
 # SPDX-License-Identifier: MIT
 # Build/push/ship one Infera engine image on a node that has docker.
 # ship = login+build+push
-#   build|push|ship <sglang|vllm|atom|kvd|server>
+#   build|push|ship <sglang|vllm|atom|kvd|server|overlay>
+#
+# `overlay` builds the base-agnostic payload (deploy/overlay/). It consumes the
+# vllm and sglang images, so it must run AFTER them — release.yml gates it.
 set -euo pipefail
 
 cmd="${1:-}"
 engine="${2:-}"
 
 case "$engine" in
-  sglang) dockerfile="deploy/docker/Dockerfile.sglang" ;;
-  vllm)   dockerfile="deploy/docker/Dockerfile.vllm" ;;
-  atom)   dockerfile="deploy/docker/Dockerfile.atom" ;;
-  kvd)    dockerfile="deploy/docker/Dockerfile.kvd" ;;
-  server) dockerfile="deploy/docker/Dockerfile.server" ;;
-  *) echo "usage: $0 <build|push|ship> <sglang|vllm|atom|kvd|server>" >&2; exit 2 ;;
+  sglang)  dockerfile="deploy/docker/Dockerfile.sglang" ;;
+  vllm)    dockerfile="deploy/docker/Dockerfile.vllm" ;;
+  atom)    dockerfile="deploy/docker/Dockerfile.atom" ;;
+  kvd)     dockerfile="deploy/docker/Dockerfile.kvd" ;;
+  server)  dockerfile="deploy/docker/Dockerfile.server" ;;
+  overlay) dockerfile="deploy/overlay/Dockerfile.payload" ;;
+  *) echo "usage: $0 <build|push|ship> <sglang|vllm|atom|kvd|server|overlay>" >&2; exit 2 ;;
 esac
 
 # Tag precedence: ID (release/nightly) > PR > local. IMAGE = target repo.
@@ -28,11 +32,54 @@ ref="${IMAGE}:${tag}"
 
 cd "$(dirname "$0")/../.."
 
+# ---- overlay build args ------------------------------------------------------
+# The overlay is not self-contained: it harvests compiled pieces (Mooncake,
+# hipFile, the Rust router) out of the engine images, and builds its Python trees
+# inside the STOCK vendor bases so they can be pruned down to what those bases
+# lack. So it needs four refs, and getting any of them wrong is silent:
+#
+#   NATIVE_IMAGE / SGLANG_NATIVE_IMAGE  <- the engine images from THIS run, so a
+#       release never ships an overlay carrying a previous release's native code.
+#   VLLM_BASE_IMAGE / SGLANG_BASE_IMAGE <- read out of the engine Dockerfiles
+#       rather than repeated here. The prune keeps exactly what the base lacks,
+#       so a base ref that drifts from the one the engine image was built on
+#       produces a payload that is wrong in both directions: missing packages the
+#       real base does not have, and shadowing ones it does.
+build_args=()
+if [ "$engine" = overlay ]; then
+  base_arg() {  # default value of an ARG in an engine Dockerfile
+    sed -n "s/^ARG $2=//p" "$1" | head -1
+  }
+  vllm_base="$(base_arg deploy/docker/Dockerfile.vllm VLLM_BASE_IMAGE)"
+  sglang_base="$(base_arg deploy/docker/Dockerfile.sglang SGLANG_BASE_IMAGE)"
+  [ -n "$vllm_base" ]   || { echo "cannot read VLLM_BASE_IMAGE from Dockerfile.vllm" >&2; exit 1; }
+  [ -n "$sglang_base" ] || { echo "cannot read SGLANG_BASE_IMAGE from Dockerfile.sglang" >&2; exit 1; }
+
+  # Same tag scheme as above, so this run's engines are what gets harvested.
+  if   [ -n "${ID:-}" ]; then esuf="${ID}"
+  elif [ -n "${PR:-}" ]; then esuf="pr${PR}"
+  else                        esuf="local"
+  fi
+  native_vllm="${NATIVE_IMAGE:-${IMAGE}:vllm-${esuf}}"
+  native_sglang="${SGLANG_NATIVE_IMAGE:-${IMAGE}:sglang-${esuf}}"
+
+  build_args=(
+    --build-arg "VLLM_BASE_IMAGE=${vllm_base}"
+    --build-arg "SGLANG_BASE_IMAGE=${sglang_base}"
+    --build-arg "NATIVE_IMAGE=${native_vllm}"
+    --build-arg "SGLANG_NATIVE_IMAGE=${native_sglang}"
+  )
+  echo "overlay: harvest  vllm=${native_vllm}  sglang=${native_sglang}"
+  echo "overlay: deps on  vllm=${vllm_base}"
+  echo "overlay: deps on  sglang=${sglang_base}"
+fi
+
 case "$cmd" in
   build)
     # --network=host: RUN steps need DNS, and these nodes resolve via 127.0.0.1
     # which a default bridge build netns can't reach.
-    docker build --network=host -f "$dockerfile" -t "$ref" .
+    docker build --network=host ${build_args[@]+"${build_args[@]}"} \
+                 -f "$dockerfile" -t "$ref" .
     ;;
 
   push)
@@ -56,5 +103,5 @@ case "$cmd" in
     ;;
 
   *)
-    echo "usage: $0 <build|push|ship> <sglang|vllm|atom|kvd|server>" >&2; exit 2 ;;
+    echo "usage: $0 <build|push|ship> <sglang|vllm|atom|kvd|server|overlay>" >&2; exit 2 ;;
 esac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,15 +63,29 @@ jobs:
         run: |
           raw="${{ github.event.inputs.engines }}"
           [ -z "$raw" ] && raw="sglang vllm atom kvd server"
-          json=$(printf '%s\n' $raw | jq -R . | jq -sc .)
+
+          has() { printf '%s\n' $raw | grep -qx "$1"; }
+          has overlay && asked_overlay=1 || asked_overlay=0
+
+          # `overlay` is never a matrix entry. It is not an engine: it harvests
+          # Mooncake/hipFile out of the vllm and sglang images, so running it
+          # beside them would harvest whatever the registry had from a previous
+          # run. It gets its own job, gated on `build`. Strip it here so typing it
+          # in the dispatch box cannot route it into the matrix.
+          engines=$(printf '%s\n' $raw | grep -vx overlay | tr '\n' ' ')
+          json=$(printf '%s\n' $engines | jq -R . | jq -sc 'map(select(length>0))')
           echo "engines=$json" >> "$GITHUB_OUTPUT"
           echo "engines=$json"
-          # The overlay harvests Mooncake/hipFile out of BOTH engine images, so it
-          # can only be built when both are part of this run. A partial dispatch
-          # (e.g. just "sglang") skips it rather than building a payload that
-          # silently carries a previous release's native code.
-          if printf '%s\n' $raw | grep -qx sglang && printf '%s\n' $raw | grep -qx vllm; then
+
+          # The overlay needs BOTH engine images from THIS run.
+          if has sglang && has vllm; then
             echo "overlay=true" >> "$GITHUB_OUTPUT"; echo "overlay=true"
+          elif [ "$asked_overlay" = 1 ]; then
+            # Explicitly requested but impossible to build correctly. Fail loudly
+            # rather than skip: a silent skip on an explicit request reads as
+            # "the overlay was published" when nothing was.
+            echo "::error::overlay was requested but needs both sglang and vllm in the engine list (got: $raw)"
+            exit 1
           else
             echo "overlay=false" >> "$GITHUB_OUTPUT"
             echo "overlay=false (needs both sglang and vllm in the engine list)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ name: Build & publish images
 #   release:  inferaimage/infera:sglang-v0.1.0
 #   nightly:  inferaimage/infera:sglang-20260711-a1b2c3d
 #
+# The `overlay` image (deploy/overlay/) is built in its own job after the engine
+# images, because it harvests their compiled pieces — see the `overlay` job.
+#   inferaimage/infera:overlay-v0.1.0
+#
 # Target repo defaults to docker.io/inferaimage/infera; override per-run with
 # the `image_repo` dispatch input, or repo-wide with the IMAGE_REPO Actions
 # variable (input > variable > default). The official repo will be
@@ -53,6 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       engines: ${{ steps.set.outputs.engines }}
+      overlay: ${{ steps.set.outputs.overlay }}
     steps:
       - id: set
         run: |
@@ -61,6 +66,16 @@ jobs:
           json=$(printf '%s\n' $raw | jq -R . | jq -sc .)
           echo "engines=$json" >> "$GITHUB_OUTPUT"
           echo "engines=$json"
+          # The overlay harvests Mooncake/hipFile out of BOTH engine images, so it
+          # can only be built when both are part of this run. A partial dispatch
+          # (e.g. just "sglang") skips it rather than building a payload that
+          # silently carries a previous release's native code.
+          if printf '%s\n' $raw | grep -qx sglang && printf '%s\n' $raw | grep -qx vllm; then
+            echo "overlay=true" >> "$GITHUB_OUTPUT"; echo "overlay=true"
+          else
+            echo "overlay=false" >> "$GITHUB_OUTPUT"
+            echo "overlay=false (needs both sglang and vllm in the engine list)"
+          fi
 
   build:
     needs: prepare
@@ -141,15 +156,92 @@ jobs:
             sleep 5
           done
 
+  # The base-agnostic overlay payload (deploy/overlay/). Unlike the engine
+  # images this one is not independent: it builds its Python trees inside the
+  # STOCK vendor bases and harvests the compiled pieces out of THIS run's vllm
+  # and sglang images, so it must run after `build` and cannot be another entry
+  # in that matrix. Skipped when a partial dispatch leaves either engine out.
+  overlay:
+    needs: [prepare, build]
+    if: needs.prepare.outputs.overlay == 'true'
+    runs-on: [self-hosted, crusoe]
+    environment: auto-docker-builder
+    timeout-minutes: 90
+    env:
+      INFERA_E2E_SLURM_PARTITION: amd-spur
+      INFERA_E2E_RESERVATION: infera-cicd-reserved
+      INFERA_E2E_JOB_TAG: ${{ github.run_id }}-overlay
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Resolve target repo
+        env:
+          INPUT_REPO: ${{ github.event.inputs.image_repo }}
+          VAR_REPO: ${{ vars.IMAGE_REPO }}
+        run: |
+          repo="${INPUT_REPO:-${VAR_REPO:-docker.io/inferaimage/infera}}"
+          echo "IMAGE=$repo" >> "$GITHUB_ENV"
+          echo "target repo=$repo"
+
+      # Same id logic as `build`, so the overlay harvests the engine images this
+      # run just pushed rather than whatever happens to be latest.
+      - name: Compute image id
+        env:
+          CUSTOM_ID: ${{ github.event.inputs.id }}
+        run: |
+          if [ -n "$CUSTOM_ID" ]; then
+            id="$CUSTOM_ID"
+          elif [ "${{ github.ref_type }}" = "tag" ]; then
+            id="${{ github.ref_name }}"
+          else
+            date="$(date -u +%Y%m%d)"; sha="$(git rev-parse --short HEAD)"
+            if desc="$(git describe --tags --long 2>/dev/null)"; then
+              gsha="${desc##*-}"; rest="${desc%-*}"
+              n="${rest##*-}"; tag="${rest%-*}"
+              id="${date}-${tag}-post${n}-${gsha#g}"
+            else
+              id="${date}-${sha}"
+            fi
+          fi
+          echo "ID=$id" >> "$GITHUB_ENV"
+          echo "overlay id=$id"
+
+      - name: build & push overlay (remote via srun)
+        timeout-minutes: 80
+        env:
+          INFERAIMAGE_DOCKERHUB_TOKEN: ${{ secrets.INFERAIMAGE_DOCKERHUB_TOKEN }}
+        run: .github/scripts/dispatch_build.sh overlay
+
+      - name: reclaim this job's SLURM job (on cancel/failure)
+        if: always() && (cancelled() || failure())
+        run: |
+          suf="-${{ github.run_id }}-overlay"
+          for i in 1 2 3 4 5; do
+            ids=$(squeue -h -u "$(id -un)" -o '%i %j' 2>/dev/null \
+              | awk -v suf="$suf" '$2 ~ /^infera-build-/ && substr($2, length($2)-length(suf)+1)==suf {print $1}')
+            [ -z "$ids" ] && { echo "no (more) SLURM jobs to reclaim"; break; }
+            echo "reclaiming SLURM job(s): $ids (try $i)"; scancel $ids 2>&1 || true
+            sleep 5
+          done
+
   # Build the /manual Sphinx site alongside the images. Always uploads the HTML
   # as a workflow artifact; on a tag (release) it also attaches a tarball to the
   # GitHub Release. No GPU needed, so this runs on a GH-hosted runner.
   #
-  # Gated on `build`: don't publish a GitHub Release (create + attach the manual)
-  # unless every engine image built and pushed successfully, so a green Release
-  # never implies images that failed to build.
+  # Gated on `build` and `overlay`: don't publish a GitHub Release (create +
+  # attach the manual) unless everything this run ships built and pushed, so a
+  # green Release never implies images that failed to build. A SKIPPED overlay
+  # (partial dispatch, see `prepare`) is fine and must not block the Release —
+  # only a FAILED one does, hence the explicit result checks rather than a plain
+  # `needs:`, which would also skip this job whenever overlay is skipped.
   manual:
-    needs: build
+    needs: [build, overlay]
+    if: >-
+      always() && needs.build.result == 'success'
+      && needs.overlay.result != 'failure'
+      && needs.overlay.result != 'cancelled'
     runs-on: ubuntu-latest
     # Same gate as the image build, so publishing a Release (create/upload)
     # goes through the auto-docker-builder protection rules too.

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,14 @@ deploy/docker/third_party/
 .review-drafts/
 temp/
 CLAUDE.md
-.claude/
+# ...except the shared repo conventions, which are meant for review and for
+# everyone's agent sessions. Excluding `.claude/*` rather than `.claude/` is what
+# makes the negation possible — git will not descend into an excluded directory,
+# so a re-include under `.claude/` would never be reached. Everything else stays
+# out: settings.local.json is per-developer, and worktrees/ holds whole nested
+# checkouts.
+.claude/*
+!.claude/CLAUDE.md
 .spur_job_*.sh
 .spur_ns_*.sh
 spur-*.out

--- a/deploy/docker/Dockerfile.sglang
+++ b/deploy/docker/Dockerfile.sglang
@@ -33,6 +33,26 @@ RUN if [ "${BUILD_MOONCAKE}" = "1" ]; then \
     fi \
     && rm -rf /tmp/build_mooncake_sglang.sh /tmp/mooncake_cpp
 
+# ---- libionic (host ionic ABI match) -----------------------------------------
+# WHY: the sglang base ships libionic with an old kernel ABI (e.g. 54.0-149 = ABI
+# 1); MI355X ionic kernel 26.03 needs ABI 4 (54.0-187) or ibv_get_device_list
+# returns 0 HCAs -> RDMA silently degrades to TCP and cross-node PD KV transfer
+# fails ("remote mooncake session not alive"). HOW: bake the ABI-4 deb so RDMA
+# works even without the runtime host-libionic injection (which the entrypoint
+# still does as a belt-and-braces match when /host-libionic is mounted).
+ARG INSTALL_LIBIONIC=1
+ARG LIBIONIC_DEB_URL=https://repo.radeon.com/amdainic/pensando/ubuntu/1.117.5-a-77/pool/main/r/rdma-core/libionic1_54.0-187-1_amd64.deb
+RUN if [ "${INSTALL_LIBIONIC}" = "1" ]; then \
+        (curl -4 -fsSL --retry 3 -o /tmp/libionic.deb "${LIBIONIC_DEB_URL}" \
+          && dpkg -i --force-downgrade /tmp/libionic.deb \
+          && ldconfig \
+          && echo "libionic: $(dpkg -l | awk '/libionic1/{print $3}')" \
+          && rm -f /tmp/libionic.deb) \
+        || echo "[libionic] install failed (offline build?) — inject at runtime instead"; \
+    else \
+        echo "INSTALL_LIBIONIC=0 — libionic injected at container start"; \
+    fi
+
 # Install infera + its declared deps from pyproject (single source of truth).
 # The base already ships torch/sglang and most of infera's runtime stack; pip
 # leaves those satisfied versions untouched and only pulls what's missing (e.g.

--- a/deploy/docker/Dockerfile.sglang.gfx942
+++ b/deploy/docker/Dockerfile.sglang.gfx942
@@ -8,6 +8,26 @@ FROM ${SGLANG_BASE_IMAGE}
 
 WORKDIR /opt/infera
 
+# ---- libionic (host ionic ABI match) -----------------------------------------
+# WHY: the sglang base ships libionic with an old kernel ABI (e.g. 54.0-149 = ABI
+# 1); the ionic RoCE kernel driver needs ABI 4 (54.0-187) or ibv_get_device_list
+# returns 0 HCAs -> RDMA silently degrades to TCP and cross-node PD KV transfer
+# fails ("remote mooncake session not alive"). HOW: bake the ABI-4 deb so RDMA
+# works even without the runtime host-libionic injection (which the entrypoint
+# still does as a belt-and-braces match when /host-libionic is mounted).
+ARG INSTALL_LIBIONIC=1
+ARG LIBIONIC_DEB_URL=https://repo.radeon.com/amdainic/pensando/ubuntu/1.117.5-a-77/pool/main/r/rdma-core/libionic1_54.0-187-1_amd64.deb
+RUN if [ "${INSTALL_LIBIONIC}" = "1" ]; then \
+        (curl -4 -fsSL --retry 3 -o /tmp/libionic.deb "${LIBIONIC_DEB_URL}" \
+          && dpkg -i --force-downgrade /tmp/libionic.deb \
+          && ldconfig \
+          && echo "libionic: $(dpkg -l | awk '/libionic1/{print $3}')" \
+          && rm -f /tmp/libionic.deb) \
+        || echo "[libionic] install failed (offline build?) — inject at runtime instead"; \
+    else \
+        echo "INSTALL_LIBIONIC=0 — libionic injected at container start"; \
+    fi
+
 # Install infera + its declared deps from pyproject (single source of truth).
 # The base already ships torch/sglang and most of infera's runtime stack; pip
 # leaves those satisfied versions untouched and only pulls what's missing.

--- a/deploy/docker/Dockerfile.vllm
+++ b/deploy/docker/Dockerfile.vllm
@@ -3,15 +3,13 @@
 # hipFile + libionic onto a digest-pinned nightly base, then the infera source,
 # and runs via `python -m infera.engine.vllm`.
 #
-# Base pinned by DIGEST to the vLLM kimi-k3 build — the vLLM that carries kimi_k3
-# model support (KimiK3ForConditionalGeneration) plus the broader model coverage
-# of a newer vLLM. The tag ":kimi-k3" is kept in the ref for readability; the
-# @sha256 is what pins it. The full stack (aiter + vLLM/DSv4 patches + Mooncake +
-# hipFile + libionic + infera + rust router) was validated on this base on MI355X.
-# To move: bump the digest + re-verify patch no-ops (the patch loop swallows a
-# patch's sys.exit(1), so a moved anchor silently drops the patch — check the
-# build log per layer).
-ARG VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3@sha256:5aa7e626ff73672f5ca7aae46754570488c23d33ca1ac90756a1d2d1a3fe099b
+# Base pinned by DIGEST to the stable vLLM v0.25.1 release (was the rolling nightly
+# cbe9c40f = 0.23.1rc0.dev861+gcbe9c40f9, which DockerHub has since rolled off).
+# The tag ":v0.25.1" is kept in the ref for readability; the @sha256 is what pins
+# it (= vllm 0.25.1, torch 2.11.0, ROCm 7.2.3). To move: bump the digest +
+# re-verify patch no-ops (the patch loop swallows a patch's sys.exit(1), so a
+# moved anchor silently drops the patch — check the build log per layer).
+ARG VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:v0.25.1@sha256:84459732ca98b40fe2f5338a3f050be6d522504e47a484a5180d58fb75956f86
 FROM ${VLLM_BASE_IMAGE}
 
 # ---- 1) AITER (flydsl fp4 for DSv4 MXFP4 MoE) ------------------------------
@@ -60,18 +58,24 @@ RUN for f in /tmp/vllm-patches/*.py; do echo "[vllm-patch] $f"; python "$f" || e
     && for f in /tmp/vllm-dsv4-patches/*.py; do echo "[vllm-dsv4-patch] $f"; python "$f" || echo "[vllm-dsv4-patch] skipped $f"; done \
     && rm -rf /tmp/vllm-patches /tmp/vllm-dsv4-patches
 
-# ---- 3) Mooncake (main + B-group C++ patches, bare ibv_reg_mr) -------------
+# ---- 3) Mooncake (main + B-group C++ patches) ------------------------------
 # WHY: cross-node RDMA on ionic needs the B-group C++ patches (B.2 hip-transport
-# gate + B.3 auto-chunk MR), carried against mooncake main. The dma-buf GPUDirect
-# path was dropped in #154 (exhausts a KFD resource at high util -> HIP-209); bare
-# ibv_reg_mr via host-libionic injection is the only supported path. HOW: shared
-# build_mooncake_rocm.sh mode 1 (MOONCAKE_DMABUF=1 = main + B-group, no dma-buf).
+# gate + B.3 auto-chunk MR), carried against mooncake main. How GPU memory is
+# registered for RDMA is chosen by the MOONCAKE_HIP_DMABUF build ARG:
+#   0 (default) = bare ibv_reg_mr via host-libionic injection — needs the legacy
+#                 ib_peer_mem kernel module (do NOT use at high util; HIP-209).
+#   1           = B.1 dma-buf GPUDirect (ibv_reg_dmabuf_mr) — REQUIRED on a
+#                 dma-buf-only RoCE fabric with no ib_peer_mem (e.g. crusoe
+#                 amd-spur), where bare ibv_reg_mr cannot pin VRAM at all.
+# HOW: shared build_mooncake_rocm.sh mode 1 (MOONCAKE_DMABUF=1 = main + B-group).
 ARG BUILD_MOONCAKE=1
 ARG MOONCAKE_GIT_REF=747003c058015c4077a266e7ccd7549bbc9baede
+ARG MOONCAKE_HIP_DMABUF=0
 COPY deploy/docker/scripts/build_mooncake_rocm.sh /tmp/build_mooncake_rocm.sh
 COPY deploy/docker/patches/mooncake_cpp/ /tmp/mooncake_cpp/
 RUN if [ "${BUILD_MOONCAKE}" = "1" ]; then \
-        MOONCAKE_DMABUF=1 MOONCAKE_GIT_REF="${MOONCAKE_GIT_REF}" \
+        MOONCAKE_DMABUF=1 MOONCAKE_HIP_DMABUF="${MOONCAKE_HIP_DMABUF}" \
+        MOONCAKE_GIT_REF="${MOONCAKE_GIT_REF}" \
         MC_CPP_PATCH_DIR=/tmp/mooncake_cpp \
         bash /tmp/build_mooncake_rocm.sh; \
     else \

--- a/deploy/docker/Dockerfile.vllm
+++ b/deploy/docker/Dockerfile.vllm
@@ -3,13 +3,15 @@
 # hipFile + libionic onto a digest-pinned nightly base, then the infera source,
 # and runs via `python -m infera.engine.vllm`.
 #
-# Base pinned by DIGEST to the stable vLLM v0.25.1 release (was the rolling nightly
-# cbe9c40f = 0.23.1rc0.dev861+gcbe9c40f9, which DockerHub has since rolled off).
-# The tag ":v0.25.1" is kept in the ref for readability; the @sha256 is what pins
-# it (= vllm 0.25.1, torch 2.11.0, ROCm 7.2.3). To move: bump the digest +
-# re-verify patch no-ops (the patch loop swallows a patch's sys.exit(1), so a
-# moved anchor silently drops the patch — check the build log per layer).
-ARG VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:v0.25.1@sha256:84459732ca98b40fe2f5338a3f050be6d522504e47a484a5180d58fb75956f86
+# Base pinned by DIGEST to the vLLM kimi-k3 build — the vLLM that carries kimi_k3
+# model support (KimiK3ForConditionalGeneration) plus the broader model coverage
+# of a newer vLLM. The tag ":kimi-k3" is kept in the ref for readability; the
+# @sha256 is what pins it. The full stack (aiter + vLLM/DSv4 patches + Mooncake +
+# hipFile + libionic + infera + rust router) was validated on this base on MI355X.
+# To move: bump the digest + re-verify patch no-ops (the patch loop swallows a
+# patch's sys.exit(1), so a moved anchor silently drops the patch — check the
+# build log per layer).
+ARG VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3@sha256:5aa7e626ff73672f5ca7aae46754570488c23d33ca1ac90756a1d2d1a3fe099b
 FROM ${VLLM_BASE_IMAGE}
 
 # ---- 1) AITER (flydsl fp4 for DSv4 MXFP4 MoE) ------------------------------

--- a/deploy/overlay/Dockerfile.payload
+++ b/deploy/overlay/Dockerfile.payload
@@ -29,19 +29,40 @@
 #   docker build -f deploy/overlay/Dockerfile.payload -t infera-overlay:latest .
 ARG NATIVE_IMAGE=rocm/infera:vllm-v0.1.1
 
+# The Python trees are built INSIDE the vendor bases they will be overlaid onto,
+# not on a plain python:X-slim. `pip install --target` ignores the environment and
+# installs the whole transitive closure, and a --target tree lands FIRST on
+# PYTHONPATH — so every duplicate silently shadows the vendor's copy at whatever
+# version PyPI resolved. Building on slim produced a tree of 52 distributions of
+# which two were new, eleven of them shadowing the base at a DIFFERENT version
+# (numpy 2.5.1 over 2.3.5, which broke the base's numba; cryptography 50.0.0 over
+# 3.4.8; protobuf 7 over 6). Building in the base lets prune_base_dists.py drop
+# everything the base already provides, restoring the property the baked images
+# had for free: add infera, touch nothing else. 325 MB -> 5.8 MB, measured.
+#
+# These need only be *representative* of their ABI family — a base bump does not
+# require bumping them, since what matters is which distributions the family
+# ships, not their exact versions.
+ARG SGLANG_BASE_IMAGE=lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
+ARG VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:v0.25.1
+
 # ---- cp310 tree (SGLang bases) ---------------------------------------------
-FROM python:3.10-slim AS deps310
+FROM ${SGLANG_BASE_IMAGE} AS deps310
 WORKDIR /src
 COPY pyproject.toml README.md ./
 COPY infera ./infera
-RUN pip install --no-cache-dir --target /payload/py310 ".[vllm]"
+COPY deploy/overlay/prune_base_dists.py /tmp/prune_base_dists.py
+RUN pip install --no-cache-dir --target /payload/py310 ".[sglang]" \
+    && python3 /tmp/prune_base_dists.py /payload/py310
 
 # ---- cp312 tree (vLLM bases) -----------------------------------------------
-FROM python:3.12-slim AS deps312
+FROM ${VLLM_BASE_IMAGE} AS deps312
 WORKDIR /src
 COPY pyproject.toml README.md ./
 COPY infera ./infera
-RUN pip install --no-cache-dir --target /payload/py312 ".[vllm]"
+COPY deploy/overlay/prune_base_dists.py /tmp/prune_base_dists.py
+RUN pip install --no-cache-dir --target /payload/py312 ".[vllm]" \
+    && python3 /tmp/prune_base_dists.py /payload/py312
 
 # ---- native: harvest the compiled artifacts + their transitive libs ---------
 # Mooncake's extension pulls ~40 system libraries (glog, jsoncpp, asio, gflags,

--- a/deploy/overlay/Dockerfile.payload
+++ b/deploy/overlay/Dockerfile.payload
@@ -1,0 +1,58 @@
+# Infera overlay payload — one image that composes with any stock vendor base.
+#
+# WHY: today every engine image bakes infera onto a digest-pinned vendor base, so
+# following an upstream vLLM/SGLang bump means rebuilding everything, and forking
+# the base for one model (Kimi-K3) broke the others. But most of what we add is
+# not tied to the base: infera and kvd are pure Python, the Rust router links only
+# libc/libstdc++, libionic is injected from the host, and aiter JITs its kernels
+# at runtime. Only Mooncake and hipFile are genuinely ABI-bound (CPython version
+# AND the ROCm major), and those stay in the built engine image.
+#
+# So: ONE payload image, mounted over an UNMODIFIED vendor image. No rebuild, no
+# base fork, no per-model image.
+#
+# Four dependencies are C extensions (msgspec, xxhash, pyzmq, msgpack) and are
+# therefore CPython-ABI bound, and the vendor bases have split — vLLM ships
+# Python 3.12, SGLang ships 3.10. Rather than publishing two payloads, this image
+# carries both trees and `infera-exec` picks the matching one at run time:
+#
+#   /payload/py310/  cp310 deps + infera + kvd   (SGLang bases)
+#   /payload/py312/  cp312 deps + infera + kvd   (vLLM bases)
+#   /payload/bin/    infera-router, infera-exec
+#
+# Build:
+#   docker build -f deploy/overlay/Dockerfile.payload -t infera-overlay:latest .
+#
+# Use — the vendor image is untouched:
+#   docker run -v infera_payload:/payload:ro \
+#     --entrypoint /payload/bin/infera-exec <ANY vendor image> \
+#     python3 -m infera.engine.vllm ...
+#
+# In Kubernetes the same thing is an initContainer that copies /payload into an
+# emptyDir the engine container mounts.
+ARG ROUTER_IMAGE=rocm/infera:vllm-v0.1.1
+
+# ---- cp310 tree (SGLang bases) ---------------------------------------------
+FROM python:3.10-slim AS deps310
+WORKDIR /src
+COPY pyproject.toml README.md ./
+COPY infera ./infera
+RUN pip install --no-cache-dir --target /payload/py310 ".[vllm]"
+
+# ---- cp312 tree (vLLM bases) -----------------------------------------------
+FROM python:3.12-slim AS deps312
+WORKDIR /src
+COPY pyproject.toml README.md ./
+COPY infera ./infera
+RUN pip install --no-cache-dir --target /payload/py312 ".[vllm]"
+
+# ---- the one compiled artifact: reuse it rather than carry a Rust toolchain --
+FROM ${ROUTER_IMAGE} AS router
+
+# ---- final: busybox, so an initContainer can `cp` the payload out -----------
+FROM busybox:1.36
+COPY --from=deps310 /payload/py310 /payload/py310
+COPY --from=deps312 /payload/py312 /payload/py312
+COPY --from=router /usr/local/bin/infera-router /payload/bin/infera-router
+COPY deploy/overlay/infera-exec /payload/bin/infera-exec
+CMD ["sh", "-c", "cp -a /payload/. /out/ && echo 'infera overlay payload installed to /out'"]

--- a/deploy/overlay/Dockerfile.payload
+++ b/deploy/overlay/Dockerfile.payload
@@ -1,36 +1,33 @@
 # Infera overlay payload — one image that composes with any stock vendor base.
 #
-# WHY: today every engine image bakes infera onto a digest-pinned vendor base, so
+# WHY: every engine image today bakes infera onto a digest-pinned vendor base, so
 # following an upstream vLLM/SGLang bump means rebuilding everything, and forking
-# the base for one model (Kimi-K3) broke the others. But most of what we add is
-# not tied to the base: infera and kvd are pure Python, the Rust router links only
-# libc/libstdc++, libionic is injected from the host, and aiter JITs its kernels
-# at runtime. Only Mooncake and hipFile are genuinely ABI-bound (CPython version
-# AND the ROCm major), and those stay in the built engine image.
+# the base for one model (Kimi-K3) broke the others. None of what we add actually
+# requires being baked into that specific base:
 #
-# So: ONE payload image, mounted over an UNMODIFIED vendor image. No rebuild, no
-# base fork, no per-model image.
+#   * infera and kvd are pure Python
+#   * the Rust router links only libc/libstdc++
+#   * libionic is injected from the host at container start
+#   * aiter JIT-compiles its kernels per GPU arch at run time
+#   * Mooncake and hipFile ARE compiled, but they bind the CPython minor and the
+#     ROCm major — NOT the specific vendor image. Ship one build per
+#     (python, rocm) pair with their transitive system libs bundled, exactly the
+#     way auditwheel vendors deps into a manylinux wheel, and they load on a
+#     stock base.
 #
-# Four dependencies are C extensions (msgspec, xxhash, pyzmq, msgpack) and are
-# therefore CPython-ABI bound, and the vendor bases have split — vLLM ships
-# Python 3.12, SGLang ships 3.10. Rather than publishing two payloads, this image
-# carries both trees and `infera-exec` picks the matching one at run time:
+# So the whole overlay is base-agnostic and a base bump costs nothing.
 #
-#   /payload/py310/  cp310 deps + infera + kvd   (SGLang bases)
-#   /payload/py312/  cp312 deps + infera + kvd   (vLLM bases)
-#   /payload/bin/    infera-router, infera-exec
+#   /payload/py310/                cp310 deps + infera + kvd     (SGLang bases)
+#   /payload/py312/                cp312 deps + infera + kvd     (vLLM bases)
+#   /payload/native/rocm7-py312/   mooncake + hipFile + their libs
+#   /payload/bin/                  infera-router, infera-exec
 #
-# Build:
+# `infera-exec` selects the trees matching the container's Python and ROCm.
+#
+# Build (NATIVE_IMAGE supplies the already-compiled Mooncake/hipFile/router;
+# rebuilding those here would mean carrying a full ROCm toolchain):
 #   docker build -f deploy/overlay/Dockerfile.payload -t infera-overlay:latest .
-#
-# Use — the vendor image is untouched:
-#   docker run -v infera_payload:/payload:ro \
-#     --entrypoint /payload/bin/infera-exec <ANY vendor image> \
-#     python3 -m infera.engine.vllm ...
-#
-# In Kubernetes the same thing is an initContainer that copies /payload into an
-# emptyDir the engine container mounts.
-ARG ROUTER_IMAGE=rocm/infera:vllm-v0.1.1
+ARG NATIVE_IMAGE=rocm/infera:vllm-v0.1.1
 
 # ---- cp310 tree (SGLang bases) ---------------------------------------------
 FROM python:3.10-slim AS deps310
@@ -46,13 +43,37 @@ COPY pyproject.toml README.md ./
 COPY infera ./infera
 RUN pip install --no-cache-dir --target /payload/py312 ".[vllm]"
 
-# ---- the one compiled artifact: reuse it rather than carry a Rust toolchain --
-FROM ${ROUTER_IMAGE} AS router
+# ---- native: harvest the compiled artifacts + their transitive libs ---------
+# Mooncake's extension pulls ~40 system libraries (glog, jsoncpp, asio, gflags,
+# ...) that a stock vendor image does not ship. Bundling them next to the .so is
+# what makes the overlay work off-base; LD_LIBRARY_PATH points at the bundle.
+FROM ${NATIVE_IMAGE} AS native
+RUN set -eu; \
+    ROCM_MAJOR="$(readlink -f /opt/rocm/lib/libamdhip64.so.* 2>/dev/null | grep -oE 'so\.[0-9]+' | head -1 | cut -d. -f2)"; \
+    PYTAG="py$(python3 -c 'import sys;print("%d%d"%sys.version_info[:2])')"; \
+    OUT="/native/rocm${ROCM_MAJOR}-${PYTAG}"; \
+    mkdir -p "$OUT/lib" "$OUT/bin"; \
+    echo "harvesting into $OUT"; \
+    MC="$(python3 -c 'import mooncake,os;print(os.path.dirname(mooncake.__file__))')"; \
+    cp -a "$MC" "$OUT/mooncake"; \
+    # transitive deps of the Mooncake extension, minus what every base already has
+    ldd "$MC"/engine*.so 2>/dev/null | awk '/=> \//{print $3}' \
+      | grep -vE 'libamdhip64|libc\.so|libm\.so|libstdc\+\+|libgcc_s|ld-linux|libpthread|libdl|librt|libnuma|libibverbs' \
+      | while read -r so; do cp -L "$so" "$OUT/lib/" 2>/dev/null || true; done; \
+    # hipFile: libhipfile + the ais-check probe (a Python script) + its module
+    for f in /opt/rocm/lib/libhipfile.so*; do cp -L "$f" "$OUT/lib/" 2>/dev/null || true; done; \
+    cp /opt/rocm/bin/ais-check "$OUT/bin/" 2>/dev/null || true; \
+    HF="$(python3 -c 'import hipfile,os;print(os.path.dirname(hipfile.__file__))' 2>/dev/null || true)"; \
+    [ -n "$HF" ] && cp -a "$HF" "$OUT/hipfile" || true; \
+    ln -sf libhipfile.so.0.3.0 "$OUT/lib/libhipfile.so.0" 2>/dev/null || true; \
+    ln -sf libhipfile.so.0 "$OUT/lib/libhipfile.so" 2>/dev/null || true; \
+    du -sh "$OUT"
 
 # ---- final: busybox, so an initContainer can `cp` the payload out -----------
 FROM busybox:1.36
 COPY --from=deps310 /payload/py310 /payload/py310
 COPY --from=deps312 /payload/py312 /payload/py312
-COPY --from=router /usr/local/bin/infera-router /payload/bin/infera-router
+COPY --from=native /native /payload/native
+COPY --from=native /usr/local/bin/infera-router /payload/bin/infera-router
 COPY deploy/overlay/infera-exec /payload/bin/infera-exec
 CMD ["sh", "-c", "cp -a /payload/. /out/ && echo 'infera overlay payload installed to /out'"]

--- a/deploy/overlay/Dockerfile.payload
+++ b/deploy/overlay/Dockerfile.payload
@@ -28,6 +28,8 @@
 # rebuilding those here would mean carrying a full ROCm toolchain):
 #   docker build -f deploy/overlay/Dockerfile.payload -t infera-overlay:latest .
 ARG NATIVE_IMAGE=rocm/infera:vllm-v0.1.1
+# The SGLang ABI family needs its own harvest: same Mooncake, different CPython.
+ARG SGLANG_NATIVE_IMAGE=rocm/infera:sglang-v0.1.2
 
 # The Python trees are built INSIDE the vendor bases they will be overlaid onto,
 # not on a plain python:X-slim. `pip install --target` ignores the environment and
@@ -65,36 +67,29 @@ RUN pip install --no-cache-dir --target /payload/py312 ".[vllm]" \
     && python3 /tmp/prune_base_dists.py /payload/py312
 
 # ---- native: harvest the compiled artifacts + their transitive libs ---------
-# Mooncake's extension pulls ~40 system libraries (glog, jsoncpp, asio, gflags,
-# ...) that a stock vendor image does not ship. Bundling them next to the .so is
-# what makes the overlay work off-base; LD_LIBRARY_PATH points at the bundle.
-FROM ${NATIVE_IMAGE} AS native
-RUN set -eu; \
-    ROCM_MAJOR="$(readlink -f /opt/rocm/lib/libamdhip64.so.* 2>/dev/null | grep -oE 'so\.[0-9]+' | head -1 | cut -d. -f2)"; \
-    PYTAG="py$(python3 -c 'import sys;print("%d%d"%sys.version_info[:2])')"; \
-    OUT="/native/rocm${ROCM_MAJOR}-${PYTAG}"; \
-    mkdir -p "$OUT/lib" "$OUT/bin"; \
-    echo "harvesting into $OUT"; \
-    MC="$(python3 -c 'import mooncake,os;print(os.path.dirname(mooncake.__file__))')"; \
-    cp -a "$MC" "$OUT/mooncake"; \
-    # transitive deps of the Mooncake extension, minus what every base already has
-    ldd "$MC"/engine*.so 2>/dev/null | awk '/=> \//{print $3}' \
-      | grep -vE 'libamdhip64|libc\.so|libm\.so|libstdc\+\+|libgcc_s|ld-linux|libpthread|libdl|librt|libnuma|libibverbs' \
-      | while read -r so; do cp -L "$so" "$OUT/lib/" 2>/dev/null || true; done; \
-    # hipFile: libhipfile + the ais-check probe (a Python script) + its module
-    for f in /opt/rocm/lib/libhipfile.so*; do cp -L "$f" "$OUT/lib/" 2>/dev/null || true; done; \
-    cp /opt/rocm/bin/ais-check "$OUT/bin/" 2>/dev/null || true; \
-    HF="$(python3 -c 'import hipfile,os;print(os.path.dirname(hipfile.__file__))' 2>/dev/null || true)"; \
-    [ -n "$HF" ] && cp -a "$HF" "$OUT/hipfile" || true; \
-    ln -sf libhipfile.so.0.3.0 "$OUT/lib/libhipfile.so.0" 2>/dev/null || true; \
-    ln -sf libhipfile.so.0 "$OUT/lib/libhipfile.so" 2>/dev/null || true; \
-    du -sh "$OUT"
+# Once per ABI family — (ROCm major, CPython minor) — because Mooncake and
+# hipFile bind both and the vendor bases disagree (vLLM 3.12, SGLang 3.10).
+# Harvesting only the vLLM family, as this did originally, left SGLang
+# deployments with no native tree at all: `infera-exec: no native payload for
+# rocm7-py310`, so PD could not work on SGLang however the manifest was written.
+#
+# hipFile is legitimately absent from the SGLang family — kvd's GPU-direct L3 is
+# a vLLM-only path — so the harvest records what each tree actually carries in a
+# CAPABILITIES file rather than assuming every tree is complete.
+FROM ${NATIVE_IMAGE} AS native312
+COPY deploy/overlay/harvest_native.sh /tmp/harvest_native.sh
+RUN sh /tmp/harvest_native.sh
+
+FROM ${SGLANG_NATIVE_IMAGE} AS native310
+COPY deploy/overlay/harvest_native.sh /tmp/harvest_native.sh
+RUN sh /tmp/harvest_native.sh
 
 # ---- final: busybox, so an initContainer can `cp` the payload out -----------
 FROM busybox:1.36
 COPY --from=deps310 /payload/py310 /payload/py310
 COPY --from=deps312 /payload/py312 /payload/py312
-COPY --from=native /native /payload/native
-COPY --from=native /usr/local/bin/infera-router /payload/bin/infera-router
+COPY --from=native312 /native /payload/native
+COPY --from=native310 /native /payload/native
+COPY --from=native312 /usr/local/bin/infera-router /payload/bin/infera-router
 COPY deploy/overlay/infera-exec /payload/bin/infera-exec
 CMD ["sh", "-c", "cp -a /payload/. /out/ && echo 'infera overlay payload installed to /out'"]

--- a/deploy/overlay/README.md
+++ b/deploy/overlay/README.md
@@ -1,0 +1,68 @@
+# Overlay payload — one image, any stock vendor base
+
+`infera-overlay` carries the base-agnostic half of an engine deployment and is
+mounted over an **unmodified** vendor image. No rebuild when upstream bumps, no
+forking a base for one model.
+
+```
+/payload/
+  py310/            cp310 deps + infera + kvd    (SGLang bases)
+  py312/            cp312 deps + infera + kvd    (vLLM bases)
+  bin/infera-router the Rust data plane (links only libc/libstdc++)
+  bin/infera-exec   picks the tree matching the container's Python, then execs
+```
+
+## Why this split
+
+| Component | Bound to | Overlay? |
+|---|---|---|
+| infera, kvd | nothing — pure Python | yes |
+| infera-router | libc/libstdc++ only | yes |
+| libionic | the host kernel, not the image | yes (already injected at start) |
+| aiter kernels | JIT-compiled per arch at runtime | yes (share `~/.aiter/build`) |
+| **Mooncake `engine.so`** | CPython minor **and** `libamdhip64.so.7` + 6 system libs | **no — stays in the engine image** |
+| **hipFile** | the ROCm version | **no** |
+
+Four dependencies are C extensions (msgspec, xxhash, pyzmq, msgpack), so the
+Python trees are per-CPython-minor. The vendor bases have split — vLLM ships
+3.12, SGLang ships 3.10 — so the image carries both and `infera-exec` selects.
+
+## Build
+
+```bash
+docker build -f deploy/overlay/Dockerfile.payload -t infera-overlay:latest .
+```
+
+## Use
+
+```bash
+docker volume create infera_payload
+docker run --rm -v infera_payload:/out infera-overlay:latest
+
+docker run -v infera_payload:/payload:ro \
+  --entrypoint /payload/bin/infera-exec \
+  <ANY vendor image> \
+  python3 -m infera.engine.vllm --model ... --served-model-name ...
+```
+
+In Kubernetes this is an initContainer that copies `/payload` into an `emptyDir`
+the engine container mounts, with the same `infera-exec` entrypoint.
+
+## Verified
+
+On MI355X, against **unmodified** vendor images:
+
+- `vllm/vllm-openai-rocm:kimi-k3` (Python 3.12) — engine ready in 70 s and
+  serving `/v1/chat/completions`; `infera` resolves to `/payload/py312/infera`.
+- `rocm/infera:sglang-v0.1.1` (Python 3.10) — `infera` resolves to
+  `/payload/py310/infera`, C-extension deps import, `infera.engine.sglang` and
+  `infera.kvd` both present.
+- `infera-router` runs from the same payload on both.
+
+## One trap this handles for you
+
+Python puts the working directory at `sys.path[0]`, **ahead of `PYTHONPATH`**.
+Vendor images that already ship infera set `WORKDIR` to its parent
+(`/opt/infera`), so the baked-in copy silently shadows the payload and the
+overlay appears to do nothing. `infera-exec` therefore `cd`s to `/` before
+exec'ing; override with `INFERA_EXEC_CHDIR` if a command needs its own cwd.

--- a/deploy/overlay/README.md
+++ b/deploy/overlay/README.md
@@ -1,37 +1,50 @@
 # Overlay payload — one image, any stock vendor base
 
-`infera-overlay` carries the base-agnostic half of an engine deployment and is
-mounted over an **unmodified** vendor image. No rebuild when upstream bumps, no
-forking a base for one model.
+`infera-overlay` carries **everything we add** to a vendor image, and is mounted
+over an **unmodified** base. Changing base costs nothing: no rebuild, no fork,
+no per-model image.
 
 ```
 /payload/
-  py310/            cp310 deps + infera + kvd    (SGLang bases)
-  py312/            cp312 deps + infera + kvd    (vLLM bases)
-  bin/infera-router the Rust data plane (links only libc/libstdc++)
-  bin/infera-exec   picks the tree matching the container's Python, then execs
+  py310/                  cp310 deps + infera + kvd        (SGLang bases)
+  py312/                  cp312 deps + infera + kvd        (vLLM bases)
+  native/rocm7-py312/     mooncake + hipFile + their libs
+  bin/infera-router       the Rust data plane
+  bin/infera-exec         picks the trees matching this container, then execs
 ```
 
-## Why this split
+## Why everything can be overlaid
 
-| Component | Bound to | Overlay? |
+The engine images exist because some of what we ship is compiled. But none of it
+binds the *specific vendor image* — only coarse, stable interfaces:
+
+| Component | Actually binds | Overlay key |
 |---|---|---|
-| infera, kvd | nothing — pure Python | yes |
-| infera-router | libc/libstdc++ only | yes |
-| libionic | the host kernel, not the image | yes (already injected at start) |
-| aiter kernels | JIT-compiled per arch at runtime | yes (share `~/.aiter/build`) |
-| **Mooncake `engine.so`** | CPython minor **and** `libamdhip64.so.7` + 6 system libs | **no — stays in the engine image** |
-| **hipFile** | the ROCm version | **no** |
+| infera, kvd | nothing — pure Python | — |
+| infera-router | `libc`/`libstdc++` only | — |
+| infera deps (msgspec, xxhash, pyzmq, msgpack) | CPython minor | `py3XX` |
+| **Mooncake** | CPython minor + ROCm major + ~40 system libs | `rocmN-py3XX` |
+| **hipFile** | ROCm major | `rocmN-py3XX` |
+| libionic | the host kernel, not the image | injected at start |
+| aiter kernels | GPU arch, JIT-compiled at run time | cache `~/.aiter/build` |
 
-Four dependencies are C extensions (msgspec, xxhash, pyzmq, msgpack), so the
-Python trees are per-CPython-minor. The vendor bases have split — vLLM ships
-3.12, SGLang ships 3.10 — so the image carries both and `infera-exec` selects.
+Mooncake's extension needs ~40 libraries (glog, jsoncpp, asio, gflags, …) a
+stock base does not ship, so the payload bundles them next to the `.so` and
+points `LD_LIBRARY_PATH` at the bundle — the same thing `auditwheel` does when
+it vendors deps into a manylinux wheel.
+
+The consequence: a payload is rebuilt only when the **ROCm major** or the
+**CPython minor** changes, not when the vendor image moves.
 
 ## Build
 
 ```bash
 docker build -f deploy/overlay/Dockerfile.payload -t infera-overlay:latest .
 ```
+
+`NATIVE_IMAGE` (default `rocm/infera:vllm-v0.1.1`) supplies the already-compiled
+Mooncake/hipFile/router; they are harvested rather than rebuilt, so the payload
+build is fast and reuses binaries that have already been validated.
 
 ## Use
 
@@ -45,24 +58,34 @@ docker run -v infera_payload:/payload:ro \
   python3 -m infera.engine.vllm --model ... --served-model-name ...
 ```
 
-In Kubernetes this is an initContainer that copies `/payload` into an `emptyDir`
-the engine container mounts, with the same `infera-exec` entrypoint.
+In Kubernetes: an initContainer copies `/payload` into an `emptyDir` the engine
+container mounts, with the same `infera-exec` entrypoint.
 
 ## Verified
 
-On MI355X, against **unmodified** vendor images:
+On MI355X against an **unmodified** `vllm/vllm-openai-rocm:kimi-k3`:
 
-- `vllm/vllm-openai-rocm:kimi-k3` (Python 3.12) — engine ready in 70 s and
-  serving `/v1/chat/completions`; `infera` resolves to `/payload/py312/infera`.
-- `rocm/infera:sglang-v0.1.1` (Python 3.10) — `infera` resolves to
-  `/payload/py310/infera`, C-extension deps import, `infera.engine.sglang` and
-  `infera.kvd` both present.
-- `infera-router` runs from the same payload on both.
+```
+1. infera      : /payload/py312/infera        (kvd + engine.vllm present)
+2. router      : Infera router data plane (Rust)
+3. mooncake    : TransferEngine OK            -> PD available
+4. hipFile     : libhipfile.so loaded
+   ais-check   : HIP runtime True, amdgpu True -> kvd GPU-direct L3 available
+```
 
-## One trap this handles for you
+Serving was verified separately end to end on the same stock image: engine ready
+in 70 s, `/v1/chat/completions` returning tokens. The cp310 tree was verified on
+`rocm/infera:sglang-v0.1.1` (Python 3.10).
 
-Python puts the working directory at `sys.path[0]`, **ahead of `PYTHONPATH`**.
-Vendor images that already ship infera set `WORKDIR` to its parent
-(`/opt/infera`), so the baked-in copy silently shadows the payload and the
-overlay appears to do nothing. `infera-exec` therefore `cd`s to `/` before
-exec'ing; override with `INFERA_EXEC_CHDIR` if a command needs its own cwd.
+## Two traps this handles for you
+
+**cwd beats PYTHONPATH.** Python puts the working directory at `sys.path[0]`,
+ahead of `PYTHONPATH`. Vendor images that already ship infera set `WORKDIR` to
+its parent, so the baked-in copy silently shadows the payload and the overlay
+appears to do nothing — this actually happened on the SGLang image during
+testing. `infera-exec` `cd`s to `/` first; override with `INFERA_EXEC_CHDIR`.
+
+**A missing native tree is not fatal, and should not be silent.** Aggregated
+serving needs no native tree at all. Only PD (Mooncake) and kvd's GPU-direct L3
+(hipFile) do, so `infera-exec` warns rather than failing; set
+`INFERA_REQUIRE_NATIVE=1` to make it an error on a PD deployment.

--- a/deploy/overlay/harvest_native.sh
+++ b/deploy/overlay/harvest_native.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+# Harvest the compiled pieces of the overlay out of an image that has them, into
+# /native/rocm<major>-py<minor>/, and record which capabilities that tree carries.
+#
+# Run once per ABI family. The families are (ROCm major, CPython minor) and the
+# vendor bases disagree: vLLM ships 3.12, SGLang 3.10. Neither Mooncake nor
+# hipFile can be shared across them, so each needs its own harvest from an image
+# built for that family.
+#
+# Not every family carries every capability, and that is not a defect:
+#
+#   mooncake   PD KV transport            both families
+#   hipfile    kvd GPU-direct L3          vLLM only, by design — the SGLang kvd
+#              (loads L3 into VRAM)       route goes through host memory, so its
+#                                         images never build hipFile
+#
+# So the tree writes a CAPABILITIES file naming what it actually has, and
+# infera-exec checks the capability a deployment asked for rather than guessing
+# from the directory's existence. A tree with mooncake and no hipfile is a
+# perfectly good SGLang tree; treating it as broken blocks working deployments.
+set -eu
+
+ROCM_MAJOR="$(readlink -f /opt/rocm/lib/libamdhip64.so.* 2>/dev/null \
+              | grep -oE 'so\.[0-9]+' | head -1 | cut -d. -f2)"
+PYTAG="py$(python3 -c 'import sys;print("%d%d"%sys.version_info[:2])')"
+: "${ROCM_MAJOR:?cannot determine ROCm major — is this a ROCm image?}"
+
+OUT="/native/rocm${ROCM_MAJOR}-${PYTAG}"
+mkdir -p "$OUT/lib" "$OUT/bin"
+echo "harvest: $OUT"
+CAPS=""
+
+# ---- Mooncake ---------------------------------------------------------------
+# The extension pulls ~40 system libraries (glog, jsoncpp, asio, gflags, ...)
+# that a stock vendor image does not ship. Bundling them next to the .so is what
+# lets the overlay work off-base; infera-exec points LD_LIBRARY_PATH at them.
+MC="$(python3 -c 'import mooncake,os;print(os.path.dirname(mooncake.__file__))' 2>/dev/null || true)"
+if [ -n "$MC" ]; then
+    cp -a "$MC" "$OUT/mooncake"
+    ldd "$MC"/engine*.so 2>/dev/null | awk '/=> \//{print $3}' \
+      | grep -vE 'libamdhip64|libc\.so|libm\.so|libstdc\+\+|libgcc_s|ld-linux|libpthread|libdl|librt|libnuma|libibverbs' \
+      | while read -r so; do cp -L "$so" "$OUT/lib/" 2>/dev/null || true; done
+    CAPS="${CAPS}mooncake "
+    echo "harvest:   mooncake <- $MC"
+else
+    echo "harvest:   mooncake ABSENT in this image"
+fi
+
+# ---- hipFile ----------------------------------------------------------------
+# libhipfile plus the ais-check probe. A missing ais-check silently downgrades
+# kvd's load path to a CPU bounce, so the capability is only claimed when the
+# library, the probe AND the Python module are all present.
+HF="$(python3 -c 'import hipfile,os;print(os.path.dirname(hipfile.__file__))' 2>/dev/null || true)"
+HAVE_LIB=0
+for f in /opt/rocm/lib/libhipfile.so*; do
+    [ -e "$f" ] || continue
+    cp -L "$f" "$OUT/lib/" 2>/dev/null && HAVE_LIB=1
+done
+cp /opt/rocm/bin/ais-check "$OUT/bin/" 2>/dev/null || true
+[ -n "$HF" ] && cp -a "$HF" "$OUT/hipfile" || true
+ln -sf libhipfile.so.0.3.0 "$OUT/lib/libhipfile.so.0" 2>/dev/null || true
+ln -sf libhipfile.so.0 "$OUT/lib/libhipfile.so" 2>/dev/null || true
+
+if [ "$HAVE_LIB" = 1 ] && [ -n "$HF" ] && [ -x "$OUT/bin/ais-check" ]; then
+    CAPS="${CAPS}hipfile "
+    echo "harvest:   hipfile <- $HF"
+else
+    echo "harvest:   hipfile ABSENT (expected on SGLang images — GPU-direct L3 is vLLM-only)"
+fi
+
+# One space-separated line — infera-exec word-matches against it.
+echo $CAPS > "$OUT/CAPABILITIES"
+echo "harvest: capabilities = [$(echo $CAPS)]"
+du -sh "$OUT"
+
+# A tree with neither capability is not worth shipping and means the harvest
+# image was wrong — fail the build rather than emit an empty directory that
+# infera-exec would later report as a missing payload.
+[ -n "$CAPS" ] || { echo "harvest: FATAL — no capabilities found" >&2; exit 1; }

--- a/deploy/overlay/infera-exec
+++ b/deploy/overlay/infera-exec
@@ -1,37 +1,59 @@
 #!/bin/sh
-# Select the payload tree matching this container's Python, then exec the command.
+# Select the payload trees matching this container, then exec the command.
 #
-# The overlay ships one tree per CPython minor because four of infera's
-# dependencies (msgspec, xxhash, pyzmq, msgpack) are C extensions; the vendor
-# bases disagree (vLLM 3.12, SGLang 3.10). This picks the right one instead of
-# making the caller know which base they are on.
+# The overlay ships one Python tree per CPython minor (four of infera's
+# dependencies are C extensions) and one native tree per (ROCm major, CPython
+# minor) — Mooncake and hipFile are compiled and bind both. The vendor bases
+# disagree on all of it (vLLM ships Python 3.12, SGLang 3.10), so this picks the
+# right trees instead of making the caller know which base they are on.
 #
 #   docker run -v infera_payload:/payload:ro \
 #     --entrypoint /payload/bin/infera-exec <vendor image> \
 #     python3 -m infera.engine.vllm --model ...
 #
-# PAYLOAD_ROOT defaults to this script's parent-of-parent, so it works from a
-# read-only mount at any path.
+# A missing native tree is not fatal: aggregated serving needs none of it. Only
+# PD (Mooncake KV transfer) and kvd's GPU-direct L3 (hipFile) do, and those warn.
 set -eu
 
 SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 PAYLOAD_ROOT="${PAYLOAD_ROOT:-$(dirname -- "$SELF_DIR")}"
 
 PY="${INFERA_PYTHON:-python3}"
-TAG=$("$PY" -c 'import sys; print("py%d%d" % sys.version_info[:2])')
-TREE="$PAYLOAD_ROOT/$TAG"
+PYTAG=$("$PY" -c 'import sys; print("py%d%d" % sys.version_info[:2])')
+PYTREE="$PAYLOAD_ROOT/$PYTAG"
 
-if [ ! -d "$TREE" ]; then
-    echo "infera-exec: no payload for $TAG in $PAYLOAD_ROOT" >&2
+if [ ! -d "$PYTREE" ]; then
+    echo "infera-exec: no Python payload for $PYTAG in $PAYLOAD_ROOT" >&2
     echo "infera-exec: available: $(ls -d "$PAYLOAD_ROOT"/py* 2>/dev/null | xargs -n1 basename | tr '\n' ' ')" >&2
     exit 1
 fi
 
-# Prepend the payload so `infera` resolves; keep any caller-supplied PYTHONPATH.
-PYTHONPATH="$TREE${PYTHONPATH:+:$PYTHONPATH}"
-export PYTHONPATH
+PYTHONPATH="$PYTREE${PYTHONPATH:+:$PYTHONPATH}"
 PATH="$PAYLOAD_ROOT/bin:$PATH"
-export PATH
+
+# --- native tree: Mooncake (PD) and hipFile (kvd GPU-direct L3) --------------
+# Keyed by the ROCm major from the container's own libamdhip64 soname, since a
+# vendor bump can move it.
+ROCM_MAJOR=$(readlink -f /opt/rocm/lib/libamdhip64.so.* 2>/dev/null \
+             | grep -oE 'so\.[0-9]+' | head -1 | cut -d. -f2)
+if [ -n "${ROCM_MAJOR:-}" ]; then
+    NATIVE="$PAYLOAD_ROOT/native/rocm${ROCM_MAJOR}-${PYTAG}"
+    if [ -d "$NATIVE" ]; then
+        PYTHONPATH="$NATIVE:$PYTHONPATH"
+        LD_LIBRARY_PATH="$NATIVE/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+        PATH="$NATIVE/bin:$PATH"
+        export LD_LIBRARY_PATH
+    elif [ "${INFERA_REQUIRE_NATIVE:-0}" = "1" ]; then
+        echo "infera-exec: no native payload for rocm${ROCM_MAJOR}-${PYTAG}" >&2
+        echo "infera-exec: available: $(ls -d "$PAYLOAD_ROOT"/native/* 2>/dev/null | xargs -n1 basename | tr '\n' ' ')" >&2
+        exit 1
+    else
+        echo "infera-exec: no native payload for rocm${ROCM_MAJOR}-${PYTAG};" \
+             "PD (Mooncake) and kvd GPU-direct L3 (hipFile) will be unavailable." >&2
+    fi
+fi
+
+export PYTHONPATH PATH
 
 # Python puts the working directory at sys.path[0] — ahead of PYTHONPATH. Vendor
 # images that already ship infera set WORKDIR to its parent (e.g. /opt/infera),

--- a/deploy/overlay/infera-exec
+++ b/deploy/overlay/infera-exec
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Select the payload tree matching this container's Python, then exec the command.
+#
+# The overlay ships one tree per CPython minor because four of infera's
+# dependencies (msgspec, xxhash, pyzmq, msgpack) are C extensions; the vendor
+# bases disagree (vLLM 3.12, SGLang 3.10). This picks the right one instead of
+# making the caller know which base they are on.
+#
+#   docker run -v infera_payload:/payload:ro \
+#     --entrypoint /payload/bin/infera-exec <vendor image> \
+#     python3 -m infera.engine.vllm --model ...
+#
+# PAYLOAD_ROOT defaults to this script's parent-of-parent, so it works from a
+# read-only mount at any path.
+set -eu
+
+SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+PAYLOAD_ROOT="${PAYLOAD_ROOT:-$(dirname -- "$SELF_DIR")}"
+
+PY="${INFERA_PYTHON:-python3}"
+TAG=$("$PY" -c 'import sys; print("py%d%d" % sys.version_info[:2])')
+TREE="$PAYLOAD_ROOT/$TAG"
+
+if [ ! -d "$TREE" ]; then
+    echo "infera-exec: no payload for $TAG in $PAYLOAD_ROOT" >&2
+    echo "infera-exec: available: $(ls -d "$PAYLOAD_ROOT"/py* 2>/dev/null | xargs -n1 basename | tr '\n' ' ')" >&2
+    exit 1
+fi
+
+# Prepend the payload so `infera` resolves; keep any caller-supplied PYTHONPATH.
+PYTHONPATH="$TREE${PYTHONPATH:+:$PYTHONPATH}"
+export PYTHONPATH
+PATH="$PAYLOAD_ROOT/bin:$PATH"
+export PATH
+
+# Python puts the working directory at sys.path[0] — ahead of PYTHONPATH. Vendor
+# images that already ship infera set WORKDIR to its parent (e.g. /opt/infera),
+# so the baked-in copy would silently shadow this payload and the overlay would
+# appear to do nothing. Move to a directory that cannot contain an importable
+# `infera`. Override with INFERA_EXEC_CHDIR if a command needs its own cwd.
+cd "${INFERA_EXEC_CHDIR:-/}"
+
+exec "$@"

--- a/deploy/overlay/infera-exec
+++ b/deploy/overlay/infera-exec
@@ -38,19 +38,47 @@ ROCM_MAJOR=$(readlink -f /opt/rocm/lib/libamdhip64.so.* 2>/dev/null \
              | grep -oE 'so\.[0-9]+' | head -1 | cut -d. -f2)
 if [ -n "${ROCM_MAJOR:-}" ]; then
     NATIVE="$PAYLOAD_ROOT/native/rocm${ROCM_MAJOR}-${PYTAG}"
+    HAVE=""
     if [ -d "$NATIVE" ]; then
         PYTHONPATH="$NATIVE:$PYTHONPATH"
         LD_LIBRARY_PATH="$NATIVE/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
         PATH="$NATIVE/bin:$PATH"
         export LD_LIBRARY_PATH
-    elif [ "${INFERA_REQUIRE_NATIVE:-0}" = "1" ]; then
-        echo "infera-exec: no native payload for rocm${ROCM_MAJOR}-${PYTAG}" >&2
-        echo "infera-exec: available: $(ls -d "$PAYLOAD_ROOT"/native/* 2>/dev/null | xargs -n1 basename | tr '\n' ' ')" >&2
-        exit 1
+        # Normalise to one spaced line: the word-match below needs space delimiters.
+        HAVE=$(tr '\n' ' ' < "$NATIVE/CAPABILITIES" 2>/dev/null || echo "mooncake hipfile")
     else
         echo "infera-exec: no native payload for rocm${ROCM_MAJOR}-${PYTAG};" \
              "PD (Mooncake) and kvd GPU-direct L3 (hipFile) will be unavailable." >&2
     fi
+
+    # INFERA_REQUIRE_NATIVE names the capabilities this deployment actually needs
+    # ("mooncake", "hipfile", or both, comma- or space-separated). A deployment
+    # that needs none leaves it unset.
+    #
+    # It is deliberately per-capability rather than a yes/no on the tree. The
+    # families do not carry the same things — hipFile is vLLM-only, because kvd's
+    # GPU-direct L3 is a vLLM-only path — so "the tree is complete" is the wrong
+    # question. Asking it would reject two configurations that work: SGLang PD,
+    # whose tree correctly has no hipFile, and SGLang kvd, which reaches its L2
+    # and file L3 through HiCacheStorage and needs no native code at all.
+    #
+    # Accepts 1/true/all for "everything this family can provide".
+    REQ="${INFERA_REQUIRE_NATIVE:-}"
+    case "$REQ" in
+        1|true|all) REQ="$HAVE"; [ -n "$REQ" ] || REQ="mooncake" ;;
+        0|"") REQ="" ;;
+    esac
+    for cap in $(echo "$REQ" | tr ',' ' '); do
+        case " $HAVE " in
+            *" $cap "*) ;;
+            *)
+                echo "infera-exec: required native capability '$cap' is not in the payload" >&2
+                echo "infera-exec: tree rocm${ROCM_MAJOR}-${PYTAG} provides: [${HAVE:-none}]" >&2
+                echo "infera-exec: available trees: $(ls -d "$PAYLOAD_ROOT"/native/* 2>/dev/null | xargs -n1 basename | tr '\n' ' ')" >&2
+                [ "$cap" = hipfile ] && echo "infera-exec: note — hipfile (kvd GPU-direct L3) is a vLLM-only capability" >&2
+                exit 1 ;;
+        esac
+    done
 fi
 
 export PYTHONPATH PATH

--- a/deploy/overlay/prune_base_dists.py
+++ b/deploy/overlay/prune_base_dists.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Delete payload distributions the vendor base already provides.
+
+The overlay's Python trees are built with `pip install --target`, and --target
+*ignores the environment*: pip installs the full transitive closure whether or
+not the base already has it. That quietly breaks the property the baked engine
+images relied on — a plain `pip install` onto the base leaves already-satisfied
+requirements untouched and pulls only what is missing.
+
+The cost is not merely size. A --target tree lands FIRST on PYTHONPATH, so every
+duplicate SHADOWS the vendor's copy at whatever version PyPI happened to resolve.
+Measured against vllm/vllm-openai-rocm on 2026-07-31, an unpruned tree carried 52
+distributions of which exactly two were new, and eleven shadowed the base at a
+different version:
+
+    numpy         2.5.1  over 2.3.5    <- broke the base's numba on import
+    cryptography 50.0.0  over 3.4.8
+    protobuf      7.35.1 over 6.33.6
+    grpcio        1.83.0 over 1.78.0
+    ...
+
+So: run this inside the vendor base after the --target install. Whatever the base
+already ships is removed from the tree and the base's own copy is used, exactly as
+in the baked images. What remains is genuinely additive — infera plus the handful
+of packages no vendor base carries.
+
+    python3 prune_base_dists.py /payload/py312
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata as md
+import shutil
+import sys
+from pathlib import Path
+
+# Never prune these even if the base happens to ship a copy: they ARE the payload.
+KEEP = {"amd-infera"}
+
+
+def _canon(name: str) -> str:
+    return name.lower().replace("_", "-").replace(".", "-")
+
+
+def _base_distributions(tree: Path) -> dict[str, str]:
+    """Distributions visible in the running interpreter, excluding the tree itself."""
+    tree = tree.resolve()
+    found: dict[str, str] = {}
+    for dist in md.distributions():
+        located = getattr(dist, "_path", None)
+        if located is not None and tree in Path(located).resolve().parents:
+            continue  # a dist inside the tree we are pruning, not the base's
+        name = dist.metadata["Name"]
+        if name:
+            found[_canon(name)] = dist.version or "?"
+    return found
+
+
+def _files_of(dist_info: Path, tree: Path) -> list[Path]:
+    """Paths a distribution owns, from its RECORD (relative to the tree)."""
+    record = dist_info / "RECORD"
+    if not record.is_file():
+        return [dist_info]
+    paths: list[Path] = []
+    with record.open(newline="", encoding="utf-8") as fh:
+        for row in csv.reader(fh):
+            if not row or not row[0]:
+                continue
+            target = (tree / row[0]).resolve()
+            if tree.resolve() in target.parents:  # never escape the tree
+                paths.append(target)
+    paths.append(dist_info)
+    return paths
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <payload-tree>", file=sys.stderr)
+        return 2
+    tree = Path(sys.argv[1])
+    if not tree.is_dir():
+        print(f"prune: {tree} is not a directory", file=sys.stderr)
+        return 2
+
+    base = _base_distributions(tree)
+    pruned: list[str] = []
+    kept: list[str] = []
+
+    for dist_info in sorted(tree.glob("*.dist-info")):
+        name = dist_info.name.rsplit("-", 2)[0]
+        canon = _canon(name)
+        if canon in KEEP:
+            kept.append(f"{name} (payload)")
+            continue
+        if canon not in base:
+            kept.append(name)
+            continue
+
+        for path in _files_of(dist_info, tree):
+            if path.is_dir() and not path.is_symlink():
+                shutil.rmtree(path, ignore_errors=True)
+            else:
+                path.unlink(missing_ok=True)
+        shutil.rmtree(dist_info, ignore_errors=True)
+        pruned.append(f"{name} (base has {base[canon]})")
+
+    # Empty package directories left behind once their files are gone.
+    for _ in range(4):  # nested packages need a few passes
+        for path in sorted(tree.rglob("*"), key=lambda p: -len(p.parts)):
+            if path.is_dir() and not path.is_symlink() and not any(path.iterdir()):
+                path.rmdir()
+
+    print(f"prune: {tree}")
+    print(f"prune: removed {len(pruned)} distribution(s) the base already provides")
+    for line in pruned:
+        print(f"  - {line}")
+    print(f"prune: kept {len(kept)} — this is what the overlay actually adds")
+    for line in kept:
+        print(f"  + {line}")
+
+    if not any(k.endswith("(payload)") for k in kept):
+        print("prune: FATAL — infera itself is missing from the tree", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/k8s-deployments/RECIPE-single-node.md
+++ b/examples/k8s-deployments/RECIPE-single-node.md
@@ -18,7 +18,7 @@ engines is *not* just the image; four coupled things change, all on the worker:
 | | SGLang | vLLM |
 |---|---|---|
 | `spec.backendFramework` | `sglang` | `vllm` |
-| container `image` | `rocm/infera:sglang-v0.1.1` | `inferaimage/infera:vllm-v0.1.0-rc5` |
+| container `image` | `rocm/infera:sglang-v0.1.1` | `rocm/infera:vllm-v0.1.1` |
 | worker module | `infera.engine.sglang` | `infera.engine.vllm` |
 | engine flags | `--model-path … --tp-size 1 --attention-backend aiter --mem-fraction-static 0.8` | `--model … --tensor-parallel-size 1 --gpu-memory-utilization 0.85` |
 

--- a/examples/k8s-deployments/RECIPE-single-node.md
+++ b/examples/k8s-deployments/RECIPE-single-node.md
@@ -18,7 +18,7 @@ engines is *not* just the image; four coupled things change, all on the worker:
 | | SGLang | vLLM |
 |---|---|---|
 | `spec.backendFramework` | `sglang` | `vllm` |
-| container `image` | `rocm/infera:sglang-v0.1.1` | `rocm/infera:vllm-v0.1.1` |
+| container `image` | `rocm/infera:sglang-v0.1.1` | `rocm/infera:vllm-v0.1.2` |
 | worker module | `infera.engine.sglang` | `infera.engine.vllm` |
 | engine flags | `--model-path … --tp-size 1 --attention-backend aiter --mem-fraction-static 0.8` | `--model … --tensor-parallel-size 1 --gpu-memory-utilization 0.85` |
 

--- a/examples/k8s-deployments/RECIPE-single-node.md
+++ b/examples/k8s-deployments/RECIPE-single-node.md
@@ -18,7 +18,7 @@ engines is *not* just the image; four coupled things change, all on the worker:
 | | SGLang | vLLM |
 |---|---|---|
 | `spec.backendFramework` | `sglang` | `vllm` |
-| container `image` | `rocm/infera:sglang-v0.1.1` | `rocm/infera:vllm-v0.1.2` |
+| container `image` | `rocm/infera:sglang-v0.1.1` | `rocm/infera:vllm-v0.1.1` |
 | worker module | `infera.engine.sglang` | `infera.engine.vllm` |
 | engine flags | `--model-path … --tp-size 1 --attention-backend aiter --mem-fraction-static 0.8` | `--model … --tensor-parallel-size 1 --gpu-memory-utilization 0.85` |
 

--- a/examples/k8s-deployments/RECIPE-single-node.md
+++ b/examples/k8s-deployments/RECIPE-single-node.md
@@ -1,0 +1,84 @@
+# Recipe: single-node aggregated (Qwen3-0.6B), vLLM & SGLang
+
+A concrete, copy-paste recipe that brings up one `InferaDeployment` (router +
+1 GPU worker) and serves an OpenAI-compatible endpoint — the infera analog of a
+vendor "recipe". Two engine variants, **validated end to end on single-node k3s
+(MI355X, `amd.com/gpu`)**:
+
+| Variant | Manifest | Worker entrypoint |
+|---|---|---|
+| SGLang | `single-node-qwen-sglang.yaml` | `infera.engine.sglang` |
+| vLLM | `single-node-qwen-vllm.yaml` | `infera.engine.vllm` |
+
+## sglang vs vllm — what differs
+
+The **router/server is engine-agnostic and identical** across both. Swapping
+engines is *not* just the image; four coupled things change, all on the worker:
+
+| | SGLang | vLLM |
+|---|---|---|
+| `spec.backendFramework` | `sglang` | `vllm` |
+| container `image` | `rocm/infera:sglang-v0.1.1` | `inferaimage/infera:vllm-v0.1.0-rc5` |
+| worker module | `infera.engine.sglang` | `infera.engine.vllm` |
+| engine flags | `--model-path … --tp-size 1 --attention-backend aiter --mem-fraction-static 0.8` | `--model … --tensor-parallel-size 1 --gpu-memory-utilization 0.85` |
+
+The two CLIs differ (`--model-path`/`--tp-size` vs `--model`/`--tensor-parallel-size`),
+so the worker `command` must match the engine — you cannot reuse one manifest and
+only change the image.
+
+## Prerequisites
+
+1. A Kubernetes cluster. Single node is fine — e.g. k3s **with its data-dir on a
+   big disk** so image imports don't fill root:
+   ```bash
+   curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--write-kubeconfig-mode=644 --data-dir /mnt/<big-disk>/k3s" sh -
+   export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+   ```
+2. AMD GPU device plugin (exposes `amd.com/gpu`):
+   ```bash
+   kubectl apply -f https://raw.githubusercontent.com/ROCm/k8s-device-plugin/master/k8s-ds-amdgpu-dp.yaml
+   kubectl describe node <node> | grep amd.com/gpu   # -> amd.com/gpu: 8
+   ```
+3. The infera-operator (CRD + controller); no LWS/NATS needed for single-node aggregated:
+   ```bash
+   INSTALL_LWS=false INSTALL_NATS=false ../../deploy/scripts/deploy-k8s.sh
+   ```
+4. Engine image present in the **node container runtime**. k3s uses containerd
+   (not docker), so import a local image into it (tar, not a stream):
+   ```bash
+   docker save rocm/infera:sglang-v0.1.1 -o /tmp/img.tar
+   sudo k3s ctr images import /tmp/img.tar
+   ```
+5. Model on a host dir the pod hostPath-mounts at `/models`:
+   ```bash
+   python3 -c 'from huggingface_hub import snapshot_download as d; d("Qwen/Qwen3-0.6B", local_dir="/mnt/<big-disk>/models/qwen/Qwen3-0.6B")'
+   ```
+
+## Deploy & verify
+
+```bash
+kubectl create namespace infera
+kubectl apply -f single-node-qwen-sglang.yaml     # or single-node-qwen-vllm.yaml
+
+# operator reconciles the CR into server+worker Deployments, a ClusterIP :8000
+# and the k8s-discovery ServiceAccount; wait for it to go ready:
+kubectl -n infera get inferadeployment -w         # STATE -> ready (~2-3 min: model load + graphs)
+kubectl -n infera get pods                        # server 1/1, worker 1/1
+
+# call it (port-forward, or curl the ClusterIP from the node):
+kubectl -n infera port-forward svc/qwen-agg-server 8000:8000 &
+curl -s localhost:8000/v1/chat/completions -H 'Content-Type: application/json' \
+  -d '{"model":"/models/Qwen3-0.6B","messages":[{"role":"user","content":"What is Kubernetes?"}],"max_tokens":64}'
+```
+
+(For the vLLM variant the served model name is `Qwen3-0.6B` and the service is
+`qwen-agg-vllm-server`.) A real completion in `choices[0].message.content`
+confirms the operator → router → engine path end to end.
+
+## Notes
+- `hostPath` keeps the recipe self-contained (no CSI). For a real cluster use a
+  PVC instead (see `pvc-models.yaml` + `single-node-aggregated.yaml`).
+- Model mount requires `extraPodSpec` with an explicit `command`; the operator's
+  simpler `args` mode auto-builds the entrypoint but only mounts dshm + `/boot`.
+- k3s image imports land under `--data-dir`; putting that on a large disk avoids
+  the DiskPressure eviction you get when 30–80 GB engine images fill root.

--- a/examples/k8s-deployments/glm5.2-sglang.yaml
+++ b/examples/k8s-deployments/glm5.2-sglang.yaml
@@ -1,0 +1,93 @@
+# GLM-5.2-MXFP4 (GlmMoeDsaForCausalLM) — single-node aggregated, SGLang, TP8.
+# GLM-5.2 uses MLA + DeepSeek Sparse Attention (DSA); SGLang is the correct and
+# fastest engine for it on ROCm (vLLM runs but its MLA/DSA decode is numerically
+# buggy -> "!!!!" garbage). Validated on k3s (MI355X): worker Ready ~6 min,
+# coherent output via the router.
+#
+# CRITICAL ENV (below): the base SGLang defaults a CUDA-only DSA top-k JIT kernel
+# that will not build on gfx950 and crashes at init. The SGLANG_OPT_* flags force
+# the ROCm tilelang path instead. Do not drop them.
+#
+# Adjust for your node: image (rocm/infera:sglang-v0.1.1, sglang 0.5.15+ — older
+# rocm sglang can't load GLM-5.2's new head_dim), and the model hostPath.
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: glm52
+  namespace: infera
+spec:
+  backendFramework: sglang
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.1
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","/models/GLM-5.2-MXFP4",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources:
+              requests: {cpu: "8", memory: 16Gi}
+              limits: {cpu: "8", memory: 16Gi}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+        volumes:
+          - {name: model, hostPath: {path: /mnt/vast/xiaobo/models, type: Directory}}
+    worker:
+      componentType: worker
+      role: mixed
+      replicas: 1
+      extraPodSpec:
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.1
+            imagePullPolicy: IfNotPresent
+            # DSA backends + fp8 KV (SGLang handles fp8 MLA KV correctly for GLM-5.2).
+            # --context-length: production uses up to 400000; keep modest to bound the
+            # KV pool. --chunked-prefill-size 8192 (DSA indexer profiling OOMs higher).
+            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--model-path","/models/GLM-5.2-MXFP4","--served-model-name","glm5.2-mxfp4",
+                      "--tp-size","8","--trust-remote-code",
+                      "--nsa-prefill-backend","tilelang","--nsa-decode-backend","tilelang",
+                      "--kv-cache-dtype","fp8_e4m3","--mem-fraction-static","0.85",
+                      "--context-length","32768","--chunked-prefill-size","8192",
+                      "--max-running-requests","24","--cuda-graph-max-bs","24",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              # --- ROCm DSA top-k fix (REQUIRED; base defaults crash init on gfx950) ---
+              - {name: SGLANG_OPT_USE_TILELANG_INDEXER, value: "1"}
+              - {name: SGLANG_OPT_USE_TOPK_V2, value: "0"}
+              - {name: SGLANG_OPT_USE_JIT_NORM, value: "0"}
+              - {name: SGLANG_USE_AITER, value: "1"}
+              - {name: SGLANG_ROCM_FUSED_DECODE_MLA, value: "0"}
+              # --- perf / quant ---
+              - {name: ROCM_QUICK_REDUCE_QUANTIZATION, value: "INT4"}
+              - {name: SAFETENSORS_FAST_GPU, value: "1"}
+              - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
+              - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
+            startupProbe:
+              httpGet: {path: /health, port: 30000}
+              periodSeconds: 10
+              timeoutSeconds: 10
+              failureThreshold: 180   # ~30 min: weights (~408 GiB) + DSA graph capture
+            resources:
+              requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+              limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+        volumes:
+          - {name: model, hostPath: {path: /mnt/vast/xiaobo/models, type: Directory}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 64Gi}}

--- a/examples/k8s-deployments/kimi-k3-vllm.yaml
+++ b/examples/k8s-deployments/kimi-k3-vllm.yaml
@@ -3,19 +3,17 @@
 # Kimi-K3 checkpoint. Structure is validated (operator reconcile + model-cache);
 # see the caveat below before expecting this to serve.
 #
-# ┌─ IMAGE ────────────────────────────────────────────────────────────────────┐
-# │ `inferaimage/infera:vllm-kimi-k3` = infera (server/router + infera.engine.   │
-# │ vllm) layered onto the upstream `vllm/vllm-openai-rocm:kimi-k3` build, which  │
-# │ is the vLLM that carries kimi_k3 model support (KimiK3ForConditionalGen).     │
-# │ Build it from the repo root:                                                  │
-# │   docker build -f deploy/docker/Dockerfile.vllm \                             │
-# │     --build-arg VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3 \               │
-# │     --build-arg BUILD_AITER=0 --build-arg BUILD_MOONCAKE=0 \                  │
-# │     --build-arg BUILD_HIPFILE=0 --build-arg INSTALL_LIBIONIC=0 \              │
-# │     -t inferaimage/infera:vllm-kimi-k3 .                                      │
-# │ (aiter stays the base's kimi-tuned build; the disabled layers are RDMA-PD /   │
-# │ kvd-L3 only, not needed for single-node aggregated serving.)                  │
-# └─────────────────────────────────────────────────────────────────────────────┘
+# IMAGE: rocm/infera:vllm-kimi-k3 = infera (server/router + infera.engine.vllm)
+# layered onto the upstream vllm/vllm-openai-rocm:kimi-k3 build — the vLLM that
+# carries kimi_k3 model support (KimiK3ForConditionalGeneration). Build it from
+# the repo root:
+#   docker build -f deploy/docker/Dockerfile.vllm \
+#     --build-arg VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3 \
+#     --build-arg BUILD_AITER=0 --build-arg BUILD_MOONCAKE=0 \
+#     --build-arg BUILD_HIPFILE=0 --build-arg INSTALL_LIBIONIC=0 \
+#     -t rocm/infera:vllm-kimi-k3 .
+# (aiter stays the base's kimi-tuned build; the disabled layers are RDMA-PD /
+# kvd-L3 only, not needed for single-node aggregated serving.)
 apiVersion: infera.amd.com/v1alpha1
 kind: InferaDeployment
 metadata:
@@ -32,7 +30,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: inferaimage/infera:vllm-kimi-k3   # see IMAGE below
+            image: rocm/infera:vllm-kimi-k3   # see IMAGE below
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/Kimi-K3",
@@ -58,7 +56,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: inferaimage/infera:vllm-kimi-k3   # see IMAGE below
+            image: rocm/infera:vllm-kimi-k3   # see IMAGE below
             imagePullPolicy: IfNotPresent
             # vLLM flags mirror examples/kimi_k3/vllm_serve.sh (TP8, mm data-parallel
             # encoder, kimi_k3 tool/reasoning parsers), routed through infera.engine.vllm.

--- a/examples/k8s-deployments/kimi-k3-vllm.yaml
+++ b/examples/k8s-deployments/kimi-k3-vllm.yaml
@@ -50,9 +50,6 @@ spec:
       componentType: worker
       role: mixed
       replicas: 1
-      # Kimi-K3 loads ~1.5 TB over ~7 min; skip the readiness probe so the operator
-      # doesn't restart the pod mid-load.
-      skipReadinessProbe: true
       extraPodSpec:
         containers:
           - name: main
@@ -83,6 +80,14 @@ spec:
               - {name: AITER_BF16_FP8_MOE_BOUND, value: "0"}
               - {name: SAFETENSORS_FAST_GPU, value: "1"}
               - {name: VLLM_USE_BREAKABLE_CUDAGRAPH, value: "0"}
+            # Kimi-K3 loads ~1.5 TB (~9 min); a generous startupProbe holds the pod
+            # non-Ready through the load, then the operator's /health readiness probe
+            # (gated by startup) takes over — cleaner than skipReadinessProbe.
+            startupProbe:
+              httpGet: {path: /health, port: 30000}
+              periodSeconds: 10
+              timeoutSeconds: 10
+              failureThreshold: 120   # up to ~20 min: weights + CUDA-graph capture
             resources:
               requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
               limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}

--- a/examples/k8s-deployments/kimi-k3-vllm.yaml
+++ b/examples/k8s-deployments/kimi-k3-vllm.yaml
@@ -3,17 +3,11 @@
 # Kimi-K3 checkpoint. Structure is validated (operator reconcile + model-cache);
 # see the caveat below before expecting this to serve.
 #
-# IMAGE: rocm/infera:vllm-kimi-k3 = infera (server/router + infera.engine.vllm)
-# layered onto the upstream vllm/vllm-openai-rocm:kimi-k3 build — the vLLM that
-# carries kimi_k3 model support (KimiK3ForConditionalGeneration). Build it from
-# the repo root:
-#   docker build -f deploy/docker/Dockerfile.vllm \
-#     --build-arg VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3 \
-#     --build-arg BUILD_AITER=0 --build-arg BUILD_MOONCAKE=0 \
-#     --build-arg BUILD_HIPFILE=0 --build-arg INSTALL_LIBIONIC=0 \
-#     -t rocm/infera:vllm-kimi-k3 .
-# (aiter stays the base's kimi-tuned build; the disabled layers are RDMA-PD /
-# kvd-L3 only, not needed for single-node aggregated serving.)
+# IMAGE: rocm/infera:vllm-v0.1.2 = the canonical infera vLLM image. Its base is
+# now the vLLM kimi-k3 build (see deploy/docker/Dockerfile.vllm), so it carries
+# kimi_k3 model support (KimiK3ForConditionalGeneration) out of the box. Build the
+# standard way from the repo root:
+#   docker build -f deploy/docker/Dockerfile.vllm -t rocm/infera:vllm-v0.1.2 .
 apiVersion: infera.amd.com/v1alpha1
 kind: InferaDeployment
 metadata:
@@ -30,7 +24,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: rocm/infera:vllm-kimi-k3   # see IMAGE below
+            image: rocm/infera:vllm-v0.1.2   # see IMAGE below
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/Kimi-K3",
@@ -53,7 +47,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: rocm/infera:vllm-kimi-k3   # see IMAGE below
+            image: rocm/infera:vllm-v0.1.2   # see IMAGE below
             imagePullPolicy: IfNotPresent
             # vLLM flags mirror examples/kimi_k3/vllm_serve.sh (TP8, mm data-parallel
             # encoder, kimi_k3 tool/reasoning parsers), routed through infera.engine.vllm.

--- a/examples/k8s-deployments/kimi-k3-vllm.yaml
+++ b/examples/k8s-deployments/kimi-k3-vllm.yaml
@@ -3,11 +3,17 @@
 # Kimi-K3 checkpoint. Structure is validated (operator reconcile + model-cache);
 # see the caveat below before expecting this to serve.
 #
-# IMAGE: rocm/infera:vllm-v0.1.2 = the canonical infera vLLM image. Its base is
-# now the vLLM kimi-k3 build (see deploy/docker/Dockerfile.vllm), so it carries
-# kimi_k3 model support (KimiK3ForConditionalGeneration) out of the box. Build the
-# standard way from the repo root:
-#   docker build -f deploy/docker/Dockerfile.vllm -t rocm/infera:vllm-v0.1.2 .
+# IMAGE: rocm/infera:vllm-kimi-k3 = infera (server/router + infera.engine.vllm)
+# layered onto the upstream vllm/vllm-openai-rocm:kimi-k3 build — the vLLM that
+# carries kimi_k3 model support (KimiK3ForConditionalGeneration). Build it from
+# the repo root:
+#   docker build -f deploy/docker/Dockerfile.vllm \
+#     --build-arg VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3 \
+#     --build-arg BUILD_AITER=0 --build-arg BUILD_MOONCAKE=0 \
+#     --build-arg BUILD_HIPFILE=0 --build-arg INSTALL_LIBIONIC=0 \
+#     -t rocm/infera:vllm-kimi-k3 .
+# (aiter stays the base's kimi-tuned build; the disabled layers are RDMA-PD /
+# kvd-L3 only, not needed for single-node aggregated serving.)
 apiVersion: infera.amd.com/v1alpha1
 kind: InferaDeployment
 metadata:
@@ -24,7 +30,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: rocm/infera:vllm-v0.1.2   # see IMAGE below
+            image: rocm/infera:vllm-kimi-k3   # see IMAGE below
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/Kimi-K3",
@@ -47,7 +53,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: rocm/infera:vllm-v0.1.2   # see IMAGE below
+            image: rocm/infera:vllm-kimi-k3   # see IMAGE below
             imagePullPolicy: IfNotPresent
             # vLLM flags mirror examples/kimi_k3/vllm_serve.sh (TP8, mm data-parallel
             # encoder, kimi_k3 tool/reasoning parsers), routed through infera.engine.vllm.

--- a/examples/k8s-deployments/kimi-k3-vllm.yaml
+++ b/examples/k8s-deployments/kimi-k3-vllm.yaml
@@ -1,0 +1,96 @@
+# Kimi-K3 (VLM) — single-node aggregated, vLLM, TP8, one 8-GPU node.
+# Mounts the model-cache PVC (model-cache/) at /models and serves the multimodal
+# Kimi-K3 checkpoint. Structure is validated (operator reconcile + model-cache);
+# see the caveat below before expecting this to serve.
+#
+# ┌─ IMAGE ────────────────────────────────────────────────────────────────────┐
+# │ `inferaimage/infera:vllm-kimi-k3` = infera (server/router + infera.engine.   │
+# │ vllm) layered onto the upstream `vllm/vllm-openai-rocm:kimi-k3` build, which  │
+# │ is the vLLM that carries kimi_k3 model support (KimiK3ForConditionalGen).     │
+# │ Build it from the repo root:                                                  │
+# │   docker build -f deploy/docker/Dockerfile.vllm \                             │
+# │     --build-arg VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3 \               │
+# │     --build-arg BUILD_AITER=0 --build-arg BUILD_MOONCAKE=0 \                  │
+# │     --build-arg BUILD_HIPFILE=0 --build-arg INSTALL_LIBIONIC=0 \              │
+# │     -t inferaimage/infera:vllm-kimi-k3 .                                      │
+# │ (aiter stays the base's kimi-tuned build; the disabled layers are RDMA-PD /   │
+# │ kvd-L3 only, not needed for single-node aggregated serving.)                  │
+# └─────────────────────────────────────────────────────────────────────────────┘
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: kimi-k3
+  namespace: infera
+spec:
+  backendFramework: vllm
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        containers:
+          - name: main
+            image: inferaimage/infera:vllm-kimi-k3   # see IMAGE below
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","/models/Kimi-K3",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources:
+              requests: {cpu: "8", memory: 16Gi}
+              limits: {cpu: "8", memory: 16Gi}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+        volumes:
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+    worker:
+      componentType: worker
+      role: mixed
+      replicas: 1
+      # Kimi-K3 loads ~1.5 TB over ~7 min; skip the readiness probe so the operator
+      # doesn't restart the pod mid-load.
+      skipReadinessProbe: true
+      extraPodSpec:
+        containers:
+          - name: main
+            image: inferaimage/infera:vllm-kimi-k3   # see IMAGE below
+            imagePullPolicy: IfNotPresent
+            # vLLM flags mirror examples/kimi_k3/vllm_serve.sh (TP8, mm data-parallel
+            # encoder, kimi_k3 tool/reasoning parsers), routed through infera.engine.vllm.
+            # NOTE --kv-cache-dtype auto: infera defaults to fp8_e4m3 KV, but Kimi-K3's
+            # MLA then selects the mla_gluon kernel (batch_size=1 only) and crashes warmup
+            # at --max-num-seqs 128. `auto` keeps the model's native KV dtype. (Equivalent:
+            # env INFERA_DEFAULT_KV_FP8=0.)
+            command: ["python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
+                      "--model","/models/Kimi-K3","--served-model-name","kimi-k3",
+                      "--tensor-parallel-size","8","--gpu-memory-utilization","0.95",
+                      "--trust-remote-code","--moe-backend","auto","--load-format","auto",
+                      "--mm-encoder-tp-mode","data","--kv-cache-dtype","auto",
+                      "--max-num-seqs","128","--max-num-batched-tokens","4096",
+                      "--enable-auto-tool-choice","--tool-call-parser","kimi_k3",
+                      "--reasoning-parser","kimi_k3",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              - {name: HF_HUB_OFFLINE, value: "1"}
+              - {name: VLLM_ROCM_USE_AITER, value: "1"}
+              - {name: AITER_SITUV2_A8W4, value: "1"}
+              - {name: AITER_BF16_FP8_MOE_BOUND, value: "0"}
+              - {name: SAFETENSORS_FAST_GPU, value: "1"}
+              - {name: VLLM_USE_BREAKABLE_CUDAGRAPH, value: "0"}
+            resources:
+              requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+              limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+        volumes:
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 32Gi}}

--- a/examples/k8s-deployments/kimi-k3-vllm.yaml
+++ b/examples/k8s-deployments/kimi-k3-vllm.yaml
@@ -1,7 +1,8 @@
 # Kimi-K3 (VLM) — single-node aggregated, vLLM, TP8, one 8-GPU node.
 # Mounts the model-cache PVC (model-cache/) at /models and serves the multimodal
-# Kimi-K3 checkpoint. Structure is validated (operator reconcile + model-cache);
-# see the caveat below before expecting this to serve.
+# Kimi-K3 checkpoint. Validated end to end on MI355X: the operator reconciles the
+# CR, the TP8 worker reaches Ready in ~9 min, and a multimodal image request
+# through the router returns a correct colour-grounded answer.
 #
 # IMAGE: rocm/infera:vllm-kimi-k3 = infera (server/router + infera.engine.vllm)
 # layered onto the upstream vllm/vllm-openai-rocm:kimi-k3 build — the vLLM that

--- a/examples/k8s-deployments/mixed-kvd-vllm.yaml
+++ b/examples/k8s-deployments/mixed-kvd-vllm.yaml
@@ -1,4 +1,4 @@
-# Mixed (aggregated) serving WITH the kvd tiered KV cache — CONCRETE recipe.
+# Mixed (aggregated) serving WITH kvd on the vLLM path — CONCRETE recipe.
 #
 # The plain mixed recipe is single-node-qwen-sglang.yaml / -vllm.yaml. This adds
 # kvd, laid out the way Kubernetes wants it rather than with host paths:
@@ -14,19 +14,12 @@
 #
 # Requires the model-cache PVC (model-cache/) or a hostPath model, as usual.
 #
-# ENGINE CHOICE — this manifest uses SGLang, which reaches kvd through its
-# HiCacheStorage backend (`--infera-kvd-socket`) and gets the L2 host-RAM arena
-# plus the L3 file tier. Verified here: 3674 entries / 421 MB landing in both.
-#
-# But **hipFile GPU-direct L3 is vLLM-only**: on the vLLM path kvd loads L3
-# straight into VRAM, while SGLang's route goes through host memory. If you want
-# GPU-direct L3, use mixed-kvd-vllm.yaml instead — same sidecar/PVC layout, with
-# the InferaKvdConnector wiring.
-#
-# NOTE ON MEMORY: `--infera-kvd-socket` enables SGLang's hierarchical cache,
-# whose host-RAM tier is sized from the GPU KV pool unless capped. Left alone it
-# requested 416 GB here and the container was OOMKilled — always pass
-# `--hicache-size` (GiB) that fits inside the engine container's memory limit.
+# ENGINE CHOICE — this is the vLLM twin of mixed-kvd.yaml. It reaches kvd
+# through the InferaKvdConnector (a vLLM KV-transfer connector) rather than
+# SGLang's HiCacheStorage backend, and it is the path that supports **hipFile
+# GPU-direct L3**: L3 loads straight into VRAM instead of bouncing through host
+# memory. Use this one when GPU-direct L3 matters; mixed-kvd.yaml (SGLang) gets
+# the L2 arena and the file tier but not the GPU-direct path.
 #
 # NOTE ON KV DTYPE: kvd only offloads KV layouts it can round-trip byte-exact.
 # Regular-attention fp8 support landed in #63 — on an engine image predating it,
@@ -36,7 +29,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: kvd-l3
+  name: kvd-l3-vllm
   namespace: infera
 spec:
   accessModes:
@@ -49,10 +42,10 @@ spec:
 apiVersion: infera.amd.com/v1alpha1
 kind: InferaDeployment
 metadata:
-  name: qwen-kvd
+  name: qwen-kvd-vllm
   namespace: infera
 spec:
-  backendFramework: sglang
+  backendFramework: vllm
   discoveryBackend: kubernetes
   nats:
     deploy: false
@@ -62,7 +55,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: rocm/infera:sglang-v0.1.1
+            image: rocm/infera:vllm-v0.1.1
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/Qwen3-0.6B",
@@ -84,19 +77,18 @@ spec:
         containers:
           # ---- the engine ----
           - name: main
-            image: rocm/infera:sglang-v0.1.1
+            image: rocm/infera:vllm-v0.1.1
             imagePullPolicy: IfNotPresent
-            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
-                      "--model-path","/models/Qwen3-0.6B",
-                      "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
-                      "--mem-fraction-static","0.8",
-                      "--infera-kvd-socket","/kvd/kvd.sock",
-                      # REQUIRED under Kubernetes: --infera-kvd-socket turns on
-                      # SGLang's hierarchical cache, which otherwise sizes its
-                      # host-RAM tier from the GPU KV pool (it asked for 416 GB
-                      # here) and the container is OOMKilled. Cap it below the
-                      # engine container's memory limit.
-                      "--hicache-size","16",
+            # kvd is reached through the connector, declared in
+            # --kv-transfer-config; INFERA_KVD_SOCKET (below) points it at the
+            # sidecar's UDS. No hierarchical-cache sizing to worry about here —
+            # that knob is SGLang-side only.
+            command: ["python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
+                      "--model","/models/Qwen3-0.6B","--served-model-name","qwen",
+                      "--tensor-parallel-size","1","--gpu-memory-utilization","0.85",
+                      "--trust-remote-code",
+                      "--kv-transfer-config",
+                      "{\"kv_connector\":\"InferaKvdConnector\",\"kv_role\":\"kv_both\",\"kv_connector_module_path\":\"infera.engine.vllm.kvd_connector\"}",
                       "--kv-event-transport","zmq","--request-transport","http"]
             env:
               - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
@@ -114,7 +106,7 @@ spec:
           # Same image (kvd is pure Python inside the infera package). L2 is the
           # pinned host-RAM arena; L3 spills to the PVC.
           - name: kvd
-            image: rocm/infera:sglang-v0.1.1
+            image: rocm/infera:vllm-v0.1.1
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.kvd",
                       "--socket","/kvd/kvd.sock",
@@ -134,5 +126,5 @@ spec:
           - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
           # engine <-> kvd UDS: a plain emptyDir shared by the two containers
           - {name: kvd-sock, emptyDir: {}}
-          - {name: kvd-l3, persistentVolumeClaim: {claimName: kvd-l3}}
+          - {name: kvd-l3, persistentVolumeClaim: {claimName: kvd-l3-vllm}}
           - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 32Gi}}

--- a/examples/k8s-deployments/mixed-kvd.yaml
+++ b/examples/k8s-deployments/mixed-kvd.yaml
@@ -1,0 +1,129 @@
+# Mixed (aggregated) serving WITH the kvd tiered KV cache — CONCRETE recipe.
+#
+# The plain mixed recipe is single-node-qwen-sglang.yaml / -vllm.yaml. This adds
+# kvd, laid out the way Kubernetes wants it rather than with host paths:
+#
+#   * kvd runs as a SIDECAR in the worker Pod. The operator only owns the
+#     container named `main`, so any extra container is passed through verbatim.
+#   * the engine <-> kvd Unix socket lives in an `emptyDir` shared by the two
+#     containers — no hostPath, nothing pinned to a node.
+#   * kvd's L3 spill is a **PVC**, so capacity is requested from the cluster and
+#     the scheduler places the Pod where it can be satisfied.
+#   * kvd's L2 arena is host RAM, so it is charged to the sidecar's memory limit
+#     and needs IPC_LOCK to pin (mlock) it.
+#
+# Requires the model-cache PVC (model-cache/) or a hostPath model, as usual.
+#
+# NOTE ON MEMORY: `--infera-kvd-socket` enables SGLang's hierarchical cache,
+# whose host-RAM tier is sized from the GPU KV pool unless capped. Left alone it
+# requested 416 GB here and the container was OOMKilled — always pass
+# `--hicache-size` (GiB) that fits inside the engine container's memory limit.
+#
+# NOTE ON KV DTYPE: kvd only offloads KV layouts it can round-trip byte-exact.
+# Regular-attention fp8 support landed in #63 — on an engine image predating it,
+# add `--kv-cache-dtype auto` (or env INFERA_DEFAULT_KV_FP8=0) to the worker or
+# kvd will silently store nothing.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kvd-l3
+  namespace: infera
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Gi        # L3 spill; size to your working set
+  storageClassName: local-path   # k3s default; use a fast local-NVMe class in production
+---
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: qwen-kvd
+  namespace: infera
+spec:
+  backendFramework: sglang
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.1
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","/models/Qwen3-0.6B",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "4", memory: 8Gi}, limits: {cpu: "4", memory: 8Gi}}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+        volumes:
+          - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
+    worker:
+      componentType: worker
+      role: mixed
+      replicas: 1
+      extraPodSpec:
+        containers:
+          # ---- the engine ----
+          - name: main
+            image: rocm/infera:sglang-v0.1.1
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--model-path","/models/Qwen3-0.6B",
+                      "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
+                      "--mem-fraction-static","0.8",
+                      "--infera-kvd-socket","/kvd/kvd.sock",
+                      # REQUIRED under Kubernetes: --infera-kvd-socket turns on
+                      # SGLang's hierarchical cache, which otherwise sizes its
+                      # host-RAM tier from the GPU KV pool (it asked for 416 GB
+                      # here) and the container is OOMKilled. Cap it below the
+                      # engine container's memory limit.
+                      "--hicache-size","16",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              - {name: INFERA_KVD_SOCKET, value: /kvd/kvd.sock}
+            resources:
+              requests: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
+              limits: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: dshm, mountPath: /dev/shm}
+          # ---- the kvd sidecar ----
+          # Same image (kvd is pure Python inside the infera package). L2 is the
+          # pinned host-RAM arena; L3 spills to the PVC.
+          - name: kvd
+            image: rocm/infera:sglang-v0.1.1
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.kvd",
+                      "--socket","/kvd/kvd.sock",
+                      "--max-bytes","34359738368",          # 32 GiB L2 host-RAM arena
+                      "--long-path","/l3/long","--long-bytes","107374182400"]  # 100 GiB L3 on the PVC
+            securityContext:
+              capabilities:
+                add: ["IPC_LOCK"]      # required to mlock the arena
+            resources:
+              # Must exceed --max-bytes: the arena is pinned host RAM charged here.
+              requests: {cpu: "4", memory: 40Gi}
+              limits: {cpu: "4", memory: 40Gi}
+            volumeMounts:
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: kvd-l3, mountPath: /l3}
+        volumes:
+          - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
+          # engine <-> kvd UDS: a plain emptyDir shared by the two containers
+          - {name: kvd-sock, emptyDir: {}}
+          - {name: kvd-l3, persistentVolumeClaim: {claimName: kvd-l3}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 32Gi}}

--- a/examples/k8s-deployments/model-cache/model-cache.yaml
+++ b/examples/k8s-deployments/model-cache/model-cache.yaml
@@ -1,0 +1,16 @@
+# Model cache PVC — the infera analog of Dynamo's recipes/*/model-cache.yaml.
+# A download Job (model-download.yaml) populates it; serving pods mount it
+# read-only at /models. Sized for Qwen3-0.6B here; for Kimi-K3 use ~3000Gi and a
+# ReadWriteMany class (a shared CSI) if workers span nodes.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache
+  namespace: infera
+spec:
+  accessModes:
+    - ReadWriteOnce          # local-path is single-node RWO; use ReadWriteMany on a shared CSI for multi-node
+  resources:
+    requests:
+      storage: 20Gi          # Qwen3-0.6B; Kimi-K3 needs ~3000Gi
+  storageClassName: local-path   # k3s default; edit for your cluster's class

--- a/examples/k8s-deployments/model-cache/model-cache.yaml
+++ b/examples/k8s-deployments/model-cache/model-cache.yaml
@@ -1,7 +1,8 @@
-# Model cache PVC — the infera analog of Dynamo's recipes/*/model-cache.yaml.
-# A download Job (model-download.yaml) populates it; serving pods mount it
-# read-only at /models. Sized for Qwen3-0.6B here; for Kimi-K3 use ~3000Gi and a
-# ReadWriteMany class (a shared CSI) if workers span nodes.
+# Model cache PVC. A download Job (model-download.yaml) populates it once, then
+# serving pods mount it read-only at /models. Size it to your model: Kimi-K3 is
+# ~1.5 TB, so the default below leaves headroom; a small model (Qwen3-0.6B) needs
+# only ~20Gi. Use a ReadWriteMany class (a shared CSI) if prefill/decode workers
+# span nodes.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -12,5 +13,5 @@ spec:
     - ReadWriteOnce          # local-path is single-node RWO; use ReadWriteMany on a shared CSI for multi-node
   resources:
     requests:
-      storage: 20Gi          # Qwen3-0.6B; Kimi-K3 needs ~3000Gi
+      storage: 2000Gi        # safe for Kimi-K3 (~1.5 TB); a small model needs only ~20Gi
   storageClassName: local-path   # k3s default; edit for your cluster's class

--- a/examples/k8s-deployments/model-cache/model-download.yaml
+++ b/examples/k8s-deployments/model-cache/model-download.yaml
@@ -27,8 +27,7 @@ spec:
       containers:
         - name: model-download
           # Light, engine-agnostic downloader — any image with huggingface_hub works;
-          # the engine image (offline) is an alternative. hf_xet accelerates large
-          # Xet-backed repos (e.g. Kimi-K3) and is harmless for plain LFS repos.
+          # the engine image (offline) is an alternative.
           image: python:3.11-slim
           securityContext:
             allowPrivilegeEscalation: false
@@ -36,16 +35,22 @@ spec:
               drop: ["ALL"]
             seccompProfile:
               type: RuntimeDefault
+          # Download accelerators — help ONLY on a bandwidth/latency-constrained link
+          # (single-stream underutilizes the pipe). On a fast network the download is
+          # already network-bound (~600 MB/s measured here) and these are no-ops.
+          #   HF_HUB_ENABLE_HF_TRANSFER: parallel-chunked LFS (Kimi-K3 is plain LFS).
+          #   HF_XET_HIGH_PERFORMANCE:   only for Xet-backed repos (Kimi-K3 is NOT one).
           env:
+            - {name: HF_HUB_ENABLE_HF_TRANSFER, value: "1"}
             - {name: HF_XET_HIGH_PERFORMANCE, value: "1"}
-          # envFrom:                       # gated repos only (Kimi-K3): HF_TOKEN
+          # envFrom:                       # gated repos only: HF_TOKEN
           #   - secretRef: {name: hf-token-secret}
           command: ["sh", "-c"]
           # Swap the repo id (and dir) for your model, e.g. moonshotai/Kimi-K3 -> /model-cache/Kimi-K3.
           args:
             - |
               set -eux
-              pip install --no-cache-dir 'huggingface_hub[hf_xet]'
+              pip install --no-cache-dir 'huggingface_hub[hf_xet,hf_transfer]'
               python -c "from huggingface_hub import snapshot_download; print('downloaded ->', snapshot_download('Qwen/Qwen3-0.6B', local_dir='/model-cache/Qwen3-0.6B'))"
           volumeMounts:
             - name: model-cache

--- a/examples/k8s-deployments/model-cache/model-download.yaml
+++ b/examples/k8s-deployments/model-cache/model-download.yaml
@@ -35,14 +35,6 @@ spec:
               drop: ["ALL"]
             seccompProfile:
               type: RuntimeDefault
-          # Download accelerators — help ONLY on a bandwidth/latency-constrained link
-          # (single-stream underutilizes the pipe). On a fast network the download is
-          # already network-bound (~600 MB/s measured here) and these are no-ops.
-          #   HF_HUB_ENABLE_HF_TRANSFER: parallel-chunked LFS (Kimi-K3 is plain LFS).
-          #   HF_XET_HIGH_PERFORMANCE:   only for Xet-backed repos (Kimi-K3 is NOT one).
-          env:
-            - {name: HF_HUB_ENABLE_HF_TRANSFER, value: "1"}
-            - {name: HF_XET_HIGH_PERFORMANCE, value: "1"}
           # envFrom:                       # gated repos only: HF_TOKEN
           #   - secretRef: {name: hf-token-secret}
           command: ["sh", "-c"]
@@ -50,7 +42,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir 'huggingface_hub[hf_xet,hf_transfer]'
+              pip install --no-cache-dir huggingface_hub
               python -c "from huggingface_hub import snapshot_download; print('downloaded ->', snapshot_download('Qwen/Qwen3-0.6B', local_dir='/model-cache/Qwen3-0.6B'))"
           volumeMounts:
             - name: model-cache

--- a/examples/k8s-deployments/model-cache/model-download.yaml
+++ b/examples/k8s-deployments/model-cache/model-download.yaml
@@ -1,6 +1,6 @@
-# Model download Job — populates the model-cache PVC (Dynamo model-download.yaml
-# analog). Runs snapshot_download into a clean dir on the PVC so serving pods can
-# mount it and reference /models/<name> directly (no HF cache-path juggling).
+# Model download Job — populates the model-cache PVC. Runs snapshot_download into
+# a clean dir on the PVC so serving pods can mount it and reference /models/<name>
+# directly (no HF cache-path juggling).
 #
 #   kubectl apply -f model-cache.yaml -n infera
 #   kubectl apply -f model-download.yaml -n infera

--- a/examples/k8s-deployments/model-cache/model-download.yaml
+++ b/examples/k8s-deployments/model-cache/model-download.yaml
@@ -4,7 +4,7 @@
 #
 #   kubectl apply -f model-cache.yaml -n infera
 #   kubectl apply -f model-download.yaml -n infera
-#   kubectl wait --for=condition=Complete job/model-download -n infera --timeout=4h
+#   kubectl wait --for=condition=Complete job/model-download -n infera --timeout=8h
 #
 # For a GATED repo (e.g. moonshotai/Kimi-K3): first create the token secret, then
 # uncomment envFrom below and swap the repo id:
@@ -26,19 +26,27 @@ spec:
       restartPolicy: Never
       containers:
         - name: model-download
-          # Any image with huggingface_hub. The engine image already has it (and
-          # is offline in-cluster); python:3.11-slim + `pip install huggingface_hub`
-          # also works if you prefer an engine-agnostic downloader.
-          image: rocm/infera:sglang-v0.1.1
-          imagePullPolicy: IfNotPresent
+          # Light, engine-agnostic downloader — any image with huggingface_hub works;
+          # the engine image (offline) is an alternative. hf_xet accelerates large
+          # Xet-backed repos (e.g. Kimi-K3) and is harmless for plain LFS repos.
+          image: python:3.11-slim
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - {name: HF_XET_HIGH_PERFORMANCE, value: "1"}
           # envFrom:                       # gated repos only (Kimi-K3): HF_TOKEN
           #   - secretRef: {name: hf-token-secret}
-          command: ["python3", "-c"]
+          command: ["sh", "-c"]
+          # Swap the repo id (and dir) for your model, e.g. moonshotai/Kimi-K3 -> /model-cache/Kimi-K3.
           args:
             - |
-              from huggingface_hub import snapshot_download
-              p = snapshot_download("Qwen/Qwen3-0.6B", local_dir="/model-cache/Qwen3-0.6B")
-              print("downloaded ->", p)
+              set -eux
+              pip install --no-cache-dir 'huggingface_hub[hf_xet]'
+              python -c "from huggingface_hub import snapshot_download; print('downloaded ->', snapshot_download('Qwen/Qwen3-0.6B', local_dir='/model-cache/Qwen3-0.6B'))"
           volumeMounts:
             - name: model-cache
               mountPath: /model-cache

--- a/examples/k8s-deployments/model-cache/model-download.yaml
+++ b/examples/k8s-deployments/model-cache/model-download.yaml
@@ -1,0 +1,48 @@
+# Model download Job — populates the model-cache PVC (Dynamo model-download.yaml
+# analog). Runs snapshot_download into a clean dir on the PVC so serving pods can
+# mount it and reference /models/<name> directly (no HF cache-path juggling).
+#
+#   kubectl apply -f model-cache.yaml -n infera
+#   kubectl apply -f model-download.yaml -n infera
+#   kubectl wait --for=condition=Complete job/model-download -n infera --timeout=4h
+#
+# For a GATED repo (e.g. moonshotai/Kimi-K3): first create the token secret, then
+# uncomment envFrom below and swap the repo id:
+#   kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<tok> -n infera
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: model-download
+  namespace: infera
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: model-download
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: model-download
+          # Any image with huggingface_hub. The engine image already has it (and
+          # is offline in-cluster); python:3.11-slim + `pip install huggingface_hub`
+          # also works if you prefer an engine-agnostic downloader.
+          image: rocm/infera:sglang-v0.1.1
+          imagePullPolicy: IfNotPresent
+          # envFrom:                       # gated repos only (Kimi-K3): HF_TOKEN
+          #   - secretRef: {name: hf-token-secret}
+          command: ["python3", "-c"]
+          args:
+            - |
+              from huggingface_hub import snapshot_download
+              p = snapshot_download("Qwen/Qwen3-0.6B", local_dir="/model-cache/Qwen3-0.6B")
+              print("downloaded ->", p)
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-cache
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache

--- a/examples/k8s-deployments/pd-1p1d-mooncake.yaml
+++ b/examples/k8s-deployments/pd-1p1d-mooncake.yaml
@@ -62,12 +62,11 @@ spec:
             command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
                       "--disaggregation-mode","prefill","--model-path","<MODEL_PATH>",
                       "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
-                      "--mem-fraction-static","0.6",
+                      "--mem-fraction-static","0.8",
                       "--kv-event-transport","zmq","--request-transport","http",
-                      "--disaggregation-transfer-backend","mooncake","--disaggregation-ib-device","ionic_0"]
+                      "--disaggregation-transfer-backend","mooncake"]
             env:
               - {name: SGLANG_USE_AITER, value: "1"}
-              - {name: NCCL_IB_HCA, value: "ionic_0"}
               - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
               - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
               - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
@@ -96,12 +95,11 @@ spec:
             command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
                       "--disaggregation-mode","decode","--model-path","<MODEL_PATH>",
                       "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
-                      "--mem-fraction-static","0.6",
+                      "--mem-fraction-static","0.8",
                       "--kv-event-transport","zmq","--request-transport","http",
-                      "--disaggregation-transfer-backend","mooncake","--disaggregation-ib-device","ionic_0"]
+                      "--disaggregation-transfer-backend","mooncake"]
             env:
               - {name: SGLANG_USE_AITER, value: "1"}
-              - {name: NCCL_IB_HCA, value: "ionic_0"}
               - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
               - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
               - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}

--- a/examples/k8s-deployments/pd-1p1d-mooncake.yaml
+++ b/examples/k8s-deployments/pd-1p1d-mooncake.yaml
@@ -1,0 +1,116 @@
+# PD-disaggregated 1P1D over Mooncake — CONCRETE 2-node recipe.
+# 1 router + 1 prefill (node A) + 1 decode (node B), tp=1 each. KV is streamed
+# prefill -> decode by the Mooncake transfer engine over the ionic RoCE fabric;
+# the Mooncake RPC/handshake rides the pod-overlay (flannel) so it needs no host
+# networking. Uses the libionic-baked engine image, so no runtime host-libionic
+# injection is required (ibv sees the 8 ionic HCAs out of the box).
+#
+# Fill in for your cluster:
+#   <PREFILL_NODE> / <DECODE_NODE>   kubernetes.io/hostname of two GPU nodes that
+#                                    share a routable RoCE fabric (prefill and
+#                                    decode must be able to open an RDMA QP over
+#                                    ionic — same rail/subnet, or a routed fabric).
+#   <MODEL_DIR>                      a directory reachable at the SAME path on both
+#                                    nodes (shared FS, e.g. /mnt/vast/.../qwen)
+#                                    holding the model dir; mounted at /models.
+#   <MODEL_PATH>                     /models/<model-dir> as seen inside the pod.
+#
+# Requirements per worker: privileged + a hostPath mount of /dev/infiniband (the
+# ionic uverbs devices); no rdma/hca device-plugin needed with this approach.
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: qwen-pd
+  namespace: infera
+spec:
+  backendFramework: sglang
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.2      # libionic (ABI 4) baked
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","<MODEL_PATH>",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "4", memory: 8Gi}, limits: {cpu: "4", memory: 8Gi}}
+            volumeMounts: [{name: model, mountPath: /models, readOnly: true}]
+        volumes: [{name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}]
+    prefill:
+      componentType: worker
+      role: prefill
+      replicas: 1
+      port: 30000
+      skipReadinessProbe: true
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.2
+            imagePullPolicy: IfNotPresent
+            securityContext: {privileged: true, capabilities: {add: ["IPC_LOCK","SYS_PTRACE"]}}
+            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--disaggregation-mode","prefill","--model-path","<MODEL_PATH>",
+                      "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
+                      "--mem-fraction-static","0.6",
+                      "--kv-event-transport","zmq","--request-transport","http",
+                      "--disaggregation-transfer-backend","mooncake","--disaggregation-ib-device","ionic_0"]
+            env:
+              - {name: SGLANG_USE_AITER, value: "1"}
+              - {name: NCCL_IB_HCA, value: "ionic_0"}
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}, limits: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+              - {name: ib, mountPath: /dev/infiniband}
+        volumes:
+          - {name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 16Gi}}
+          - {name: ib, hostPath: {path: /dev/infiniband, type: Directory}}
+    decode:
+      componentType: worker
+      role: decode
+      replicas: 1
+      port: 30000
+      skipReadinessProbe: true
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <DECODE_NODE>}
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.2
+            imagePullPolicy: IfNotPresent
+            securityContext: {privileged: true, capabilities: {add: ["IPC_LOCK","SYS_PTRACE"]}}
+            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--disaggregation-mode","decode","--model-path","<MODEL_PATH>",
+                      "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
+                      "--mem-fraction-static","0.6",
+                      "--kv-event-transport","zmq","--request-transport","http",
+                      "--disaggregation-transfer-backend","mooncake","--disaggregation-ib-device","ionic_0"]
+            env:
+              - {name: SGLANG_USE_AITER, value: "1"}
+              - {name: NCCL_IB_HCA, value: "ionic_0"}
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}, limits: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+              - {name: ib, mountPath: /dev/infiniband}
+        volumes:
+          - {name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 16Gi}}
+          - {name: ib, hostPath: {path: /dev/infiniband, type: Directory}}

--- a/examples/k8s-deployments/pd-kvd.yaml
+++ b/examples/k8s-deployments/pd-kvd.yaml
@@ -1,0 +1,200 @@
+# PD-disaggregated 1P1D over Mooncake, WITH the kvd tiered KV cache — the fourth
+# recipe shape (mixed, mixed+kvd, pd, pd+kvd).
+#
+# PD structure is pd-1p1d-mooncake.yaml; kvd is layered on the same way as in
+# mixed-kvd.yaml, but on BOTH roles: prefill and decode each get their own kvd
+# sidecar, their own emptyDir socket, and their own L3 PVC.
+#
+# Why per-role rather than one shared kvd: the two roles hold different KV.
+# Prefill produces prefix KV worth reusing across requests; decode holds the
+# transferred working set. They also sit on different nodes, and a PVC is
+# ReadWriteOnce — a shared daemon would pin both roles to one node and undo the
+# point of disaggregating them.
+#
+# NOTE ON THE L3 PVCs AND SCHEDULING: with a node-local StorageClass (k3s
+# `local-path`, local-static-provisioner, most local-NVMe CSIs) each PV is bound
+# to the node that first consumed it, and that binding OUTLIVES the Pod. If a
+# role is later pinned to a different node, the scheduler cannot satisfy both the
+# PV's node affinity and the Pod's, and the Pod stays Pending forever:
+#
+#   0/2 nodes are available: 1 node(s) didn't match PersistentVolume's node
+#   affinity, 1 node(s) didn't match Pod's node affinity
+#
+# So either (a) delete and recreate the PVC when you move a role between nodes,
+# or (b) use a StorageClass whose volumes are not node-local. This is why the two
+# roles get SEPARATE PVCs — a single shared ReadWriteOnce claim would pin prefill
+# and decode to the same node and defeat the disaggregation.
+#
+# Fill in for your cluster:
+#   <PREFILL_NODE> / <DECODE_NODE>   two GPU nodes on a routable RoCE fabric
+#                                    (see pd-1p1d-mooncake.yaml — prefill and
+#                                    decode must be able to open an RDMA QP)
+#   <MODEL_DIR>                      a directory at the SAME path on both nodes
+#   <MODEL_PATH>                     /models/<model-dir> inside the pod
+#
+# NOTE ON MEMORY: `--infera-kvd-socket` enables SGLang's hierarchical cache,
+# whose host-RAM tier is sized from the GPU KV pool unless capped. Left alone it
+# will ask for hundreds of GB and the container is OOMKilled — `--hicache-size`
+# (GiB) must fit inside the engine container's memory limit.
+#
+# NOTE ON KV DTYPE: kvd only offloads KV layouts it can round-trip byte-exact.
+# Regular-attention fp8 support landed in #63; on an older engine image add
+# `--kv-cache-dtype auto` or kvd silently stores nothing.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kvd-l3-prefill
+  namespace: infera
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: {requests: {storage: 200Gi}}
+  storageClassName: local-path
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kvd-l3-decode
+  namespace: infera
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: {requests: {storage: 200Gi}}
+  storageClassName: local-path
+---
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: qwen-pd-kvd
+  namespace: infera
+spec:
+  backendFramework: sglang
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.2      # libionic (ABI 4) baked
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","<MODEL_PATH>",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "4", memory: 8Gi}, limits: {cpu: "4", memory: 8Gi}}
+            volumeMounts: [{name: model, mountPath: /models, readOnly: true}]
+        volumes: [{name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}]
+    prefill:
+      componentType: worker
+      role: prefill
+      replicas: 1
+      port: 30000
+      skipReadinessProbe: true
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.2
+            imagePullPolicy: IfNotPresent
+            securityContext: {privileged: true, capabilities: {add: ["IPC_LOCK","SYS_PTRACE"]}}
+            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--disaggregation-mode","prefill","--model-path","<MODEL_PATH>",
+                      "--infera-kvd-socket","/kvd/kvd.sock","--hicache-size","16",
+                      "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
+                      "--mem-fraction-static","0.8",
+                      "--kv-event-transport","zmq","--request-transport","http",
+                      "--disaggregation-transfer-backend","mooncake"]
+            env:
+              - {name: SGLANG_USE_AITER, value: "1"}
+              - {name: INFERA_KVD_SOCKET, value: /kvd/kvd.sock}
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}, limits: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+              - {name: ib, mountPath: /dev/infiniband}
+              - {name: kvd-sock, mountPath: /kvd}
+          # ---- kvd sidecar for this role ----
+          - name: kvd
+            image: rocm/infera:sglang-v0.1.2
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.kvd",
+                      "--socket","/kvd/kvd.sock",
+                      "--max-bytes","34359738368",
+                      "--long-path","/l3/long","--long-bytes","107374182400"]
+            securityContext:
+              capabilities: {add: ["IPC_LOCK"]}
+            resources:
+              requests: {cpu: "4", memory: 40Gi}
+              limits: {cpu: "4", memory: 40Gi}
+            volumeMounts:
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: kvd-l3, mountPath: /l3}
+        volumes:
+          - {name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}
+          - {name: kvd-sock, emptyDir: {}}
+          - {name: kvd-l3, persistentVolumeClaim: {claimName: kvd-l3-prefill}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 16Gi}}
+          - {name: ib, hostPath: {path: /dev/infiniband, type: Directory}}
+    decode:
+      componentType: worker
+      role: decode
+      replicas: 1
+      port: 30000
+      skipReadinessProbe: true
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <DECODE_NODE>}
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.2
+            imagePullPolicy: IfNotPresent
+            securityContext: {privileged: true, capabilities: {add: ["IPC_LOCK","SYS_PTRACE"]}}
+            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--disaggregation-mode","decode","--model-path","<MODEL_PATH>",
+                      "--infera-kvd-socket","/kvd/kvd.sock","--hicache-size","16",
+                      "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
+                      "--mem-fraction-static","0.8",
+                      "--kv-event-transport","zmq","--request-transport","http",
+                      "--disaggregation-transfer-backend","mooncake"]
+            env:
+              - {name: SGLANG_USE_AITER, value: "1"}
+              - {name: INFERA_KVD_SOCKET, value: /kvd/kvd.sock}
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}, limits: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+              - {name: ib, mountPath: /dev/infiniband}
+              - {name: kvd-sock, mountPath: /kvd}
+          # ---- kvd sidecar for this role ----
+          - name: kvd
+            image: rocm/infera:sglang-v0.1.2
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.kvd",
+                      "--socket","/kvd/kvd.sock",
+                      "--max-bytes","34359738368",
+                      "--long-path","/l3/long","--long-bytes","107374182400"]
+            securityContext:
+              capabilities: {add: ["IPC_LOCK"]}
+            resources:
+              requests: {cpu: "4", memory: 40Gi}
+              limits: {cpu: "4", memory: 40Gi}
+            volumeMounts:
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: kvd-l3, mountPath: /l3}
+        volumes:
+          - {name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}
+          - {name: kvd-sock, emptyDir: {}}
+          - {name: kvd-l3, persistentVolumeClaim: {claimName: kvd-l3-decode}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 16Gi}}
+          - {name: ib, hostPath: {path: /dev/infiniband, type: Directory}}

--- a/examples/k8s-deployments/single-node-qwen-sglang.yaml
+++ b/examples/k8s-deployments/single-node-qwen-sglang.yaml
@@ -1,0 +1,67 @@
+# Single-node aggregated — CONCRETE, ready-to-apply validation recipe.
+# 1 router (server, no GPU) + 1 mixed worker (sglang, tp=1, 1 amd.com/gpu),
+# Qwen3-0.6B mounted from a host dir via hostPath (no PVC/CSI needed). This is a
+# filled-in copy of single-node-aggregated.yaml used to validate the operator +
+# engine path end to end on a single box (k3s). Adjust the two host values for
+# your node:
+#   image        rocm/infera:sglang-v0.1.1   (must be present in the node runtime)
+#   model dir    /mnt/k3local/models/qwen    (contains Qwen3-0.6B/)
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: qwen-agg
+  namespace: infera
+spec:
+  backendFramework: sglang
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.1
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","/models/Qwen3-0.6B",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources:
+              requests: {cpu: "4", memory: 8Gi}
+              limits: {cpu: "4", memory: 8Gi}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+        volumes:
+          - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
+    worker:
+      componentType: worker
+      role: mixed
+      replicas: 1
+      extraPodSpec:
+        containers:
+          - name: main
+            image: rocm/infera:sglang-v0.1.1
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--model-path","/models/Qwen3-0.6B",
+                      "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
+                      "--mem-fraction-static","0.8",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources:
+              requests: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
+              limits: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+        volumes:
+          - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 32Gi}}

--- a/examples/k8s-deployments/single-node-qwen-vllm.yaml
+++ b/examples/k8s-deployments/single-node-qwen-vllm.yaml
@@ -4,7 +4,7 @@
 # (infera.server) is engine-agnostic; only the worker changes to
 # infera.engine.vllm with vLLM-style flags (--model / --tensor-parallel-size /
 # --gpu-memory-utilization). Adjust for your node:
-#   image        infera/infera:vllm-v0.1.0-rc5   (present in the node runtime)
+#   image        rocm/infera:vllm-v0.1.1   (present in the node runtime)
 #   model dir    /mnt/k3local/models/qwen        (contains Qwen3-0.6B/)
 apiVersion: infera.amd.com/v1alpha1
 kind: InferaDeployment
@@ -22,7 +22,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: inferaimage/infera:vllm-v0.1.0-rc5
+            image: rocm/infera:vllm-v0.1.1
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/Qwen3-0.6B",
@@ -45,7 +45,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: inferaimage/infera:vllm-v0.1.0-rc5
+            image: rocm/infera:vllm-v0.1.1
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
                       "--model","/models/Qwen3-0.6B","--served-model-name","Qwen3-0.6B",

--- a/examples/k8s-deployments/single-node-qwen-vllm.yaml
+++ b/examples/k8s-deployments/single-node-qwen-vllm.yaml
@@ -1,0 +1,66 @@
+# Single-node aggregated (vLLM) — CONCRETE, ready-to-apply validation recipe.
+# 1 router (server, no GPU) + 1 mixed worker (vLLM, tp=1, 1 amd.com/gpu),
+# Qwen3-0.6B via hostPath. vLLM twin of single-node-qwen-sglang.yaml: the router
+# (infera.server) is engine-agnostic; only the worker changes to
+# infera.engine.vllm with vLLM-style flags (--model / --tensor-parallel-size /
+# --gpu-memory-utilization). Adjust for your node:
+#   image        infera/infera:vllm-v0.1.0-rc5   (present in the node runtime)
+#   model dir    /mnt/k3local/models/qwen        (contains Qwen3-0.6B/)
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: qwen-agg-vllm
+  namespace: infera
+spec:
+  backendFramework: vllm
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        containers:
+          - name: main
+            image: inferaimage/infera:vllm-v0.1.0-rc5
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","/models/Qwen3-0.6B",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources:
+              requests: {cpu: "4", memory: 8Gi}
+              limits: {cpu: "4", memory: 8Gi}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+        volumes:
+          - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
+    worker:
+      componentType: worker
+      role: mixed
+      replicas: 1
+      extraPodSpec:
+        containers:
+          - name: main
+            image: inferaimage/infera:vllm-v0.1.0-rc5
+            imagePullPolicy: IfNotPresent
+            command: ["python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
+                      "--model","/models/Qwen3-0.6B","--served-model-name","Qwen3-0.6B",
+                      "--tensor-parallel-size","1","--gpu-memory-utilization","0.85","--trust-remote-code",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources:
+              requests: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
+              limits: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
+            volumeMounts:
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+        volumes:
+          - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 32Gi}}

--- a/examples/k8s-deployments/single-node-qwen-vllm.yaml
+++ b/examples/k8s-deployments/single-node-qwen-vllm.yaml
@@ -4,7 +4,7 @@
 # (infera.server) is engine-agnostic; only the worker changes to
 # infera.engine.vllm with vLLM-style flags (--model / --tensor-parallel-size /
 # --gpu-memory-utilization). Adjust for your node:
-#   image        rocm/infera:vllm-v0.1.1   (present in the node runtime)
+#   image        rocm/infera:vllm-v0.1.2   (present in the node runtime)
 #   model dir    /mnt/k3local/models/qwen        (contains Qwen3-0.6B/)
 apiVersion: infera.amd.com/v1alpha1
 kind: InferaDeployment
@@ -22,7 +22,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: rocm/infera:vllm-v0.1.1
+            image: rocm/infera:vllm-v0.1.2
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/Qwen3-0.6B",
@@ -45,7 +45,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: rocm/infera:vllm-v0.1.1
+            image: rocm/infera:vllm-v0.1.2
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
                       "--model","/models/Qwen3-0.6B","--served-model-name","Qwen3-0.6B",

--- a/examples/k8s-deployments/single-node-qwen-vllm.yaml
+++ b/examples/k8s-deployments/single-node-qwen-vllm.yaml
@@ -4,7 +4,7 @@
 # (infera.server) is engine-agnostic; only the worker changes to
 # infera.engine.vllm with vLLM-style flags (--model / --tensor-parallel-size /
 # --gpu-memory-utilization). Adjust for your node:
-#   image        rocm/infera:vllm-v0.1.2   (present in the node runtime)
+#   image        rocm/infera:vllm-v0.1.1   (present in the node runtime)
 #   model dir    /mnt/k3local/models/qwen        (contains Qwen3-0.6B/)
 apiVersion: infera.amd.com/v1alpha1
 kind: InferaDeployment
@@ -22,7 +22,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: rocm/infera:vllm-v0.1.2
+            image: rocm/infera:vllm-v0.1.1
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/Qwen3-0.6B",
@@ -45,7 +45,7 @@ spec:
       extraPodSpec:
         containers:
           - name: main
-            image: rocm/infera:vllm-v0.1.2
+            image: rocm/infera:vllm-v0.1.1
             imagePullPolicy: IfNotPresent
             command: ["python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
                       "--model","/models/Qwen3-0.6B","--served-model-name","Qwen3-0.6B",

--- a/examples/kimi_k3/README.md
+++ b/examples/kimi_k3/README.md
@@ -1,0 +1,37 @@
+# Kimi-K3 on AMD Instinct (MI355X)
+
+Serve **Kimi-K3** on AMD Instinct GPUs. Per the AMD "Kimi-K3 on AMD Instinct GPUs"
+guide, low-bit (MXFP4 / A8W4) is done **at runtime by aiter** from the native
+checkpoint — no separate quantized download.
+
+## Base images
+- **vLLM:** `vllm/vllm-openai-rocm:kimi-k3`
+- **SGLang:** `lmsysorg/sglang-rocm:rocm720-mi35x-k3-20260727`
+
+## Model
+`moonshotai/Kimi-K3` — native checkpoint (~1.5 TB, 96 shards), cached at
+`/mnt/vast/yaocheng/models/moonshotai/Kimi-K3`. The aiter env flags
+(`AITER_SITUV2_A8W4=1`, `AITER_BF16_FP8_MOE_BOUND=0`) do the low-bit MoE at load.
+
+## Run (8-GPU node, TP8)
+
+```bash
+bash vllm_serve.sh            # TP8 on the cached checkpoint, port 8000
+MODEL=<path-or-repo> TP=8 PORT=8000 bash vllm_serve.sh   # overrides
+docker logs -f kimi_k3_vllm
+```
+
+The vLLM image ENTRYPOINT is `/bin/bash`, so the script serves via `vllm serve
+<model> <flags>` (entrypoint overridden). Flags/env match the AMD guide:
+`VLLM_ROCM_USE_AITER=1`, `--moe-backend auto`, `--tensor-parallel-size 8`,
+`--gpu-memory-utilization 0.95`, `--mm-encoder-tp-mode data`,
+`--tool-call-parser kimi_k3 --reasoning-parser kimi_k3`.
+
+## Smoke test
+
+```bash
+curl -s http://localhost:8000/v1/chat/completions -H 'Content-Type: application/json' \
+  -d '{"model":"kimi-k3","messages":[{"role":"user","content":"hi"}],"max_tokens":16}'
+```
+
+SGLang launcher: TODO (base image above).

--- a/examples/kimi_k3/mm_test.py
+++ b/examples/kimi_k3/mm_test.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Multimodal smoke test for Kimi-K3 (VL) on vLLM.
+
+Sends an image + question via the OpenAI chat/completions API and prints the
+answer — proves the vision encode → prefill → decode path works end to end.
+Default image is a stdlib-generated solid colour (no network); pass --url for a
+real image.
+
+  python mm_test.py --port 8000
+  python mm_test.py --port 8000 --url https://.../cat.jpg
+"""
+
+import argparse
+import base64
+import json
+import struct
+import sys
+import urllib.request
+import zlib
+
+
+def solid_png(r, g, b, side=64) -> bytes:
+    def chunk(tag, data):
+        return (
+            struct.pack(">I", len(data))
+            + tag
+            + data
+            + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+        )
+
+    raw = (b"\x00" + bytes([r, g, b]) * side) * side
+    ihdr = struct.pack(">IIBBBBB", side, side, 8, 2, 0, 0, 0)
+    return b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) + chunk(b"IDAT", zlib.compress(raw, 9)) + chunk(b"IEND", b"")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=8000)
+    ap.add_argument("--model", default="kimi-k3")
+    ap.add_argument("--url", help="image URL; default = a generated crimson square")
+    ap.add_argument("--prompt", default="What is the dominant colour of this image? Answer in one word.")
+    args = ap.parse_args()
+
+    image = args.url or ("data:image/png;base64," + base64.b64encode(solid_png(220, 20, 60)).decode())
+    body = {
+        "model": args.model,
+        "max_tokens": 64,
+        "temperature": 0,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": args.prompt},
+                    {"type": "image_url", "image_url": {"url": image}},
+                ],
+            }
+        ],
+    }
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{args.port}/v1/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=120) as r:
+        out = json.load(r)
+    msg = out["choices"][0]["message"]
+    print("answer:", repr(msg.get("content")))
+    if msg.get("reasoning_content"):
+        print("reasoning:", repr(msg["reasoning_content"])[:200])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/kimi_k3/mm_test.py
+++ b/examples/kimi_k3/mm_test.py
@@ -30,7 +30,12 @@ def solid_png(r, g, b, side=64) -> bytes:
 
     raw = (b"\x00" + bytes([r, g, b]) * side) * side
     ihdr = struct.pack(">IIBBBBB", side, side, 8, 2, 0, 0, 0)
-    return b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) + chunk(b"IDAT", zlib.compress(raw, 9)) + chunk(b"IEND", b"")
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", ihdr)
+        + chunk(b"IDAT", zlib.compress(raw, 9))
+        + chunk(b"IEND", b"")
+    )
 
 
 def main():
@@ -38,10 +43,14 @@ def main():
     ap.add_argument("--port", type=int, default=8000)
     ap.add_argument("--model", default="kimi-k3")
     ap.add_argument("--url", help="image URL; default = a generated crimson square")
-    ap.add_argument("--prompt", default="What is the dominant colour of this image? Answer in one word.")
+    ap.add_argument(
+        "--prompt", default="What is the dominant colour of this image? Answer in one word."
+    )
     args = ap.parse_args()
 
-    image = args.url or ("data:image/png;base64," + base64.b64encode(solid_png(220, 20, 60)).decode())
+    image = args.url or (
+        "data:image/png;base64," + base64.b64encode(solid_png(220, 20, 60)).decode()
+    )
     body = {
         "model": args.model,
         "max_tokens": 64,

--- a/examples/kimi_k3/vllm_serve.sh
+++ b/examples/kimi_k3/vllm_serve.sh
@@ -12,13 +12,19 @@ TP=${TP:-8}
 NAME=${NAME:-kimi_k3_vllm}
 
 docker rm -f "$NAME" >/dev/null 2>&1
+# Make the model visible inside the container: mount the top-level filesystem the
+# MODEL path lives on (e.g. /mnt/vast or /mnt/k3local). Without this a local path
+# is invisible in the container and HF treats it as a repo id -> HFValidationError.
+MODEL_MNT="/$(echo "$MODEL" | cut -d/ -f2-3)"   # e.g. /mnt/k3local, /mnt/vast
+MOUNTS=(-v /mnt/vast:/mnt/vast)
+[ "$MODEL_MNT" != "/mnt/vast" ] && [ -d "$MODEL_MNT" ] && MOUNTS+=(-v "$MODEL_MNT":"$MODEL_MNT")
 # Image ENTRYPOINT is /bin/bash (dev image), so serve via the vllm CLI:
 # `vllm serve <model> <flags>` (override the entrypoint).
 docker run -d --name "$NAME" \
   --device=/dev/kfd --device=/dev/dri \
   --security-opt seccomp=unconfined --group-add video \
   --privileged --ipc=host --shm-size 32g -p "$PORT":8000 \
-  -v /mnt/vast:/mnt/vast \
+  "${MOUNTS[@]}" \
   -v ~/.cache/huggingface:/root/.cache/huggingface \
   -e HF_HUB_OFFLINE=1 \
   -e VLLM_ROCM_USE_AITER=1 \

--- a/examples/kimi_k3/vllm_serve.sh
+++ b/examples/kimi_k3/vllm_serve.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Kimi-K3 on AMD Instinct — vLLM serve (TP8), MXFP4/A8W4 runtime quant via aiter.
+# Base image + flags per the AMD "Kimi-K3 on AMD Instinct GPUs" guide. Run ON an
+# 8-GPU node. The native moonshotai/Kimi-K3 checkpoint (~1.5 TB) is cached on the
+# shared mount; the aiter A8W4 env flags do the low-bit quantization at load.
+set -u
+IMG=${IMG:-vllm/vllm-openai-rocm:kimi-k3}
+# Local cached checkpoint (plain dir); override MODEL to use a different path/repo.
+MODEL=${MODEL:-/mnt/vast/yaocheng/models/moonshotai/Kimi-K3}
+PORT=${PORT:-8000}
+TP=${TP:-8}
+NAME=${NAME:-kimi_k3_vllm}
+
+docker rm -f "$NAME" >/dev/null 2>&1
+# Image ENTRYPOINT is /bin/bash (dev image), so serve via the vllm CLI:
+# `vllm serve <model> <flags>` (override the entrypoint).
+docker run -d --name "$NAME" \
+  --device=/dev/kfd --device=/dev/dri \
+  --security-opt seccomp=unconfined --group-add video \
+  --privileged --ipc=host --shm-size 32g -p "$PORT":8000 \
+  -v /mnt/vast:/mnt/vast \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  -e HF_HUB_OFFLINE=1 \
+  -e VLLM_ROCM_USE_AITER=1 \
+  -e SAFETENSORS_FAST_GPU=1 \
+  -e AITER_SITUV2_A8W4=1 \
+  -e AITER_BF16_FP8_MOE_BOUND=0 \
+  -e VLLM_USE_BREAKABLE_CUDAGRAPH=0 \
+  --entrypoint vllm \
+  "$IMG" serve "$MODEL" \
+  --served-model-name kimi-k3 \
+  --trust-remote-code \
+  --moe-backend auto \
+  --tensor-parallel-size "$TP" \
+  --load-format auto \
+  --gpu-memory-utilization 0.95 \
+  --mm-encoder-tp-mode data \
+  --max-num-seqs 128 \
+  --max-num-batched-tokens 4096 \
+  --enable-auto-tool-choice \
+  --tool-call-parser kimi_k3 \
+  --reasoning-parser kimi_k3
+
+echo "launched $NAME (TP$TP) on port $PORT; follow: docker logs -f $NAME"

--- a/examples/recipes/README.md
+++ b/examples/recipes/README.md
@@ -1,0 +1,49 @@
+# Infera recipes
+
+Ready-to-run Kubernetes deployments for specific models, in the shape you want to
+serve them. Pick a model, pick a combo, `kubectl apply`.
+
+| Model | Engine | Recipe |
+|---|---|---|
+| GLM-5.2-MXFP4 | SGLang | [`glm5.2/`](glm5.2/README.md) |
+| Kimi-K3 | vLLM | [`kimi-k3/`](kimi-k3/README.md) |
+
+## The four combos
+
+Every recipe comes in the same four shapes. They compose two independent choices:
+**how requests are split across GPUs**, and **whether KV survives past the GPU**.
+
+| Combo | Serving | KV cache | Use it when |
+|---|---|---|---|
+| `mixed` | one worker does prefill + decode | GPU only | default; simplest thing that works |
+| `mixed-kvd` | one worker does prefill + decode | + kvd L2 host RAM, L3 on a PVC | repeated/long prefixes — shared system prompts, multi-turn chat, RAG |
+| `pd` | prefill and decode on separate nodes | GPU only | prefill and decode want different batching; you have a RoCE fabric |
+| `pd-kvd` | prefill and decode on separate nodes | + kvd on each role | both of the above |
+
+`pd` needs the two nodes on a **mutually routable RoCE fabric** — the KV handoff is
+RDMA, and there is no TCP fallback. If you are on one box, use `mixed`.
+
+## How these manifests are built
+
+Every recipe is **stock vendor image + overlay + (optional) sidecar**. The vendor
+image is never forked:
+
+```
+initContainer  infera-overlay   busybox carrying /payload  ──cp──▶ emptyDir
+container      main             STOCK vllm/sglang image, runs /overlay/bin/infera-exec
+container      kvd              same vendor image, also runs from /overlay   (kvd combos)
+```
+
+`infera-exec` picks the payload trees matching the container's CPython minor and
+ROCm major, then execs the engine. So following an upstream vLLM or SGLang release
+is an image-tag edit here — no rebuild of ours, and no repeat of the incident where
+forking the base for one model broke every other model.
+
+See [`deploy/overlay/README.md`](../../deploy/overlay/README.md) for how the payload
+is assembled.
+
+## Source
+
+- Manifests: [`examples/recipes/`](.) in [AMD-AGI/Infera](https://github.com/AMD-AGI/Infera)
+- Overlay build: [`deploy/overlay/`](../../deploy/overlay)
+- More deployment shapes: [`examples/k8s-deployments/`](../k8s-deployments)

--- a/examples/recipes/README.md
+++ b/examples/recipes/README.md
@@ -45,12 +45,23 @@ Build the overlay before deploying:
 docker build -f deploy/overlay/Dockerfile.payload -t rocm/infera-overlay:latest .
 ```
 
-**The payload must contain a `native/` tree** (Mooncake + hipFile) for the `kvd`
-and `pd` combos. Build it from an image that has them — that is what the
-`NATIVE_IMAGE` build arg is for. A payload without `native/` still runs `mixed`
-perfectly, and merely *warns* on the others, so the kvd and pd manifests set
-`INFERA_REQUIRE_NATIVE=1`: without it a wrong overlay tag deploys clean and
-silently serves without the GPU-direct L3 or the KV transport you asked for.
+The build harvests **one native tree per ABI family** — `NATIVE_IMAGE` supplies
+the vLLM one (CPython 3.12) and `SGLANG_NATIVE_IMAGE` the SGLang one (3.10).
+Mooncake and hipFile bind both the ROCm major and the CPython minor, so neither
+tree can stand in for the other.
+
+The families do not carry the same capabilities, and that is by design:
+
+| | `mooncake` (PD KV transport) | `hipfile` (kvd GPU-direct L3) |
+|---|---|---|
+| `rocm7-py312` (vLLM) | yes | yes |
+| `rocm7-py310` (SGLang) | yes | **no — vLLM-only path** |
+
+So each manifest names the capabilities it needs via `INFERA_REQUIRE_NATIVE`
+(e.g. `mooncake`, `hipfile`, or `mooncake,hipfile`) and `infera-exec` refuses to
+start without them. Combos that need nothing native — `mixed` anywhere, and
+`mixed-kvd` on SGLang, which reaches its L2 and file L3 through pure-Python
+HiCacheStorage — leave it unset.
 
 See [`deploy/overlay/README.md`](../../deploy/overlay/README.md) for how the payload
 is assembled.

--- a/examples/recipes/README.md
+++ b/examples/recipes/README.md
@@ -39,6 +39,19 @@ ROCm major, then execs the engine. So following an upstream vLLM or SGLang relea
 is an image-tag edit here — no rebuild of ours, and no repeat of the incident where
 forking the base for one model broke every other model.
 
+Build the overlay before deploying:
+
+```bash
+docker build -f deploy/overlay/Dockerfile.payload -t rocm/infera-overlay:latest .
+```
+
+**The payload must contain a `native/` tree** (Mooncake + hipFile) for the `kvd`
+and `pd` combos. Build it from an image that has them — that is what the
+`NATIVE_IMAGE` build arg is for. A payload without `native/` still runs `mixed`
+perfectly, and merely *warns* on the others, so the kvd and pd manifests set
+`INFERA_REQUIRE_NATIVE=1`: without it a wrong overlay tag deploys clean and
+silently serves without the GPU-direct L3 or the KV transport you asked for.
+
 See [`deploy/overlay/README.md`](../../deploy/overlay/README.md) for how the payload
 is assembled.
 

--- a/examples/recipes/glm5.2/README.md
+++ b/examples/recipes/glm5.2/README.md
@@ -21,18 +21,22 @@ only if you have two nodes on a mutually routable RoCE fabric.
 
 `export COMBO=mixed` (or `mixed-kvd`, `pd`, `pd-kvd`) — the commands below use it.
 
-```{admonition} SGLang kvd/pd combos need a py310 native tree
-The overlay harvests its native tree (Mooncake, hipFile) from `NATIVE_IMAGE`,
-which defaults to a **vLLM** image — so a default build ships `native/rocm7-py312`
-only. SGLang bases are CPython 3.10, so `mixed-kvd`, `pd` and `pd-kvd` here will
-stop at startup with:
+```{admonition} What each combo needs from the overlay's native tree
+The overlay harvests one native tree per ABI family — `rocm7-py310` for SGLang
+bases, `rocm7-py312` for vLLM — and each records what it carries:
 
-    infera-exec: no native payload for rocm7-py310
+| combo | needs | why |
+|---|---|---|
+| `mixed` | nothing | |
+| `mixed-kvd` | nothing | SGLang reaches kvd's L2 and file L3 through HiCacheStorage, which is pure Python |
+| `pd`, `pd-kvd` | `mooncake` | the KV handoff is Mooncake, a compiled extension |
 
-That is the `INFERA_REQUIRE_NATIVE=1` guard doing its job — without it the Pod
-would come up green and quietly serve with no kvd L3 and no KV transport. Build
-the overlay with an SGLang-based `NATIVE_IMAGE` to get the py310 tree. `mixed`
-needs none of this and is unaffected.
+`hipfile` is **absent from the SGLang tree on purpose** — kvd's GPU-direct L3 is
+a vLLM-only path — so its absence here is not a broken payload.
+
+The combos that need something declare it as `INFERA_REQUIRE_NATIVE`, and
+`infera-exec` fails at startup if the payload cannot supply it. Without that, a
+payload missing Mooncake comes up green and serves with no KV transfer at all.
 ```
 
 ## 2. Prerequisites

--- a/examples/recipes/glm5.2/README.md
+++ b/examples/recipes/glm5.2/README.md
@@ -102,9 +102,15 @@ curl -s localhost:8000/v1/chat/completions \
        "max_tokens":60}' | jq -r '.choices[0].message.content'
 ```
 
-Expect a coherent answer naming Paris. **Garbage or repeated tokens** means the ROCm
-DSA indexer env vars did not take effect — check that `SGLANG_OPT_USE_TILELANG_INDEXER=1`,
-`SGLANG_OPT_USE_TOPK_V2=0` and `SGLANG_OPT_USE_JIT_NORM=0` are set on the worker.
+Expect exactly `The capital of France is Paris.` **Garbage or repeated tokens**
+means the ROCm DSA indexer env vars did not take effect — check that
+`SGLANG_OPT_USE_TILELANG_INDEXER=1`, `SGLANG_OPT_USE_TOPK_V2=0` and
+`SGLANG_OPT_USE_JIT_NORM=0` are set on the worker.
+
+GLM-5.2 is a thinking model, so the manifest passes `--reasoning-parser glm45`
+and the trace lands in `reasoning_content`, leaving `content` clean. Without it
+the answer is still correct but arrives with the chain-of-thought and a raw
+`</think>` inlined — right output, unusable shape.
 
 On the kvd combos, confirm KV is actually landing in the tiers — this is the check
 that catches a silently-storing-nothing kvd:
@@ -136,14 +142,22 @@ rocm-smi --showpids
 
 | What | Status |
 |---|---|
-| GLM-5.2 TP8 SGLang serving, real tokens | validated on MI355X — [`manual/examples/k8s_glm5.2_sglang.md`](../../../manual/examples/k8s_glm5.2_sglang.md) |
-| kvd sidecar + PVC L3 under SGLang | validated (3674 entries / 421 MB), on Qwen3-0.6B |
-| overlay payload on a stock SGLang base | validated — [`deploy/overlay/README.md`](../../../deploy/overlay/README.md) |
-| these three combined, as written here | **not yet run end-to-end** |
+| **`mixed/deploy.yaml` exactly as written** | **validated end-to-end on k3s (MI355X, 8×`amd.com/gpu`)** — see below |
+| kvd sidecar + PVC L3 under SGLang | validated (3674 entries / 421 MB), on Qwen3-0.6B — but see the py310 native-tree note above |
 | pd / pd-kvd for this model | structure only; needs a routable RoCE fabric |
 
-The validated runs used the baked `rocm/infera:sglang-*` images. These manifests
-compose that same software as an overlay — proven separately, not yet together.
+The `mixed` run used the **stock `lmsysorg/sglang` image** with the overlay
+mounted in — no infera-built engine image anywhere in the Pod:
+
+| | |
+|---|---|
+| router Ready | ~20 s (`infera.server` running from the overlay's py310 tree) |
+| worker Ready | ~13 min (408 GiB over NFS, plus DSA graph capture) |
+| output | `The capital of France is Paris.` — correct and coherent |
+| reasoning | separated into `reasoning_content`, no `</think>` in `content` |
+
+Weights came over NFS here. On local NVMe expect materially less than 13 min;
+the comparable Kimi-K3 run loaded 1453 GiB in 502 s from local disk.
 
 ## Source
 

--- a/examples/recipes/glm5.2/README.md
+++ b/examples/recipes/glm5.2/README.md
@@ -21,6 +21,20 @@ only if you have two nodes on a mutually routable RoCE fabric.
 
 `export COMBO=mixed` (or `mixed-kvd`, `pd`, `pd-kvd`) — the commands below use it.
 
+```{admonition} SGLang kvd/pd combos need a py310 native tree
+The overlay harvests its native tree (Mooncake, hipFile) from `NATIVE_IMAGE`,
+which defaults to a **vLLM** image — so a default build ships `native/rocm7-py312`
+only. SGLang bases are CPython 3.10, so `mixed-kvd`, `pd` and `pd-kvd` here will
+stop at startup with:
+
+    infera-exec: no native payload for rocm7-py310
+
+That is the `INFERA_REQUIRE_NATIVE=1` guard doing its job — without it the Pod
+would come up green and quietly serve with no kvd L3 and no KV transport. Build
+the overlay with an SGLang-based `NATIVE_IMAGE` to get the py310 tree. `mixed`
+needs none of this and is unaffected.
+```
+
 ## 2. Prerequisites
 
 **Hardware.** 8× MI355X (or MI300X+) on one node for `mixed`; two such nodes on a

--- a/examples/recipes/glm5.2/README.md
+++ b/examples/recipes/glm5.2/README.md
@@ -1,0 +1,137 @@
+# GLM-5.2-MXFP4 on Kubernetes
+
+Serve GLM-5.2-MXFP4 with infera on an AMD MI355X node (TP8, SGLang).
+
+Built as **stock vendor image + overlay + sidecar**: the manifests run the
+unmodified `lmsysorg/sglang` image and mount infera in from an overlay payload, so
+an upstream SGLang bump is a one-line image-tag edit here.
+
+## 1. Choose your combo
+
+| Combo | Serving | KV cache | Manifest |
+|---|---|---|---|
+| **mixed** | one worker, prefill + decode | GPU only | [`mixed/deploy.yaml`](mixed/deploy.yaml) |
+| **mixed + kvd** | one worker, prefill + decode | + L2 host RAM, L3 on a PVC | [`mixed-kvd/deploy.yaml`](mixed-kvd/deploy.yaml) |
+| **pd** | prefill and decode on separate nodes | GPU only | [`pd/deploy.yaml`](pd/deploy.yaml) |
+| **pd + kvd** | prefill and decode on separate nodes | + kvd per role | [`pd-kvd/deploy.yaml`](pd-kvd/deploy.yaml) |
+
+Start with **mixed**. Add **kvd** when requests share long prefixes (a common system
+prompt, multi-turn chat, RAG) — that is what the L2/L3 tiers pay for. Move to **pd**
+only if you have two nodes on a mutually routable RoCE fabric.
+
+`export COMBO=mixed` (or `mixed-kvd`, `pd`, `pd-kvd`) — the commands below use it.
+
+## 2. Prerequisites
+
+**Hardware.** 8× MI355X (or MI300X+) on one node for `mixed`; two such nodes on a
+shared RoCE fabric for `pd`. ~700 GB of host RAM if you enable kvd — its L2 arena is
+pinned host memory charged to the sidecar's limit.
+
+**Cluster.** Kubernetes 1.28+ with:
+
+```bash
+# AMD GPU device plugin — nodes must advertise amd.com/gpu
+kubectl get nodes -o custom-columns=NODE:.metadata.name,GPU:.status.allocatable.'amd\.com/gpu'
+
+# the infera operator (provides the InferaDeployment CRD)
+helm install infera-operator deploy/operator/helm/infera-operator -n infera-system --create-namespace
+kubectl -n infera-system rollout status deploy/infera-operator
+```
+
+On k3s, install with `--data-dir` on a large disk. The default lives under `/var/lib`,
+and pulling these images fills it — the node goes `DiskPressure` and evicts the
+operator before anything serves.
+
+**Weights.** The manifests expect the `model-cache` PVC to hold GLM-5.2-MXFP4 at
+`/models/GLM-5.2-MXFP4`:
+
+```bash
+kubectl apply -f examples/k8s-deployments/model-cache/model-cache.yaml
+kubectl apply -f examples/k8s-deployments/model-cache/model-download.yaml
+kubectl -n infera wait --for=condition=complete job/model-download --timeout=6h
+```
+
+Keeping weights on the node instead? Replace the `model` volume with a `hostPath`.
+
+## 3. Deploy
+
+```bash
+kubectl create namespace infera --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f examples/recipes/glm5.2/${COMBO}/deploy.yaml
+```
+
+For the `pd` combos, first substitute the two node names:
+
+```bash
+sed -e "s/<PREFILL_NODE>/node-a/" -e "s/<DECODE_NODE>/node-b/" \
+    examples/recipes/glm5.2/${COMBO}/deploy.yaml | kubectl apply -f -
+```
+
+Watch it come up — weight load is several minutes, which is why the worker uses a
+`startupProbe` rather than a readiness probe:
+
+```bash
+kubectl -n infera get pods -w
+kubectl -n infera logs -f -c main \
+  -l infera.amd.com/deployment=glm52-${COMBO},infera.amd.com/service=worker
+```
+
+## 4. Smoke test
+
+```bash
+kubectl -n infera port-forward svc/glm52-${COMBO}-server 8000:8000 &
+
+curl -s localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"glm5.2-mxfp4",
+       "messages":[{"role":"user","content":"What is the capital of France?"}],
+       "max_tokens":60}' | jq -r '.choices[0].message.content'
+```
+
+Expect a coherent answer naming Paris. **Garbage or repeated tokens** means the ROCm
+DSA indexer env vars did not take effect — check that `SGLANG_OPT_USE_TILELANG_INDEXER=1`,
+`SGLANG_OPT_USE_TOPK_V2=0` and `SGLANG_OPT_USE_JIT_NORM=0` are set on the worker.
+
+On the kvd combos, confirm KV is actually landing in the tiers — this is the check
+that catches a silently-storing-nothing kvd:
+
+```bash
+POD=$(kubectl -n infera get pod -o name \
+  -l infera.amd.com/deployment=glm52-${COMBO},infera.amd.com/service=worker | head -1)
+kubectl -n infera exec $POD -c kvd -- \
+  /overlay/bin/infera-exec python3 -m infera.kvd.statctl --socket /kvd/kvd.sock
+```
+
+`entries` and `long_bytes` must be non-zero after a few requests. If `entries: 0`,
+kvd rejected the KV layout — see the `NOTE ON KV DTYPE` header in the manifest.
+
+## 5. Tear down
+
+```bash
+kubectl -n infera delete -f examples/recipes/glm5.2/${COMBO}/deploy.yaml
+```
+
+Then check the GPUs actually released. A deleted Pod can leave processes holding
+VRAM, and the next deploy OOMs on a box that looks idle:
+
+```bash
+rocm-smi --showpids
+```
+
+## Validation status
+
+| What | Status |
+|---|---|
+| GLM-5.2 TP8 SGLang serving, real tokens | validated on MI355X — [`manual/examples/k8s_glm5.2_sglang.md`](../../../manual/examples/k8s_glm5.2_sglang.md) |
+| kvd sidecar + PVC L3 under SGLang | validated (3674 entries / 421 MB), on Qwen3-0.6B |
+| overlay payload on a stock SGLang base | validated — [`deploy/overlay/README.md`](../../../deploy/overlay/README.md) |
+| these three combined, as written here | **not yet run end-to-end** |
+| pd / pd-kvd for this model | structure only; needs a routable RoCE fabric |
+
+The validated runs used the baked `rocm/infera:sglang-*` images. These manifests
+compose that same software as an overlay — proven separately, not yet together.
+
+## Source
+
+[`examples/recipes/glm5.2/`](.) in [AMD-AGI/Infera](https://github.com/AMD-AGI/Infera)
+· [all combos](../README.md) · [overlay build](../../../deploy/overlay)

--- a/examples/recipes/glm5.2/mixed-kvd/deploy.yaml
+++ b/examples/recipes/glm5.2/mixed-kvd/deploy.yaml
@@ -118,11 +118,6 @@ spec:
               - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
               - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
               - {name: INFERA_KVD_SOCKET, value: "/kvd/kvd.sock"}
-            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
-            # the overlay's native tree. Without this, a payload built without that
-            # tree only WARNS and both silently become unavailable — the run looks
-            # healthy and quietly serves without the thing you deployed it for.
-              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10
@@ -147,8 +142,6 @@ spec:
                       "--socket","/kvd/kvd.sock",
                       "--max-bytes","34359738368",                            # 32 GiB L2 arena
                       "--long-path","/l3/long","--long-bytes","107374182400"] # 100 GiB L3 on the PVC
-            env:
-              - {name: INFERA_REQUIRE_NATIVE, value: "1"}   # hipFile, or fail loudly
             securityContext:
               capabilities: {add: ["IPC_LOCK"]}     # required to mlock the arena
             resources:

--- a/examples/recipes/glm5.2/mixed-kvd/deploy.yaml
+++ b/examples/recipes/glm5.2/mixed-kvd/deploy.yaml
@@ -117,6 +117,11 @@ spec:
               - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
               - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
               - {name: INFERA_KVD_SOCKET, value: "/kvd/kvd.sock"}
+            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
+            # the overlay's native tree. Without this, a payload built without that
+            # tree only WARNS and both silently become unavailable — the run looks
+            # healthy and quietly serves without the thing you deployed it for.
+              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10
@@ -141,6 +146,8 @@ spec:
                       "--socket","/kvd/kvd.sock",
                       "--max-bytes","34359738368",                            # 32 GiB L2 arena
                       "--long-path","/l3/long","--long-bytes","107374182400"] # 100 GiB L3 on the PVC
+            env:
+              - {name: INFERA_REQUIRE_NATIVE, value: "1"}   # hipFile, or fail loudly
             securityContext:
               capabilities: {add: ["IPC_LOCK"]}     # required to mlock the arena
             resources:

--- a/examples/recipes/glm5.2/mixed-kvd/deploy.yaml
+++ b/examples/recipes/glm5.2/mixed-kvd/deploy.yaml
@@ -1,0 +1,160 @@
+# GLM-5.2-MXFP4 — mixed-kvd — Kubernetes recipe
+#
+#   base image   lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x      (stock vendor image, unmodified)
+#   overlay      rocm/infera-overlay:latest                     (infera + router + kvd + native deps)
+#   engine       infera.engine.sglang   TP8
+#
+# Deploy:  kubectl apply -f examples/recipes/glm5.2/mixed-kvd/deploy.yaml
+# Docs:    examples/recipes/glm5.2/README.md
+#
+# Expects the `model-cache` PVC to hold the weights at /models/GLM-5.2-MXFP4
+# (examples/k8s-deployments/model-cache/). Swap the `model` volume for a
+# hostPath if you keep weights on the node instead.
+#
+# GLM-5.2 runs fp8_e4m3 KV. kvd only offloads layouts it can
+# round-trip byte-exact, and regular-attention fp8 support landed in #63 —
+# which the overlay carries (it is built from this tree). If you pin an
+# older overlay, add `--kv-cache-dtype auto` or kvd silently stores nothing.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kvd-l3
+  namespace: infera
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: {requests: {storage: 200Gi}}   # L3 spill; size to your working set
+  storageClassName: local-path                 # k3s default; use fast local NVMe in production
+---
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: glm52-mixed-kvd
+  namespace: infera
+spec:
+  backendFramework: sglang
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.server",
+                      "--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","/models/GLM-5.2-MXFP4",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "8", memory: 16Gi}, limits: {cpu: "8", memory: 16Gi}}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+    worker:
+      componentType: worker
+      role: mixed
+      replicas: 1
+      extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec",
+                      "python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--model-path","/models/GLM-5.2-MXFP4",
+                      "--served-model-name","glm5.2-mxfp4",
+                      "--tp-size","8","--trust-remote-code",
+                      "--nsa-prefill-backend","tilelang","--nsa-decode-backend","tilelang",
+                      "--kv-cache-dtype","fp8_e4m3","--mem-fraction-static","0.85",
+                      "--context-length","32768","--chunked-prefill-size","8192",
+                      "--max-running-requests","24","--cuda-graph-max-bs","24",
+                      "--infera-kvd-socket","/kvd/kvd.sock","--hicache-size","16",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            # NOTE: --infera-kvd-socket turns on SGLang's hierarchical cache, whose
+            # host-RAM tier is sized from the GPU KV pool unless capped. Left alone
+            # it asked for 416 GB here and the container was OOMKilled — keep
+            # --hicache-size below this container's memory limit.
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              - {name: SGLANG_OPT_USE_TILELANG_INDEXER, value: "1"}
+              - {name: SGLANG_OPT_USE_TOPK_V2, value: "0"}
+              - {name: SGLANG_OPT_USE_JIT_NORM, value: "0"}
+              - {name: SGLANG_USE_AITER, value: "1"}
+              - {name: SGLANG_ROCM_FUSED_DECODE_MLA, value: "0"}
+              - {name: ROCM_QUICK_REDUCE_QUANTIZATION, value: "INT4"}
+              - {name: SAFETENSORS_FAST_GPU, value: "1"}
+              - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
+              - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
+              - {name: INFERA_KVD_SOCKET, value: "/kvd/kvd.sock"}
+            startupProbe:
+              httpGet: {path: /health, port: 30000}
+              periodSeconds: 10
+              timeoutSeconds: 10
+              failureThreshold: 180     # weight load is slow; do not use a readinessProbe here
+            resources:
+              requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+              limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: dshm, mountPath: /dev/shm}
+          # ---- kvd sidecar: L2 pinned host RAM + L3 on a PVC ----
+          # Same image as `main` (already on the node, so no extra pull) running
+          # infera.kvd out of the shared overlay. The overlay image itself is a
+          # busybox carrying the payload — it has no interpreter to run kvd with.
+          - name: kvd
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.kvd",
+                      "--socket","/kvd/kvd.sock",
+                      "--max-bytes","34359738368",                            # 32 GiB L2 arena
+                      "--long-path","/l3/long","--long-bytes","107374182400"] # 100 GiB L3 on the PVC
+            securityContext:
+              capabilities: {add: ["IPC_LOCK"]}     # required to mlock the arena
+            resources:
+              # Must exceed --max-bytes: the arena is pinned host RAM charged here.
+              requests: {cpu: "4", memory: 40Gi}
+              limits: {cpu: "4", memory: 40Gi}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: kvd-l3, mountPath: /l3}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+          # engine <-> kvd UDS: a plain emptyDir shared by the two containers
+          - {name: kvd-sock, emptyDir: {}}
+          - {name: kvd-l3, persistentVolumeClaim: {claimName: kvd-l3}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 64Gi}}

--- a/examples/recipes/glm5.2/mixed-kvd/deploy.yaml
+++ b/examples/recipes/glm5.2/mixed-kvd/deploy.yaml
@@ -97,6 +97,7 @@ spec:
                       "--kv-cache-dtype","fp8_e4m3","--mem-fraction-static","0.85",
                       "--context-length","32768","--chunked-prefill-size","8192",
                       "--max-running-requests","24","--cuda-graph-max-bs","24",
+                      "--reasoning-parser","glm45",
                       "--infera-kvd-socket","/kvd/kvd.sock","--hicache-size","16",
                       "--kv-event-transport","zmq","--request-transport","http"]
             # NOTE: --infera-kvd-socket turns on SGLang's hierarchical cache, whose

--- a/examples/recipes/glm5.2/mixed/deploy.yaml
+++ b/examples/recipes/glm5.2/mixed/deploy.yaml
@@ -86,6 +86,7 @@ spec:
                       "--kv-cache-dtype","fp8_e4m3","--mem-fraction-static","0.85",
                       "--context-length","32768","--chunked-prefill-size","8192",
                       "--max-running-requests","24","--cuda-graph-max-bs","24",
+                      "--reasoning-parser","glm45",
                       "--kv-event-transport","zmq","--request-transport","http"]
             env:
               - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}

--- a/examples/recipes/glm5.2/mixed/deploy.yaml
+++ b/examples/recipes/glm5.2/mixed/deploy.yaml
@@ -1,0 +1,118 @@
+# GLM-5.2-MXFP4 — mixed — Kubernetes recipe
+#
+#   base image   lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x      (stock vendor image, unmodified)
+#   overlay      rocm/infera-overlay:latest                     (infera + router + kvd + native deps)
+#   engine       infera.engine.sglang   TP8
+#
+# Deploy:  kubectl apply -f examples/recipes/glm5.2/mixed/deploy.yaml
+# Docs:    examples/recipes/glm5.2/README.md
+#
+# Expects the `model-cache` PVC to hold the weights at /models/GLM-5.2-MXFP4
+# (examples/k8s-deployments/model-cache/). Swap the `model` volume for a
+# hostPath if you keep weights on the node instead.
+#
+# The five SGLANG_OPT_* / SGLANG_USE_AITER vars are NOT optional on
+# ROCm: without them GLM-5.2's DSA indexer picks a path that produces
+# garbage decode. See manual/examples/k8s_glm5.2_sglang.md.
+---
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: glm52-mixed
+  namespace: infera
+spec:
+  backendFramework: sglang
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.server",
+                      "--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","/models/GLM-5.2-MXFP4",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "8", memory: 16Gi}, limits: {cpu: "8", memory: 16Gi}}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+    worker:
+      componentType: worker
+      role: mixed
+      replicas: 1
+      extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec",
+                      "python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--model-path","/models/GLM-5.2-MXFP4",
+                      "--served-model-name","glm5.2-mxfp4",
+                      "--tp-size","8","--trust-remote-code",
+                      "--nsa-prefill-backend","tilelang","--nsa-decode-backend","tilelang",
+                      "--kv-cache-dtype","fp8_e4m3","--mem-fraction-static","0.85",
+                      "--context-length","32768","--chunked-prefill-size","8192",
+                      "--max-running-requests","24","--cuda-graph-max-bs","24",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              - {name: SGLANG_OPT_USE_TILELANG_INDEXER, value: "1"}
+              - {name: SGLANG_OPT_USE_TOPK_V2, value: "0"}
+              - {name: SGLANG_OPT_USE_JIT_NORM, value: "0"}
+              - {name: SGLANG_USE_AITER, value: "1"}
+              - {name: SGLANG_ROCM_FUSED_DECODE_MLA, value: "0"}
+              - {name: ROCM_QUICK_REDUCE_QUANTIZATION, value: "INT4"}
+              - {name: SAFETENSORS_FAST_GPU, value: "1"}
+              - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
+              - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
+            startupProbe:
+              httpGet: {path: /health, port: 30000}
+              periodSeconds: 10
+              timeoutSeconds: 10
+              failureThreshold: 180     # weight load is slow; do not use a readinessProbe here
+            resources:
+              requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+              limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 64Gi}}

--- a/examples/recipes/glm5.2/pd-kvd/deploy.yaml
+++ b/examples/recipes/glm5.2/pd-kvd/deploy.yaml
@@ -1,0 +1,268 @@
+# GLM-5.2-MXFP4 — pd-kvd — Kubernetes recipe
+#
+#   base image   lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x      (stock vendor image, unmodified)
+#   overlay      rocm/infera-overlay:latest                     (infera + router + kvd + native deps)
+#   engine       infera.engine.sglang   TP8
+#
+# Deploy:  kubectl apply -f examples/recipes/glm5.2/pd-kvd/deploy.yaml
+# Docs:    examples/recipes/glm5.2/README.md
+#
+# Expects the `model-cache` PVC to hold the weights at /models/GLM-5.2-MXFP4
+# (examples/k8s-deployments/model-cache/). Swap the `model` volume for a
+# hostPath if you keep weights on the node instead.
+#
+# PD REQUIRES the prefill and decode nodes to sit on a MUTUALLY ROUTABLE RoCE
+# fabric — the KV transfer is RDMA, not TCP, and there is no fallback. Set
+# <PREFILL_NODE>/<DECODE_NODE> to two such nodes. Not validated for this model;
+# examples/k8s-deployments/pd-1p1d-mooncake.yaml is the validated reference.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kvd-l3-prefill
+  namespace: infera
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: {requests: {storage: 200Gi}}   # L3 spill; size to your working set
+  storageClassName: local-path                 # k3s default; use fast local NVMe in production
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kvd-l3-decode
+  namespace: infera
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: {requests: {storage: 200Gi}}   # L3 spill; size to your working set
+  storageClassName: local-path                 # k3s default; use fast local NVMe in production
+---
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: glm52-pd-kvd
+  namespace: infera
+spec:
+  backendFramework: sglang
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.server",
+                      "--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","/models/GLM-5.2-MXFP4",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "8", memory: 16Gi}, limits: {cpu: "8", memory: 16Gi}}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+    prefill:
+      componentType: worker
+      role: prefill
+      replicas: 1
+      port: 30000
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec",
+                      "python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--model-path","/models/GLM-5.2-MXFP4",
+                      "--served-model-name","glm5.2-mxfp4",
+                      "--disaggregation-mode","prefill",
+                      "--disaggregation-transfer-backend","mooncake",
+                      "--tp-size","8","--trust-remote-code",
+                      "--nsa-prefill-backend","tilelang","--nsa-decode-backend","tilelang",
+                      "--kv-cache-dtype","fp8_e4m3","--mem-fraction-static","0.85",
+                      "--context-length","32768","--chunked-prefill-size","8192",
+                      "--max-running-requests","24","--cuda-graph-max-bs","24",
+                      "--infera-kvd-socket","/kvd/kvd.sock","--hicache-size","16",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            # NOTE: --infera-kvd-socket turns on SGLang's hierarchical cache, whose
+            # host-RAM tier is sized from the GPU KV pool unless capped. Left alone
+            # it asked for 416 GB here and the container was OOMKilled — keep
+            # --hicache-size below this container's memory limit.
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              - {name: SGLANG_OPT_USE_TILELANG_INDEXER, value: "1"}
+              - {name: SGLANG_OPT_USE_TOPK_V2, value: "0"}
+              - {name: SGLANG_OPT_USE_JIT_NORM, value: "0"}
+              - {name: SGLANG_USE_AITER, value: "1"}
+              - {name: SGLANG_ROCM_FUSED_DECODE_MLA, value: "0"}
+              - {name: ROCM_QUICK_REDUCE_QUANTIZATION, value: "INT4"}
+              - {name: SAFETENSORS_FAST_GPU, value: "1"}
+              - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
+              - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
+              - {name: INFERA_KVD_SOCKET, value: "/kvd/kvd.sock"}
+            startupProbe:
+              httpGet: {path: /health, port: 30000}
+              periodSeconds: 10
+              timeoutSeconds: 10
+              failureThreshold: 180     # weight load is slow; do not use a readinessProbe here
+            resources:
+              requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+              limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: dshm, mountPath: /dev/shm}
+          # ---- kvd sidecar: L2 pinned host RAM + L3 on a PVC ----
+          # Same image as `main` (already on the node, so no extra pull) running
+          # infera.kvd out of the shared overlay. The overlay image itself is a
+          # busybox carrying the payload — it has no interpreter to run kvd with.
+          - name: kvd
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.kvd",
+                      "--socket","/kvd/kvd.sock",
+                      "--max-bytes","34359738368",                            # 32 GiB L2 arena
+                      "--long-path","/l3/long","--long-bytes","107374182400"] # 100 GiB L3 on the PVC
+            securityContext:
+              capabilities: {add: ["IPC_LOCK"]}     # required to mlock the arena
+            resources:
+              # Must exceed --max-bytes: the arena is pinned host RAM charged here.
+              requests: {cpu: "4", memory: 40Gi}
+              limits: {cpu: "4", memory: 40Gi}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: kvd-l3, mountPath: /l3}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+          # engine <-> kvd UDS: a plain emptyDir shared by the two containers
+          - {name: kvd-sock, emptyDir: {}}
+          - {name: kvd-l3, persistentVolumeClaim: {claimName: kvd-l3-prefill}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 64Gi}}
+    decode:
+      componentType: worker
+      role: decode
+      replicas: 1
+      port: 30000
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <DECODE_NODE>}
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec",
+                      "python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--model-path","/models/GLM-5.2-MXFP4",
+                      "--served-model-name","glm5.2-mxfp4",
+                      "--disaggregation-mode","decode",
+                      "--disaggregation-transfer-backend","mooncake",
+                      "--tp-size","8","--trust-remote-code",
+                      "--nsa-prefill-backend","tilelang","--nsa-decode-backend","tilelang",
+                      "--kv-cache-dtype","fp8_e4m3","--mem-fraction-static","0.85",
+                      "--context-length","32768","--chunked-prefill-size","8192",
+                      "--max-running-requests","24","--cuda-graph-max-bs","24",
+                      "--infera-kvd-socket","/kvd/kvd.sock","--hicache-size","16",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            # NOTE: --infera-kvd-socket turns on SGLang's hierarchical cache, whose
+            # host-RAM tier is sized from the GPU KV pool unless capped. Left alone
+            # it asked for 416 GB here and the container was OOMKilled — keep
+            # --hicache-size below this container's memory limit.
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              - {name: SGLANG_OPT_USE_TILELANG_INDEXER, value: "1"}
+              - {name: SGLANG_OPT_USE_TOPK_V2, value: "0"}
+              - {name: SGLANG_OPT_USE_JIT_NORM, value: "0"}
+              - {name: SGLANG_USE_AITER, value: "1"}
+              - {name: SGLANG_ROCM_FUSED_DECODE_MLA, value: "0"}
+              - {name: ROCM_QUICK_REDUCE_QUANTIZATION, value: "INT4"}
+              - {name: SAFETENSORS_FAST_GPU, value: "1"}
+              - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
+              - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
+              - {name: INFERA_KVD_SOCKET, value: "/kvd/kvd.sock"}
+            startupProbe:
+              httpGet: {path: /health, port: 30000}
+              periodSeconds: 10
+              timeoutSeconds: 10
+              failureThreshold: 180     # weight load is slow; do not use a readinessProbe here
+            resources:
+              requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+              limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: dshm, mountPath: /dev/shm}
+          # ---- kvd sidecar: L2 pinned host RAM + L3 on a PVC ----
+          # Same image as `main` (already on the node, so no extra pull) running
+          # infera.kvd out of the shared overlay. The overlay image itself is a
+          # busybox carrying the payload — it has no interpreter to run kvd with.
+          - name: kvd
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.kvd",
+                      "--socket","/kvd/kvd.sock",
+                      "--max-bytes","34359738368",                            # 32 GiB L2 arena
+                      "--long-path","/l3/long","--long-bytes","107374182400"] # 100 GiB L3 on the PVC
+            securityContext:
+              capabilities: {add: ["IPC_LOCK"]}     # required to mlock the arena
+            resources:
+              # Must exceed --max-bytes: the arena is pinned host RAM charged here.
+              requests: {cpu: "4", memory: 40Gi}
+              limits: {cpu: "4", memory: 40Gi}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: kvd-l3, mountPath: /l3}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+          # engine <-> kvd UDS: a plain emptyDir shared by the two containers
+          - {name: kvd-sock, emptyDir: {}}
+          - {name: kvd-l3, persistentVolumeClaim: {claimName: kvd-l3-decode}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 64Gi}}

--- a/examples/recipes/glm5.2/pd-kvd/deploy.yaml
+++ b/examples/recipes/glm5.2/pd-kvd/deploy.yaml
@@ -112,6 +112,7 @@ spec:
                       "--kv-cache-dtype","fp8_e4m3","--mem-fraction-static","0.85",
                       "--context-length","32768","--chunked-prefill-size","8192",
                       "--max-running-requests","24","--cuda-graph-max-bs","24",
+                      "--reasoning-parser","glm45",
                       "--infera-kvd-socket","/kvd/kvd.sock","--hicache-size","16",
                       "--kv-event-transport","zmq","--request-transport","http"]
             # NOTE: --infera-kvd-socket turns on SGLang's hierarchical cache, whose
@@ -212,6 +213,7 @@ spec:
                       "--kv-cache-dtype","fp8_e4m3","--mem-fraction-static","0.85",
                       "--context-length","32768","--chunked-prefill-size","8192",
                       "--max-running-requests","24","--cuda-graph-max-bs","24",
+                      "--reasoning-parser","glm45",
                       "--infera-kvd-socket","/kvd/kvd.sock","--hicache-size","16",
                       "--kv-event-transport","zmq","--request-transport","http"]
             # NOTE: --infera-kvd-socket turns on SGLang's hierarchical cache, whose

--- a/examples/recipes/glm5.2/pd-kvd/deploy.yaml
+++ b/examples/recipes/glm5.2/pd-kvd/deploy.yaml
@@ -132,6 +132,11 @@ spec:
               - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
               - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
               - {name: INFERA_KVD_SOCKET, value: "/kvd/kvd.sock"}
+            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
+            # the overlay's native tree. Without this, a payload built without that
+            # tree only WARNS and both silently become unavailable — the run looks
+            # healthy and quietly serves without the thing you deployed it for.
+              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10
@@ -156,6 +161,8 @@ spec:
                       "--socket","/kvd/kvd.sock",
                       "--max-bytes","34359738368",                            # 32 GiB L2 arena
                       "--long-path","/l3/long","--long-bytes","107374182400"] # 100 GiB L3 on the PVC
+            env:
+              - {name: INFERA_REQUIRE_NATIVE, value: "1"}   # hipFile, or fail loudly
             securityContext:
               capabilities: {add: ["IPC_LOCK"]}     # required to mlock the arena
             resources:
@@ -225,6 +232,11 @@ spec:
               - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
               - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
               - {name: INFERA_KVD_SOCKET, value: "/kvd/kvd.sock"}
+            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
+            # the overlay's native tree. Without this, a payload built without that
+            # tree only WARNS and both silently become unavailable — the run looks
+            # healthy and quietly serves without the thing you deployed it for.
+              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10
@@ -249,6 +261,8 @@ spec:
                       "--socket","/kvd/kvd.sock",
                       "--max-bytes","34359738368",                            # 32 GiB L2 arena
                       "--long-path","/l3/long","--long-bytes","107374182400"] # 100 GiB L3 on the PVC
+            env:
+              - {name: INFERA_REQUIRE_NATIVE, value: "1"}   # hipFile, or fail loudly
             securityContext:
               capabilities: {add: ["IPC_LOCK"]}     # required to mlock the arena
             resources:

--- a/examples/recipes/glm5.2/pd-kvd/deploy.yaml
+++ b/examples/recipes/glm5.2/pd-kvd/deploy.yaml
@@ -133,11 +133,10 @@ spec:
               - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
               - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
               - {name: INFERA_KVD_SOCKET, value: "/kvd/kvd.sock"}
-            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
-            # the overlay's native tree. Without this, a payload built without that
-            # tree only WARNS and both silently become unavailable — the run looks
-            # healthy and quietly serves without the thing you deployed it for.
-              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
+            # PD's KV transport is Mooncake, which lives in the overlay's native
+            # tree. Name it so a payload lacking it fails at startup instead of only
+            # warning and quietly serving with no KV transfer at all.
+              - {name: INFERA_REQUIRE_NATIVE, value: "mooncake"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10
@@ -162,8 +161,6 @@ spec:
                       "--socket","/kvd/kvd.sock",
                       "--max-bytes","34359738368",                            # 32 GiB L2 arena
                       "--long-path","/l3/long","--long-bytes","107374182400"] # 100 GiB L3 on the PVC
-            env:
-              - {name: INFERA_REQUIRE_NATIVE, value: "1"}   # hipFile, or fail loudly
             securityContext:
               capabilities: {add: ["IPC_LOCK"]}     # required to mlock the arena
             resources:
@@ -234,11 +231,10 @@ spec:
               - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
               - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
               - {name: INFERA_KVD_SOCKET, value: "/kvd/kvd.sock"}
-            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
-            # the overlay's native tree. Without this, a payload built without that
-            # tree only WARNS and both silently become unavailable — the run looks
-            # healthy and quietly serves without the thing you deployed it for.
-              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
+            # PD's KV transport is Mooncake, which lives in the overlay's native
+            # tree. Name it so a payload lacking it fails at startup instead of only
+            # warning and quietly serving with no KV transfer at all.
+              - {name: INFERA_REQUIRE_NATIVE, value: "mooncake"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10
@@ -263,8 +259,6 @@ spec:
                       "--socket","/kvd/kvd.sock",
                       "--max-bytes","34359738368",                            # 32 GiB L2 arena
                       "--long-path","/l3/long","--long-bytes","107374182400"] # 100 GiB L3 on the PVC
-            env:
-              - {name: INFERA_REQUIRE_NATIVE, value: "1"}   # hipFile, or fail loudly
             securityContext:
               capabilities: {add: ["IPC_LOCK"]}     # required to mlock the arena
             resources:

--- a/examples/recipes/glm5.2/pd/deploy.yaml
+++ b/examples/recipes/glm5.2/pd/deploy.yaml
@@ -107,11 +107,10 @@ spec:
               - {name: SAFETENSORS_FAST_GPU, value: "1"}
               - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
               - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
-            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
-            # the overlay's native tree. Without this, a payload built without that
-            # tree only WARNS and both silently become unavailable — the run looks
-            # healthy and quietly serves without the thing you deployed it for.
-              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
+            # PD's KV transport is Mooncake, which lives in the overlay's native
+            # tree. Name it so a payload lacking it fails at startup instead of only
+            # warning and quietly serving with no KV transfer at all.
+              - {name: INFERA_REQUIRE_NATIVE, value: "mooncake"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10
@@ -175,11 +174,10 @@ spec:
               - {name: SAFETENSORS_FAST_GPU, value: "1"}
               - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
               - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
-            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
-            # the overlay's native tree. Without this, a payload built without that
-            # tree only WARNS and both silently become unavailable — the run looks
-            # healthy and quietly serves without the thing you deployed it for.
-              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
+            # PD's KV transport is Mooncake, which lives in the overlay's native
+            # tree. Name it so a payload lacking it fails at startup instead of only
+            # warning and quietly serving with no KV transfer at all.
+              - {name: INFERA_REQUIRE_NATIVE, value: "mooncake"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10

--- a/examples/recipes/glm5.2/pd/deploy.yaml
+++ b/examples/recipes/glm5.2/pd/deploy.yaml
@@ -106,6 +106,11 @@ spec:
               - {name: SAFETENSORS_FAST_GPU, value: "1"}
               - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
               - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
+            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
+            # the overlay's native tree. Without this, a payload built without that
+            # tree only WARNS and both silently become unavailable — the run looks
+            # healthy and quietly serves without the thing you deployed it for.
+              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10
@@ -168,6 +173,11 @@ spec:
               - {name: SAFETENSORS_FAST_GPU, value: "1"}
               - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
               - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
+            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
+            # the overlay's native tree. Without this, a payload built without that
+            # tree only WARNS and both silently become unavailable — the run looks
+            # healthy and quietly serves without the thing you deployed it for.
+              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10

--- a/examples/recipes/glm5.2/pd/deploy.yaml
+++ b/examples/recipes/glm5.2/pd/deploy.yaml
@@ -1,0 +1,186 @@
+# GLM-5.2-MXFP4 — pd — Kubernetes recipe
+#
+#   base image   lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x      (stock vendor image, unmodified)
+#   overlay      rocm/infera-overlay:latest                     (infera + router + kvd + native deps)
+#   engine       infera.engine.sglang   TP8
+#
+# Deploy:  kubectl apply -f examples/recipes/glm5.2/pd/deploy.yaml
+# Docs:    examples/recipes/glm5.2/README.md
+#
+# Expects the `model-cache` PVC to hold the weights at /models/GLM-5.2-MXFP4
+# (examples/k8s-deployments/model-cache/). Swap the `model` volume for a
+# hostPath if you keep weights on the node instead.
+#
+# PD REQUIRES the prefill and decode nodes to sit on a MUTUALLY ROUTABLE RoCE
+# fabric — the KV transfer is RDMA, not TCP, and there is no fallback. Set
+# <PREFILL_NODE>/<DECODE_NODE> to two such nodes. Not validated for this model;
+# examples/k8s-deployments/pd-1p1d-mooncake.yaml is the validated reference.
+---
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: glm52-pd
+  namespace: infera
+spec:
+  backendFramework: sglang
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.server",
+                      "--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","/models/GLM-5.2-MXFP4",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "8", memory: 16Gi}, limits: {cpu: "8", memory: 16Gi}}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+    prefill:
+      componentType: worker
+      role: prefill
+      replicas: 1
+      port: 30000
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec",
+                      "python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--model-path","/models/GLM-5.2-MXFP4",
+                      "--served-model-name","glm5.2-mxfp4",
+                      "--disaggregation-mode","prefill",
+                      "--disaggregation-transfer-backend","mooncake",
+                      "--tp-size","8","--trust-remote-code",
+                      "--nsa-prefill-backend","tilelang","--nsa-decode-backend","tilelang",
+                      "--kv-cache-dtype","fp8_e4m3","--mem-fraction-static","0.85",
+                      "--context-length","32768","--chunked-prefill-size","8192",
+                      "--max-running-requests","24","--cuda-graph-max-bs","24",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              - {name: SGLANG_OPT_USE_TILELANG_INDEXER, value: "1"}
+              - {name: SGLANG_OPT_USE_TOPK_V2, value: "0"}
+              - {name: SGLANG_OPT_USE_JIT_NORM, value: "0"}
+              - {name: SGLANG_USE_AITER, value: "1"}
+              - {name: SGLANG_ROCM_FUSED_DECODE_MLA, value: "0"}
+              - {name: ROCM_QUICK_REDUCE_QUANTIZATION, value: "INT4"}
+              - {name: SAFETENSORS_FAST_GPU, value: "1"}
+              - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
+              - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
+            startupProbe:
+              httpGet: {path: /health, port: 30000}
+              periodSeconds: 10
+              timeoutSeconds: 10
+              failureThreshold: 180     # weight load is slow; do not use a readinessProbe here
+            resources:
+              requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+              limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 64Gi}}
+    decode:
+      componentType: worker
+      role: decode
+      replicas: 1
+      port: 30000
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <DECODE_NODE>}
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec",
+                      "python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+                      "--model-path","/models/GLM-5.2-MXFP4",
+                      "--served-model-name","glm5.2-mxfp4",
+                      "--disaggregation-mode","decode",
+                      "--disaggregation-transfer-backend","mooncake",
+                      "--tp-size","8","--trust-remote-code",
+                      "--nsa-prefill-backend","tilelang","--nsa-decode-backend","tilelang",
+                      "--kv-cache-dtype","fp8_e4m3","--mem-fraction-static","0.85",
+                      "--context-length","32768","--chunked-prefill-size","8192",
+                      "--max-running-requests","24","--cuda-graph-max-bs","24",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              - {name: SGLANG_OPT_USE_TILELANG_INDEXER, value: "1"}
+              - {name: SGLANG_OPT_USE_TOPK_V2, value: "0"}
+              - {name: SGLANG_OPT_USE_JIT_NORM, value: "0"}
+              - {name: SGLANG_USE_AITER, value: "1"}
+              - {name: SGLANG_ROCM_FUSED_DECODE_MLA, value: "0"}
+              - {name: ROCM_QUICK_REDUCE_QUANTIZATION, value: "INT4"}
+              - {name: SAFETENSORS_FAST_GPU, value: "1"}
+              - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
+              - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
+            startupProbe:
+              httpGet: {path: /health, port: 30000}
+              periodSeconds: 10
+              timeoutSeconds: 10
+              failureThreshold: 180     # weight load is slow; do not use a readinessProbe here
+            resources:
+              requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+              limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 64Gi}}

--- a/examples/recipes/glm5.2/pd/deploy.yaml
+++ b/examples/recipes/glm5.2/pd/deploy.yaml
@@ -92,6 +92,7 @@ spec:
                       "--kv-cache-dtype","fp8_e4m3","--mem-fraction-static","0.85",
                       "--context-length","32768","--chunked-prefill-size","8192",
                       "--max-running-requests","24","--cuda-graph-max-bs","24",
+                      "--reasoning-parser","glm45",
                       "--kv-event-transport","zmq","--request-transport","http"]
             env:
               - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
@@ -159,6 +160,7 @@ spec:
                       "--kv-cache-dtype","fp8_e4m3","--mem-fraction-static","0.85",
                       "--context-length","32768","--chunked-prefill-size","8192",
                       "--max-running-requests","24","--cuda-graph-max-bs","24",
+                      "--reasoning-parser","glm45",
                       "--kv-event-transport","zmq","--request-transport","http"]
             env:
               - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}

--- a/examples/recipes/kimi-k3/README.md
+++ b/examples/recipes/kimi-k3/README.md
@@ -93,8 +93,12 @@ curl -s localhost:8000/v1/chat/completions \
   -H 'Content-Type: application/json' \
   -d '{"model":"kimi-k3",
        "messages":[{"role":"user","content":"What is the capital of France?"}],
-       "max_tokens":60}' | jq -r '.choices[0].message.content'
+       "max_tokens":200}' | jq -r '.choices[0].message.content'
 ```
+
+Expect `The capital of France is Paris.` Keep `max_tokens` generous: Kimi-K3
+spent 73 completion tokens on that sentence, so a 60-token cap truncates it to
+the single word `The` and the recipe looks broken when it is not.
 
 **Multimodal** — Kimi-K3 is a vision model, so the text test alone does not cover
 it. `examples/kimi_k3/mm_test.py` generates a test image with the standard library
@@ -152,14 +156,26 @@ on this hardware.
 
 | What | Status |
 |---|---|
-| Kimi-K3 TP8 vLLM serving + multimodal | validated on MI355X — [`manual/examples/k8s_kimi_k3.md`](../../../manual/examples/k8s_kimi_k3.md) |
+| **`mixed/deploy.yaml` exactly as written** | **validated end-to-end on k3s (MI355X, 8×`amd.com/gpu`)** — see below |
 | kvd sidecar + PVC L3 under vLLM | validated (2 entries / 271 MB on a 3510-token request), on Qwen3-0.6B |
-| overlay payload on a stock vLLM base | validated — [`deploy/overlay/README.md`](../../../deploy/overlay/README.md) |
-| these three combined, as written here | **not yet run end-to-end** |
 | pd / pd-kvd for this model | structure only; the vLLM MultiConnector wiring is unproven for Kimi-K3 |
 
-The validated runs used the baked `rocm/infera:vllm-*` images. These manifests
-compose that same software as an overlay — proven separately, not yet together.
+The `mixed` run used the **stock `vllm/vllm-openai-rocm:kimi-k3` image** with the
+overlay mounted in — no infera-built engine image anywhere in the Pod:
+
+| | |
+|---|---|
+| router Ready | ~20 s (`infera.server` running from `/overlay`) |
+| weight load | 502 s, 96 shards, 1453 GiB from local XFS NVMe |
+| worker Ready | ~11 min including aiter JIT + CUDA graph capture |
+| text | `The capital of France is Paris.` (73 completion tokens, `finish_reason: stop`) |
+| multimodal | correctly identified the generated crimson image |
+
+That run is also what surfaced the payload-shadowing bug: the engine logged
+`ImportError: Numba needs NumPy 2.4 or less. Got NumPy 2.5` on repeat, because
+the overlay was shipping numpy 2.5.1 over the base's 2.3.5. Non-fatal here, but
+fixed properly in `deploy/overlay/prune_base_dists.py` — the payload now adds
+only what the base lacks.
 
 ## Source
 

--- a/examples/recipes/kimi-k3/README.md
+++ b/examples/recipes/kimi-k3/README.md
@@ -1,0 +1,167 @@
+# Kimi-K3 on Kubernetes
+
+Serve Kimi-K3 with infera on an AMD MI355X node (TP8, vLLM), including its
+multimodal and tool-calling paths.
+
+Built as **stock vendor image + overlay + sidecar**: the manifests run the
+unmodified `vllm/vllm-openai-rocm` image and mount infera in from an overlay
+payload. That separation is not cosmetic here — forking the vLLM base image for
+Kimi-K3 is exactly what broke serving for every *other* model in CI. The overlay
+keeps Kimi-K3's base choice from being everyone else's problem.
+
+## 1. Choose your combo
+
+| Combo | Serving | KV cache | Manifest |
+|---|---|---|---|
+| **mixed** | one worker, prefill + decode | GPU only | [`mixed/deploy.yaml`](mixed/deploy.yaml) |
+| **mixed + kvd** | one worker, prefill + decode | + L2 host RAM, L3 on a PVC, **GPU-direct** | [`mixed-kvd/deploy.yaml`](mixed-kvd/deploy.yaml) |
+| **pd** | prefill and decode on separate nodes | GPU only | [`pd/deploy.yaml`](pd/deploy.yaml) |
+| **pd + kvd** | prefill and decode on separate nodes | + kvd per role | [`pd-kvd/deploy.yaml`](pd-kvd/deploy.yaml) |
+
+Start with **mixed**. Add **kvd** when requests share long prefixes (a common system
+prompt, multi-turn chat, RAG). Move to **pd** only if you have two nodes on a
+mutually routable RoCE fabric.
+
+Because this recipe runs vLLM, its kvd combos get **GPU-direct L3**: kvd loads the
+L3 tier straight into VRAM through hipFile. SGLang's route (`--infera-kvd-socket`)
+bounces through host memory instead, so GPU-direct L3 is a vLLM-only capability.
+
+`export COMBO=mixed` (or `mixed-kvd`, `pd`, `pd-kvd`) — the commands below use it.
+
+## 2. Prerequisites
+
+**Hardware.** 8× MI355X (or MI300X+) on one node for `mixed`; two such nodes on a
+shared RoCE fabric for `pd`. Kimi-K3's weights are ~1.5 TB — put them on **local
+NVMe**, not NFS. Loading over NFS took about an hour here; local disk is minutes.
+
+**Cluster.** Kubernetes 1.28+ with:
+
+```bash
+# AMD GPU device plugin — nodes must advertise amd.com/gpu
+kubectl get nodes -o custom-columns=NODE:.metadata.name,GPU:.status.allocatable.'amd\.com/gpu'
+
+# the infera operator (provides the InferaDeployment CRD)
+helm install infera-operator deploy/operator/helm/infera-operator -n infera-system --create-namespace
+kubectl -n infera-system rollout status deploy/infera-operator
+```
+
+On k3s, install with `--data-dir` on a large disk. The default lives under `/var/lib`,
+and 1.5 TB of weights plus these images fills it — the node goes `DiskPressure` and
+evicts the operator before anything serves.
+
+**Weights.** The manifests expect the `model-cache` PVC to hold Kimi-K3 at
+`/models/Kimi-K3`. Size the PVC for 1.5 TB before you start:
+
+```bash
+kubectl apply -f examples/k8s-deployments/model-cache/model-cache.yaml
+kubectl apply -f examples/k8s-deployments/model-cache/model-download.yaml
+kubectl -n infera wait --for=condition=complete job/model-download --timeout=12h
+```
+
+## 3. Deploy
+
+```bash
+kubectl create namespace infera --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f examples/recipes/kimi-k3/${COMBO}/deploy.yaml
+```
+
+For the `pd` combos, first substitute the two node names:
+
+```bash
+sed -e "s/<PREFILL_NODE>/node-a/" -e "s/<DECODE_NODE>/node-b/" \
+    examples/recipes/kimi-k3/${COMBO}/deploy.yaml | kubectl apply -f -
+```
+
+Weight load takes tens of minutes, which is why the worker uses a `startupProbe`
+(`failureThreshold: 120`) instead of a readiness probe — a readiness probe would
+declare the Pod dead long before the model is up:
+
+```bash
+kubectl -n infera get pods -w
+kubectl -n infera logs -f -c main \
+  -l infera.amd.com/deployment=kimi-k3-${COMBO},infera.amd.com/service=worker
+```
+
+## 4. Smoke test
+
+**Text:**
+
+```bash
+kubectl -n infera port-forward svc/kimi-k3-${COMBO}-server 8000:8000 &
+
+curl -s localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"kimi-k3",
+       "messages":[{"role":"user","content":"What is the capital of France?"}],
+       "max_tokens":60}' | jq -r '.choices[0].message.content'
+```
+
+**Multimodal** — Kimi-K3 is a vision model, so the text test alone does not cover
+it. `examples/kimi_k3/mm_test.py` generates a test image with the standard library
+(no Pillow needed) and posts it as an image content part:
+
+```bash
+python3 examples/kimi_k3/mm_test.py --port 8000 --model kimi-k3
+```
+
+The model should describe the generated image rather than answer generically.
+
+On the kvd combos, confirm KV is actually landing in the tiers:
+
+```bash
+POD=$(kubectl -n infera get pod -o name \
+  -l infera.amd.com/deployment=kimi-k3-${COMBO},infera.amd.com/service=worker | head -1)
+kubectl -n infera exec $POD -c kvd -- \
+  /overlay/bin/infera-exec python3 -m infera.kvd.statctl --socket /kvd/kvd.sock
+```
+
+`entries` and `long_bytes` must be non-zero. Two things make this read zero even
+when everything looks healthy:
+
+- **The prompt was too short.** kvd stores whole chunks. A short request never
+  fills one, so nothing is written and nothing is wrong. Send a few thousand tokens.
+- **kvd rejected the KV layout**, logging `NOT a plain MLA fp8`. Keep
+  `--kv-cache-dtype auto` as the manifest sets it.
+
+## 5. Tear down
+
+```bash
+kubectl -n infera delete -f examples/recipes/kimi-k3/${COMBO}/deploy.yaml
+```
+
+Then check the GPUs actually released — a deleted Pod can leave processes holding
+hundreds of GB of VRAM, and the next deploy OOMs on a box that looks idle:
+
+```bash
+rocm-smi --showpids
+```
+
+## Model-specific gotchas
+
+These are not tuning preferences; each one is a failure that was hit and diagnosed
+on this hardware.
+
+| Setting | Why it is not optional |
+|---|---|
+| `--kv-cache-dtype auto` | infera otherwise injects fp8_e4m3, which selects the batch-1-only `mla_gluon` kernel: `requires batch_size=1, got 128`. |
+| no `--enable-prefix-caching` | Kimi-K3 is a hybrid Mamba model and crashes with it on, despite what the generic vLLM recipe suggests. |
+| `--load-format auto` | `fastsafetensors` needs GDS; without it the load stalls in 30-second queue waits. |
+| `startupProbe`, not readiness | weight load outlives any sane readiness deadline. |
+
+## Validation status
+
+| What | Status |
+|---|---|
+| Kimi-K3 TP8 vLLM serving + multimodal | validated on MI355X — [`manual/examples/k8s_kimi_k3.md`](../../../manual/examples/k8s_kimi_k3.md) |
+| kvd sidecar + PVC L3 under vLLM | validated (2 entries / 271 MB on a 3510-token request), on Qwen3-0.6B |
+| overlay payload on a stock vLLM base | validated — [`deploy/overlay/README.md`](../../../deploy/overlay/README.md) |
+| these three combined, as written here | **not yet run end-to-end** |
+| pd / pd-kvd for this model | structure only; the vLLM MultiConnector wiring is unproven for Kimi-K3 |
+
+The validated runs used the baked `rocm/infera:vllm-*` images. These manifests
+compose that same software as an overlay — proven separately, not yet together.
+
+## Source
+
+[`examples/recipes/kimi-k3/`](.) in [AMD-AGI/Infera](https://github.com/AMD-AGI/Infera)
+· [all combos](../README.md) · [overlay build](../../../deploy/overlay)

--- a/examples/recipes/kimi-k3/mixed-kvd/deploy.yaml
+++ b/examples/recipes/kimi-k3/mixed-kvd/deploy.yaml
@@ -1,0 +1,150 @@
+# Kimi-K3 — mixed-kvd — Kubernetes recipe
+#
+#   base image   vllm/vllm-openai-rocm:kimi-k3      (stock vendor image, unmodified)
+#   overlay      rocm/infera-overlay:latest                     (infera + router + kvd + native deps)
+#   engine       infera.engine.vllm   TP8
+#
+# Deploy:  kubectl apply -f examples/recipes/kimi-k3/mixed-kvd/deploy.yaml
+# Docs:    examples/recipes/kimi-k3/README.md
+#
+# Expects the `model-cache` PVC to hold the weights at /models/Kimi-K3
+# (examples/k8s-deployments/model-cache/). Swap the `model` volume for a
+# hostPath if you keep weights on the node instead.
+#
+# This is the GPU-direct L3 path: on vLLM, kvd loads L3 straight
+# into VRAM through hipFile. SGLang's route (`--infera-kvd-socket`) goes
+# through host memory instead — GPU-direct L3 is vLLM-only.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kvd-l3
+  namespace: infera
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: {requests: {storage: 200Gi}}   # L3 spill; size to your working set
+  storageClassName: local-path                 # k3s default; use fast local NVMe in production
+---
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: kimi-k3-mixed-kvd
+  namespace: infera
+spec:
+  backendFramework: vllm
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: vllm/vllm-openai-rocm:kimi-k3
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.server",
+                      "--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","/models/Kimi-K3",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "8", memory: 16Gi}, limits: {cpu: "8", memory: 16Gi}}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+    worker:
+      componentType: worker
+      role: mixed
+      replicas: 1
+      extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: vllm/vllm-openai-rocm:kimi-k3
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec",
+                      "python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
+                      "--model","/models/Kimi-K3",
+                      "--served-model-name","kimi-k3",
+                      "--tensor-parallel-size","8","--gpu-memory-utilization","0.95",
+                      "--trust-remote-code","--load-format","auto",
+                      "--mm-encoder-tp-mode","data","--kv-cache-dtype","auto",
+                      "--max-num-seqs","128","--max-num-batched-tokens","4096",
+                      "--enable-auto-tool-choice","--tool-call-parser","kimi_k3",
+                      "--reasoning-parser","kimi_k3",
+                      "--kv-transfer-config","{\"kv_connector\":\"InferaKvdConnector\",\"kv_role\":\"kv_both\",\"kv_connector_module_path\":\"infera.engine.vllm.kvd_connector\"}",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              - {name: HF_HUB_OFFLINE, value: "1"}
+              - {name: VLLM_ROCM_USE_AITER, value: "1"}
+              - {name: SAFETENSORS_FAST_GPU, value: "1"}
+              - {name: INFERA_KVD_SOCKET, value: "/kvd/kvd.sock"}
+            startupProbe:
+              httpGet: {path: /health, port: 30000}
+              periodSeconds: 10
+              timeoutSeconds: 10
+              failureThreshold: 120     # weight load is slow; do not use a readinessProbe here
+            resources:
+              requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+              limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: dshm, mountPath: /dev/shm}
+          # ---- kvd sidecar: L2 pinned host RAM + L3 on a PVC ----
+          # Same image as `main` (already on the node, so no extra pull) running
+          # infera.kvd out of the shared overlay. The overlay image itself is a
+          # busybox carrying the payload — it has no interpreter to run kvd with.
+          - name: kvd
+            image: vllm/vllm-openai-rocm:kimi-k3
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.kvd",
+                      "--socket","/kvd/kvd.sock",
+                      "--max-bytes","34359738368",                            # 32 GiB L2 arena
+                      "--long-path","/l3/long","--long-bytes","107374182400"] # 100 GiB L3 on the PVC
+            securityContext:
+              capabilities: {add: ["IPC_LOCK"]}     # required to mlock the arena
+            resources:
+              # Must exceed --max-bytes: the arena is pinned host RAM charged here.
+              requests: {cpu: "4", memory: 40Gi}
+              limits: {cpu: "4", memory: 40Gi}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: kvd-l3, mountPath: /l3}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+          # engine <-> kvd UDS: a plain emptyDir shared by the two containers
+          - {name: kvd-sock, emptyDir: {}}
+          - {name: kvd-l3, persistentVolumeClaim: {claimName: kvd-l3}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 64Gi}}

--- a/examples/recipes/kimi-k3/mixed-kvd/deploy.yaml
+++ b/examples/recipes/kimi-k3/mixed-kvd/deploy.yaml
@@ -107,11 +107,10 @@ spec:
               - {name: VLLM_ROCM_USE_AITER, value: "1"}
               - {name: SAFETENSORS_FAST_GPU, value: "1"}
               - {name: INFERA_KVD_SOCKET, value: "/kvd/kvd.sock"}
-            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
-            # the overlay's native tree. Without this, a payload built without that
-            # tree only WARNS and both silently become unavailable — the run looks
-            # healthy and quietly serves without the thing you deployed it for.
-              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
+            # kvd's GPU-direct L3 is hipFile, which lives in the overlay's native
+            # tree. Name it so a payload lacking it fails at startup instead of only
+            # warning and quietly serving from host memory.
+              - {name: INFERA_REQUIRE_NATIVE, value: "hipfile"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10
@@ -137,7 +136,7 @@ spec:
                       "--max-bytes","34359738368",                            # 32 GiB L2 arena
                       "--long-path","/l3/long","--long-bytes","107374182400"] # 100 GiB L3 on the PVC
             env:
-              - {name: INFERA_REQUIRE_NATIVE, value: "1"}   # hipFile, or fail loudly
+              - {name: INFERA_REQUIRE_NATIVE, value: "hipfile"}
             securityContext:
               capabilities: {add: ["IPC_LOCK"]}     # required to mlock the arena
             resources:

--- a/examples/recipes/kimi-k3/mixed-kvd/deploy.yaml
+++ b/examples/recipes/kimi-k3/mixed-kvd/deploy.yaml
@@ -107,6 +107,11 @@ spec:
               - {name: VLLM_ROCM_USE_AITER, value: "1"}
               - {name: SAFETENSORS_FAST_GPU, value: "1"}
               - {name: INFERA_KVD_SOCKET, value: "/kvd/kvd.sock"}
+            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
+            # the overlay's native tree. Without this, a payload built without that
+            # tree only WARNS and both silently become unavailable — the run looks
+            # healthy and quietly serves without the thing you deployed it for.
+              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10
@@ -131,6 +136,8 @@ spec:
                       "--socket","/kvd/kvd.sock",
                       "--max-bytes","34359738368",                            # 32 GiB L2 arena
                       "--long-path","/l3/long","--long-bytes","107374182400"] # 100 GiB L3 on the PVC
+            env:
+              - {name: INFERA_REQUIRE_NATIVE, value: "1"}   # hipFile, or fail loudly
             securityContext:
               capabilities: {add: ["IPC_LOCK"]}     # required to mlock the arena
             resources:

--- a/examples/recipes/kimi-k3/mixed/deploy.yaml
+++ b/examples/recipes/kimi-k3/mixed/deploy.yaml
@@ -1,0 +1,115 @@
+# Kimi-K3 — mixed — Kubernetes recipe
+#
+#   base image   vllm/vllm-openai-rocm:kimi-k3      (stock vendor image, unmodified)
+#   overlay      rocm/infera-overlay:latest                     (infera + router + kvd + native deps)
+#   engine       infera.engine.vllm   TP8
+#
+# Deploy:  kubectl apply -f examples/recipes/kimi-k3/mixed/deploy.yaml
+# Docs:    examples/recipes/kimi-k3/README.md
+#
+# Expects the `model-cache` PVC to hold the weights at /models/Kimi-K3
+# (examples/k8s-deployments/model-cache/). Swap the `model` volume for a
+# hostPath if you keep weights on the node instead.
+#
+# `--kv-cache-dtype auto` is REQUIRED. infera otherwise injects
+# fp8_e4m3, which selects the batch-1-only `mla_gluon` kernel and the
+# engine dies with `requires batch_size=1, got 128`.
+# Do NOT add --enable-prefix-caching: Kimi-K3 is a hybrid Mamba model
+# and it crashes. Do NOT use --load-format fastsafetensors without GDS.
+---
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: kimi-k3-mixed
+  namespace: infera
+spec:
+  backendFramework: vllm
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: vllm/vllm-openai-rocm:kimi-k3
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.server",
+                      "--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","/models/Kimi-K3",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "8", memory: 16Gi}, limits: {cpu: "8", memory: 16Gi}}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+    worker:
+      componentType: worker
+      role: mixed
+      replicas: 1
+      extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: vllm/vllm-openai-rocm:kimi-k3
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec",
+                      "python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
+                      "--model","/models/Kimi-K3",
+                      "--served-model-name","kimi-k3",
+                      "--tensor-parallel-size","8","--gpu-memory-utilization","0.95",
+                      "--trust-remote-code","--load-format","auto",
+                      "--mm-encoder-tp-mode","data","--kv-cache-dtype","auto",
+                      "--max-num-seqs","128","--max-num-batched-tokens","4096",
+                      "--enable-auto-tool-choice","--tool-call-parser","kimi_k3",
+                      "--reasoning-parser","kimi_k3",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              - {name: HF_HUB_OFFLINE, value: "1"}
+              - {name: VLLM_ROCM_USE_AITER, value: "1"}
+              - {name: SAFETENSORS_FAST_GPU, value: "1"}
+            startupProbe:
+              httpGet: {path: /health, port: 30000}
+              periodSeconds: 10
+              timeoutSeconds: 10
+              failureThreshold: 120     # weight load is slow; do not use a readinessProbe here
+            resources:
+              requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+              limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 64Gi}}

--- a/examples/recipes/kimi-k3/pd-kvd/deploy.yaml
+++ b/examples/recipes/kimi-k3/pd-kvd/deploy.yaml
@@ -1,0 +1,246 @@
+# Kimi-K3 — pd-kvd — Kubernetes recipe
+#
+#   base image   vllm/vllm-openai-rocm:kimi-k3      (stock vendor image, unmodified)
+#   overlay      rocm/infera-overlay:latest                     (infera + router + kvd + native deps)
+#   engine       infera.engine.vllm   TP8
+#
+# Deploy:  kubectl apply -f examples/recipes/kimi-k3/pd-kvd/deploy.yaml
+# Docs:    examples/recipes/kimi-k3/README.md
+#
+# Expects the `model-cache` PVC to hold the weights at /models/Kimi-K3
+# (examples/k8s-deployments/model-cache/). Swap the `model` volume for a
+# hostPath if you keep weights on the node instead.
+#
+# PD REQUIRES the prefill and decode nodes to sit on a MUTUALLY ROUTABLE RoCE
+# fabric — the KV transfer is RDMA, not TCP, and there is no fallback. Set
+# <PREFILL_NODE>/<DECODE_NODE> to two such nodes. Not validated for this model;
+# examples/k8s-deployments/pd-1p1d-mooncake.yaml is the validated reference.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kvd-l3-prefill
+  namespace: infera
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: {requests: {storage: 200Gi}}   # L3 spill; size to your working set
+  storageClassName: local-path                 # k3s default; use fast local NVMe in production
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kvd-l3-decode
+  namespace: infera
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: {requests: {storage: 200Gi}}   # L3 spill; size to your working set
+  storageClassName: local-path                 # k3s default; use fast local NVMe in production
+---
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: kimi-k3-pd-kvd
+  namespace: infera
+spec:
+  backendFramework: vllm
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: vllm/vllm-openai-rocm:kimi-k3
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.server",
+                      "--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","/models/Kimi-K3",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "8", memory: 16Gi}, limits: {cpu: "8", memory: 16Gi}}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+    prefill:
+      componentType: worker
+      role: prefill
+      replicas: 1
+      port: 30000
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: vllm/vllm-openai-rocm:kimi-k3
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec",
+                      "python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
+                      "--model","/models/Kimi-K3",
+                      "--served-model-name","kimi-k3",
+                      "--tensor-parallel-size","8","--gpu-memory-utilization","0.95",
+                      "--trust-remote-code","--load-format","auto",
+                      "--mm-encoder-tp-mode","data","--kv-cache-dtype","auto",
+                      "--max-num-seqs","128","--max-num-batched-tokens","4096",
+                      "--enable-auto-tool-choice","--tool-call-parser","kimi_k3",
+                      "--reasoning-parser","kimi_k3",
+                      "--kv-transfer-config","{\"kv_connector\":\"MultiConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"connectors\":[{\"kv_connector\":\"MooncakeConnector\",\"kv_role\":\"kv_producer\"},{\"kv_connector\":\"InferaKvdConnector\",\"kv_role\":\"kv_both\",\"kv_connector_module_path\":\"infera.engine.vllm.kvd_connector\"}]}}",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              - {name: HF_HUB_OFFLINE, value: "1"}
+              - {name: VLLM_ROCM_USE_AITER, value: "1"}
+              - {name: SAFETENSORS_FAST_GPU, value: "1"}
+              - {name: INFERA_KVD_SOCKET, value: "/kvd/kvd.sock"}
+            startupProbe:
+              httpGet: {path: /health, port: 30000}
+              periodSeconds: 10
+              timeoutSeconds: 10
+              failureThreshold: 120     # weight load is slow; do not use a readinessProbe here
+            resources:
+              requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+              limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: dshm, mountPath: /dev/shm}
+          # ---- kvd sidecar: L2 pinned host RAM + L3 on a PVC ----
+          # Same image as `main` (already on the node, so no extra pull) running
+          # infera.kvd out of the shared overlay. The overlay image itself is a
+          # busybox carrying the payload — it has no interpreter to run kvd with.
+          - name: kvd
+            image: vllm/vllm-openai-rocm:kimi-k3
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.kvd",
+                      "--socket","/kvd/kvd.sock",
+                      "--max-bytes","34359738368",                            # 32 GiB L2 arena
+                      "--long-path","/l3/long","--long-bytes","107374182400"] # 100 GiB L3 on the PVC
+            securityContext:
+              capabilities: {add: ["IPC_LOCK"]}     # required to mlock the arena
+            resources:
+              # Must exceed --max-bytes: the arena is pinned host RAM charged here.
+              requests: {cpu: "4", memory: 40Gi}
+              limits: {cpu: "4", memory: 40Gi}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: kvd-l3, mountPath: /l3}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+          # engine <-> kvd UDS: a plain emptyDir shared by the two containers
+          - {name: kvd-sock, emptyDir: {}}
+          - {name: kvd-l3, persistentVolumeClaim: {claimName: kvd-l3-prefill}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 64Gi}}
+    decode:
+      componentType: worker
+      role: decode
+      replicas: 1
+      port: 30000
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <DECODE_NODE>}
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: vllm/vllm-openai-rocm:kimi-k3
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec",
+                      "python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
+                      "--model","/models/Kimi-K3",
+                      "--served-model-name","kimi-k3",
+                      "--tensor-parallel-size","8","--gpu-memory-utilization","0.95",
+                      "--trust-remote-code","--load-format","auto",
+                      "--mm-encoder-tp-mode","data","--kv-cache-dtype","auto",
+                      "--max-num-seqs","128","--max-num-batched-tokens","4096",
+                      "--enable-auto-tool-choice","--tool-call-parser","kimi_k3",
+                      "--reasoning-parser","kimi_k3",
+                      "--kv-transfer-config","{\"kv_connector\":\"MultiConnector\",\"kv_role\":\"kv_both\",\"kv_connector_extra_config\":{\"connectors\":[{\"kv_connector\":\"MooncakeConnector\",\"kv_role\":\"kv_consumer\"},{\"kv_connector\":\"InferaKvdConnector\",\"kv_role\":\"kv_both\",\"kv_connector_module_path\":\"infera.engine.vllm.kvd_connector\"}]}}",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              - {name: HF_HUB_OFFLINE, value: "1"}
+              - {name: VLLM_ROCM_USE_AITER, value: "1"}
+              - {name: SAFETENSORS_FAST_GPU, value: "1"}
+              - {name: INFERA_KVD_SOCKET, value: "/kvd/kvd.sock"}
+            startupProbe:
+              httpGet: {path: /health, port: 30000}
+              periodSeconds: 10
+              timeoutSeconds: 10
+              failureThreshold: 120     # weight load is slow; do not use a readinessProbe here
+            resources:
+              requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+              limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: dshm, mountPath: /dev/shm}
+          # ---- kvd sidecar: L2 pinned host RAM + L3 on a PVC ----
+          # Same image as `main` (already on the node, so no extra pull) running
+          # infera.kvd out of the shared overlay. The overlay image itself is a
+          # busybox carrying the payload — it has no interpreter to run kvd with.
+          - name: kvd
+            image: vllm/vllm-openai-rocm:kimi-k3
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.kvd",
+                      "--socket","/kvd/kvd.sock",
+                      "--max-bytes","34359738368",                            # 32 GiB L2 arena
+                      "--long-path","/l3/long","--long-bytes","107374182400"] # 100 GiB L3 on the PVC
+            securityContext:
+              capabilities: {add: ["IPC_LOCK"]}     # required to mlock the arena
+            resources:
+              # Must exceed --max-bytes: the arena is pinned host RAM charged here.
+              requests: {cpu: "4", memory: 40Gi}
+              limits: {cpu: "4", memory: 40Gi}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: kvd-sock, mountPath: /kvd}
+              - {name: kvd-l3, mountPath: /l3}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+          # engine <-> kvd UDS: a plain emptyDir shared by the two containers
+          - {name: kvd-sock, emptyDir: {}}
+          - {name: kvd-l3, persistentVolumeClaim: {claimName: kvd-l3-decode}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 64Gi}}

--- a/examples/recipes/kimi-k3/pd-kvd/deploy.yaml
+++ b/examples/recipes/kimi-k3/pd-kvd/deploy.yaml
@@ -121,11 +121,10 @@ spec:
               - {name: VLLM_ROCM_USE_AITER, value: "1"}
               - {name: SAFETENSORS_FAST_GPU, value: "1"}
               - {name: INFERA_KVD_SOCKET, value: "/kvd/kvd.sock"}
-            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
-            # the overlay's native tree. Without this, a payload built without that
-            # tree only WARNS and both silently become unavailable — the run looks
-            # healthy and quietly serves without the thing you deployed it for.
-              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
+            # PD needs Mooncake and kvd's GPU-direct L3 needs hipFile, both in
+            # the overlay's native tree. Named so a payload missing either fails at
+            # startup rather than silently dropping that half of the design.
+              - {name: INFERA_REQUIRE_NATIVE, value: "mooncake,hipfile"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10
@@ -151,7 +150,7 @@ spec:
                       "--max-bytes","34359738368",                            # 32 GiB L2 arena
                       "--long-path","/l3/long","--long-bytes","107374182400"] # 100 GiB L3 on the PVC
             env:
-              - {name: INFERA_REQUIRE_NATIVE, value: "1"}   # hipFile, or fail loudly
+              - {name: INFERA_REQUIRE_NATIVE, value: "hipfile"}
             securityContext:
               capabilities: {add: ["IPC_LOCK"]}     # required to mlock the arena
             resources:
@@ -210,11 +209,10 @@ spec:
               - {name: VLLM_ROCM_USE_AITER, value: "1"}
               - {name: SAFETENSORS_FAST_GPU, value: "1"}
               - {name: INFERA_KVD_SOCKET, value: "/kvd/kvd.sock"}
-            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
-            # the overlay's native tree. Without this, a payload built without that
-            # tree only WARNS and both silently become unavailable — the run looks
-            # healthy and quietly serves without the thing you deployed it for.
-              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
+            # PD needs Mooncake and kvd's GPU-direct L3 needs hipFile, both in
+            # the overlay's native tree. Named so a payload missing either fails at
+            # startup rather than silently dropping that half of the design.
+              - {name: INFERA_REQUIRE_NATIVE, value: "mooncake,hipfile"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10
@@ -240,7 +238,7 @@ spec:
                       "--max-bytes","34359738368",                            # 32 GiB L2 arena
                       "--long-path","/l3/long","--long-bytes","107374182400"] # 100 GiB L3 on the PVC
             env:
-              - {name: INFERA_REQUIRE_NATIVE, value: "1"}   # hipFile, or fail loudly
+              - {name: INFERA_REQUIRE_NATIVE, value: "hipfile"}
             securityContext:
               capabilities: {add: ["IPC_LOCK"]}     # required to mlock the arena
             resources:

--- a/examples/recipes/kimi-k3/pd-kvd/deploy.yaml
+++ b/examples/recipes/kimi-k3/pd-kvd/deploy.yaml
@@ -121,6 +121,11 @@ spec:
               - {name: VLLM_ROCM_USE_AITER, value: "1"}
               - {name: SAFETENSORS_FAST_GPU, value: "1"}
               - {name: INFERA_KVD_SOCKET, value: "/kvd/kvd.sock"}
+            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
+            # the overlay's native tree. Without this, a payload built without that
+            # tree only WARNS and both silently become unavailable — the run looks
+            # healthy and quietly serves without the thing you deployed it for.
+              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10
@@ -145,6 +150,8 @@ spec:
                       "--socket","/kvd/kvd.sock",
                       "--max-bytes","34359738368",                            # 32 GiB L2 arena
                       "--long-path","/l3/long","--long-bytes","107374182400"] # 100 GiB L3 on the PVC
+            env:
+              - {name: INFERA_REQUIRE_NATIVE, value: "1"}   # hipFile, or fail loudly
             securityContext:
               capabilities: {add: ["IPC_LOCK"]}     # required to mlock the arena
             resources:
@@ -203,6 +210,11 @@ spec:
               - {name: VLLM_ROCM_USE_AITER, value: "1"}
               - {name: SAFETENSORS_FAST_GPU, value: "1"}
               - {name: INFERA_KVD_SOCKET, value: "/kvd/kvd.sock"}
+            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
+            # the overlay's native tree. Without this, a payload built without that
+            # tree only WARNS and both silently become unavailable — the run looks
+            # healthy and quietly serves without the thing you deployed it for.
+              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10
@@ -227,6 +239,8 @@ spec:
                       "--socket","/kvd/kvd.sock",
                       "--max-bytes","34359738368",                            # 32 GiB L2 arena
                       "--long-path","/l3/long","--long-bytes","107374182400"] # 100 GiB L3 on the PVC
+            env:
+              - {name: INFERA_REQUIRE_NATIVE, value: "1"}   # hipFile, or fail loudly
             securityContext:
               capabilities: {add: ["IPC_LOCK"]}     # required to mlock the arena
             resources:

--- a/examples/recipes/kimi-k3/pd/deploy.yaml
+++ b/examples/recipes/kimi-k3/pd/deploy.yaml
@@ -1,0 +1,174 @@
+# Kimi-K3 — pd — Kubernetes recipe
+#
+#   base image   vllm/vllm-openai-rocm:kimi-k3      (stock vendor image, unmodified)
+#   overlay      rocm/infera-overlay:latest                     (infera + router + kvd + native deps)
+#   engine       infera.engine.vllm   TP8
+#
+# Deploy:  kubectl apply -f examples/recipes/kimi-k3/pd/deploy.yaml
+# Docs:    examples/recipes/kimi-k3/README.md
+#
+# Expects the `model-cache` PVC to hold the weights at /models/Kimi-K3
+# (examples/k8s-deployments/model-cache/). Swap the `model` volume for a
+# hostPath if you keep weights on the node instead.
+#
+# PD REQUIRES the prefill and decode nodes to sit on a MUTUALLY ROUTABLE RoCE
+# fabric — the KV transfer is RDMA, not TCP, and there is no fallback. Set
+# <PREFILL_NODE>/<DECODE_NODE> to two such nodes. Not validated for this model;
+# examples/k8s-deployments/pd-1p1d-mooncake.yaml is the validated reference.
+---
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: kimi-k3-pd
+  namespace: infera
+spec:
+  backendFramework: vllm
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: vllm/vllm-openai-rocm:kimi-k3
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.server",
+                      "--host","0.0.0.0","--port","8000",
+                      "--router-tokenizer-path","/models/Kimi-K3",
+                      "--request-transport","http","--kv-event-transport","zmq"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            resources: {requests: {cpu: "8", memory: 16Gi}, limits: {cpu: "8", memory: 16Gi}}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+    prefill:
+      componentType: worker
+      role: prefill
+      replicas: 1
+      port: 30000
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: vllm/vllm-openai-rocm:kimi-k3
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec",
+                      "python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
+                      "--model","/models/Kimi-K3",
+                      "--served-model-name","kimi-k3",
+                      "--tensor-parallel-size","8","--gpu-memory-utilization","0.95",
+                      "--trust-remote-code","--load-format","auto",
+                      "--mm-encoder-tp-mode","data","--kv-cache-dtype","auto",
+                      "--max-num-seqs","128","--max-num-batched-tokens","4096",
+                      "--enable-auto-tool-choice","--tool-call-parser","kimi_k3",
+                      "--reasoning-parser","kimi_k3",
+                      "--kv-transfer-config","{\"kv_connector\":\"MooncakeConnector\",\"kv_role\":\"kv_producer\"}",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              - {name: HF_HUB_OFFLINE, value: "1"}
+              - {name: VLLM_ROCM_USE_AITER, value: "1"}
+              - {name: SAFETENSORS_FAST_GPU, value: "1"}
+            startupProbe:
+              httpGet: {path: /health, port: 30000}
+              periodSeconds: 10
+              timeoutSeconds: 10
+              failureThreshold: 120     # weight load is slow; do not use a readinessProbe here
+            resources:
+              requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+              limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 64Gi}}
+    decode:
+      componentType: worker
+      role: decode
+      replicas: 1
+      port: 30000
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <DECODE_NODE>}
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it. The vendor image is never forked,
+        # so following an upstream bump costs nothing in this repo.
+        initContainers:
+          - name: infera-overlay
+            image: rocm/infera-overlay:latest
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+        containers:
+          - name: main
+            image: vllm/vllm-openai-rocm:kimi-k3
+            imagePullPolicy: IfNotPresent
+            command: ["/overlay/bin/infera-exec",
+                      "python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
+                      "--model","/models/Kimi-K3",
+                      "--served-model-name","kimi-k3",
+                      "--tensor-parallel-size","8","--gpu-memory-utilization","0.95",
+                      "--trust-remote-code","--load-format","auto",
+                      "--mm-encoder-tp-mode","data","--kv-cache-dtype","auto",
+                      "--max-num-seqs","128","--max-num-batched-tokens","4096",
+                      "--enable-auto-tool-choice","--tool-call-parser","kimi_k3",
+                      "--reasoning-parser","kimi_k3",
+                      "--kv-transfer-config","{\"kv_connector\":\"MooncakeConnector\",\"kv_role\":\"kv_consumer\"}",
+                      "--kv-event-transport","zmq","--request-transport","http"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              - {name: HF_HUB_OFFLINE, value: "1"}
+              - {name: VLLM_ROCM_USE_AITER, value: "1"}
+              - {name: SAFETENSORS_FAST_GPU, value: "1"}
+            startupProbe:
+              httpGet: {path: /health, port: 30000}
+              periodSeconds: 10
+              timeoutSeconds: 10
+              failureThreshold: 120     # weight load is slow; do not use a readinessProbe here
+            resources:
+              requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+              limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
+              - {name: model, mountPath: /models, readOnly: true}
+              - {name: dshm, mountPath: /dev/shm}
+        volumes:
+          - {name: overlay, emptyDir: {}}
+          - {name: model, persistentVolumeClaim: {claimName: model-cache}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 64Gi}}

--- a/examples/recipes/kimi-k3/pd/deploy.yaml
+++ b/examples/recipes/kimi-k3/pd/deploy.yaml
@@ -100,6 +100,11 @@ spec:
               - {name: HF_HUB_OFFLINE, value: "1"}
               - {name: VLLM_ROCM_USE_AITER, value: "1"}
               - {name: SAFETENSORS_FAST_GPU, value: "1"}
+            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
+            # the overlay's native tree. Without this, a payload built without that
+            # tree only WARNS and both silently become unavailable — the run looks
+            # healthy and quietly serves without the thing you deployed it for.
+              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10
@@ -156,6 +161,11 @@ spec:
               - {name: HF_HUB_OFFLINE, value: "1"}
               - {name: VLLM_ROCM_USE_AITER, value: "1"}
               - {name: SAFETENSORS_FAST_GPU, value: "1"}
+            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
+            # the overlay's native tree. Without this, a payload built without that
+            # tree only WARNS and both silently become unavailable — the run looks
+            # healthy and quietly serves without the thing you deployed it for.
+              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10

--- a/examples/recipes/kimi-k3/pd/deploy.yaml
+++ b/examples/recipes/kimi-k3/pd/deploy.yaml
@@ -100,11 +100,10 @@ spec:
               - {name: HF_HUB_OFFLINE, value: "1"}
               - {name: VLLM_ROCM_USE_AITER, value: "1"}
               - {name: SAFETENSORS_FAST_GPU, value: "1"}
-            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
-            # the overlay's native tree. Without this, a payload built without that
-            # tree only WARNS and both silently become unavailable — the run looks
-            # healthy and quietly serves without the thing you deployed it for.
-              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
+            # PD's KV transport is Mooncake, which lives in the overlay's native
+            # tree. Name it so a payload lacking it fails at startup instead of only
+            # warning and quietly serving with no KV transfer at all.
+              - {name: INFERA_REQUIRE_NATIVE, value: "mooncake"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10
@@ -161,11 +160,10 @@ spec:
               - {name: HF_HUB_OFFLINE, value: "1"}
               - {name: VLLM_ROCM_USE_AITER, value: "1"}
               - {name: SAFETENSORS_FAST_GPU, value: "1"}
-            # kvd's GPU-direct L3 (hipFile) and PD's KV transport (Mooncake) live in
-            # the overlay's native tree. Without this, a payload built without that
-            # tree only WARNS and both silently become unavailable — the run looks
-            # healthy and quietly serves without the thing you deployed it for.
-              - {name: INFERA_REQUIRE_NATIVE, value: "1"}
+            # PD's KV transport is Mooncake, which lives in the overlay's native
+            # tree. Name it so a payload lacking it fails at startup instead of only
+            # warning and quietly serving with no KV transfer at all.
+              - {name: INFERA_REQUIRE_NATIVE, value: "mooncake"}
             startupProbe:
               httpGet: {path: /health, port: 30000}
               periodSeconds: 10

--- a/manual/examples/k8s_glm5.2_sglang.md
+++ b/manual/examples/k8s_glm5.2_sglang.md
@@ -20,6 +20,18 @@ via the router returns a correct answer ("… the capital of France is Paris …
 the same request on the vLLM image returns garbage.
 ```
 
+```{admonition} What is validated
+:class: note
+On single-node k3s (MI355X, `amd.com/gpu: 8`), GLM-5.2-MXFP4 at TP8 through this
+manifest: the operator reconciled the CR into router + worker, the worker reached
+Ready in **~6 min** (~408 GiB of weights plus DSA graph capture), and a
+`/v1/chat/completions` request through the router returned a **correct, coherent**
+answer.
+
+The same request against the vLLM image on the same hardware returned
+`'1!!!!!!!...'` — which is why this recipe is SGLang-only.
+```
+
 ```{admonition} REQUIRED ROCm env — GLM-5.2 crashes at init without it
 :class: warning
 Stock SGLang defaults a **CUDA-only DSA top-k JIT kernel** that will not build on

--- a/manual/examples/k8s_glm5.2_sglang.md
+++ b/manual/examples/k8s_glm5.2_sglang.md
@@ -1,0 +1,86 @@
+# Example: GLM-5.2 on Kubernetes — SGLang (DSA), single node
+
+A **Kubernetes-native** recipe for **GLM-5.2-MXFP4** (`GlmMoeDsaForCausalLM` —
+MLA + DeepSeek Sparse Attention): an **`InferaDeployment`** the operator
+reconciles into a router + a TP8 **SGLang** worker on one 8-GPU node. SGLang is
+the correct and fastest engine for GLM-5.2 on ROCm.
+
+The manifest is
+[`examples/k8s-deployments/glm5.2-sglang.yaml`](https://github.com/AMD-AGI/Infera/tree/main/examples/k8s-deployments/glm5.2-sglang.yaml).
+See [Kubernetes deployment](../serving/kubernetes.md) for the general flow and
+the [Kimi-K3 recipe](k8s_kimi_k3.md) for the vLLM/multimodal single-node case.
+
+```{admonition} Use SGLang, not vLLM, for GLM-5.2
+:class: important
+GLM-5.2's MLA/DSA decode is **numerically buggy on vLLM** (ROCm) — the engine
+loads and serves, but decode degrades to `!!!!` garbage after a few tokens.
+**SGLang produces correct, coherent output** and is the fastest engine here.
+Validated on k3s (MI355X): worker Ready ~6 min, a `/v1/chat/completions` request
+via the router returns a correct answer ("… the capital of France is Paris …");
+the same request on the vLLM image returns garbage.
+```
+
+```{admonition} REQUIRED ROCm env — GLM-5.2 crashes at init without it
+:class: warning
+Stock SGLang defaults a **CUDA-only DSA top-k JIT kernel** that will not build on
+gfx950 (MI355X) and crashes engine init. Force the ROCm tilelang path:
+`SGLANG_OPT_USE_TILELANG_INDEXER=1`, `SGLANG_OPT_USE_TOPK_V2=0`,
+`SGLANG_OPT_USE_JIT_NORM=0` (+ `SGLANG_USE_AITER=1`,
+`SGLANG_ROCM_FUSED_DECODE_MLA=0`), and pass `--nsa-prefill-backend tilelang
+--nsa-decode-backend tilelang`. Needs SGLang **0.5.15+** — older ROCm SGLang
+can't load GLM-5.2's changed `head_dim`. All wired into the manifest.
+```
+
+## Topology
+
+One 8-GPU node, aggregated: a CPU-only **router** (`infera.server`) in front of
+one **mixed SGLang worker** at **TP8**, both mounting the model read-only.
+
+| Component | GPUs | What it runs |
+|---|---|---|
+| `glm52-server` | 0 | `infera.server` — OpenAI endpoint + router, ClusterIP `:8000` |
+| `glm52-worker` | 8 | `infera.engine.sglang` — GLM-5.2, `--tp-size 8`, DSA tilelang backends, fp8 KV |
+
+## Prerequisites
+
+- A Kubernetes cluster with one **8× ROCm-GPU node**, `kubectl`/`helm`, the AMD
+  GPU device plugin (`amd.com/gpu`), and the infera-operator — see
+  [Kubernetes deployment](../serving/kubernetes.md).
+- The SGLang engine image (`rocm/infera:sglang-v0.1.1`, SGLang 0.5.15+) present
+  in the node's containerd (`k3s ctr images import` for a local image).
+- The GLM-5.2-MXFP4 checkpoint reachable inside the pod — a `hostPath` (as in the
+  manifest) or the [model-cache](k8s_kimi_k3.md#1-model-cache-pvc-download-job) PVC.
+
+## Deploy & verify
+
+```bash
+kubectl create namespace infera
+# adjust the model hostPath / image in the manifest for your node
+kubectl apply -f examples/k8s-deployments/glm5.2-sglang.yaml
+
+kubectl -n infera get inferadeployment -w     # STATE -> ready (~6-18 min: weights + DSA graphs)
+kubectl -n infera get pods                     # glm52-server 1/1, glm52-worker 1/1
+
+kubectl -n infera port-forward svc/glm52-server 8000:8000 &
+curl -s localhost:8000/v1/chat/completions -H 'Content-Type: application/json' \
+  -d '{"model":"glm5.2-mxfp4","messages":[{"role":"user","content":"What is the capital of France?"}],"max_tokens":60}'
+```
+
+A coherent answer confirms router → SGLang DSA worker end to end.
+
+## Notes & gotchas
+
+- **fp8 KV is fine on SGLang** (`--kv-cache-dtype fp8_e4m3`) — SGLang handles the
+  fp8 MLA KV correctly for GLM-5.2. (On vLLM, fp8 KV gives immediate garbage and
+  even bf16 KV degrades — hence "use SGLang".)
+- **Bound the DSA memory.** `--chunked-prefill-size 8192` (the DSA indexer
+  profiling OOMs higher) and a modest `--context-length` keep the KV pool in
+  check; production long-context runs push `--context-length` to ~400000.
+- **Slow load — startupProbe.** ~408 GiB of weights load in ~6-18 min (faster
+  from local NVMe than a shared FS); a generous `startupProbe` holds the pod
+  non-Ready through the load. See the [Kimi-K3 recipe](k8s_kimi_k3.md) for the
+  same pattern.
+- **Free the GPUs between runs.** Deleting the `InferaDeployment` does not always
+  reap the engine processes; a lingering TP group can hold VRAM and the next
+  deploy fails with "free memory … less than desired". Kill stragglers
+  (`rocm-smi --showpids`) before redeploying.

--- a/manual/examples/k8s_kimi_k3.md
+++ b/manual/examples/k8s_kimi_k3.md
@@ -19,19 +19,23 @@ reconciling an `InferaDeployment` into router + worker + Service, and a real
 engines on `Qwen3-0.6B`, including serving straight from the model-cache PVC
 (see [`RECIPE-single-node.md`](https://github.com/AMD-AGI/Infera/blob/main/examples/k8s-deployments/RECIPE-single-node.md)).
 
-Kimi-K3 needs a vLLM build with `kimi_k3` model support. The standard infera vLLM
-image now bases on the `kimi_k3` vLLM build (see `deploy/docker/Dockerfile.vllm`),
-so it carries that support out of the box — just build it the normal way:
+Kimi-K3 needs a vLLM build with `kimi_k3` model support. Layer infera onto the
+upstream `kimi_k3` vLLM by overriding the base of the standard vLLM image build:
 
 ```bash
-docker build -f deploy/docker/Dockerfile.vllm -t rocm/infera:vllm-v0.1.2 .
+docker build -f deploy/docker/Dockerfile.vllm \
+  --build-arg VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3 \
+  --build-arg BUILD_AITER=0 --build-arg BUILD_MOONCAKE=0 \
+  --build-arg BUILD_HIPFILE=0 --build-arg INSTALL_LIBIONIC=0 \
+  -t rocm/infera:vllm-kimi-k3 .
 ```
 
 The result carries `infera.server` + `infera.engine.vllm` **and**
 `KimiK3ForConditionalGeneration`. With this image the full path is validated on a
 single 8-GPU node: operator → router → `infera.engine.vllm` TP8 worker serving
 Kimi-K3 (MXFP4), and a **multimodal** image request through the router returns a
-correct colour-grounded answer.
+correct colour-grounded answer. The disabled layers are RDMA-PD / kvd-L3 only;
+aiter stays the base's kimi-tuned build.
 ```
 
 ## Topology
@@ -69,7 +73,7 @@ PVC read-only.
 - The engine **image present in the node container runtime**. k3s uses
   containerd (not docker) — import a local image as a tar, not a stream:
   ```bash
-  docker save rocm/infera:vllm-v0.1.2 -o /mnt/<big-disk>/img.tar
+  docker save <infera-vllm-kimi-k3-image> -o /mnt/<big-disk>/img.tar
   sudo k3s ctr images import /mnt/<big-disk>/img.tar
   ```
 

--- a/manual/examples/k8s_kimi_k3.md
+++ b/manual/examples/k8s_kimi_k3.md
@@ -2,9 +2,8 @@
 
 A **Kubernetes-native** recipe for **Kimi-K3** (the multimodal VLM): a
 `model-cache` PVC populated by a download Job, then an **`InferaDeployment`** the
-operator reconciles into a router + a TP8 vLLM worker on one 8-GPU node. This is
-the infera analog of a vendor "recipe" (e.g. NVIDIA Dynamo's `recipes/kimi-k3`),
-using only `kubectl`/`helm` and one CR.
+operator reconciles into a router + a TP8 vLLM worker on one 8-GPU node, using
+only `kubectl`/`helm` and one CR.
 
 The runnable manifests live in the repo under
 [`examples/k8s-deployments/`](https://github.com/AMD-AGI/Infera/tree/main/examples/k8s-deployments)
@@ -28,7 +27,7 @@ docker build -f deploy/docker/Dockerfile.vllm \
   --build-arg VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3 \
   --build-arg BUILD_AITER=0 --build-arg BUILD_MOONCAKE=0 \
   --build-arg BUILD_HIPFILE=0 --build-arg INSTALL_LIBIONIC=0 \
-  -t inferaimage/infera:vllm-kimi-k3 .
+  -t rocm/infera:vllm-kimi-k3 .
 ```
 
 The result carries `infera.server` + `infera.engine.vllm` **and**
@@ -81,15 +80,15 @@ PVC read-only.
 ## 1. Model cache (PVC + download Job)
 
 The [`model-cache/`](https://github.com/AMD-AGI/Infera/tree/main/examples/k8s-deployments/model-cache)
-pair mirrors Dynamo's model-cache: a PVC plus a Job that downloads the checkpoint
-into it. Kimi-K3 is **gated (~1.5 TB)**, so create the HF token secret and size
-the PVC to ~3000 Gi first:
+pair is a PVC plus a Job that downloads the checkpoint into it. Kimi-K3 is
+**gated (~1.5 TB)**, so create the HF token secret and size the PVC to ~2000 Gi
+first:
 
 ```bash
 kubectl create namespace infera
 kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<token> -n infera
 
-# edit model-cache.yaml: storage: 3000Gi (+ a ReadWriteMany class if multi-node)
+# edit model-cache.yaml: storage: 2000Gi (+ a ReadWriteMany class if multi-node)
 # edit model-download.yaml: uncomment envFrom(hf-token-secret); repo -> moonshotai/Kimi-K3
 kubectl apply -f examples/k8s-deployments/model-cache/model-cache.yaml -n infera
 kubectl apply -f examples/k8s-deployments/model-cache/model-download.yaml -n infera

--- a/manual/examples/k8s_kimi_k3.md
+++ b/manual/examples/k8s_kimi_k3.md
@@ -19,23 +19,19 @@ reconciling an `InferaDeployment` into router + worker + Service, and a real
 engines on `Qwen3-0.6B`, including serving straight from the model-cache PVC
 (see [`RECIPE-single-node.md`](https://github.com/AMD-AGI/Infera/blob/main/examples/k8s-deployments/RECIPE-single-node.md)).
 
-Kimi-K3 needs a vLLM build with `kimi_k3` model support. Layer infera onto the
-upstream `kimi_k3` vLLM by overriding the base of the standard vLLM image build:
+Kimi-K3 needs a vLLM build with `kimi_k3` model support. The standard infera vLLM
+image now bases on the `kimi_k3` vLLM build (see `deploy/docker/Dockerfile.vllm`),
+so it carries that support out of the box — just build it the normal way:
 
 ```bash
-docker build -f deploy/docker/Dockerfile.vllm \
-  --build-arg VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3 \
-  --build-arg BUILD_AITER=0 --build-arg BUILD_MOONCAKE=0 \
-  --build-arg BUILD_HIPFILE=0 --build-arg INSTALL_LIBIONIC=0 \
-  -t rocm/infera:vllm-kimi-k3 .
+docker build -f deploy/docker/Dockerfile.vllm -t rocm/infera:vllm-v0.1.2 .
 ```
 
 The result carries `infera.server` + `infera.engine.vllm` **and**
 `KimiK3ForConditionalGeneration`. With this image the full path is validated on a
 single 8-GPU node: operator → router → `infera.engine.vllm` TP8 worker serving
 Kimi-K3 (MXFP4), and a **multimodal** image request through the router returns a
-correct colour-grounded answer. The disabled layers are RDMA-PD / kvd-L3 only;
-aiter stays the base's kimi-tuned build.
+correct colour-grounded answer.
 ```
 
 ## Topology
@@ -73,7 +69,7 @@ PVC read-only.
 - The engine **image present in the node container runtime**. k3s uses
   containerd (not docker) — import a local image as a tar, not a stream:
   ```bash
-  docker save <infera-vllm-kimi-k3-image> -o /mnt/<big-disk>/img.tar
+  docker save rocm/infera:vllm-v0.1.2 -o /mnt/<big-disk>/img.tar
   sudo k3s ctr images import /mnt/<big-disk>/img.tar
   ```
 

--- a/manual/examples/k8s_kimi_k3.md
+++ b/manual/examples/k8s_kimi_k3.md
@@ -149,6 +149,14 @@ image test against the standalone docker serve is
   fp8_e4m3 KV cache, but Kimi-K3's MLA then picks the `mla_gluon` kernel
   (batch_size=1 only) and crashes warmup at `--max-num-seqs 128`. Pass
   `--kv-cache-dtype auto` (or env `INFERA_DEFAULT_KV_FP8=0`) to keep the native KV.
-- **Slow load vs the readiness probe.** Kimi-K3 loads ~1.5 TB (~7 min); set
-  `skipReadinessProbe: true` on the worker so the operator doesn't restart it
-  mid-load.
+- **Slow load — use a startupProbe.** Kimi-K3 loads ~1.5 TB (~9 min to Ready). A
+  generous `startupProbe` on `/health` (e.g. `failureThreshold: 120`,
+  `periodSeconds: 10`) holds the pod non-Ready through the load; the operator's
+  readiness probe is gated by it and takes over once weights + CUDA graphs are up.
+  (`skipReadinessProbe: true` also works but never surfaces a Ready signal.)
+- **Don't enable prefix caching or fastsafetensors here.** Kimi-K3 is a hybrid
+  **Mamba** model — `--enable-prefix-caching` forces the experimental Mamba
+  "align" cache and fails engine init. `--load-format fastsafetensors` needs GPU
+  Direct Storage (cufile/GDS); without it, loads stall (~30 s queue waits per
+  batch). Neither is in the upstream vLLM ROCm Kimi-K3 command — keep
+  `--load-format auto` and no prefix caching.

--- a/manual/examples/k8s_kimi_k3.md
+++ b/manual/examples/k8s_kimi_k3.md
@@ -1,0 +1,155 @@
+# Example: Kimi-K3 on Kubernetes — vLLM, model-cache, single node
+
+A **Kubernetes-native** recipe for **Kimi-K3** (the multimodal VLM): a
+`model-cache` PVC populated by a download Job, then an **`InferaDeployment`** the
+operator reconciles into a router + a TP8 vLLM worker on one 8-GPU node. This is
+the infera analog of a vendor "recipe" (e.g. NVIDIA Dynamo's `recipes/kimi-k3`),
+using only `kubectl`/`helm` and one CR.
+
+The runnable manifests live in the repo under
+[`examples/k8s-deployments/`](https://github.com/AMD-AGI/Infera/tree/main/examples/k8s-deployments)
+(`model-cache/`, `kimi-k3-vllm.yaml`). For the general k8s flow and the CR field
+reference, read [Kubernetes deployment](../serving/kubernetes.md) first.
+
+```{admonition} What is validated
+:class: important
+The **recipe mechanics** are validated end to end on single-node **k3s**
+(MI355X, `amd.com/gpu`): the `model-cache` PVC + download Job, the operator
+reconciling an `InferaDeployment` into router + worker + Service, and a real
+`/v1/chat/completions` completion — checked with both the **sglang** and **vLLM**
+engines on `Qwen3-0.6B`, including serving straight from the model-cache PVC
+(see [`RECIPE-single-node.md`](https://github.com/AMD-AGI/Infera/blob/main/examples/k8s-deployments/RECIPE-single-node.md)).
+
+Kimi-K3 needs a vLLM build with `kimi_k3` model support. Layer infera onto the
+upstream `kimi_k3` vLLM by overriding the base of the standard vLLM image build:
+
+```bash
+docker build -f deploy/docker/Dockerfile.vllm \
+  --build-arg VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3 \
+  --build-arg BUILD_AITER=0 --build-arg BUILD_MOONCAKE=0 \
+  --build-arg BUILD_HIPFILE=0 --build-arg INSTALL_LIBIONIC=0 \
+  -t inferaimage/infera:vllm-kimi-k3 .
+```
+
+The result carries `infera.server` + `infera.engine.vllm` **and**
+`KimiK3ForConditionalGeneration`. With this image the full path is validated on a
+single 8-GPU node: operator → router → `infera.engine.vllm` TP8 worker serving
+Kimi-K3 (MXFP4), and a **multimodal** image request through the router returns a
+correct colour-grounded answer. The disabled layers are RDMA-PD / kvd-L3 only;
+aiter stays the base's kimi-tuned build.
+```
+
+## Topology
+
+One 8-GPU node, aggregated (no PD): a CPU-only **router** (`infera.server`) in
+front of one **mixed vLLM worker** at **TP8**, both mounting the same model-cache
+PVC read-only.
+
+| Component | GPUs | What it runs |
+|---|---|---|
+| `kimi-k3-server` | 0 | `infera.server` — OpenAI endpoint + router, ClusterIP `:8000` |
+| `kimi-k3-worker` | 8 | `infera.engine.vllm` — Kimi-K3, `--tensor-parallel-size 8`, `--mm-encoder-tp-mode data` |
+
+## Prerequisites
+
+- A Kubernetes cluster with one **8× ROCm-GPU node** and `kubectl` + `helm`.
+  Single-node **k3s** is fine — put its data-dir on a **large disk** so the
+  engine-image import doesn't fill root:
+  ```bash
+  curl -sfL https://get.k3s.io | \
+    INSTALL_K3S_EXEC="--write-kubeconfig-mode=644 --data-dir /mnt/<big-disk>/k3s" sh -
+  export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+  ```
+- **AMD GPU device plugin** so GPUs schedule as `amd.com/gpu`:
+  ```bash
+  kubectl apply -f https://raw.githubusercontent.com/ROCm/k8s-device-plugin/master/k8s-ds-amdgpu-dp.yaml
+  kubectl describe node | grep amd.com/gpu     # -> amd.com/gpu: 8
+  ```
+- The **infera-operator** (CRD + controller); no LWS/NATS needed for single-node
+  aggregated:
+  ```bash
+  INSTALL_LWS=false INSTALL_NATS=false deploy/scripts/deploy-k8s.sh
+  kubectl get crd inferadeployments.infera.amd.com
+  ```
+- The engine **image present in the node container runtime**. k3s uses
+  containerd (not docker) — import a local image as a tar, not a stream:
+  ```bash
+  docker save <infera-vllm-kimi-k3-image> -o /mnt/<big-disk>/img.tar
+  sudo k3s ctr images import /mnt/<big-disk>/img.tar
+  ```
+
+## 1. Model cache (PVC + download Job)
+
+The [`model-cache/`](https://github.com/AMD-AGI/Infera/tree/main/examples/k8s-deployments/model-cache)
+pair mirrors Dynamo's model-cache: a PVC plus a Job that downloads the checkpoint
+into it. Kimi-K3 is **gated (~1.5 TB)**, so create the HF token secret and size
+the PVC to ~3000 Gi first:
+
+```bash
+kubectl create namespace infera
+kubectl create secret generic hf-token-secret --from-literal=HF_TOKEN=<token> -n infera
+
+# edit model-cache.yaml: storage: 3000Gi (+ a ReadWriteMany class if multi-node)
+# edit model-download.yaml: uncomment envFrom(hf-token-secret); repo -> moonshotai/Kimi-K3
+kubectl apply -f examples/k8s-deployments/model-cache/model-cache.yaml -n infera
+kubectl apply -f examples/k8s-deployments/model-cache/model-download.yaml -n infera
+kubectl wait --for=condition=Complete job/model-download -n infera --timeout=8h
+```
+
+```{admonition} Already have the checkpoint on the node?
+:class: tip
+Skip the download Job and back the model volume with a `hostPath` pointing at the
+cached directory instead of the PVC (see `single-node-qwen-*.yaml` for the
+`hostPath` form). The download Job is for a cold cluster.
+```
+
+## 2. Deploy
+
+```bash
+# set image: in kimi-k3-vllm.yaml to your kimi_k3-capable infera-vLLM image
+kubectl apply -f examples/k8s-deployments/kimi-k3-vllm.yaml -n infera
+
+kubectl -n infera get inferadeployment -w    # STATE -> ready (weights + graphs: several min)
+kubectl -n infera get pods                   # kimi-k3-server 1/1, kimi-k3-worker 1/1
+```
+
+The operator creates the two Deployments, the `kimi-k3-server` ClusterIP
+Service on `:8000`, and the k8s-discovery ServiceAccount.
+
+## 3. Send a multimodal request
+
+```bash
+kubectl -n infera port-forward svc/kimi-k3-server 8000:8000 &
+curl -s localhost:8000/v1/chat/completions -H 'Content-Type: application/json' -d '{
+  "model": "kimi-k3", "max_tokens": 64,
+  "messages": [{"role":"user","content":[
+    {"type":"text","text":"What is the dominant colour of this image?"},
+    {"type":"image_url","image_url":{"url":"data:image/png;base64,<...>"}}
+  ]}]}'
+```
+
+A colour-grounded answer confirms the vision → prefill → decode path. (The same
+image test against the standalone docker serve is
+[`examples/kimi_k3/mm_test.py`](https://github.com/AMD-AGI/Infera/blob/main/examples/kimi_k3/mm_test.py).)
+
+## Notes & gotchas
+
+- **k3s stores images under `--data-dir`.** A 30–80 GB engine image imported into
+  the default (root-disk) location trips the kubelet DiskPressure eviction
+  threshold and evicts the operator/worker. Put the data-dir on a large disk.
+- **containerd ≠ docker.** A locally-built image must be imported into the node
+  runtime (`k3s ctr images import <tar>`); `imagePullPolicy: IfNotPresent` then
+  resolves it without a registry.
+- **Model mount needs `extraPodSpec`.** The operator's simpler `args` mode
+  auto-builds the entrypoint but only mounts `dshm` + `/boot`; to mount a
+  PVC/hostPath model you must give the full `command` (as these manifests do).
+- **sglang ↔ vLLM is not just the image.** The router is engine-agnostic; the
+  worker's entrypoint module *and* flags differ (`--model-path`/`--tp-size` vs
+  `--model`/`--tensor-parallel-size`). See `RECIPE-single-node.md`.
+- **Kimi-K3 needs `--kv-cache-dtype auto`.** `infera.engine.vllm` defaults to an
+  fp8_e4m3 KV cache, but Kimi-K3's MLA then picks the `mla_gluon` kernel
+  (batch_size=1 only) and crashes warmup at `--max-num-seqs 128`. Pass
+  `--kv-cache-dtype auto` (or env `INFERA_DEFAULT_KV_FP8=0`) to keep the native KV.
+- **Slow load vs the readiness probe.** Kimi-K3 loads ~1.5 TB (~7 min); set
+  `skipReadinessProbe: true` on the worker so the operator doesn't restart it
+  mid-load.

--- a/manual/examples/k8s_pd_1p1d_mooncake.md
+++ b/manual/examples/k8s_pd_1p1d_mooncake.md
@@ -1,0 +1,109 @@
+# Example: PD-disaggregated 1P1D on Kubernetes — SGLang over Mooncake
+
+A **prefill/decode-disaggregated** recipe: one router, one **prefill** worker on
+node A and one **decode** worker on node B (**1P1D**, tp=1 each). KV is streamed
+prefill → decode by the **Mooncake** transfer engine over the ionic **RoCE**
+fabric, while Mooncake's RPC/handshake rides the pod-overlay (flannel) — so no
+host networking is needed. Uses the **libionic-baked** engine image
+(`rocm/infera:sglang-v0.1.2`), so RDMA works without any runtime host-lib
+injection.
+
+The manifest is
+[`examples/k8s-deployments/pd-1p1d-mooncake.yaml`](https://github.com/AMD-AGI/Infera/tree/main/examples/k8s-deployments/pd-1p1d-mooncake.yaml).
+Read [Kubernetes deployment](../serving/kubernetes.md) for the general flow and
+the single-node [Kimi-K3 recipe](k8s_kimi_k3.md) for the aggregated (mixed) case.
+
+```{admonition} The hard prerequisite: a routable RoCE fabric between the two nodes
+:class: important
+PD only works if the **prefill and decode nodes can open an RDMA queue-pair over
+ionic** — i.e. their RoCE NICs are on the **same rail/subnet or a routed fabric**.
+Mooncake connects the RPC over the pod network, exchanges segment descriptors,
+then does the KV move over RDMA; if the two nodes' ionic GIDs are on isolated
+`/64`s with no route between them, the QP never comes up and every request fails
+with `remote mooncake session … is not alive` / `Failed to get kvcache from
+prefill`. Confirm the fabric first:
+
+    # on each node — the group-4 field of the GID_Index-1 RoCE v2 GID:
+    for d in 0 1; do cat /sys/class/infiniband/ionic_$d/ports/1/gids/1; done
+
+If node A's `ionic_0` and node B's `ionic_0` share no routable subnet, pick a
+pair of nodes that do (a multi-rail training fabric pairs rail *i* on every node).
+```
+
+## Topology
+
+| Component | Node | GPUs | Runs |
+|---|---|---|---|
+| `qwen-pd-server` | A | 0 | `infera.server` — OpenAI endpoint + PD-aware router (`:8000`) |
+| `qwen-pd-prefill` | A | 1 | `infera.engine.sglang --disaggregation-mode prefill …mooncake` |
+| `qwen-pd-decode` | B | 1 | `infera.engine.sglang --disaggregation-mode decode …mooncake` |
+
+The router auto-selects the disaggregated dispatcher once a model has **both**
+prefill and decode workers registered (it dual-dispatches each request: prompt to
+prefill, then decode pulls the KV).
+
+## Prerequisites
+
+- A **two-node** k3s cluster (control-plane + one agent), both GPU nodes on a
+  routable RoCE fabric (see the admonition). Join the second node with its
+  data-dir on a large disk:
+  ```bash
+  # on the agent node (K3S_URL = the server's IP):
+  curl -sfL https://get.k3s.io | K3S_URL=https://<server-ip>:6443 \
+    K3S_TOKEN=$(ssh <server> sudo cat /var/lib/rancher/k3s/server/node-token) \
+    INSTALL_K3S_EXEC="--data-dir /mnt/<big-disk>/k3s" sh -
+  kubectl get nodes          # both Ready
+  ```
+- AMD GPU device plugin (auto-schedules on both nodes) and the infera-operator —
+  see [Kubernetes deployment](../serving/kubernetes.md).
+- The **libionic-baked** engine image in **each** node's containerd:
+  ```bash
+  docker build -f deploy/docker/Dockerfile.sglang \
+    --build-arg INSTALL_LIBIONIC=1 -t rocm/infera:sglang-v0.1.2 .
+  docker save rocm/infera:sglang-v0.1.2 -o /tmp/img.tar   # on each node
+  sudo k3s ctr images import /tmp/img.tar                 # (or build locally)
+  ```
+- The model at the **same path on both nodes** — a shared FS (`/mnt/vast/…`) is
+  simplest; or the model-cache Job on a RWX PVC (see [Kimi-K3 recipe](k8s_kimi_k3.md)).
+
+## Deploy & verify
+
+```bash
+# edit <PREFILL_NODE>/<DECODE_NODE>/<MODEL_DIR>/<MODEL_PATH> in the manifest
+kubectl create namespace infera
+kubectl apply -f examples/k8s-deployments/pd-1p1d-mooncake.yaml
+
+kubectl -n infera get pods -o wide      # prefill on A, decode on B, both Running
+kubectl -n infera port-forward svc/qwen-pd-server 8000:8000 &
+curl -s localhost:8000/v1/chat/completions -H 'Content-Type: application/json' \
+  -d '{"model":"<MODEL_PATH>","messages":[{"role":"user","content":"Name three primary colors."}],"max_tokens":40}'
+```
+
+A completion confirms the full path: router → prefill → **Mooncake KV over RoCE**
+→ decode.
+
+```{admonition} What is validated
+:class: note
+On a two-node k3s (MI355X) the operator reconcile, cross-node worker registration,
+PD dual-dispatch, the baked-libionic RDMA device discovery (8 active ionic HCAs
+in-pod, no injection), and the pod-overlay Mooncake RPC were all confirmed. The
+final KV move additionally needs the two nodes on a **mutually routable RoCE
+fabric** (above) — a pair whose ionic rails don't interconnect will reconcile and
+dispatch but fail the transfer.
+```
+
+## Notes & gotchas
+
+- **libionic ABI.** The stock sglang base ships libionic ABI 1; the ionic kernel
+  needs ABI 4, or `ibv_get_device_list` returns 0 HCAs and Mooncake silently
+  drops to TCP (KV transfer then fails). `Dockerfile.sglang` now bakes ABI-4
+  libionic (`INSTALL_LIBIONIC=1`); the entrypoint still injects a host build if
+  `/host-libionic` is mounted, as a belt-and-braces version match.
+- **No hostNetwork.** Mooncake's RPC advertises `POD_IP`; on the pod-overlay that
+  is a flannel address both nodes route to. hostNetwork would advertise the public
+  host IP and, on a single node, also collide prefill/decode on `:30000`.
+- **Slow-load probe.** `skipReadinessProbe: true` on the workers so the operator
+  doesn't restart them during model load / graph capture.
+- **mori alternative.** `--disaggregation-transfer-backend mori` is the other
+  RoCE path; it needs an active RDMA device in-pod too (same libionic fix) and, on
+  a single node, `MORI_DISABLE_AUTO_XGMI=0` for the intra-node XGMI fallback.

--- a/manual/examples/k8s_pd_1p1d_mooncake.md
+++ b/manual/examples/k8s_pd_1p1d_mooncake.md
@@ -48,9 +48,11 @@ prefill, then decode pulls the KV).
   routable RoCE fabric (see the admonition). Join the second node with its
   data-dir on a large disk:
   ```bash
-  # on the agent node (K3S_URL = the server's IP):
+  # on the agent node (K3S_URL = the server's IP). The node-token lives under the
+  # server's data-dir — /var/lib/rancher/k3s/... by default, or <data-dir>/server/
+  # node-token if the server was installed with --data-dir on a big disk.
   curl -sfL https://get.k3s.io | K3S_URL=https://<server-ip>:6443 \
-    K3S_TOKEN=$(ssh <server> sudo cat /var/lib/rancher/k3s/server/node-token) \
+    K3S_TOKEN=$(ssh <server> sudo cat /mnt/<big-disk>/k3s/server/node-token) \
     INSTALL_K3S_EXEC="--data-dir /mnt/<big-disk>/k3s" sh -
   kubectl get nodes          # both Ready
   ```
@@ -104,6 +106,11 @@ dispatch but fail the transfer.
   host IP and, on a single node, also collide prefill/decode on `:30000`.
 - **Slow-load probe.** `skipReadinessProbe: true` on the workers so the operator
   doesn't restart them during model load / graph capture.
+- **NICs — Mooncake auto-discovers, mori lists.** Mooncake runs its own topology
+  discovery, so **drop** `--disaggregation-ib-device` and it uses every active
+  ionic HCA (pinning one, e.g. `ionic_0`, limits KV transfer to a single rail).
+  `mori` is the opposite: pass **all** active NICs explicitly,
+  `--disaggregation-ib-device ionic_0,ionic_1,…,ionic_7`.
 - **mori alternative.** `--disaggregation-transfer-backend mori` is the other
   RoCE path; it needs an active RDMA device in-pod too (same libionic fix) and, on
   a single node, `MORI_DISABLE_AUTO_XGMI=0` for the intra-node XGMI fallback.

--- a/manual/sphinx/_toc.yml.in
+++ b/manual/sphinx/_toc.yml.in
@@ -59,6 +59,8 @@ subtrees:
         title: Kubernetes recipe — Kimi-K3 (vLLM, mixed)
       - file: examples/k8s_pd_1p1d_mooncake.md
         title: Kubernetes recipe — PD 1P1D (SGLang, Mooncake)
+      - file: examples/k8s_glm5.2_sglang.md
+        title: Kubernetes recipe — GLM-5.2 (SGLang, DSA)
       - file: examples/sglang_1p2d_kimi2.6.md
         title: SGLang 1P2D — Kimi-K2.6
       - file: examples/sglang_mix_dsv4.md

--- a/manual/sphinx/_toc.yml.in
+++ b/manual/sphinx/_toc.yml.in
@@ -55,6 +55,10 @@ subtrees:
 
   - caption: Examples
     entries:
+      - file: examples/k8s_kimi_k3.md
+        title: Kubernetes recipe — Kimi-K3 (vLLM, mixed)
+      - file: examples/k8s_pd_1p1d_mooncake.md
+        title: Kubernetes recipe — PD 1P1D (SGLang, Mooncake)
       - file: examples/sglang_1p2d_kimi2.6.md
         title: SGLang 1P2D — Kimi-K2.6
       - file: examples/sglang_mix_dsv4.md

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -44,7 +44,25 @@ GPU_FLAGS=(
 
 # Per-run host scratch (HF cache + logs), shared into every container at
 # /scratch and removed on exit (via a container, since containers write as root).
-SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/infera-test.XXXXXX")"
+#
+# This script has no `set -e`, so an unchecked mktemp is not merely untidy: on a
+# node where TMPDIR is not writable, $SCRATCH goes empty and every path built
+# from it silently retargets the filesystem root — `mkdir /hf`, `: > /failures.txt`
+# — which also fail, and the run limps on to report
+#
+#     (a tier failed but no per-test detail was captured — likely an image
+#      build error or a native crash before pytest ran; scan above.)
+#
+# i.e. it blames the image for an unwritable /tmp. Seen on a Spur node in CI.
+# Fail here instead, naming the directory, so the next person reads one line.
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/infera-test.XXXXXX" 2>/dev/null)" || SCRATCH=""
+if [ -z "$SCRATCH" ] || [ ! -d "$SCRATCH" ] || [ ! -w "$SCRATCH" ]; then
+  echo "FATAL: cannot create a writable scratch dir under '${TMPDIR:-/tmp}'." >&2
+  echo "       This node's temp space is unusable, so the run cannot start." >&2
+  echo "       Set TMPDIR to somewhere writable, or take the node out of the pool." >&2
+  ls -ld "${TMPDIR:-/tmp}" >&2 2>/dev/null || true
+  exit 1
+fi
 mkdir -p "$SCRATCH/hf"
 : > "$SCRATCH/failures.txt"
 chmod 666 "$SCRATCH/failures.txt" 2>/dev/null || true


### PR DESCRIPTION
Adds `examples/recipes/` — a recipe page per model in the shape people actually consume one: pick a combo, check prerequisites, `kubectl apply`, smoke test, link to source.

```
examples/recipes/<model>/<combo>/deploy.yaml
examples/recipes/<model>/README.md
```

Four combos per model — `mixed`, `mixed+kvd`, `pd`, `pd+kvd` — so the two independent choices (how requests split across GPUs; whether KV survives past the GPU) are **selected** rather than hand-assembled from a wiki page.

## Every manifest is stock base + overlay + sidecar

The vendor image is never forked. An initContainer drops the overlay payload into an `emptyDir`, and `infera-exec` runs infera out of it:

```
initContainer  infera-overlay   busybox carrying /payload  ──cp──▶ emptyDir
container      main             STOCK vllm/sglang image, runs /overlay/bin/infera-exec
container      kvd              same vendor image, also runs from /overlay
```

Following an upstream release becomes an image-tag edit. That is the point — forking the vLLM base for Kimi-K3 is what broke serving for every other model in CI (#55).

## Validated end-to-end, and that is where most of this PR came from

Both `mixed` recipes were run **as written**, with no infera-built engine image anywhere in the Pod:

| | Kimi-K3 (vLLM) | GLM-5.2 (SGLang) |
|---|---|---|
| base | stock `vllm/vllm-openai-rocm:kimi-k3` | stock `lmsysorg/sglang` |
| weight load | 502 s, 1453 GiB, local NVMe | 408 GiB over NFS |
| worker Ready | ~11 min | ~13 min |
| output | `The capital of France is Paris.` | `The capital of France is Paris.` |
| extra | multimodal identified the test image | reasoning split into `reasoning_content` |

Running them is what surfaced the four fixes below. Each page carries a **Validation status** table separating what has run on hardware from what has only been composed; `pd`/`pd-kvd` are structural and need two nodes on a routable RoCE fabric.

## Fixes this turned up

**The overlay was shadowing the vendor's Python stack.** The engine logged `ImportError: Numba needs NumPy 2.4 or less. Got NumPy 2.5` on repeat. `pip install --target` ignores the environment and installs the full closure, and a `--target` tree lands first on `PYTHONPATH`. Of 52 distributions, **two** were new; eleven shadowed the base at a different version (numpy 2.5.1 over 2.3.5, cryptography 50.0.0 over 3.4.8). `prune_base_dists.py` now builds each tree inside the base it will be laid onto and drops what the base already has — **325 MB → 5.8 MB**.

**The overlay shipped no native tree for SGLang.** It harvested only from a vLLM image, so `native/rocm7-py312` existed and nothing else; PD on SGLang could not work at all. Now harvested once per ABI family.

**The native guard asked the wrong question.** `INFERA_REQUIRE_NATIVE=1` meant "the tree must exist", but the families deliberately differ — hipFile is vLLM-only, because GPU-direct L3 is a vLLM-only path. As written it would have **rejected two working configurations**: SGLang PD, whose tree correctly has no hipFile, and SGLang `mixed-kvd`, which needs no native code at all. A guard that blocks working deployments is worse than the silent downgrade it was added to prevent. Each tree now records a `CAPABILITIES` file and manifests name what they need.

**GLM-5.2 had no reasoning parser.** The first run answered correctly but inlined the whole chain-of-thought and a raw `</think>` into `content`. Added `--reasoning-parser glm45` and **re-ran** rather than shipping the flag untested.

## Release CI

`deploy/overlay/Dockerfile.payload` was only ever built by hand, so the overlay these recipes depend on was in no release. It now builds as `inferaimage/infera:overlay-<id>`, in its own job after the engines — it is the one image here that is not self-contained, since it builds its Python trees inside the stock bases and harvests native code from the engine images. Both classes of ref are derived, not restated, because either drifting fails silently.

## Verification

- All eight manifests pass `kubectl apply --dry-run=server` against the live CRD
- The capability guard tested in **both** directions on real images: sglang starts with no requirement and with `mooncake`, fails on `hipfile` saying it is vLLM-only; vllm starts with `mooncake,hipfile`. That last case failed the first time — `CAPABILITIES` was written one word per line and the match needs space delimiters, so a complete tree reported itself incomplete
- Harvest output confirms the split: `rocm7-py312 [mooncake hipfile]`, `rocm7-py310 [mooncake]`
- **Not verified:** the release job has not been dispatched, so the SLURM path is unexercised

## Also

`.claude/CLAUDE.md` records the DCO requirement and is now tracked (`.claude/*` plus a negation, since git will not descend into an excluded directory). The sign-off example uses a placeholder — main carries five distinct signer identities, and copying someone else's line inverts what the DCO asserts.

## Depends on

- #55 — `model-cache/`, `manual/examples/` pages, `examples/kimi_k3/mm_test.py`
- #61 — `deploy/overlay/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pw7JSvdQb796xh5pEcctLz
