### PR TITLE
fix: make cross-node PD work — five defects between the manifest and the RDMA wire

### DIFF
--- a/deploy/overlay/Dockerfile.payload
+++ b/deploy/overlay/Dockerfile.payload
@@ -80,7 +80,28 @@ FROM ${NATIVE_IMAGE} AS native312
 COPY deploy/overlay/harvest_native.sh /tmp/harvest_native.sh
 RUN sh /tmp/harvest_native.sh
 
-FROM ${SGLANG_NATIVE_IMAGE} AS native310
+# Mooncake for the SGLang family is BUILT HERE, not harvested. The published
+# engine images ship the base's own Mooncake: in rocm/infera:sglang-v0.1.1 and
+# v0.1.2 the engine.so has mtime 2026-07-15 04:57:53 — byte-identical to the base
+# — and `strings` finds no MC_ENABLE_HIP_TRANSPORT, so the B.2 HIP-transport gate
+# never reached them even though it landed on 2026-07-21, before both builds.
+#
+# Without the gate, Mooncake registers the HIP (hipIpc) transport unconditionally
+# and prefers it for GPU-to-GPU, and cross-node PD then dies in
+# hipIpcOpenMemHandle — an IPC handle is host-local, so a peer node can never open
+# it. Harvesting Mooncake from an engine image inherits whatever that image
+# happened to have; building it here means the overlay carries a payload we can
+# state properties about.
+FROM ${SGLANG_BASE_IMAGE} AS mooncake310
+COPY deploy/docker/patches/mooncake_cpp/ /tmp/mooncake_cpp/
+COPY deploy/docker/scripts/build_mooncake_sglang.sh /tmp/build_mooncake_sglang.sh
+RUN MC_CPP_PATCH_DIR=/tmp/mooncake_cpp bash /tmp/build_mooncake_sglang.sh \
+    && python3 -c "import mooncake.engine as e; print(e.__file__)" \
+    && strings "$(python3 -c 'import mooncake.engine as e; print(e.__file__)')" \
+         | grep -q MC_ENABLE_HIP_TRANSPORT \
+    && echo "mooncake310: HIP-transport gate verified present"
+
+FROM mooncake310 AS native310
 COPY deploy/overlay/harvest_native.sh /tmp/harvest_native.sh
 RUN sh /tmp/harvest_native.sh
 

--- a/deploy/overlay/infera-exec
+++ b/deploy/overlay/infera-exec
@@ -83,6 +83,33 @@ fi
 
 export PYTHONPATH PATH
 
+# --- host libionic (RoCE provider ABI) --------------------------------------
+# The vendor bases ship whatever libionic they were built with; the ionic kernel
+# driver only accepts a matching ABI. On this fleet the stock SGLang image has
+# 54.0-149 (ABI 1) against a host needing 54.0-187 (ABI 4), and libibverbs then
+# rejects every device:
+#
+#   libibverbs: Driver ionic does not support the kernel ABI of 1 (supports 4 to 4)
+#
+# which surfaces as "No RDMA devices found" and sends Mooncake down its HIP-IPC
+# path, where cross-node PD dies on hipIpcOpenMemHandle. The baked images solved
+# this twice over (a pinned deb plus an entrypoint injector); a stock base keeps
+# neither, so do it here — infera-exec is what replaced that entrypoint.
+#
+# Mount the host build at /host-libionic to enable this. A missing mount is not an
+# error: aggregated serving never touches RDMA.
+if [ -e /host-libionic/libionic.so ]; then
+    _tgt=$(readlink -f /usr/lib/x86_64-linux-gnu/libionic.so.1 2>/dev/null || true)
+    if [ -n "$_tgt" ] && [ -f "$_tgt" ] && ! cmp -s /host-libionic/libionic.so "$_tgt"; then
+        if cp -f /host-libionic/libionic.so "$_tgt" 2>/dev/null; then
+            ldconfig 2>/dev/null || true
+            echo "infera-exec: replaced $_tgt with the host libionic build" >&2
+        else
+            echo "infera-exec: cannot write $_tgt (read-only rootfs?); RDMA may be unavailable" >&2
+        fi
+    fi
+fi
+
 # Python puts the working directory at sys.path[0] — ahead of PYTHONPATH. Vendor
 # images that already ship infera set WORKDIR to its parent (e.g. /opt/infera),
 # so the baked-in copy would silently shadow this payload and the overlay would

--- a/examples/k8s-deployments/pd-1p1d-mooncake.yaml
+++ b/examples/k8s-deployments/pd-1p1d-mooncake.yaml
@@ -64,6 +64,12 @@ spec:
       skipReadinessProbe: true
       extraPodSpec:
         nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        # hostNetwork is REQUIRED, not a tuning choice. The RDMA rails are host
+        # interfaces; the flannel pod network (10.42.0.0/24) cannot reach them, so
+        # without this Mooncake has no path to the peer and the KV transfer fails
+        # with the engine otherwise looking healthy.
+        hostNetwork: true
+        dnsPolicy: ClusterFirstWithHostNet
         # The overlay payload is dropped into an emptyDir here; the STOCK vendor
         # image below then runs infera out of it, so following an upstream bump
         # is an image-tag edit rather than a rebuild of ours.
@@ -96,11 +102,17 @@ spec:
               - {name: model, mountPath: /models, readOnly: true}
               - {name: dshm, mountPath: /dev/shm}
               - {name: ib, mountPath: /dev/infiniband}
+              # The vendor base's libionic must match the host ionic kernel ABI or
+              # libibverbs rejects every device ("does not support the kernel ABI").
+              # infera-exec swaps it in from here; see deploy/overlay/infera-exec.
+              - {name: host-libionic, mountPath: /host-libionic/libionic.so, readOnly: true}
         volumes:
           - {name: overlay, emptyDir: {}}
           - {name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}
           - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 16Gi}}
           - {name: ib, hostPath: {path: /dev/infiniband, type: Directory}}
+          - name: host-libionic
+            hostPath: {path: /usr/lib/x86_64-linux-gnu/libionic.so.1, type: File}
     decode:
       componentType: worker
       role: decode
@@ -109,6 +121,12 @@ spec:
       skipReadinessProbe: true
       extraPodSpec:
         nodeSelector: {kubernetes.io/hostname: <DECODE_NODE>}
+        # hostNetwork is REQUIRED, not a tuning choice. The RDMA rails are host
+        # interfaces; the flannel pod network (10.42.0.0/24) cannot reach them, so
+        # without this Mooncake has no path to the peer and the KV transfer fails
+        # with the engine otherwise looking healthy.
+        hostNetwork: true
+        dnsPolicy: ClusterFirstWithHostNet
         # The overlay payload is dropped into an emptyDir here; the STOCK vendor
         # image below then runs infera out of it, so following an upstream bump
         # is an image-tag edit rather than a rebuild of ours.
@@ -141,8 +159,14 @@ spec:
               - {name: model, mountPath: /models, readOnly: true}
               - {name: dshm, mountPath: /dev/shm}
               - {name: ib, mountPath: /dev/infiniband}
+              # The vendor base's libionic must match the host ionic kernel ABI or
+              # libibverbs rejects every device ("does not support the kernel ABI").
+              # infera-exec swaps it in from here; see deploy/overlay/infera-exec.
+              - {name: host-libionic, mountPath: /host-libionic/libionic.so, readOnly: true}
         volumes:
           - {name: overlay, emptyDir: {}}
           - {name: model, hostPath: {path: <MODEL_DIR>, type: Directory}}
           - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 16Gi}}
           - {name: ib, hostPath: {path: /dev/infiniband, type: Directory}}
+          - name: host-libionic
+            hostPath: {path: /usr/lib/x86_64-linux-gnu/libionic.so.1, type: File}

--- a/examples/recipes/glm5.2/README.md
+++ b/examples/recipes/glm5.2/README.md
@@ -148,7 +148,7 @@ rocm-smi --showpids
 |---|---|
 | **`mixed/deploy.yaml` exactly as written** | **validated end-to-end on k3s (MI355X, 8×`amd.com/gpu`)** — see below |
 | kvd sidecar + PVC L3 under SGLang | validated (3674 entries / 421 MB), on Qwen3-0.6B — but see the py310 native-tree note above |
-| pd / pd-kvd for this model | structure only; needs a routable RoCE fabric |
+| pd / pd-kvd for this model | the PD path itself is validated cross-node (SGLang + Mooncake over RoCE, chi2800→chi2866); not yet run with these GLM-5.2 settings |
 
 The `mixed` run used the **stock `lmsysorg/sglang` image** with the overlay
 mounted in — no infera-built engine image anywhere in the Pod:

--- a/infera/engine/rocm_rdma_env.py
+++ b/infera/engine/rocm_rdma_env.py
@@ -170,18 +170,53 @@ def _is_private_ipv4(ip: str) -> bool:
     return False
 
 
+# Interface name prefixes that are virtual by construction — container bridges,
+# CNI plugins, veth pairs, tunnels. None can carry RoCE, and several are private
+# RFC1918, which is exactly what makes them dangerous to a "first private IPv4"
+# scan.
+_VIRTUAL_IF_PREFIXES = (
+    "docker",
+    "cni",
+    "flannel",
+    "cali",
+    "cilium",
+    "weave",
+    "kube-",
+    "veth",
+    "br-",
+    "virbr",
+    "tunl",
+    "gre",
+    "ip6tnl",
+    "dummy",
+    "bond-dummy",
+)
+
+
 def _private_rail_ipv4() -> str | None:
     """First private (RFC1918) NIC IPv4, sorted by ifname for determinism.
 
     The KV-transfer P2P-handshake host must be a peer-reachable, NON-public
     address; ``get_ip()`` (route to 8.8.8.8) returns the PUBLIC NIC on a
-    multi-homed host. Skip loopback and the docker bridge."""
+    multi-homed host.
+
+    Skip virtual interfaces, not just loopback and docker. On a Kubernetes node
+    the CNI bridge is private, RFC1918 and — sorted by name — comes FIRST, so a
+    naive scan picks `cni0` (10.42.0.1) and pins the KV host IP to an address the
+    peer cannot reach. Observed on k3s/flannel: prefill advertised 10.42.0.1 and
+    decode 10.42.1.1, each the other node's unreachable bridge gateway. The host
+    interface list there begins:
+
+        cni0  docker0  enp105s0  enp121s0 ...
+
+    so ordering alone guarantees the wrong answer. These names are virtual by
+    construction and can never be an RDMA rail."""
     try:
         ifs = sorted(os.listdir(_NET_PATH))
     except OSError:
         return None
     for n in ifs:
-        if n == "lo" or n.startswith("docker"):
+        if n == "lo" or n.startswith(_VIRTUAL_IF_PREFIXES):
             continue
         ip = _ifaddr_ipv4(n)
         if ip and _is_private_ipv4(ip):

--- a/infera/engine/sglang/__main__.py
+++ b/infera/engine/sglang/__main__.py
@@ -114,7 +114,16 @@ async def _maybe_start_kv_plane(
 
     # 0.0.0.0 bind is fine inside the worker but useless on the wire;
     # the registered endpoint must be reachable by the server.
-    advertise_host = args.server_args.host
+    #
+    # Use the resolved advertise host, not the bind host. main() sets
+    # args.advertise_host from POD_IP under Kubernetes discovery precisely so these
+    # endpoints can be reached — its own comment says "the registered url/worker_id
+    # and kv endpoints all derive from this" — but this path ignored it and
+    # published the bind address. With the usual `--host 0.0.0.0` the router then
+    # polled `http://0.0.0.0:8801` for every worker and logged "All connection
+    # attempts failed" on a loop, while both workers registered and looked healthy.
+    # The vLLM worker already does `args.advertise_host or args.host`.
+    advertise_host = args.advertise_host or args.server_args.host
     events_advertise = args.kv_events_advertise or resolve_advertise_endpoint(
         args.kv_events_bind, advertise_host
     )

--- a/manual/recipes/index.md
+++ b/manual/recipes/index.md
@@ -48,6 +48,22 @@ The prefill→decode KV handoff is RDMA, and there is **no TCP fallback**. Both 
 must sit on a mutually routable RoCE fabric. On a single box, use `mixed`.
 ```
 
+```{admonition} Checking RoCE reachability: bind the source rail
+:class: tip
+This fabric is **routed L3 RoCEv2**: every NIC gets its own /64, so no two hosts
+ever share a subnet — by design, not a fault. An unbound `ping6` picks a default
+source, leaves via the wrong rail and reports "No route", which reads as "these
+nodes cannot do PD". Bind the matching local rail instead:
+
+```bash
+ping6 -I <local-rail-ULA> <peer-rail-ULA>
+```
+
+Mooncake binds its QP to a device and GID index, so it takes the working path the
+naive ping does not. On this fleet all 8 rails answer at ~0.1 ms once bound.
+```
+
+
 ## What the overlay provides
 
 The overlay carries one native tree per ABI family and records what each provides,

--- a/tests/unit/engine/test_rdma_rail_ipv4.py
+++ b/tests/unit/engine/test_rdma_rail_ipv4.py
@@ -1,0 +1,53 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""The RDMA-rail IPv4 scan must not pick a container/CNI bridge.
+
+On a Kubernetes node the CNI bridge is private, RFC1918 and sorts FIRST, so a
+"first private IPv4" scan returns it. Observed on k3s/flannel: PD prefill pinned
+its KV host IP to 10.42.0.1 and decode to 10.42.1.1 — each the other node's
+unreachable bridge gateway — while the routable rail was 10.2.122.x.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from infera.engine import rocm_rdma_env as env
+
+
+@pytest.fixture
+def fake_host(monkeypatch):
+    """A node laid out the way k3s leaves one: cni0 first, real NIC later."""
+    addrs = {
+        "cni0": "10.42.0.1",  # flannel bridge — private, and sorts first
+        "docker0": "172.17.0.1",
+        "flannel.1": "10.42.0.0",
+        "enp105s0": "10.2.122.22",  # the routable private rail
+        "veth9f2a1b": "10.42.0.7",
+        "lo": "127.0.0.1",
+    }
+    monkeypatch.setattr(env.os, "listdir", lambda _p: sorted(addrs))
+    monkeypatch.setattr(env, "_ifaddr_ipv4", lambda n: addrs.get(n))
+    return addrs
+
+
+def test_skips_cni_bridge_and_picks_the_real_nic(fake_host) -> None:
+    assert env._private_rail_ipv4() == "10.2.122.22"
+
+
+@pytest.mark.parametrize(
+    "name", ["cni0", "docker0", "flannel.1", "veth9f2a1b", "br-abc123", "cali12ab", "kube-ipvs0"]
+)
+def test_virtual_interfaces_are_excluded(name: str) -> None:
+    assert name.startswith(env._VIRTUAL_IF_PREFIXES), f"{name} would be scanned as a rail"
+
+
+def test_no_private_nic_yields_none(monkeypatch) -> None:
+    """A host with only a public address must return None, not a public IP."""
+    addrs = {"lo": "127.0.0.1", "enp1s0": "149.28.124.225"}
+    monkeypatch.setattr(env.os, "listdir", lambda _p: sorted(addrs))
+    monkeypatch.setattr(env, "_ifaddr_ipv4", lambda n: addrs.get(n))
+    assert env._private_rail_ipv4() is None


### PR DESCRIPTION
Cross-node PD (prefill/decode disaggregation) now works: prefill on `chi2800`, decode on `chi2866`, KV over RoCE, correct answer through the router.

It needed five fixes. Each was only visible once the previous one was cleared — every layer failed with a message pointing somewhere other than its cause.

| # | Defect | How it presented |
|---|---|---|
| 1 | manifest had no `hostNetwork` | flannel (10.42.0.0/24) cannot reach the RDMA rails |
| 2 | `_private_rail_ipv4()` picked the CNI bridge | KV host IP pinned to `10.42.0.1` — the peer's own unreachable gateway |
| 3 | SGLang published the **bind** host as its advertise host | router polled `http://0.0.0.0:8801` forever; requests answered `no active mixed worker` |
| 4 | stock image's libionic ABI 1 vs host ABI 4 | `libibverbs: Driver ionic does not support the kernel ABI` → **0 RDMA devices** |
| 5 | Mooncake's HIP transport was never gated | `hipIpcOpenMemHandle failed (201)` — an IPC handle is host-local, so a peer node can never open one |

## The one worth reading: #5

**The B.2 HIP-transport gate is absent from every published SGLang image.** In both `rocm/infera:sglang-v0.1.1` and `v0.1.2`:

```
site-packages/mooncake/engine.so   mtime 2026-07-15 04:57:53   MC_ENABLE_HIP_TRANSPORT: 0
Mooncake/build/.../engine.so       mtime 2026-07-15 04:57:53   MC_ENABLE_HIP_TRANSPORT: 0
```

Identical timestamps, straight from the base image. The patch landed **2026-07-21**; those images were built **07-22** and **07-31**. And `build_mooncake_sglang.sh` self-verifies the gate and exits 1 without it — so the step did not run at all, rather than running and failing silently. **Why is not determined here**; that needs the release build logs, and I have not guessed at it in the code.

The consequence is not limited to the overlay: without the gate, Mooncake registers the HIP transport unconditionally and prefers it for GPU-to-GPU, so **cross-node SGLang PD has been broken on the shipped images**, not just on a stock base.

So the overlay now **compiles Mooncake itself** and fails its own build if the gate is not in the result. Harvesting inherits whatever an image happened to contain; building means the payload has properties we can state. ~55 s, against rebuilding a 78 GB engine image. Measured: `HIP transport installed` 1 → 0, and PD went from `KVTransferError` to a correct answer.

## A conclusion this overturns

The recipes have said PD needs "two nodes on a mutually routable RoCE fabric", implying we had none. **We always did.** The fabric is routed L3 RoCEv2 — every NIC gets its own /64, so no two hosts share a subnet *by design*. An unbound `ping6` picks a default source, exits via the wrong rail and says "No route", which is what produced the standing belief. Source-bound per rail, all 8 answer at ~0.1 ms; Mooncake binds its QP to a device and GID index and takes the path the naive ping does not.

The docs now carry the bound-ping check, because getting it wrong costs a "we can't do PD here" that survives a long time.

## Verification

- **End to end**, as written: prefill chi2800 → decode chi2866, KV over RDMA (GID index 1, `ionic_6`), correct answer.
- **#2 has a regression test** that models the real interface ordering (`cni0` sorts first and is RFC1918) and asserts a public-only host yields `None` rather than a public IP. Confirmed it fails against the original two-name skip list.
- **#4 measured directly**: 0 RDMA devices before the injection, 8 after.
- **#5 measured directly**: gate string absent → present in the payload; `HIP transport installed` 1 → 0.

## Not verified

The verbs layer was never exercised in isolation (`ib_send_bw` between hosts) — what is proven is that a real PD request completes over RDMA, which is the stronger end-to-end statement but does not isolate PFC/ECN behaviour under load.

A related name mismatch is left alone here: `infera/engine/rocm_rdma_env.py` sets `MC_DISABLE_HIP_TRANSPORT=1` while the patch reads `MC_ENABLE_HIP_TRANSPORT`, so that default is a no-op. It is being handled separately along with whether the HIP transport should be removed outright on ROCm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pw7JSvdQb796xh5pEcctLz