### PR TITLE
fix(overlay): harvest a hipfile that actually imports; move k8s-deployments to the overlay

### DIFF
--- a/deploy/overlay/harvest_native.sh
+++ b/deploy/overlay/harvest_native.sh
@@ -48,24 +48,53 @@ fi
 
 # ---- hipFile ----------------------------------------------------------------
 # libhipfile plus the ais-check probe. A missing ais-check silently downgrades
-# kvd's load path to a CPU bounce, so the capability is only claimed when the
-# library, the probe AND the Python module are all present.
-HF="$(python3 -c 'import hipfile,os;print(os.path.dirname(hipfile.__file__))' 2>/dev/null || true)"
+# kvd's load path to a CPU bounce.
+#
+# hipfile is a SPLIT package: the .py sources live in the ROCm source tree and the
+# compiled _hipfile*.so in dist-packages, as two entries of one package __path__.
+# Copying either alone yields a package that cannot import — no .so in the first
+# case, no __init__.py in the second — so every search location is merged. Probe
+# from / so the build image's cwd cannot shadow the resolution.
+HF="$(cd / && python3 -c '
+import importlib.util
+s = importlib.util.find_spec("hipfile")
+print(" ".join(s.submodule_search_locations or []))
+' 2>/dev/null || true)"
 HAVE_LIB=0
 for f in /opt/rocm/lib/libhipfile.so*; do
     [ -e "$f" ] || continue
     cp -L "$f" "$OUT/lib/" 2>/dev/null && HAVE_LIB=1
 done
 cp /opt/rocm/bin/ais-check "$OUT/bin/" 2>/dev/null || true
-[ -n "$HF" ] && cp -a "$HF" "$OUT/hipfile" || true
-ln -sf libhipfile.so.0.3.0 "$OUT/lib/libhipfile.so.0" 2>/dev/null || true
-ln -sf libhipfile.so.0 "$OUT/lib/libhipfile.so" 2>/dev/null || true
+if [ -n "$HF" ]; then
+    mkdir -p "$OUT/hipfile"
+    for d in $HF; do cp -a "$d"/. "$OUT/hipfile/" 2>/dev/null || true; done
+fi
+# Rebuild the soname chain from the file that is actually present. This was
+# hardcoded to libhipfile.so.0.3.0; the image now ships 0.4.0, so the symlink
+# dangled and every import died with "libhipfile.so.0: cannot open shared object
+# file" — with the capability still claimed.
+REAL="$(cd "$OUT/lib" 2>/dev/null && ls libhipfile.so.*.* 2>/dev/null | head -1 || true)"
+[ -n "$REAL" ] && (cd "$OUT/lib" && ln -sf "$REAL" libhipfile.so.0 && ln -sf libhipfile.so.0 libhipfile.so)
 
-if [ "$HAVE_LIB" = 1 ] && [ -n "$HF" ] && [ -x "$OUT/bin/ais-check" ]; then
+# Claim the capability only if the HARVESTED tree actually imports. "The files are
+# there" is a different question, and answering that one instead is how the first
+# version of this harvest shipped a CAPABILITIES file claiming hipfile while every
+# consumer failed at `import hipfile._hipfile`. A capability file that can lie is
+# worse than no capability file.
+HF_IMPORTS=0
+if [ -d "$OUT/hipfile" ]; then
+    (cd / && PYTHONPATH="$OUT" LD_LIBRARY_PATH="$OUT/lib:${LD_LIBRARY_PATH:-}" \
+        python3 -c 'import hipfile, hipfile._hipfile' >/dev/null 2>&1) && HF_IMPORTS=1
+fi
+
+if [ "$HAVE_LIB" = 1 ] && [ "$HF_IMPORTS" = 1 ] && [ -x "$OUT/bin/ais-check" ]; then
     CAPS="${CAPS}hipfile "
-    echo "harvest:   hipfile <- $HF"
+    echo "harvest:   hipfile <- $HF (import verified)"
 else
-    echo "harvest:   hipfile ABSENT (expected on SGLang images — GPU-direct L3 is vLLM-only)"
+    echo "harvest:   hipfile NOT CLAIMED (lib=$HAVE_LIB import=$HF_IMPORTS" \
+         "probe=$([ -x "$OUT/bin/ais-check" ] && echo 1 || echo 0));" \
+         "expected on SGLang images — GPU-direct L3 is vLLM-only"
 fi
 
 # One space-separated line — infera-exec word-matches against it.

--- a/examples/k8s-deployments/glm5.2-sglang.yaml
+++ b/examples/k8s-deployments/glm5.2-sglang.yaml
@@ -24,11 +24,21 @@ spec:
     server:
       componentType: server
       extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it, so following an upstream bump
+        # is an image-tag edit rather than a rebuild of ours.
+        initContainers:
+          - name: infera-overlay
+            image: inferaimage/infera-overlay:v0.2.1
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
         containers:
           - name: main
-            image: rocm/infera:sglang-v0.1.1
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
             imagePullPolicy: IfNotPresent
-            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/GLM-5.2-MXFP4",
                       "--request-transport","http","--kv-event-transport","zmq"]
             env:
@@ -39,22 +49,34 @@ spec:
               requests: {cpu: "8", memory: 16Gi}
               limits: {cpu: "8", memory: 16Gi}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: model, mountPath: /models, readOnly: true}
         volumes:
+          - {name: overlay, emptyDir: {}}
           - {name: model, hostPath: {path: /mnt/vast/xiaobo/models, type: Directory}}
     worker:
       componentType: worker
       role: mixed
       replicas: 1
       extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it, so following an upstream bump
+        # is an image-tag edit rather than a rebuild of ours.
+        initContainers:
+          - name: infera-overlay
+            image: inferaimage/infera-overlay:v0.2.1
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
         containers:
           - name: main
-            image: rocm/infera:sglang-v0.1.1
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
             imagePullPolicy: IfNotPresent
             # DSA backends + fp8 KV (SGLang handles fp8 MLA KV correctly for GLM-5.2).
             # --context-length: production uses up to 400000; keep modest to bound the
             # KV pool. --chunked-prefill-size 8192 (DSA indexer profiling OOMs higher).
-            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
                       "--model-path","/models/GLM-5.2-MXFP4","--served-model-name","glm5.2-mxfp4",
                       "--tp-size","8","--trust-remote-code",
                       "--nsa-prefill-backend","tilelang","--nsa-decode-backend","tilelang",
@@ -86,8 +108,10 @@ spec:
               requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
               limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: model, mountPath: /models, readOnly: true}
               - {name: dshm, mountPath: /dev/shm}
         volumes:
+          - {name: overlay, emptyDir: {}}
           - {name: model, hostPath: {path: /mnt/vast/xiaobo/models, type: Directory}}
           - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 64Gi}}

--- a/examples/k8s-deployments/kimi-k3-vllm.yaml
+++ b/examples/k8s-deployments/kimi-k3-vllm.yaml
@@ -29,11 +29,21 @@ spec:
     server:
       componentType: server
       extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it, so following an upstream bump
+        # is an image-tag edit rather than a rebuild of ours.
+        initContainers:
+          - name: infera-overlay
+            image: inferaimage/infera-overlay:v0.2.1
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
         containers:
           - name: main
-            image: rocm/infera:vllm-kimi-k3   # see IMAGE below
+            image: vllm/vllm-openai-rocm:kimi-k3   # see IMAGE below
             imagePullPolicy: IfNotPresent
-            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/Kimi-K3",
                       "--request-transport","http","--kv-event-transport","zmq"]
             env:
@@ -44,17 +54,29 @@ spec:
               requests: {cpu: "8", memory: 16Gi}
               limits: {cpu: "8", memory: 16Gi}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: model, mountPath: /models, readOnly: true}
         volumes:
+          - {name: overlay, emptyDir: {}}
           - {name: model, persistentVolumeClaim: {claimName: model-cache}}
     worker:
       componentType: worker
       role: mixed
       replicas: 1
       extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it, so following an upstream bump
+        # is an image-tag edit rather than a rebuild of ours.
+        initContainers:
+          - name: infera-overlay
+            image: inferaimage/infera-overlay:v0.2.1
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
         containers:
           - name: main
-            image: rocm/infera:vllm-kimi-k3   # see IMAGE below
+            image: vllm/vllm-openai-rocm:kimi-k3   # see IMAGE below
             imagePullPolicy: IfNotPresent
             # vLLM flags mirror examples/kimi_k3/vllm_serve.sh (TP8, mm data-parallel
             # encoder, kimi_k3 tool/reasoning parsers), routed through infera.engine.vllm.
@@ -62,7 +84,7 @@ spec:
             # MLA then selects the mla_gluon kernel (batch_size=1 only) and crashes warmup
             # at --max-num-seqs 128. `auto` keeps the model's native KV dtype. (Equivalent:
             # env INFERA_DEFAULT_KV_FP8=0.)
-            command: ["python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
                       "--model","/models/Kimi-K3","--served-model-name","kimi-k3",
                       "--tensor-parallel-size","8","--gpu-memory-utilization","0.95",
                       "--trust-remote-code","--moe-backend","auto","--load-format","auto",
@@ -93,8 +115,10 @@ spec:
               requests: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
               limits: {cpu: "32", memory: 512Gi, amd.com/gpu: 8}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: model, mountPath: /models, readOnly: true}
               - {name: dshm, mountPath: /dev/shm}
         volumes:
+          - {name: overlay, emptyDir: {}}
           - {name: model, persistentVolumeClaim: {claimName: model-cache}}
           - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 32Gi}}

--- a/examples/k8s-deployments/mixed-kvd-vllm.yaml
+++ b/examples/k8s-deployments/mixed-kvd-vllm.yaml
@@ -53,11 +53,21 @@ spec:
     server:
       componentType: server
       extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it, so following an upstream bump
+        # is an image-tag edit rather than a rebuild of ours.
+        initContainers:
+          - name: infera-overlay
+            image: inferaimage/infera-overlay:v0.2.1
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
         containers:
           - name: main
-            image: rocm/infera:vllm-v0.1.1
+            image: vllm/vllm-openai-rocm:v0.25.1
             imagePullPolicy: IfNotPresent
-            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/Qwen3-0.6B",
                       "--request-transport","http","--kv-event-transport","zmq"]
             env:
@@ -66,25 +76,42 @@ spec:
               - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
             resources: {requests: {cpu: "4", memory: 8Gi}, limits: {cpu: "4", memory: 8Gi}}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: model, mountPath: /models, readOnly: true}
         volumes:
+          - {name: overlay, emptyDir: {}}
           - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
     worker:
       componentType: worker
       role: mixed
       replicas: 1
       extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it, so following an upstream bump
+        # is an image-tag edit rather than a rebuild of ours.
+        initContainers:
+          - name: infera-overlay
+            image: inferaimage/infera-overlay:v0.2.1
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
         containers:
           # ---- the engine ----
           - name: main
-            image: rocm/infera:vllm-v0.1.1
+            image: vllm/vllm-openai-rocm:v0.25.1
             imagePullPolicy: IfNotPresent
             # kvd is reached through the connector, declared in
             # --kv-transfer-config; INFERA_KVD_SOCKET (below) points it at the
             # sidecar's UDS. No hierarchical-cache sizing to worry about here —
             # that knob is SGLang-side only.
-            command: ["python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
                       "--model","/models/Qwen3-0.6B","--served-model-name","qwen",
+                      # REQUIRED, and the NOTE at the top of this file says so:
+                      # infera injects fp8_e4m3 KV, whose scale-packed layout kvd
+                      # refuses to round-trip, so it stores nothing at all. The
+                      # deployment looks healthy and the cache is simply never used.
+                      "--kv-cache-dtype","auto",
                       "--tensor-parallel-size","1","--gpu-memory-utilization","0.85",
                       "--trust-remote-code",
                       "--kv-transfer-config",
@@ -99,6 +126,7 @@ spec:
               requests: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
               limits: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: model, mountPath: /models, readOnly: true}
               - {name: kvd-sock, mountPath: /kvd}
               - {name: dshm, mountPath: /dev/shm}
@@ -106,9 +134,9 @@ spec:
           # Same image (kvd is pure Python inside the infera package). L2 is the
           # pinned host-RAM arena; L3 spills to the PVC.
           - name: kvd
-            image: rocm/infera:vllm-v0.1.1
+            image: vllm/vllm-openai-rocm:v0.25.1
             imagePullPolicy: IfNotPresent
-            command: ["python3","-m","infera.kvd",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.kvd",
                       "--socket","/kvd/kvd.sock",
                       "--max-bytes","34359738368",          # 32 GiB L2 host-RAM arena
                       "--long-path","/l3/long","--long-bytes","107374182400"]  # 100 GiB L3 on the PVC
@@ -120,9 +148,11 @@ spec:
               requests: {cpu: "4", memory: 40Gi}
               limits: {cpu: "4", memory: 40Gi}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: kvd-sock, mountPath: /kvd}
               - {name: kvd-l3, mountPath: /l3}
         volumes:
+          - {name: overlay, emptyDir: {}}
           - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
           # engine <-> kvd UDS: a plain emptyDir shared by the two containers
           - {name: kvd-sock, emptyDir: {}}

--- a/examples/k8s-deployments/mixed-kvd.yaml
+++ b/examples/k8s-deployments/mixed-kvd.yaml
@@ -60,11 +60,21 @@ spec:
     server:
       componentType: server
       extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it, so following an upstream bump
+        # is an image-tag edit rather than a rebuild of ours.
+        initContainers:
+          - name: infera-overlay
+            image: inferaimage/infera-overlay:v0.2.1
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
         containers:
           - name: main
-            image: rocm/infera:sglang-v0.1.1
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
             imagePullPolicy: IfNotPresent
-            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/Qwen3-0.6B",
                       "--request-transport","http","--kv-event-transport","zmq"]
             env:
@@ -73,20 +83,32 @@ spec:
               - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
             resources: {requests: {cpu: "4", memory: 8Gi}, limits: {cpu: "4", memory: 8Gi}}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: model, mountPath: /models, readOnly: true}
         volumes:
+          - {name: overlay, emptyDir: {}}
           - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
     worker:
       componentType: worker
       role: mixed
       replicas: 1
       extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it, so following an upstream bump
+        # is an image-tag edit rather than a rebuild of ours.
+        initContainers:
+          - name: infera-overlay
+            image: inferaimage/infera-overlay:v0.2.1
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
         containers:
           # ---- the engine ----
           - name: main
-            image: rocm/infera:sglang-v0.1.1
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
             imagePullPolicy: IfNotPresent
-            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
                       "--model-path","/models/Qwen3-0.6B",
                       "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
                       "--mem-fraction-static","0.8",
@@ -107,6 +129,7 @@ spec:
               requests: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
               limits: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: model, mountPath: /models, readOnly: true}
               - {name: kvd-sock, mountPath: /kvd}
               - {name: dshm, mountPath: /dev/shm}
@@ -114,9 +137,9 @@ spec:
           # Same image (kvd is pure Python inside the infera package). L2 is the
           # pinned host-RAM arena; L3 spills to the PVC.
           - name: kvd
-            image: rocm/infera:sglang-v0.1.1
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
             imagePullPolicy: IfNotPresent
-            command: ["python3","-m","infera.kvd",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.kvd",
                       "--socket","/kvd/kvd.sock",
                       "--max-bytes","34359738368",          # 32 GiB L2 host-RAM arena
                       "--long-path","/l3/long","--long-bytes","107374182400"]  # 100 GiB L3 on the PVC
@@ -128,9 +151,11 @@ spec:
               requests: {cpu: "4", memory: 40Gi}
               limits: {cpu: "4", memory: 40Gi}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: kvd-sock, mountPath: /kvd}
               - {name: kvd-l3, mountPath: /l3}
         volumes:
+          - {name: overlay, emptyDir: {}}
           - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
           # engine <-> kvd UDS: a plain emptyDir shared by the two containers
           - {name: kvd-sock, emptyDir: {}}

--- a/examples/k8s-deployments/pd-1p1d-mooncake.yaml
+++ b/examples/k8s-deployments/pd-1p1d-mooncake.yaml
@@ -32,11 +32,21 @@ spec:
       componentType: server
       extraPodSpec:
         nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it, so following an upstream bump
+        # is an image-tag edit rather than a rebuild of ours.
+        initContainers:
+          - name: infera-overlay
+            image: inferaimage/infera-overlay:v0.2.1
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
         containers:
           - name: main
-            image: rocm/infera:sglang-v0.1.2      # libionic (ABI 4) baked
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x      # libionic (ABI 4) baked
             imagePullPolicy: IfNotPresent
-            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","<MODEL_PATH>",
                       "--request-transport","http","--kv-event-transport","zmq"]
             env:
@@ -44,8 +54,8 @@ spec:
               - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
               - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
             resources: {requests: {cpu: "4", memory: 8Gi}, limits: {cpu: "4", memory: 8Gi}}
-            volumeMounts: [{name: model, mountPath: /models, readOnly: true}]
-        volumes: [{name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}]
+            volumeMounts: [{name: overlay, mountPath: /overlay, readOnly: true}, {name: model, mountPath: /models, readOnly: true}]
+        volumes: [{name: overlay, emptyDir: {}}, {name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}]
     prefill:
       componentType: worker
       role: prefill
@@ -54,12 +64,22 @@ spec:
       skipReadinessProbe: true
       extraPodSpec:
         nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it, so following an upstream bump
+        # is an image-tag edit rather than a rebuild of ours.
+        initContainers:
+          - name: infera-overlay
+            image: inferaimage/infera-overlay:v0.2.1
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
         containers:
           - name: main
-            image: rocm/infera:sglang-v0.1.2
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
             imagePullPolicy: IfNotPresent
             securityContext: {privileged: true, capabilities: {add: ["IPC_LOCK","SYS_PTRACE"]}}
-            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
                       "--disaggregation-mode","prefill","--model-path","<MODEL_PATH>",
                       "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
                       "--mem-fraction-static","0.8",
@@ -72,10 +92,12 @@ spec:
               - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
             resources: {requests: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}, limits: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: model, mountPath: /models, readOnly: true}
               - {name: dshm, mountPath: /dev/shm}
               - {name: ib, mountPath: /dev/infiniband}
         volumes:
+          - {name: overlay, emptyDir: {}}
           - {name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}
           - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 16Gi}}
           - {name: ib, hostPath: {path: /dev/infiniband, type: Directory}}
@@ -87,12 +109,22 @@ spec:
       skipReadinessProbe: true
       extraPodSpec:
         nodeSelector: {kubernetes.io/hostname: <DECODE_NODE>}
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it, so following an upstream bump
+        # is an image-tag edit rather than a rebuild of ours.
+        initContainers:
+          - name: infera-overlay
+            image: inferaimage/infera-overlay:v0.2.1
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
         containers:
           - name: main
-            image: rocm/infera:sglang-v0.1.2
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
             imagePullPolicy: IfNotPresent
             securityContext: {privileged: true, capabilities: {add: ["IPC_LOCK","SYS_PTRACE"]}}
-            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
                       "--disaggregation-mode","decode","--model-path","<MODEL_PATH>",
                       "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
                       "--mem-fraction-static","0.8",
@@ -105,10 +137,12 @@ spec:
               - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
             resources: {requests: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}, limits: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: model, mountPath: /models, readOnly: true}
               - {name: dshm, mountPath: /dev/shm}
               - {name: ib, mountPath: /dev/infiniband}
         volumes:
+          - {name: overlay, emptyDir: {}}
           - {name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}
           - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 16Gi}}
           - {name: ib, hostPath: {path: /dev/infiniband, type: Directory}}

--- a/examples/k8s-deployments/pd-kvd.yaml
+++ b/examples/k8s-deployments/pd-kvd.yaml
@@ -76,11 +76,21 @@ spec:
       componentType: server
       extraPodSpec:
         nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it, so following an upstream bump
+        # is an image-tag edit rather than a rebuild of ours.
+        initContainers:
+          - name: infera-overlay
+            image: inferaimage/infera-overlay:v0.2.1
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
         containers:
           - name: main
-            image: rocm/infera:sglang-v0.1.2      # libionic (ABI 4) baked
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x      # libionic (ABI 4) baked
             imagePullPolicy: IfNotPresent
-            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","<MODEL_PATH>",
                       "--request-transport","http","--kv-event-transport","zmq"]
             env:
@@ -88,8 +98,8 @@ spec:
               - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
               - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
             resources: {requests: {cpu: "4", memory: 8Gi}, limits: {cpu: "4", memory: 8Gi}}
-            volumeMounts: [{name: model, mountPath: /models, readOnly: true}]
-        volumes: [{name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}]
+            volumeMounts: [{name: overlay, mountPath: /overlay, readOnly: true}, {name: model, mountPath: /models, readOnly: true}]
+        volumes: [{name: overlay, emptyDir: {}}, {name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}]
     prefill:
       componentType: worker
       role: prefill
@@ -98,12 +108,22 @@ spec:
       skipReadinessProbe: true
       extraPodSpec:
         nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it, so following an upstream bump
+        # is an image-tag edit rather than a rebuild of ours.
+        initContainers:
+          - name: infera-overlay
+            image: inferaimage/infera-overlay:v0.2.1
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
         containers:
           - name: main
-            image: rocm/infera:sglang-v0.1.2
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
             imagePullPolicy: IfNotPresent
             securityContext: {privileged: true, capabilities: {add: ["IPC_LOCK","SYS_PTRACE"]}}
-            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
                       "--disaggregation-mode","prefill","--model-path","<MODEL_PATH>",
                       "--infera-kvd-socket","/kvd/kvd.sock","--hicache-size","16",
                       "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
@@ -118,15 +138,16 @@ spec:
               - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
             resources: {requests: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}, limits: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: model, mountPath: /models, readOnly: true}
               - {name: dshm, mountPath: /dev/shm}
               - {name: ib, mountPath: /dev/infiniband}
               - {name: kvd-sock, mountPath: /kvd}
           # ---- kvd sidecar for this role ----
           - name: kvd
-            image: rocm/infera:sglang-v0.1.2
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
             imagePullPolicy: IfNotPresent
-            command: ["python3","-m","infera.kvd",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.kvd",
                       "--socket","/kvd/kvd.sock",
                       "--max-bytes","34359738368",
                       "--long-path","/l3/long","--long-bytes","107374182400"]
@@ -136,9 +157,11 @@ spec:
               requests: {cpu: "4", memory: 40Gi}
               limits: {cpu: "4", memory: 40Gi}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: kvd-sock, mountPath: /kvd}
               - {name: kvd-l3, mountPath: /l3}
         volumes:
+          - {name: overlay, emptyDir: {}}
           - {name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}
           - {name: kvd-sock, emptyDir: {}}
           - {name: kvd-l3, persistentVolumeClaim: {claimName: kvd-l3-prefill}}
@@ -152,12 +175,22 @@ spec:
       skipReadinessProbe: true
       extraPodSpec:
         nodeSelector: {kubernetes.io/hostname: <DECODE_NODE>}
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it, so following an upstream bump
+        # is an image-tag edit rather than a rebuild of ours.
+        initContainers:
+          - name: infera-overlay
+            image: inferaimage/infera-overlay:v0.2.1
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
         containers:
           - name: main
-            image: rocm/infera:sglang-v0.1.2
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
             imagePullPolicy: IfNotPresent
             securityContext: {privileged: true, capabilities: {add: ["IPC_LOCK","SYS_PTRACE"]}}
-            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
                       "--disaggregation-mode","decode","--model-path","<MODEL_PATH>",
                       "--infera-kvd-socket","/kvd/kvd.sock","--hicache-size","16",
                       "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
@@ -172,15 +205,16 @@ spec:
               - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
             resources: {requests: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}, limits: {cpu: "16", memory: 96Gi, amd.com/gpu: 1}}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: model, mountPath: /models, readOnly: true}
               - {name: dshm, mountPath: /dev/shm}
               - {name: ib, mountPath: /dev/infiniband}
               - {name: kvd-sock, mountPath: /kvd}
           # ---- kvd sidecar for this role ----
           - name: kvd
-            image: rocm/infera:sglang-v0.1.2
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
             imagePullPolicy: IfNotPresent
-            command: ["python3","-m","infera.kvd",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.kvd",
                       "--socket","/kvd/kvd.sock",
                       "--max-bytes","34359738368",
                       "--long-path","/l3/long","--long-bytes","107374182400"]
@@ -190,9 +224,11 @@ spec:
               requests: {cpu: "4", memory: 40Gi}
               limits: {cpu: "4", memory: 40Gi}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: kvd-sock, mountPath: /kvd}
               - {name: kvd-l3, mountPath: /l3}
         volumes:
+          - {name: overlay, emptyDir: {}}
           - {name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}
           - {name: kvd-sock, emptyDir: {}}
           - {name: kvd-l3, persistentVolumeClaim: {claimName: kvd-l3-decode}}

--- a/examples/k8s-deployments/single-node-qwen-sglang.yaml
+++ b/examples/k8s-deployments/single-node-qwen-sglang.yaml
@@ -20,11 +20,21 @@ spec:
     server:
       componentType: server
       extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it, so following an upstream bump
+        # is an image-tag edit rather than a rebuild of ours.
+        initContainers:
+          - name: infera-overlay
+            image: inferaimage/infera-overlay:v0.2.1
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
         containers:
           - name: main
-            image: rocm/infera:sglang-v0.1.1
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
             imagePullPolicy: IfNotPresent
-            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/Qwen3-0.6B",
                       "--request-transport","http","--kv-event-transport","zmq"]
             env:
@@ -35,19 +45,31 @@ spec:
               requests: {cpu: "4", memory: 8Gi}
               limits: {cpu: "4", memory: 8Gi}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: model, mountPath: /models, readOnly: true}
         volumes:
+          - {name: overlay, emptyDir: {}}
           - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
     worker:
       componentType: worker
       role: mixed
       replicas: 1
       extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it, so following an upstream bump
+        # is an image-tag edit rather than a rebuild of ours.
+        initContainers:
+          - name: infera-overlay
+            image: inferaimage/infera-overlay:v0.2.1
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
         containers:
           - name: main
-            image: rocm/infera:sglang-v0.1.1
+            image: lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x
             imagePullPolicy: IfNotPresent
-            command: ["python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.engine.sglang","--host","0.0.0.0","--port","30000",
                       "--model-path","/models/Qwen3-0.6B",
                       "--tp-size","1","--attention-backend","aiter","--trust-remote-code",
                       "--mem-fraction-static","0.8",
@@ -60,8 +82,10 @@ spec:
               requests: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
               limits: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: model, mountPath: /models, readOnly: true}
               - {name: dshm, mountPath: /dev/shm}
         volumes:
+          - {name: overlay, emptyDir: {}}
           - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
           - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 32Gi}}

--- a/examples/k8s-deployments/single-node-qwen-vllm.yaml
+++ b/examples/k8s-deployments/single-node-qwen-vllm.yaml
@@ -20,11 +20,21 @@ spec:
     server:
       componentType: server
       extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it, so following an upstream bump
+        # is an image-tag edit rather than a rebuild of ours.
+        initContainers:
+          - name: infera-overlay
+            image: inferaimage/infera-overlay:v0.2.1
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
         containers:
           - name: main
-            image: rocm/infera:vllm-v0.1.1
+            image: vllm/vllm-openai-rocm:v0.25.1
             imagePullPolicy: IfNotPresent
-            command: ["python3","-m","infera.server","--host","0.0.0.0","--port","8000",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.server","--host","0.0.0.0","--port","8000",
                       "--router-tokenizer-path","/models/Qwen3-0.6B",
                       "--request-transport","http","--kv-event-transport","zmq"]
             env:
@@ -35,19 +45,31 @@ spec:
               requests: {cpu: "4", memory: 8Gi}
               limits: {cpu: "4", memory: 8Gi}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: model, mountPath: /models, readOnly: true}
         volumes:
+          - {name: overlay, emptyDir: {}}
           - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
     worker:
       componentType: worker
       role: mixed
       replicas: 1
       extraPodSpec:
+        # The overlay payload is dropped into an emptyDir here; the STOCK vendor
+        # image below then runs infera out of it, so following an upstream bump
+        # is an image-tag edit rather than a rebuild of ours.
+        initContainers:
+          - name: infera-overlay
+            image: inferaimage/infera-overlay:v0.2.1
+            imagePullPolicy: IfNotPresent
+            command: ["sh","-c","cp -a /payload/. /overlay/"]
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
         containers:
           - name: main
-            image: rocm/infera:vllm-v0.1.1
+            image: vllm/vllm-openai-rocm:v0.25.1
             imagePullPolicy: IfNotPresent
-            command: ["python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
+            command: ["/overlay/bin/infera-exec","python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
                       "--model","/models/Qwen3-0.6B","--served-model-name","Qwen3-0.6B",
                       "--tensor-parallel-size","1","--gpu-memory-utilization","0.85","--trust-remote-code",
                       "--kv-event-transport","zmq","--request-transport","http"]
@@ -59,8 +81,10 @@ spec:
               requests: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
               limits: {cpu: "16", memory: 64Gi, amd.com/gpu: 1}
             volumeMounts:
+              - {name: overlay, mountPath: /overlay, readOnly: true}
               - {name: model, mountPath: /models, readOnly: true}
               - {name: dshm, mountPath: /dev/shm}
         volumes:
+          - {name: overlay, emptyDir: {}}
           - {name: model, hostPath: {path: /mnt/k3local/models/qwen, type: Directory}}
           - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 32Gi}}

--- a/manual/examples/k8s_kimi_k3.md
+++ b/manual/examples/k8s_kimi_k3.md
@@ -23,12 +23,20 @@ Kimi-K3 needs a vLLM build with `kimi_k3` model support. Layer infera onto the
 upstream `kimi_k3` vLLM by overriding the base of the standard vLLM image build:
 
 ```bash
-docker build -f deploy/docker/Dockerfile.vllm \
-  --build-arg VLLM_BASE_IMAGE=vllm/vllm-openai-rocm:kimi-k3 \
-  --build-arg BUILD_AITER=0 --build-arg BUILD_MOONCAKE=0 \
-  --build-arg BUILD_HIPFILE=0 --build-arg INSTALL_LIBIONIC=0 \
-  -t rocm/infera:vllm-kimi-k3 .
+docker pull vllm/vllm-openai-rocm:kimi-k3          # the vLLM carrying kimi_k3 support
+docker pull inferaimage/infera-overlay:v0.2.1      # infera, kvd, router, Mooncake, hipFile
 ```
+
+Nothing is built here. The manifest runs the **stock** vLLM image and mounts infera
+in from the overlay, so following an upstream vLLM release is an image-tag edit
+rather than a rebuild. Both images are public; on k3s, import them into containerd
+as below.
+
+The overlay carries one tree per ABI family and records what each provides —
+`rocm7-py312` has `mooncake` and `hipfile`, `rocm7-py310` has `mooncake` only,
+because kvd's GPU-direct L3 is a vLLM-only path. `infera-exec` picks the tree
+matching the container and refuses to start if a manifest asks for a capability
+the payload cannot supply.
 
 The result carries `infera.server` + `infera.engine.vllm` **and**
 `KimiK3ForConditionalGeneration`. With this image the full path is validated on a
@@ -73,7 +81,7 @@ PVC read-only.
 - The engine **image present in the node container runtime**. k3s uses
   containerd (not docker) — import a local image as a tar, not a stream:
   ```bash
-  docker save <infera-vllm-kimi-k3-image> -o /mnt/<big-disk>/img.tar
+  docker save vllm/vllm-openai-rocm:kimi-k3 inferaimage/infera-overlay:v0.2.1 -o /mnt/<big-disk>/img.tar
   sudo k3s ctr images import /mnt/<big-disk>/img.tar
   ```
 


### PR DESCRIPTION
Moves `examples/k8s-deployments/` off baked engine images and onto the overlay, and fixes the overlay bugs that running them exposed.

## The overlay's CAPABILITIES file was lying

`v0.2.0` declared `hipfile` for the vLLM ABI family. Every consumer failed:

```
hipfile binding unavailable: hipfile python package is not installed
gpu_direct=True but hipfile shim is_available()=False — falling back to POSIX
```

Three bugs, each sufficient on its own:

- **Harvested the source tree, not the install.** `os.path.dirname(hipfile.__file__)` resolves to the ROCm source tree in the build image — `_hipfile.pyx`, no compiled extension. `hipfile` is a **split package**: `.py` sources in the source tree, `_hipfile*.so` in dist-packages, as two entries of one `__path__`. Copying either alone cannot import. Now merges every search location and probes from `/` so cwd cannot shadow it.
- **Hardcoded soname.** The symlink pointed at `libhipfile.so.0.3.0`; the image ships `0.4.0`, so `libhipfile.so.0` dangled and imports died with "cannot open shared object file" — capability still claimed. Now derived from the real file.
- **Claimed the capability on the wrong question.** It checked *the files are there*, not *it imports*. Answering the easy question is what let the first two ship. The harvest now imports the harvested tree and only claims `hipfile` if that succeeds.

A capability file that can lie is worse than no capability file — `INFERA_REQUIRE_NATIVE` exists precisely so a payload missing something fails loudly instead of silently degrading, and a false claim defeats it.

Verified on a stock `vllm/vllm-openai-rocm:v0.25.1`: `hipfile._hipfile`, `mooncake` and `infera` all import from the payload; the soname chain resolves to the real 0.4.0.

## The manifests

The eight concrete manifests now run the **stock vendor image** with the overlay mounted in. The four `<ENGINE_IMAGE>` templates are untouched — they are templates.

This removes a real trap. `rocm/infera:vllm-kimi-k3`, which `kimi-k3-vllm.yaml` referenced, **does not exist on Docker Hub and no CI can produce it** — `build_test_push.sh` tags `${engine}-${ID}`, so that name is unreachable by construction. With `imagePullPolicy: IfNotPresent`, skipping the manual 42.8 GB build got you `manifest unknown`, which points nowhere near "you were supposed to build this". Both images are now public.

`mixed-kvd-vllm.yaml` also gains `--kv-cache-dtype auto`, which its own NOTE always said was required. Without it kvd stores **nothing** and the deployment looks perfectly healthy. On Qwen3-0.6B with a 17k-token prompt:

| | entries | L2 | L3 |
|---|---|---|---|
| before | 0 | 0 | 0 |
| after | 14 | 1.9 GB | 1.9 GB |

## Validated on hardware

k3s, MI355X. Each applied as written, then asked for the capital of France:

| manifest | result |
|---|---|
| `single-node-qwen-sglang.yaml` | ✅ ready 180 s, correct answer |
| `single-node-qwen-vllm.yaml` | ✅ correct answer |
| `mixed-kvd.yaml` | ✅ correct answer |
| `mixed-kvd-vllm.yaml` | ✅ correct answer + kvd storing 1.9 GB |
| `glm5.2-sglang.yaml` | ✅ correct answer, stock `lmsysorg/sglang` + overlay |
| `kimi-k3-vllm.yaml` | ✅ ready 530 s, correct answer, **and** the multimodal test identified the generated image |
| `pd-1p1d-mooncake.yaml`, `pd-kvd.yaml` | structural — need two nodes on a routable RoCE fabric |

Six of the eight ran as written and served correctly; the two PD manifests cannot be run here. An earlier draft of this PR claimed GLM-5.2 and Kimi-K3 were covered because "the same overlay mechanism" had been validated — that was the `examples/recipes/` variants, not these files. Both have now been run as written.

All eight pass `kubectl apply --dry-run=server` against the live CRD. That check earned its keep: a first pass produced valid YAML that my own structural check accepted, and the API server rejected it for a duplicate `/overlay` mountPath inside the initContainer.

## Docs

`manual/examples/k8s_kimi_k3.md` replaces its `docker build` with two public `docker pull`s, and states what the overlay provides per ABI family — `rocm7-py312` has `mooncake` and `hipfile`, `rocm7-py310` has `mooncake` only, since GPU-direct L3 is vLLM-only.

## Images

`inferaimage/infera-overlay:v0.2.1` (public, anonymous pull verified). `v0.2.0` is the one with the broken hipfile — **do not use it**.

Release CI keeps producing `inferaimage/infera:overlay-<id>` in the private repo; the public `infera-overlay` tag is what docs and manifests point at.

## Not verified

The release workflow's overlay job still has not been dispatched, so its SLURM path is unexercised — though this PR did run `build_test_push.sh build overlay` locally, which is the same code path, and confirmed it refuses to build when the engine images for that run do not exist rather than silently harvesting a stale tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pw7JSvdQb796xh5pEcctLz

