### PR TITLE
fix(mooncake): disable the HIP (hipIpc) transport on ROCm — it cannot work cross-node, and the existing gate never shipped

### DIFF
--- a/deploy/docker/Dockerfile.sglang
+++ b/deploy/docker/Dockerfile.sglang
@@ -15,10 +15,12 @@ WORKDIR /opt/infera
 # The v0.5.15.post1 base bundles Mooncake at upstream #2682. Rebuild it IN PLACE
 # (no extra version) so a single image supports every KV-transfer config and the
 # choice is made at RUNTIME:
-#   * HIP intra-node P2P transport — opt-in via MC_ENABLE_HIP_TRANSPORT=1 (default
-#     OFF so CROSS-NODE PD stays on RDMA; #2682 installs it unconditionally and
-#     prefers it over RDMA, breaking cross-node PD — hipIpcOpenMemHandle can't
-#     open a peer's handle).
+#   * HIP intra-node P2P transport — OFF on ROCm. #2682 installs it
+#     unconditionally and selectTransport prefers it over RDMA, which breaks
+#     cross-node PD: a hipIpc handle is host-local by construction, so a peer
+#     NODE's hipIpcOpenMemHandle fails ("invalid device context", 201).
+#     MC_ENABLE_HIP_TRANSPORT=1 opts back in for single-node-only P2P;
+#     MC_DISABLE_HIP_TRANSPORT=1 (infera's default) vetoes even that.
 #   * dma-buf GPUDirect (ibv_reg_dmabuf_mr) vs bare ibv_reg_mr+peermem — the
 #     dma-buf branch is COMPILED IN (fixing #2682's CMake propagation bug that
 #     silently drops it), and #2682's own runtime switch then decides per
@@ -37,6 +39,33 @@ RUN if [ "${BUILD_MOONCAKE}" = "1" ]; then \
         echo "BUILD_MOONCAKE=0 — leaving base Mooncake as-is"; \
     fi \
     && rm -rf /tmp/build_mooncake_sglang.sh /tmp/mooncake_cpp
+
+# ---- assert the gate is in the .so this image will LOAD -----------------------
+# Separate layer on purpose: it runs in BOTH BUILD_MOONCAKE branches, so
+# BUILD_MOONCAKE=0 can no longer silently ship a stock #2682 engine.so that
+# breaks cross-node PD. It also leaves a visible marker in `docker history`,
+# so you can tell from a published image whether the check ever ran.
+# This does NOT catch an image built FROM an already-published infera image
+# (the stage simply never re-runs) — for that, run the artifact-level check:
+#   deploy/docker/scripts/verify_image_mooncake.sh <image>
+# Set REQUIRE_MOONCAKE_HIP_GATE=0 to build an image deliberately without it.
+ARG REQUIRE_MOONCAKE_HIP_GATE=1
+RUN set -eu; \
+    if [ "${REQUIRE_MOONCAKE_HIP_GATE}" != "1" ]; then \
+        echo "REQUIRE_MOONCAKE_HIP_GATE=0 — skipping HIP-transport gate assertion"; \
+    else \
+        so_dir="$(python3 -c 'import mooncake, os; print(os.path.dirname(mooncake.__file__))')"; \
+        so="$(ls "$so_dir"/engine*.so | head -1)"; \
+        for v in MC_ENABLE_HIP_TRANSPORT MC_DISABLE_HIP_TRANSPORT; do \
+            n="$(strings "$so" | grep -c "$v" || true)"; \
+            [ "$n" != "0" ] || { \
+                echo "ERROR: $so lacks $v — stock upstream #2682 installs the HIP" >&2; \
+                echo "       transport unconditionally and prefers it over RDMA, so" >&2; \
+                echo "       cross-node PD dies with hipIpcOpenMemHandle 201." >&2; \
+                exit 1; }; \
+        done; \
+        echo "MOONCAKE_HIP_GATE=present ($so)"; \
+    fi
 
 # ---- libionic (host ionic ABI match) -----------------------------------------
 # WHY: the sglang base ships libionic with an old kernel ABI (e.g. 54.0-149 = ABI

--- a/deploy/docker/Dockerfile.vllm
+++ b/deploy/docker/Dockerfile.vllm
@@ -83,6 +83,32 @@ RUN if [ "${BUILD_MOONCAKE}" = "1" ]; then \
     fi \
     && rm -rf /tmp/build_mooncake_rocm.sh /tmp/mooncake_cpp
 
+# ---- 3b) assert the HIP-transport gate is in the .so this image will LOAD ----
+# Same defect class as the sglang image: a build that skips or silently no-ops
+# the Mooncake rebuild ships stock upstream #2682, which installs the HIP
+# transport unconditionally and prefers it over RDMA -> cross-node PD dies with
+# hipIpcOpenMemHandle 201. Separate layer so it runs in BOTH BUILD_MOONCAKE
+# branches and is visible in `docker history`. For images built FROM an already
+# published image (where this stage never re-runs), use the artifact-level check:
+#   deploy/docker/scripts/verify_image_mooncake.sh <image>
+ARG REQUIRE_MOONCAKE_HIP_GATE=1
+RUN set -eu; \
+    if [ "${REQUIRE_MOONCAKE_HIP_GATE}" != "1" ]; then \
+        echo "REQUIRE_MOONCAKE_HIP_GATE=0 — skipping HIP-transport gate assertion"; \
+    else \
+        so_dir="$(python3 -c 'import mooncake, os; print(os.path.dirname(mooncake.__file__))')"; \
+        so="$(ls "$so_dir"/engine*.so | head -1)"; \
+        for v in MC_ENABLE_HIP_TRANSPORT MC_DISABLE_HIP_TRANSPORT; do \
+            n="$(strings "$so" | grep -c "$v" || true)"; \
+            [ "$n" != "0" ] || { \
+                echo "ERROR: $so lacks $v — stock upstream #2682 installs the HIP" >&2; \
+                echo "       transport unconditionally and prefers it over RDMA, so" >&2; \
+                echo "       cross-node PD dies with hipIpcOpenMemHandle 201." >&2; \
+                exit 1; }; \
+        done; \
+        echo "MOONCAKE_HIP_GATE=present ($so)"; \
+    fi
+
 # ---- 4) hipFile (AIS gpu-direct L3) ---------------------------------------
 # WHY: kvd's gpu-direct L3 needs libhipfile + the `ais-check` probe; a missing
 # ais-check SILENTLY downgrades the load path to CPU-bounce. HOW: build_hipfile.sh

--- a/deploy/docker/patches/mooncake_cpp/apply_mooncake_cpp_patches.sh
+++ b/deploy/docker/patches/mooncake_cpp/apply_mooncake_cpp_patches.sh
@@ -6,8 +6,12 @@
 #   the cmake/ninja build — both required for cross-node GDR on AMD (MI355X+ionic).
 #   B.1 CMakeLists: propagate USE_HIP_DMABUF+hsa-runtime64 to rdma_transport (else
 #       the ibv_reg_dmabuf_mr branch compiles out -> bare ibv_reg_mr fails on ionic).
-#   B.2 transfer_engine_impl: gate installTransport("hip") behind MC_ENABLE_HIP_TRANSPORT
-#       (else GPU bufs become intra-node hip IPC segments a cross-node peer can't open).
+#   B.2 transfer_engine_impl: do NOT installTransport("hip") on ROCm by default
+#       (else GPU bufs become intra-node hip IPC segments a cross-node peer can't
+#       open — an IPC handle is host-local, so hipIpcOpenMemHandle on a peer NODE
+#       fails with "invalid device context"/201). MC_ENABLE_HIP_TRANSPORT=1 opts
+#       back in for single-node-only P2P; MC_DISABLE_HIP_TRANSPORT=1 vetoes even
+#       that, so infera's rocm_rdma_env.py default is honoured rather than a no-op.
 #   B.3 rdma_auto_chunk_mr_2017: split buffers larger than the device max_mr_size
 #       into <=max_mr_size MRs (one BufferDesc per chunk) instead of silently
 #       truncating ibv_reg_mr — on ionic (max_mr_size ~2GiB) a truncated MR makes

--- a/deploy/docker/patches/mooncake_cpp/transfer_engine_impl.diff
+++ b/deploy/docker/patches/mooncake_cpp/transfer_engine_impl.diff
@@ -1,14 +1,38 @@
 --- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
 +++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
-@@ -402,7 +402,10 @@
+@@ -402,7 +402,34 @@ int TransferEngineImpl::init(const std::string& metadata_conn_string,
  #ifdef USE_HIP
          // HIP transport handles intra-node GPU P2P via XGMI/IPC and can
          // coexist with the cross-node transport (RDMA/TCP) selected above.
 -        {
-+        // FIX(yihou): default OFF — else GPU bufs register as a "hip" IPC segment
-+        // a cross-node peer can't open ("Corrupted segment descriptor hipbuffer").
-+        // Set MC_ENABLE_HIP_TRANSPORT=1 to opt back in for intra-node P2P.
-+        if (getenv("MC_ENABLE_HIP_TRANSPORT")) {
++        //
++        // infera: the HIP (hipIpc) transport is DISABLED BY DEFAULT on ROCm.
++        // Upstream #2682 installs it unconditionally and selectTransport then
++        // PREFERS it over RDMA for GPU->GPU, which breaks cross-node PD: a HIP
++        // IPC handle is host-local by construction, so opening a peer NODE's
++        // handle can never work -- hipIpcOpenMemHandle fails with "invalid
++        // device context" (error 201) and KV transfer dies even when RDMA
++        // itself is healthy. There is no upstream knob for this: MC_USE_HIP_IPC
++        // only picks IPC-vs-fabric *within* the HIP transport, it cannot
++        // prevent the transport from being installed.
++        //
++        // Escape hatch for a single-node-only deployment that wants XGMI P2P:
++        //   MC_ENABLE_HIP_TRANSPORT=1
++        // MC_DISABLE_HIP_TRANSPORT=1 always wins, so the spelling used by
++        // infera's rocm_rdma_env.py, the manual and the tests agrees with the
++        // gate instead of being a silent no-op.
++        const char* mc_hip_enable = getenv("MC_ENABLE_HIP_TRANSPORT");
++        const char* mc_hip_disable = getenv("MC_DISABLE_HIP_TRANSPORT");
++        const bool mc_hip_wanted =
++            mc_hip_enable && strcmp(mc_hip_enable, "0") != 0;
++        const bool mc_hip_vetoed =
++            mc_hip_disable && strcmp(mc_hip_disable, "0") != 0;
++        if (!mc_hip_wanted || mc_hip_vetoed) {
++            LOG(INFO) << "HIP transport NOT installed (default OFF on ROCm: "
++                         "hipIpc handles are host-local, so they break "
++                         "cross-node PD). Set MC_ENABLE_HIP_TRANSPORT=1 to opt "
++                         "in for intra-node-only GPU P2P.";
++        } else {
              Transport* hip_transport =
                  multi_transports_->installTransport("hip", nullptr);
              if (!hip_transport) {

--- a/deploy/docker/scripts/build_mooncake_rocm.sh
+++ b/deploy/docker/scripts/build_mooncake_rocm.sh
@@ -145,5 +145,20 @@ if [ "$MOONCAKE_HIP_DMABUF" = "1" ]; then
         exit 1
     fi
 fi
+# Assert the B.2 HIP-transport gate compiled in. Without it the binary is stock
+# upstream #2682: it installs the HIP transport unconditionally and selectTransport
+# prefers it over RDMA, so cross-node PD dies in KV transfer with
+# "hipIpcOpenMemHandle failed (201 - invalid device context)" — an IPC handle is
+# host-local, so a peer NODE can never open it. Both spellings must be present:
+# MC_ENABLE_HIP_TRANSPORT (opt back in) and MC_DISABLE_HIP_TRANSPORT (hard veto,
+# the spelling infera's rocm_rdma_env.py sets).
+for _v in MC_ENABLE_HIP_TRANSPORT MC_DISABLE_HIP_TRANSPORT; do
+    if ! strings "$SO" | grep -c "$_v" | grep -qv '^0$'; then
+        echo "ERROR: $SO lacks $_v — the B.2 HIP-transport gate did not take." >&2
+        echo "       Cross-node PD would break (hipIpcOpenMemHandle 201)." >&2
+        exit 1
+    fi
+done
+echo "MC_HIP_GATE_VERIFY OK (HIP transport OFF by default)"
 python3 -c "from mooncake.engine import TransferEngine; print('MOONCAKE IMPORT OK')"
 echo "MC_BUILD_DONE"

--- a/deploy/docker/scripts/build_mooncake_sglang.sh
+++ b/deploy/docker/scripts/build_mooncake_sglang.sh
@@ -9,7 +9,8 @@
 #   * single-node  vs  cross-node PD        — decided by how you launch the legs
 #   * dma-buf GPUDirect (ibv_reg_dmabuf_mr)  — the DEFAULT registration path
 #   * bare ibv_reg_mr + peermem              — MOONCAKE_DISABLE_HIP_DMABUF=1
-#   * HIP intra-node P2P transport           — opt-in via MC_ENABLE_HIP_TRANSPORT=1
+#   * HIP intra-node P2P transport           — OFF on ROCm (never worked cross-node);
+#                                              MC_ENABLE_HIP_TRANSPORT=1 opts back in
 #
 # WHY this is a single in-place build (not two images):
 #   The base bundles Mooncake at upstream #2682 (commit 01d1eb2a), whose
@@ -27,8 +28,10 @@
 #         Fix: propagate USE_HIP_DMABUF + hsa-runtime64 to rdma_transport.
 #     (b) it installs a HIP IPC transport UNCONDITIONALLY and selectTransport
 #         prefers it over RDMA, so CROSS-NODE PD breaks (hipIpcOpenMemHandle
-#         cannot open a peer's handle). Fix: gate it behind MC_ENABLE_HIP_TRANSPORT
-#         (default OFF) — the reusable in-tree B-group C++ patch, shared verbatim
+#         cannot open a peer's handle — an IPC handle is host-local by
+#         construction). Fix: gate it OFF by default; MC_ENABLE_HIP_TRANSPORT=1
+#         opts back in and MC_DISABLE_HIP_TRANSPORT=1 vetoes even that
+#         — the reusable in-tree B-group C++ patch, shared verbatim
 #         with the vLLM build (deploy/docker/patches/mooncake_cpp), so there is no
 #         duplicated hand-written source edit.
 #
@@ -121,13 +124,21 @@ cp "$SO" "$DEST"
 ASIO="$(ls "$MC_ROOT"/build/mooncake-common/libasio.so 2>/dev/null | head -1 || true)"
 [ -n "$ASIO" ] && { cp "$ASIO" "$(dirname "$DEST")/" 2>/dev/null || true; cp "$ASIO" /usr/local/lib/ 2>/dev/null || true; ldconfig 2>/dev/null || true; }
 
-# (a) HIP-transport gate present (grep into a var, not `strings | grep -q`: under
-#     pipefail, grep -q closing the pipe early SIGPIPEs strings -> false negative).
-if ! strings "$DEST" | grep -c MC_ENABLE_HIP_TRANSPORT | grep -qv '^0$'; then
-    echo "[mc-build] ERROR: rebuilt engine.so lacks the HIP-transport gate — patch/build did not take" >&2
-    exit 1
-fi
-echo "  HIP_GATE=yes"
+# (a) HIP-transport gate present. BOTH spellings must be in the binary: the gate
+#     reads MC_ENABLE_HIP_TRANSPORT (opt back in) *and* MC_DISABLE_HIP_TRANSPORT
+#     (hard veto, the spelling infera/docs/tests use). Checking only the first
+#     would pass a binary that still ignores the second.
+#     (grep into a count, not `strings | grep -q`: under pipefail, grep -q closing
+#     the pipe early SIGPIPEs strings -> false negative.)
+for _v in MC_ENABLE_HIP_TRANSPORT MC_DISABLE_HIP_TRANSPORT; do
+    if ! strings "$DEST" | grep -c "$_v" | grep -qv '^0$'; then
+        echo "[mc-build] ERROR: rebuilt engine.so lacks $_v — the HIP-transport gate" \
+             "patch/build did not take. Cross-node PD would break (hipIpcOpenMemHandle" \
+             "cannot open a peer node's handle)." >&2
+        exit 1
+    fi
+done
+echo "  HIP_GATE=yes (MC_ENABLE_HIP_TRANSPORT + MC_DISABLE_HIP_TRANSPORT)"
 
 # (b) dma-buf actually compiled into rdma_context.o (EXTERNAL symbols, so inspect
 #     the object's undefined refs — not `strings`).
@@ -148,7 +159,7 @@ else
 fi
 
 python3 -c "from mooncake.engine import TransferEngine" || { echo "[mc-build] import failed" >&2; exit 1; }
-echo "[mc-build] DONE — one engine.so: HIP gated (MC_ENABLE_HIP_TRANSPORT), dma-buf"
+echo "[mc-build] DONE — one engine.so: HIP transport OFF by default, dma-buf"
 echo "           compiled-in (default ibv_reg_dmabuf_mr; MOONCAKE_DISABLE_HIP_DMABUF=1"
 echo "           forces bare ibv_reg_mr). Runtime decides every path."
 

--- a/deploy/docker/scripts/verify_image_mooncake.sh
+++ b/deploy/docker/scripts/verify_image_mooncake.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Verify, AGAINST A BUILT IMAGE, that the Mooncake engine.so it will actually
+# load carries the HIP-transport gate.
+#
+# WHY THIS EXISTS (and why the in-build check was not enough):
+#   build_mooncake_sglang.sh already self-verifies the gate and `exit 1`s if the
+#   rebuild did not take. That check can only fire if the build STEP RUNS. Both
+#   rocm/infera:sglang-v0.1.1 and :sglang-v0.1.2 shipped an UNPATCHED engine.so
+#   anyway, because the step was never in their build at all:
+#     - v0.1.1 (built 2026-07-22) predates the Dockerfile stage that invokes the
+#       script (added 2026-07-27, a546137c);
+#     - v0.1.2 (built 2026-07-31) is v0.1.1 + exactly ONE appended layer (the
+#       libionic deb) — i.e. it was built FROM the older image, not from
+#       deploy/docker/Dockerfile.sglang, so the stage never re-ran.
+#   A build-step assertion cannot catch "the build step is not in this image".
+#   Only an assertion on the finished ARTIFACT can. That is this script.
+#
+# It is deliberately image-level and dependency-free: give it any image ref
+# (local or registry) and it inspects the installed mooncake package the same
+# way an engine would resolve it at runtime.
+#
+# USAGE:
+#   deploy/docker/scripts/verify_image_mooncake.sh <image> [<image> ...]
+#
+# EXIT: 0 = every image carries the gate; 1 = at least one does not.
+set -uo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "usage: $0 <image> [<image> ...]" >&2
+    exit 2
+fi
+
+# Runs inside the image. Resolves the mooncake package the way Python would,
+# then asserts BOTH gate spellings are present in the binary that gets loaded:
+#   MC_ENABLE_HIP_TRANSPORT  — opt back in for intra-node-only P2P
+#   MC_DISABLE_HIP_TRANSPORT — hard veto (what infera/rocm_rdma_env.py sets)
+# A binary with neither is upstream #2682 stock: it installs the HIP transport
+# unconditionally and prefers it over RDMA, so cross-node PD cannot work.
+read -r -d '' PROBE <<'SH' || true
+set -u
+SO_DIR=$(python3 -c 'import mooncake, os; print(os.path.dirname(mooncake.__file__))' 2>/dev/null)
+if [ -z "${SO_DIR:-}" ]; then
+    echo "MOONCAKE_ABSENT"
+    exit 0
+fi
+SO=$(ls "$SO_DIR"/engine*.so 2>/dev/null | head -1)
+if [ -z "${SO:-}" ]; then
+    echo "ENGINE_SO_ABSENT $SO_DIR"
+    exit 0
+fi
+echo "ENGINE_SO $SO"
+for v in MC_ENABLE_HIP_TRANSPORT MC_DISABLE_HIP_TRANSPORT; do
+    echo "COUNT $v $(strings "$SO" | grep -c "$v")"
+done
+SH
+
+rc=0
+for image in "$@"; do
+    echo "=== $image"
+    out="$(docker run --rm --entrypoint sh "$image" -c "$PROBE" 2>/dev/null)" || {
+        echo "  ERROR: could not run $image" >&2
+        rc=1
+        continue
+    }
+
+    case "$out" in
+        *MOONCAKE_ABSENT*)
+            # Not every image bundles Mooncake (e.g. the router/server images).
+            # Nothing to gate, so nothing to fail.
+            echo "  SKIP: no mooncake package in this image"
+            continue
+            ;;
+        *ENGINE_SO_ABSENT*)
+            echo "  ERROR: mooncake package present but no engine*.so" >&2
+            rc=1
+            continue
+            ;;
+    esac
+
+    so="$(printf '%s\n' "$out" | awk '/^ENGINE_SO /{print $2}')"
+    enable="$(printf '%s\n' "$out" | awk '/^COUNT MC_ENABLE_HIP_TRANSPORT /{print $3}')"
+    disable="$(printf '%s\n' "$out" | awk '/^COUNT MC_DISABLE_HIP_TRANSPORT /{print $3}')"
+    echo "  engine.so                 : $so"
+    echo "  MC_ENABLE_HIP_TRANSPORT   : ${enable:-0}"
+    echo "  MC_DISABLE_HIP_TRANSPORT  : ${disable:-0}"
+
+    if [ "${enable:-0}" != "0" ] && [ "${disable:-0}" != "0" ]; then
+        echo "  OK: HIP-transport gate present (cross-node PD will use RDMA)"
+    else
+        echo "  FAIL: engine.so has NO HIP-transport gate — this is stock upstream" >&2
+        echo "        #2682, which installs the HIP transport unconditionally and" >&2
+        echo "        prefers it over RDMA. Cross-node PD will die in KV transfer" >&2
+        echo "        with: hipIpcOpenMemHandle failed (201 - invalid device context)." >&2
+        echo "        Rebuild with deploy/docker/Dockerfile.sglang (BUILD_MOONCAKE=1)" >&2
+        echo "        FROM THE PINNED BASE — not FROM a previously published image." >&2
+        rc=1
+    fi
+done
+
+if [ "$rc" -ne 0 ]; then
+    echo
+    echo "verify_image_mooncake: FAILED" >&2
+fi
+exit "$rc"

--- a/infera/engine/rocm_rdma_env.py
+++ b/infera/engine/rocm_rdma_env.py
@@ -33,7 +33,17 @@ logger = logging.getLogger(__name__)
 # separate concern, irrelevant for intra-node TP, so it's intentionally not here.)
 _ROCM_RDMA_DEFAULTS: dict[str, str] = {
     "MC_GID_INDEX": "1",  # Mooncake transfer engine: ionic RoCE v2 GID
-    "MC_DISABLE_HIP_TRANSPORT": "1",  # Mooncake: use RDMA, not the HIP P2P transport
+    # Mooncake: use RDMA, not the HIP (hipIpc) P2P transport. A hipIpc handle is
+    # host-local by construction, so a peer NODE can never open it -- cross-node
+    # PD dies with "hipIpcOpenMemHandle failed (201 - invalid device context)".
+    # NOTE: this is belt-and-braces. The B.2 patch we build into the image
+    # (deploy/docker/patches/mooncake_cpp/transfer_engine_impl.diff) already
+    # defaults the HIP transport OFF with no env var set at all, precisely so the
+    # safe behaviour does not depend on anyone remembering to export this. Until
+    # 2026-08 this name was a NO-OP -- the gate read MC_ENABLE_HIP_TRANSPORT and
+    # nothing read MC_DISABLE_HIP_TRANSPORT; the patch now honours both, with
+    # this one taking precedence.
+    "MC_DISABLE_HIP_TRANSPORT": "1",
     # The unified sglang image compiles the dma-buf MR path IN, but the whole AMD
     # fleet is ionic (no ODP): ibv_reg_dmabuf_mr there PINS + DUPLICATES the KV
     # pool in VRAM (and can exhaust a KFD resource). Default the safe bare

--- a/infera/tools/preflight/network/mooncakeperf.py
+++ b/infera/tools/preflight/network/mooncakeperf.py
@@ -404,11 +404,16 @@ def _spawn(
     env.pop("MC_GID_INDEX", None)
     env.pop("MC_FORCE_TCP", None)
     env.pop("MC_DISABLE_HIP_TRANSPORT", None)
+    # An inherited MC_ENABLE_HIP_TRANSPORT would re-install the hipIpc transport
+    # and skew every variant, so clear it too rather than letting the caller's
+    # shell leak into the measurement.
+    env.pop("MC_ENABLE_HIP_TRANSPORT", None)
     if protocol == "rdma":
         # Documented cross-node requirement (Infera rocm_rdma_env default): force
-        # RDMA, not the intra-node HIP/XGMI shortcut, which advertises an empty
-        # segment the peer rejects. Set on all rdma variants so rdma-default varies
-        # ONLY in the missing MC_GID_INDEX it is meant to demonstrate.
+        # RDMA, not the intra-node HIP (hipIpc) transport, whose handles are
+        # host-local and so cannot be opened by a peer node. Set on all rdma
+        # variants so rdma-default varies ONLY in the missing MC_GID_INDEX it is
+        # meant to demonstrate.
         env["MC_DISABLE_HIP_TRANSPORT"] = "1"
     if env_kind == "gid":
         env["MC_GID_INDEX"] = str(_ref_gid())

--- a/manual/features/pd_disaggregation.md
+++ b/manual/features/pd_disaggregation.md
@@ -191,8 +191,14 @@ Intra-host PD "just works." Cross-host PD moves the KV over RDMA and needs care:
   `NCCL_IB_GID_INDEX=1` for the collectives path). Infera sets these defaults on
   ROCm for you; the default index 0 is link-local and times out on `QP → RTR`
   between hosts.
-- **Force RDMA, not the intra-node shortcut** — Mooncake: `MC_DISABLE_HIP_TRANSPORT=1`
-  (else its XGMI path advertises an empty segment the peer rejects).
+- **Force RDMA, not the intra-node shortcut** — Mooncake: `MC_DISABLE_HIP_TRANSPORT=1`.
+  Our image already defaults the HIP (hipIpc) transport OFF, so this is
+  belt-and-braces. Upstream Mooncake installs it unconditionally and prefers it
+  over RDMA for GPU→GPU; because a hipIpc handle is host-local by construction, a
+  peer node can never open it and KV transfer dies with
+  `hipIpcOpenMemHandle failed (Error code: 201 - invalid device context)` — even
+  though RDMA itself is healthy. If you see that line, your image predates the
+  gate; check it with `deploy/docker/scripts/verify_image_mooncake.sh <image>`.
 - **Routable addresses + shared etcd** — `--advertise-host <node-ip>`, all
   workers/servers on one reachable `--etcd-endpoint`.
 
@@ -255,7 +261,7 @@ flags like `--advertise-host` / `--kv-transfer-config` cover the rest.
 |---|---|---|
 | `MC_GID_INDEX` | `1` | Mooncake RoCEv2 GID index — index 0 is link-local and times out cross-node. |
 | `NCCL_IB_GID_INDEX` | `1` | RoCEv2 GID index for the collectives (RCCL) path. |
-| `MC_DISABLE_HIP_TRANSPORT` | `1` | Force RDMA, not the intra-node HIP/XGMI shortcut (cross-node). |
+| `MC_DISABLE_HIP_TRANSPORT` | `1` | Force RDMA, not the HIP (hipIpc) transport. Already the image default; set explicitly as belt-and-braces. |
 | `MORI_IB_GID_INDEX` | `1` | RoCEv2 GID index for the MoRIIO transport. |
 | `VLLM_MORIIO_CONNECTOR_READ_MODE` | `1` | MoRIIO read/pull mode (decode reads KV from prefill). Set on both legs. |
 | `VLLM_HOST_IP` | *(routable IP)* | Address a vLLM worker advertises for KV transfer; pair with `--advertise-host`. |

--- a/manual/reference/cli.md
+++ b/manual/reference/cli.md
@@ -111,6 +111,6 @@ daemon-level concern today, not a per-request knob on the vLLM path.
 |---|---|---|
 | `PYTHONHASHSEED=0` | vLLM worker | **mandatory** for cross-restart cache hits (vLLM salts block hashes per process) |
 | `HIP_VISIBLE_DEVICES` | worker | which GPU(s) the worker uses |
-| `MC_DISABLE_HIP_TRANSPORT=1` | PD worker | force RDMA, not the empty XGMI shortcut |
+| `MC_DISABLE_HIP_TRANSPORT=1` | PD worker | force RDMA, not the hipIpc transport (already the image default) |
 | `MC_GID_INDEX=1` / `NCCL_IB_GID_INDEX=1` | cross-node PD | RoCEv2 GID (default 0 is link-local) |
 | `VLLM_HOST_IP` | vLLM PD | routable host IP for the connector |

--- a/manual/reference/environment.md
+++ b/manual/reference/environment.md
@@ -45,7 +45,8 @@ ones that matter.
 |---|---|---|
 | `MC_GID_INDEX` | `1` | Mooncake **RoCEv2 (routable) GID index** — `1` on our ionic fleet; verify with `show_gids` (often 1 or 3). Index 0 is the link-local/RoCEv1 GID and times out cross-node. |
 | `NCCL_IB_GID_INDEX` | `1` | Same idea for the collectives (RCCL) path. |
-| `MC_DISABLE_HIP_TRANSPORT` | `1` (cross-node) | Force RDMA instead of the intra-node HIP/XGMI shortcut (which advertises an empty segment a remote peer rejects). |
+| `MC_DISABLE_HIP_TRANSPORT` | `1` | Force RDMA instead of the intra-node HIP (hipIpc) transport. Belt-and-braces only: our image already defaults that transport OFF. A hipIpc handle is host-local, so a peer node's `hipIpcOpenMemHandle` fails with `201 - invalid device context` and cross-node PD dies. |
+| `MC_ENABLE_HIP_TRANSPORT` | unset | Escape hatch: opt the HIP intra-node P2P transport back **in**. Single-node deployments only — it breaks cross-node PD. `MC_DISABLE_HIP_TRANSPORT=1` overrides it. |
 | `MORI_IB_GID_INDEX` | `1` | RoCEv2 GID index for the MoRI transport. |
 | `VLLM_HOST_IP` | *(none)* | Routable IP a vLLM worker advertises for KV transfer (cross-node). Pair with `--advertise-host`. |
 | `RDMAV_FORK_SAFE` | `1` | libibverbs fork-safety; set for RDMA workers. |

--- a/tests/engine/test_rocm_rdma_env.py
+++ b/tests/engine/test_rocm_rdma_env.py
@@ -7,6 +7,8 @@
 
 from __future__ import annotations
 
+import pathlib
+
 import infera.engine.rocm_rdma_env as rre
 
 
@@ -95,3 +97,62 @@ def test_aiter_noop_off_rocm(monkeypatch):
     monkeypatch.delenv("VLLM_ROCM_USE_AITER", raising=False)
     monkeypatch.setattr(rre, "_is_rocm", lambda: False)
     assert rre.apply_vllm_aiter_default() is None
+
+
+# --- Mooncake HIP-transport gate: the two halves must agree ------------------
+#
+# Regression guard for a defect that shipped: rocm_rdma_env set
+# MC_DISABLE_HIP_TRANSPORT=1 while the C++ gate we patch into Mooncake read only
+# MC_ENABLE_HIP_TRANSPORT, so NOTHING consumed the variable infera was setting
+# and the "disable" default was a silent no-op. Cross-node PD then died in KV
+# transfer with hipIpcOpenMemHandle 201 (a hipIpc handle is host-local, so a peer
+# node can never open it).
+#
+# These tests pin the Python default and the C++ patch to the same spelling, so
+# renaming either half without the other fails here instead of on a cluster.
+
+_MC_PATCH = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / "deploy"
+    / "docker"
+    / "patches"
+    / "mooncake_cpp"
+    / "transfer_engine_impl.diff"
+)
+
+
+def test_hip_transport_disabled_by_default():
+    """infera must ship the HIP transport OFF, via the name the gate reads."""
+    assert rre._ROCM_RDMA_DEFAULTS["MC_DISABLE_HIP_TRANSPORT"] == "1"
+    # It must NOT hand out an "enable" default -- that would re-break cross-node PD.
+    assert "MC_ENABLE_HIP_TRANSPORT" not in rre._ROCM_RDMA_DEFAULTS
+
+
+def test_mooncake_patch_consumes_the_var_infera_sets():
+    """The C++ gate must read every MC_*_HIP_TRANSPORT var infera sets."""
+    patch = _MC_PATCH.read_text()
+    added = "\n".join(line[1:] for line in patch.splitlines() if line.startswith("+"))
+    for var in rre._ROCM_RDMA_DEFAULTS:
+        if "HIP_TRANSPORT" in var:
+            assert f'getenv("{var}")' in added, (
+                f"{var} is set by rocm_rdma_env but never read by the Mooncake "
+                f"gate patch -- it would be a silent no-op"
+            )
+
+
+def test_mooncake_patch_defaults_off_without_any_env():
+    """The gate must not require an env var to be safe.
+
+    The installTransport("hip") call must sit in the `else` of a check that is
+    false when nothing is set, so an operator who exports nothing still gets RDMA.
+    """
+    patch = _MC_PATCH.read_text()
+    added = "\n".join(line[1:] for line in patch.splitlines() if line.startswith("+"))
+    # Enabling requires MC_ENABLE_HIP_TRANSPORT to be present AND non-"0" ...
+    assert 'mc_hip_enable && strcmp(mc_hip_enable, "0") != 0' in added
+    # ... and MC_DISABLE_HIP_TRANSPORT vetoes it outright.
+    assert 'mc_hip_disable && strcmp(mc_hip_disable, "0") != 0' in added
+    assert "if (!mc_hip_wanted || mc_hip_vetoed) {" in added
+    # The unconditional upstream block must be gone.
+    removed = [line[1:] for line in patch.splitlines() if line.startswith("-")]
+    assert any(line.strip() == "{" for line in removed)


### PR DESCRIPTION
## Summary

Cross-node PD (prefill on `chi2800`, decode on `chi2866`) dies at KV transfer. Mooncake installs the HIP transport and `selectTransport` prefers it over RDMA for GPU→GPU:

```
transfer_engine_impl.cpp:389] installTransport, type=rdma
transfer_engine_impl.cpp:413] HIP transport installed for intra-node GPU P2P
hip_transport.cpp:70] HipTransport: hipIpcOpenMemHandle failed (Error code: 201 - invalid device context)
```

A hipIpc handle is **host-local by construction**, so a peer *node* can never open it. This is not a tuning problem — the HIP transport cannot work cross-node at all. RDMA itself was healthy on the very same run (decode logged `Using user-specified GID index: 1 on ionic_6` and a valid RoCEv2 GID).

This PR makes the HIP transport **off by default on ROCm**, fixes an env-var name mismatch that made infera's own default a no-op, and adds an *artifact-level* check because the existing build-step check provably could not catch what shipped.

## Reproduce the finding in a few commands

**1. The gate is absent from both shipped images.** Read-only, no GPU needed:

```bash
for img in rocm/infera:sglang-v0.1.1 rocm/infera:sglang-v0.1.2; do
  echo "=== $img"
  docker run --rm --entrypoint sh "$img" -c '
    SO=$(python3 -c "import mooncake,os;print(os.path.dirname(mooncake.__file__))")
    echo "MC_ENABLE_HIP_TRANSPORT : $(strings "$SO"/engine*.so | grep -c MC_ENABLE_HIP_TRANSPORT)"
    echo "MC_DISABLE_HIP_TRANSPORT: $(strings "$SO"/engine*.so | grep -c MC_DISABLE_HIP_TRANSPORT)"
    md5sum "$SO"/engine*.so /sgl-workspace/Mooncake/build/mooncake-integration/engine*.so'
done
```

Actual output — both images, and both counts are `0`:

```
=== rocm/infera:sglang-v0.1.1
MC_ENABLE_HIP_TRANSPORT : 0
MC_DISABLE_HIP_TRANSPORT: 0
d192b213b6b9c95b49f2914ee98315dd  /opt/venv/lib/python3.10/site-packages/mooncake/engine.cpython-310-x86_64-linux-gnu.so
d192b213b6b9c95b49f2914ee98315dd  /sgl-workspace/Mooncake/build/mooncake-integration/engine.cpython-310-x86_64-linux-gnu.so
=== rocm/infera:sglang-v0.1.2
MC_ENABLE_HIP_TRANSPORT : 0
MC_DISABLE_HIP_TRANSPORT: 0
d192b213b6b9c95b49f2914ee98315dd  /opt/venv/lib/python3.10/site-packages/mooncake/engine.cpython-310-x86_64-linux-gnu.so
d192b213b6b9c95b49f2914ee98315dd  /sgl-workspace/Mooncake/build/mooncake-integration/engine.cpython-310-x86_64-linux-gnu.so
```

That md5 is also the **pinned base image's** engine.so:

```
$ docker run --rm --entrypoint sh lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x -c '...'
d192b213b6b9c95b49f2914ee98315dd  /opt/venv/lib/python3.10/site-packages/mooncake/engine.cpython-310-x86_64-linux-gnu.so
MC_ENABLE_HIP_TRANSPORT count: 0
```

The Mooncake **source tree** in the shipped image is unpatched too — still the bare `{` from upstream, at commit `01d1eb2a` (`[TE] Support rdma+hip multi-protocol segments for single-node disaggregation (#2682)`). `build_mooncake_sglang.sh` ends with `rm -rf "$MC_ROOT/build"`, yet `/sgl-workspace/Mooncake/build/` is still present with mtime `2026-07-15 04:57:53` — i.e. the script never ran.

**2. There is no upstream knob to fall back on.** `MC_USE_HIP_IPC` *is* in the stock binary, but reading `hip_transport.cpp` shows it only chooses IPC-vs-fabric **within** the HIP transport — it cannot prevent the transport being installed:

```cpp
static bool supportFabricMem() {
    // By default, use IPC mode. Fabric memory is enabled only when
    // MC_USE_HIP_IPC=0 or MC_USE_NVLINK_IPC=0 is explicitly set.
```

So the source patch is genuinely required; no env-only workaround exists on the shipped images.

**3. Verify with the script this PR adds:**

```bash
deploy/docker/scripts/verify_image_mooncake.sh rocm/infera:sglang-v0.1.1 rocm/infera:sglang-v0.1.2
```

```
=== rocm/infera:sglang-v0.1.1
  MC_ENABLE_HIP_TRANSPORT   : 0
  MC_DISABLE_HIP_TRANSPORT  : 0
  FAIL: engine.so has NO HIP-transport gate — this is stock upstream
        #2682, which installs the HIP transport unconditionally and
        prefers it over RDMA. Cross-node PD will die in KV transfer
        with: hipIpcOpenMemHandle failed (201 - invalid device context).
...
verify_image_mooncake: FAILED     (exit 1)
```

## Defect 2 — the name mismatch made infera's default a no-op

`infera/engine/rocm_rdma_env.py` set `MC_DISABLE_HIP_TRANSPORT=1`, but the B.2 patch read `MC_ENABLE_HIP_TRANSPORT`. Nothing anywhere consumed `MC_DISABLE_HIP_TRANSPORT` — it is referenced only in infera's own Python, docs, tests and example launchers, never in Mooncake:

```
$ strings <shipped engine.so> | grep -c MC_DISABLE_HIP_TRANSPORT
0
```

The gate now reads **both**, with `MC_DISABLE_HIP_TRANSPORT` taking precedence. Verified truth table (compiled the gate expression standalone, `g++ -Wall -Wextra`, no warnings):

| env | result |
|---|---|
| *(nothing set)* — the default | `OFF` |
| `MC_DISABLE_HIP_TRANSPORT=1` — what infera sets | `OFF` |
| `MC_ENABLE_HIP_TRANSPORT=1` — escape hatch | `ON` |
| `MC_ENABLE_HIP_TRANSPORT=0` | `OFF` |
| `ENABLE=1` + `DISABLE=1` | `OFF` (disable wins) |
| `ENABLE=1` + `DISABLE=0` | `ON` |

Note the old gate was `if (getenv("MC_ENABLE_HIP_TRANSPORT"))`, which treated `MC_ENABLE_HIP_TRANSPORT=0` as *enable*. That is fixed too.

Crucially, **the default is off with no env var set at all** — the safe behaviour does not depend on anyone remembering to export anything. `MC_DISABLE_HIP_TRANSPORT=1` stays in `rocm_rdma_env.py` as belt-and-braces (and because the docs/tests/launchers already use that spelling), but it is no longer load-bearing.

## Defect 3 — why the build-step check did not catch it

`build_mooncake_sglang.sh` **does** self-verify and `exit 1`, yet an unpatched engine.so shipped twice. The reason is not `BUILD_MOONCAKE=0` and not a stale cache — **the build step was never in either image's build at all.** `docker history` shows no `COPY deploy/docker/patches/mooncake_cpp/` and no `RUN … build_mooncake_sglang.sh` layer in either image:

```bash
docker history --no-trunc --format '{{.CreatedBy}}' rocm/infera:sglang-v0.1.2 | grep -c mooncake_cpp          # -> 0
docker history --no-trunc --format '{{.CreatedBy}}' rocm/infera:sglang-v0.1.2 | grep -c build_mooncake_sglang # -> 0
```

(The single `ENV BUILD_MOONCAKE=1` in that history is inherited from the base image, not infera's `ARG`.)

Timeline, all measured:

| when | what |
|---|---|
| `2026-07-15 05:31` | base `lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x` built (engine.so mtime `07-15 04:57:53`) |
| `2026-07-20 22:29` | B.2 gate patch lands (`89c86fb8`) |
| `2026-07-22 10:46` | **`sglang-v0.1.1` built** — predates the Dockerfile stage that invokes the patch |
| `2026-07-27 08:55` | `a546137c` adds the Mooncake rebuild stage to `Dockerfile.sglang` |
| `2026-07-31 01:06` | **`sglang-v0.1.2` built** — stage existed in the repo, but the image has no such layer |

And `v0.1.2` is literally `v0.1.1` plus **one** appended layer:

```bash
$ diff <(docker inspect -f '{{range .RootFS.Layers}}{{println .}}{{end}}' rocm/infera:sglang-v0.1.1) \
       <(docker inspect -f '{{range .RootFS.Layers}}{{println .}}{{end}}' rocm/infera:sglang-v0.1.2)
45a46
> sha256:039539003c13aa7b1a040eb9a26bf27d88b8055933f6092ef547409d3114ead0
```

That extra layer is the libionic deb install. So `v0.1.2` was built **FROM the older published image**, not from `deploy/docker/Dockerfile.sglang` — which is why the stage never re-ran.

**A build-step assertion cannot detect that the build step is absent.** Only an assertion on the finished artifact can. Hence `verify_image_mooncake.sh`.

## Changes

- **`patches/mooncake_cpp/transfer_engine_impl.diff`** — HIP transport off by default; reads both `MC_ENABLE_HIP_TRANSPORT` (opt back in) and `MC_DISABLE_HIP_TRANSPORT` (hard veto); handles `=0` correctly.
- **`rocm_rdma_env.py`** — unchanged behaviour, but the variable is now actually consumed; comment records that this is belt-and-braces, not the mechanism.
- **`build_mooncake_sglang.sh`** — asserts *both* spellings (checking only one would pass a binary that still ignores the other).
- **`build_mooncake_rocm.sh`** (vLLM) — **had no gate assertion at all**; added.
- **`Dockerfile.sglang` / `Dockerfile.vllm`** — new assertion layer that runs in **both** `BUILD_MOONCAKE` branches, so `BUILD_MOONCAKE=0` can no longer silently ship a stock `#2682` engine.so. Waive deliberately with `--build-arg REQUIRE_MOONCAKE_HIP_GATE=0`. Being its own layer, it is also visible in `docker history` as evidence the check ran.
- **`deploy/docker/scripts/verify_image_mooncake.sh`** (new) — artifact-level check for CI/release gating.
- **`tests/engine/test_rocm_rdma_env.py`** — pins the Python default and the C++ patch to the same spelling.
- **docs** — `manual/reference/environment.md`, `manual/reference/cli.md`, `manual/features/pd_disaggregation.md`. These described the failure as "advertises an empty segment a remote peer rejects", which is not what the logs show; corrected to the actual `hipIpcOpenMemHandle 201`, and `MC_ENABLE_HIP_TRANSPORT` is now documented.

## Testing

- `pytest tests/engine/test_rocm_rdma_env.py` → **13 passed**.
- **Negative control:** restoring the old mismatched patch fails the new tests with `AssertionError: MC_DISABLE_HIP_TRANSPORT is set by rocm_rdma_env but never read by the Mooncake gate patch -- it would be a silent no-op` (2 failed, 11 passed). Restored → 13 passed. The guard genuinely catches the original defect.
- Patch applies clean to the pristine tree extracted from the shipped image (`git apply --check` clean; `git apply --reverse --check` then detects already-applied, so the idempotent skip in `apply_mooncake_cpp_patches.sh` still works). Brace/paren balance of the patched file verified `0`.
- Gate truth table verified by compiling the expression standalone (table above).
- `verify_image_mooncake.sh` exercised on all three paths: **FAIL** on both shipped images, **SKIP** on an image with no mooncake (`rocm/infera-overlay:latest`), **OK** on a purpose-built positive control containing both strings.
- Dockerfile assertion snippet run inside real containers: fails on `sglang-v0.1.2`, passes on the gated control. `strings` confirmed present in the base image.
- `docker build --check` clean on both Dockerfiles; `bash -n` clean on all touched shell and on the joined `RUN` bodies for `REQUIRE_MOONCAKE_HIP_GATE` in `{0,1}`; `ruff check` + `ruff format --check` clean.
- The 8 pre-existing collection errors under `tests/engine/vllm/` reproduce unchanged on `origin/main` (missing vLLM dep) and are unrelated.
- No GPU workloads run and nothing deployed to k3s — all inspection was read-only, per the constraint that the GPUs were in use.

## Note for reviewers

The C++ behaviour change itself is **not** verified end-to-end here: doing so needs a Mooncake rebuild and a two-node PD run, and the GPUs were in use. What *is* verified is that the patch applies cleanly to the exact source in the shipped image, that the gate logic compiles warning-free and has the intended truth table, and that every check added here fires correctly on real images. **The images currently in use (`sglang-v0.1.1`, `v0.1.2`) do not contain this fix and cannot do cross-node PD** — they need a rebuild from the pinned base, not `FROM` a published image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pw7JSvdQb796xh5pEcctLz
