### PR TITLE
fix(recipes): point at the published overlay image, not a local build name

### DIFF
--- a/examples/recipes/README.md
+++ b/examples/recipes/README.md
@@ -42,7 +42,7 @@ forking the base for one model broke every other model.
 Build the overlay before deploying:
 
 ```bash
-docker build -f deploy/overlay/Dockerfile.payload -t rocm/infera-overlay:latest .
+docker build -f deploy/overlay/Dockerfile.payload -t inferaimage/infera-overlay:v0.2.1 .
 ```
 
 The build harvests **one native tree per ABI family** — `NATIVE_IMAGE` supplies

--- a/examples/recipes/glm5.2/mixed-kvd/deploy.yaml
+++ b/examples/recipes/glm5.2/mixed-kvd/deploy.yaml
@@ -1,7 +1,7 @@
 # GLM-5.2-MXFP4 — mixed-kvd — Kubernetes recipe
 #
 #   base image   lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x      (stock vendor image, unmodified)
-#   overlay      rocm/infera-overlay:latest                     (infera + router + kvd + native deps)
+#   overlay      inferaimage/infera-overlay:v0.2.1                     (infera + router + kvd + native deps)
 #   engine       infera.engine.sglang   TP8
 #
 # Deploy:  kubectl apply -f examples/recipes/glm5.2/mixed-kvd/deploy.yaml
@@ -45,7 +45,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:
@@ -79,7 +79,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:

--- a/examples/recipes/glm5.2/mixed/deploy.yaml
+++ b/examples/recipes/glm5.2/mixed/deploy.yaml
@@ -1,7 +1,7 @@
 # GLM-5.2-MXFP4 — mixed — Kubernetes recipe
 #
 #   base image   lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x      (stock vendor image, unmodified)
-#   overlay      rocm/infera-overlay:latest                     (infera + router + kvd + native deps)
+#   overlay      inferaimage/infera-overlay:v0.2.1                     (infera + router + kvd + native deps)
 #   engine       infera.engine.sglang   TP8
 #
 # Deploy:  kubectl apply -f examples/recipes/glm5.2/mixed/deploy.yaml
@@ -34,7 +34,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:
@@ -68,7 +68,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:

--- a/examples/recipes/glm5.2/pd-kvd/deploy.yaml
+++ b/examples/recipes/glm5.2/pd-kvd/deploy.yaml
@@ -1,7 +1,7 @@
 # GLM-5.2-MXFP4 — pd-kvd — Kubernetes recipe
 #
 #   base image   lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x      (stock vendor image, unmodified)
-#   overlay      rocm/infera-overlay:latest                     (infera + router + kvd + native deps)
+#   overlay      inferaimage/infera-overlay:v0.2.1                     (infera + router + kvd + native deps)
 #   engine       infera.engine.sglang   TP8
 #
 # Deploy:  kubectl apply -f examples/recipes/glm5.2/pd-kvd/deploy.yaml
@@ -56,7 +56,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:
@@ -92,7 +92,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:
@@ -190,7 +190,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:

--- a/examples/recipes/glm5.2/pd/deploy.yaml
+++ b/examples/recipes/glm5.2/pd/deploy.yaml
@@ -1,7 +1,7 @@
 # GLM-5.2-MXFP4 — pd — Kubernetes recipe
 #
 #   base image   lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x      (stock vendor image, unmodified)
-#   overlay      rocm/infera-overlay:latest                     (infera + router + kvd + native deps)
+#   overlay      inferaimage/infera-overlay:v0.2.1                     (infera + router + kvd + native deps)
 #   engine       infera.engine.sglang   TP8
 #
 # Deploy:  kubectl apply -f examples/recipes/glm5.2/pd/deploy.yaml
@@ -36,7 +36,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:
@@ -72,7 +72,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:
@@ -139,7 +139,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:

--- a/examples/recipes/kimi-k3/mixed-kvd/deploy.yaml
+++ b/examples/recipes/kimi-k3/mixed-kvd/deploy.yaml
@@ -1,7 +1,7 @@
 # Kimi-K3 — mixed-kvd — Kubernetes recipe
 #
 #   base image   vllm/vllm-openai-rocm:kimi-k3      (stock vendor image, unmodified)
-#   overlay      rocm/infera-overlay:latest                     (infera + router + kvd + native deps)
+#   overlay      inferaimage/infera-overlay:v0.2.1                     (infera + router + kvd + native deps)
 #   engine       infera.engine.vllm   TP8
 #
 # Deploy:  kubectl apply -f examples/recipes/kimi-k3/mixed-kvd/deploy.yaml
@@ -44,7 +44,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:
@@ -78,7 +78,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:

--- a/examples/recipes/kimi-k3/mixed/deploy.yaml
+++ b/examples/recipes/kimi-k3/mixed/deploy.yaml
@@ -1,7 +1,7 @@
 # Kimi-K3 — mixed — Kubernetes recipe
 #
 #   base image   vllm/vllm-openai-rocm:kimi-k3      (stock vendor image, unmodified)
-#   overlay      rocm/infera-overlay:latest                     (infera + router + kvd + native deps)
+#   overlay      inferaimage/infera-overlay:v0.2.1                     (infera + router + kvd + native deps)
 #   engine       infera.engine.vllm   TP8
 #
 # Deploy:  kubectl apply -f examples/recipes/kimi-k3/mixed/deploy.yaml
@@ -36,7 +36,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:
@@ -70,7 +70,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:

--- a/examples/recipes/kimi-k3/pd-kvd/deploy.yaml
+++ b/examples/recipes/kimi-k3/pd-kvd/deploy.yaml
@@ -1,7 +1,7 @@
 # Kimi-K3 — pd-kvd — Kubernetes recipe
 #
 #   base image   vllm/vllm-openai-rocm:kimi-k3      (stock vendor image, unmodified)
-#   overlay      rocm/infera-overlay:latest                     (infera + router + kvd + native deps)
+#   overlay      inferaimage/infera-overlay:v0.2.1                     (infera + router + kvd + native deps)
 #   engine       infera.engine.vllm   TP8
 #
 # Deploy:  kubectl apply -f examples/recipes/kimi-k3/pd-kvd/deploy.yaml
@@ -56,7 +56,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:
@@ -92,7 +92,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:
@@ -180,7 +180,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:

--- a/examples/recipes/kimi-k3/pd/deploy.yaml
+++ b/examples/recipes/kimi-k3/pd/deploy.yaml
@@ -1,7 +1,7 @@
 # Kimi-K3 — pd — Kubernetes recipe
 #
 #   base image   vllm/vllm-openai-rocm:kimi-k3      (stock vendor image, unmodified)
-#   overlay      rocm/infera-overlay:latest                     (infera + router + kvd + native deps)
+#   overlay      inferaimage/infera-overlay:v0.2.1                     (infera + router + kvd + native deps)
 #   engine       infera.engine.vllm   TP8
 #
 # Deploy:  kubectl apply -f examples/recipes/kimi-k3/pd/deploy.yaml
@@ -36,7 +36,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:
@@ -72,7 +72,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:
@@ -132,7 +132,7 @@ spec:
         # so following an upstream bump costs nothing in this repo.
         initContainers:
           - name: infera-overlay
-            image: rocm/infera-overlay:latest
+            image: inferaimage/infera-overlay:v0.2.1
             imagePullPolicy: IfNotPresent
             command: ["sh","-c","cp -a /payload/. /overlay/"]
             volumeMounts:


### PR DESCRIPTION
`examples/recipes/` references `rocm/infera-overlay:latest` — the name I built under locally while writing #64. **It does not exist on Docker Hub (404).**

So every recipe on `main` right now tells the reader to deploy an image they cannot pull, and `imagePullPolicy: IfNotPresent` turns that into `manifest unknown`, which points nowhere near the cause.

This is exactly the defect #65 just fixed for `rocm/infera:vllm-kimi-k3` in the Kimi-K3 page. I introduced the same one next door in #64, and it missed the #65 merge by a few minutes.

Now `inferaimage/infera-overlay:v0.2.1`, verified pullable with **no credentials**. The header comments carried the wrong name too and are updated with it — a stale image name in a comment misleads exactly as well as one in a field.

## Audited every image reference while here

| reference | Docker Hub |
|---|---|
| `inferaimage/infera-overlay:v0.2.1` | ✅ |
| `lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x` | ✅ |
| `vllm/vllm-openai-rocm:kimi-k3` | ✅ |
| `vllm/vllm-openai-rocm:v0.25.1` | ✅ |
| `python:3.11-slim` | ✅ |
| `infera/engine-sglang-mi300x:dev` | ❌ 404 |

The last is in the operator's CRD samples, where a `:dev` tag reads as "substitute your own image" rather than something to pull. **Left alone deliberately** — noted so it is a decision rather than an oversight.

All eight manifests pass `kubectl apply --dry-run=server` against the live CRD.

## Worth considering separately

This is the third time an unpullable image reference has shipped — the Kimi-K3 page, these recipes, and the comments inside them — and all three were caught by someone reading, not by CI. A check that walks `image:` fields in `examples/` and asks the registry whether each tag exists would close the class rather than the instances. Happy to add it if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pw7JSvdQb796xh5pEcctLz