### PR TITLE
docs(manual): organise recipes by model, with a combination selector

### DIFF
--- a/manual/recipes/glm5.2.md
+++ b/manual/recipes/glm5.2.md
@@ -1,0 +1,155 @@
+# GLM-5.2-MXFP4
+
+Serve GLM-5.2-MXFP4 with infera on an AMD MI355X node (SGLANG, TP8).
+
+Every combination below runs the **stock `lmsysorg/sglang` image** with the infera overlay
+mounted in — the vendor image is never forked, so following an upstream release is
+an image-tag edit.
+
+## 1. Choose the combination
+
+::::{tab-set}
+
+:::{tab-item} Mixed
+:sync: mixed
+
+One worker does prefill and decode. Start here.
+
+```bash
+kubectl apply -f examples/recipes/glm5.2/mixed/deploy.yaml
+kubectl -n infera get pods -w
+```
+
+[`glm5.2/mixed/deploy.yaml`](https://github.com/AMD-AGI/Infera/tree/main/examples/recipes/glm5.2/mixed/deploy.yaml)
+:::
+:::{tab-item} Mixed + kvd
+:sync: mixed-kvd
+
+Adds the kvd tiered cache: an L2 arena in pinned host RAM and an L3 tier on a PVC. Worth it when requests share long prefixes.
+
+```bash
+kubectl apply -f examples/recipes/glm5.2/mixed-kvd/deploy.yaml
+kubectl -n infera get pods -w
+```
+
+[`glm5.2/mixed-kvd/deploy.yaml`](https://github.com/AMD-AGI/Infera/tree/main/examples/recipes/glm5.2/mixed-kvd/deploy.yaml)
+:::
+:::{tab-item} PD
+:sync: pd
+
+Prefill and decode on separate nodes, KV handed over by Mooncake.
+
+This combination declares `INFERA_REQUIRE_NATIVE=mooncake`, so it fails at startup rather than serving quietly without it.
+
+```{admonition} Two nodes on a routable RoCE fabric
+:class: warning
+Substitute `<PREFILL_NODE>` and `<DECODE_NODE>` first. The KV handoff is RDMA with no TCP fallback — on one box this cannot work.
+```
+
+```bash
+kubectl apply -f examples/recipes/glm5.2/pd/deploy.yaml
+kubectl -n infera get pods -w
+```
+
+[`glm5.2/pd/deploy.yaml`](https://github.com/AMD-AGI/Infera/tree/main/examples/recipes/glm5.2/pd/deploy.yaml)
+:::
+:::{tab-item} PD + kvd
+:sync: pd-kvd
+
+Disaggregated, with kvd on each role.
+
+This combination declares `INFERA_REQUIRE_NATIVE=mooncake`, so it fails at startup rather than serving quietly without it.
+
+```{admonition} Two nodes on a routable RoCE fabric
+:class: warning
+Substitute `<PREFILL_NODE>` and `<DECODE_NODE>` first. The KV handoff is RDMA with no TCP fallback — on one box this cannot work.
+```
+
+```bash
+kubectl apply -f examples/recipes/glm5.2/pd-kvd/deploy.yaml
+kubectl -n infera get pods -w
+```
+
+[`glm5.2/pd-kvd/deploy.yaml`](https://github.com/AMD-AGI/Infera/tree/main/examples/recipes/glm5.2/pd-kvd/deploy.yaml)
+:::
+
+::::
+
+## 2. Prerequisites
+
+```bash
+# nodes must advertise amd.com/gpu
+kubectl get nodes -o custom-columns=NODE:.metadata.name,GPU:.status.allocatable.'amd\.com/gpu'
+
+# the operator (provides the InferaDeployment CRD)
+helm install infera-operator deploy/operator/helm/infera-operator -n infera-system --create-namespace
+```
+
+The weights are expected in the `model-cache` PVC. On k3s, install with `--data-dir`
+on a large disk — the default lives under `/var/lib`, and these images plus the
+checkpoint fill it, at which point the node goes `DiskPressure` and evicts the
+operator before anything serves.
+
+```bash
+kubectl apply -f examples/k8s-deployments/model-cache/model-cache.yaml
+kubectl apply -f examples/k8s-deployments/model-cache/model-download.yaml
+```
+
+```{admonition} Edit the download Job first
+:class: important
+`model-download.yaml` ships with a small default model. Change the repo id (and the
+target directory) to the one this page is about before applying it, or the
+deployment will come up and find nothing to load.
+```
+
+## 3. Smoke test
+
+```bash
+kubectl -n infera port-forward svc/glm52-<combo>-server 8000:8000 &
+
+curl -s localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"glm5.2-mxfp4",
+       "messages":[{"role":"user","content":"What is the capital of France?"}],
+       "max_tokens":200}' | jq -r '.choices[0].message.content'
+```
+
+Expect `The capital of France is Paris.` Keep `max_tokens` generous — both models
+here spend 70+ completion tokens on that sentence, and a tight cap truncates it into
+something that reads like a broken deployment.
+
+On the kvd combinations, confirm KV is actually landing in the tiers:
+
+```bash
+POD=$(kubectl -n infera get pod -o name \
+  -l infera.amd.com/deployment=glm52-<combo>,infera.amd.com/service=worker | head -1)
+kubectl -n infera exec $POD -c kvd -- \
+  /overlay/bin/infera-exec python3 -m infera.kvd.statctl --socket /kvd/kvd.sock
+```
+
+`entries` and `long_bytes` must be non-zero after a few requests. Zero usually means
+the prompt was too short to fill a chunk, or kvd refused the KV layout — see the
+manifest's own KV-dtype note.
+
+## 4. Tear down
+
+```bash
+kubectl -n infera delete -f examples/recipes/glm5.2/<combo>/deploy.yaml
+rocm-smi --showpids     # a deleted Pod can leave processes holding VRAM
+```
+
+## Model-specific gotchas
+
+Each of these is a failure that was hit and diagnosed on this hardware, not a tuning
+preference.
+
+| Setting | Why it is not optional |
+|---|---|
+| `SGLANG_OPT_USE_TILELANG_INDEXER=1`, `SGLANG_OPT_USE_TOPK_V2=0`, `SGLANG_OPT_USE_JIT_NORM=0` | stock SGLang defaults to a CUDA-only DSA top-k JIT kernel that will not build on gfx950 and crashes engine init. |
+| `--nsa-prefill-backend tilelang`, `--nsa-decode-backend tilelang` | same reason, on the attention path. |
+| `--reasoning-parser glm45` | GLM-5.2 is a thinking model. Without it the answer is still correct but arrives with the chain-of-thought and a raw `</think>` inlined in `content`. |
+| SGLang, not vLLM | GLM-5.2's MLA/DSA decode is numerically buggy on vLLM/ROCm — it serves, then degrades to garbage. |
+
+## Source
+
+[`examples/recipes/glm5.2/`](https://github.com/AMD-AGI/Infera/tree/main/examples/recipes/glm5.2) · [all recipes](index)

--- a/manual/recipes/index.md
+++ b/manual/recipes/index.md
@@ -1,0 +1,64 @@
+# Recipes
+
+Ready-to-run deployments for a specific model, in the shape you want to serve it.
+Pick the model, pick the combination, `kubectl apply`.
+
+Every recipe runs the **stock vendor image** with the infera overlay mounted in, so
+following an upstream vLLM or SGLang release is an image-tag edit rather than a
+rebuild.
+
+::::{grid} 1 1 2 2
+:gutter: 3
+
+:::{grid-item-card} GLM-5.2-MXFP4
+:link: glm5.2
+:link-type: doc
+
+SGLang · TP8 · MI355X
+
+MLA + DeepSeek Sparse Attention. Needs the ROCm tilelang indexer path.
+:::
+
+:::{grid-item-card} Kimi-K3
+:link: kimi-k3
+:link-type: doc
+
+vLLM · TP8 · MI355X
+
+Multimodal, ~1.5 TB of weights, hybrid Mamba.
+:::
+
+::::
+
+## The four combinations
+
+Each recipe comes in the same four shapes, composing two independent choices:
+**how requests are split across GPUs**, and **whether KV survives past the GPU**.
+
+| Combination | Serving | KV cache | Reach for it when |
+|---|---|---|---|
+| `mixed` | one worker does prefill and decode | GPU only | the default; the simplest thing that works |
+| `mixed + kvd` | one worker does prefill and decode | plus L2 host RAM and L3 on a PVC | requests share long prefixes — a common system prompt, multi-turn chat, RAG |
+| `pd` | prefill and decode on separate nodes | GPU only | prefill and decode want different batching |
+| `pd + kvd` | prefill and decode on separate nodes | plus kvd on each role | both of the above |
+
+```{admonition} PD needs a routable RoCE fabric
+:class: warning
+The prefill→decode KV handoff is RDMA, and there is **no TCP fallback**. Both nodes
+must sit on a mutually routable RoCE fabric. On a single box, use `mixed`.
+```
+
+## What the overlay provides
+
+The overlay carries one native tree per ABI family and records what each provides,
+because the families genuinely differ:
+
+| | `mooncake` (PD KV transport) | `hipfile` (kvd GPU-direct L3) |
+|---|---|---|
+| `rocm7-py312` (vLLM bases) | yes | yes |
+| `rocm7-py310` (SGLang bases) | yes | **no — a vLLM-only path** |
+
+Manifests name what they need through `INFERA_REQUIRE_NATIVE`, and `infera-exec`
+refuses to start if the payload cannot supply it. Without that check a missing
+piece is silent: the Pod comes up green and serves without the tier you deployed
+it for.

--- a/manual/recipes/kimi-k3.md
+++ b/manual/recipes/kimi-k3.md
@@ -1,0 +1,165 @@
+# Kimi-K3
+
+Serve Kimi-K3 with infera on an AMD MI355X node (VLLM, TP8).
+
+Every combination below runs the **stock `vllm/vllm-openai-rocm` image** with the infera overlay
+mounted in — the vendor image is never forked, so following an upstream release is
+an image-tag edit.
+
+## 1. Choose the combination
+
+::::{tab-set}
+
+:::{tab-item} Mixed
+:sync: mixed
+
+One worker does prefill and decode. Start here.
+
+```bash
+kubectl apply -f examples/recipes/kimi-k3/mixed/deploy.yaml
+kubectl -n infera get pods -w
+```
+
+[`kimi-k3/mixed/deploy.yaml`](https://github.com/AMD-AGI/Infera/tree/main/examples/recipes/kimi-k3/mixed/deploy.yaml)
+:::
+:::{tab-item} Mixed + kvd
+:sync: mixed-kvd
+
+Adds the kvd tiered cache: an L2 arena in pinned host RAM and an L3 tier on a PVC. Worth it when requests share long prefixes.
+
+This combination declares `INFERA_REQUIRE_NATIVE=hipfile`, so it fails at startup rather than serving quietly without it.
+
+```bash
+kubectl apply -f examples/recipes/kimi-k3/mixed-kvd/deploy.yaml
+kubectl -n infera get pods -w
+```
+
+[`kimi-k3/mixed-kvd/deploy.yaml`](https://github.com/AMD-AGI/Infera/tree/main/examples/recipes/kimi-k3/mixed-kvd/deploy.yaml)
+:::
+:::{tab-item} PD
+:sync: pd
+
+Prefill and decode on separate nodes, KV handed over by Mooncake.
+
+This combination declares `INFERA_REQUIRE_NATIVE=mooncake`, so it fails at startup rather than serving quietly without it.
+
+```{admonition} Two nodes on a routable RoCE fabric
+:class: warning
+Substitute `<PREFILL_NODE>` and `<DECODE_NODE>` first. The KV handoff is RDMA with no TCP fallback — on one box this cannot work.
+```
+
+```bash
+kubectl apply -f examples/recipes/kimi-k3/pd/deploy.yaml
+kubectl -n infera get pods -w
+```
+
+[`kimi-k3/pd/deploy.yaml`](https://github.com/AMD-AGI/Infera/tree/main/examples/recipes/kimi-k3/pd/deploy.yaml)
+:::
+:::{tab-item} PD + kvd
+:sync: pd-kvd
+
+Disaggregated, with kvd on each role.
+
+This combination declares `INFERA_REQUIRE_NATIVE=mooncake,hipfile`, so it fails at startup rather than serving quietly without it.
+
+```{admonition} Two nodes on a routable RoCE fabric
+:class: warning
+Substitute `<PREFILL_NODE>` and `<DECODE_NODE>` first. The KV handoff is RDMA with no TCP fallback — on one box this cannot work.
+```
+
+```bash
+kubectl apply -f examples/recipes/kimi-k3/pd-kvd/deploy.yaml
+kubectl -n infera get pods -w
+```
+
+[`kimi-k3/pd-kvd/deploy.yaml`](https://github.com/AMD-AGI/Infera/tree/main/examples/recipes/kimi-k3/pd-kvd/deploy.yaml)
+:::
+
+::::
+
+## 2. Prerequisites
+
+```bash
+# nodes must advertise amd.com/gpu
+kubectl get nodes -o custom-columns=NODE:.metadata.name,GPU:.status.allocatable.'amd\.com/gpu'
+
+# the operator (provides the InferaDeployment CRD)
+helm install infera-operator deploy/operator/helm/infera-operator -n infera-system --create-namespace
+```
+
+The weights are expected in the `model-cache` PVC. On k3s, install with `--data-dir`
+on a large disk — the default lives under `/var/lib`, and these images plus the
+checkpoint fill it, at which point the node goes `DiskPressure` and evicts the
+operator before anything serves.
+
+```bash
+kubectl apply -f examples/k8s-deployments/model-cache/model-cache.yaml
+kubectl apply -f examples/k8s-deployments/model-cache/model-download.yaml
+```
+
+```{admonition} Edit the download Job first
+:class: important
+`model-download.yaml` ships with a small default model. Change the repo id (and the
+target directory) to the one this page is about before applying it, or the
+deployment will come up and find nothing to load.
+```
+
+## 3. Smoke test
+
+```bash
+kubectl -n infera port-forward svc/kimi-k3-<combo>-server 8000:8000 &
+
+curl -s localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"kimi-k3",
+       "messages":[{"role":"user","content":"What is the capital of France?"}],
+       "max_tokens":200}' | jq -r '.choices[0].message.content'
+```
+
+Expect `The capital of France is Paris.` Keep `max_tokens` generous — both models
+here spend 70+ completion tokens on that sentence, and a tight cap truncates it into
+something that reads like a broken deployment.
+
+**Multimodal.** Kimi-K3 is a vision model, so the text test alone does not cover it.
+`examples/kimi_k3/mm_test.py` builds a test image with the standard library and posts
+it as an image content part:
+
+```bash
+python3 examples/kimi_k3/mm_test.py --port 8000 --model kimi-k3
+```
+
+On the kvd combinations, confirm KV is actually landing in the tiers:
+
+```bash
+POD=$(kubectl -n infera get pod -o name \
+  -l infera.amd.com/deployment=kimi-k3-<combo>,infera.amd.com/service=worker | head -1)
+kubectl -n infera exec $POD -c kvd -- \
+  /overlay/bin/infera-exec python3 -m infera.kvd.statctl --socket /kvd/kvd.sock
+```
+
+`entries` and `long_bytes` must be non-zero after a few requests. Zero usually means
+the prompt was too short to fill a chunk, or kvd refused the KV layout — see the
+manifest's own KV-dtype note.
+
+## 4. Tear down
+
+```bash
+kubectl -n infera delete -f examples/recipes/kimi-k3/<combo>/deploy.yaml
+rocm-smi --showpids     # a deleted Pod can leave processes holding VRAM
+```
+
+## Model-specific gotchas
+
+Each of these is a failure that was hit and diagnosed on this hardware, not a tuning
+preference.
+
+| Setting | Why it is not optional |
+|---|---|
+| `--kv-cache-dtype auto` | infera otherwise injects fp8_e4m3, which selects the batch-1-only `mla_gluon` kernel and warmup dies with `requires batch_size=1, got 128`. |
+| no `--enable-prefix-caching` | Kimi-K3 is a hybrid Mamba model and crashes with it on, whatever the generic vLLM recipe suggests. |
+| `--load-format auto` | `fastsafetensors` needs GDS; without it the load stalls in 30-second queue waits. |
+| `startupProbe`, not readiness | ~1.5 TB of weights outlives any sane readiness deadline. |
+
+## Source
+
+[`examples/recipes/kimi-k3/`](https://github.com/AMD-AGI/Infera/tree/main/examples/recipes/kimi-k3) · [all recipes](index)

--- a/manual/sphinx/_toc.yml.in
+++ b/manual/sphinx/_toc.yml.in
@@ -53,6 +53,16 @@ subtrees:
       - file: serving/kubernetes.md
         title: Kubernetes
 
+  - caption: Recipes
+    entries:
+      - file: recipes/index.md
+        title: Recipes — by model
+        entries:
+          - file: recipes/glm5.2.md
+            title: GLM-5.2-MXFP4 (SGLang)
+          - file: recipes/kimi-k3.md
+            title: Kimi-K3 (vLLM)
+
   - caption: Examples
     entries:
       - file: examples/k8s_kimi_k3.md


### PR DESCRIPTION
The manual lists recipes by *deployment shape* — "Kubernetes recipe — Kimi-K3 (vLLM, mixed)", "— PD 1P1D", "— GLM-5.2 (SGLang, DSA)". That asks the reader to already know which shape they want before they can find their model, and it has no room for a model's other three combinations without three more top-level entries each.

This inverts it, in the shape a vendor recipe page usually takes:

```
Recipes
├── Recipes — by model          model cards + what the four combinations mean
├── GLM-5.2-MXFP4 (SGLang)      tab-set: mixed | mixed+kvd | pd | pd+kvd
└── Kimi-K3 (vLLM)              tab-set: mixed | mixed+kvd | pd | pd+kvd
```

Picking the **model** is the first decision because it is the one the reader arrives with. Picking mixed vs PD vs kvd is the second, and now happens in place rather than by navigating away. The tabs are `:sync:`-grouped on the combination name, so choosing one anywhere selects it everywhere on the page.

## What is on each page

Not generic prose — the things specific to that model, each of which is a failure diagnosed on hardware:

- **GLM-5.2** — the ROCm DSA env vars (stock SGLang defaults to a CUDA-only top-k JIT kernel that will not build on gfx950), `--reasoning-parser glm45` (without it the answer is correct but arrives with the chain-of-thought and a raw `</think>` inlined), and why SGLang rather than vLLM.
- **Kimi-K3** — `--kv-cache-dtype auto` (fp8 otherwise selects the batch-1-only `mla_gluon` kernel), no `--enable-prefix-caching` (hybrid Mamba, crashes), `--load-format auto`, `startupProbe` over readiness, and the multimodal test.

The index also states what the overlay provides **per ABI family**, since that now decides whether PD and kvd's GPU-direct L3 are available at all:

| | `mooncake` | `hipfile` |
|---|---|---|
| `rocm7-py312` (vLLM) | yes | yes |
| `rocm7-py310` (SGLang) | yes | no — vLLM-only path |

An SGLang tree carrying only `mooncake` is correct, not broken, and the page says so — otherwise the obvious reading of a missing capability is "the build is broken".

## Verified

Built the manual and inspected the output rather than trusting the syntax: four tab labels render per model page (`Mixed`, `Mixed + kvd`, `PD`, `PD + kvd`), sync groups are emitted, and the model cards link correctly.

The one remaining build warning is a pre-existing broken anchor in `examples/k8s_glm5.2_sglang.md` that **reproduces identically on unmodified main**, so it is not from this change.

## Scope

Existing `examples/` pages are left in place — this adds a way in rather than moving their content, so no inbound links break. Folding them in can follow once this shape is agreed.

Related: #65 migrates the manifests these pages point at onto the overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pw7JSvdQb796xh5pEcctLz