### PR TITLE
docs(recipes): add kimi-k3-optimized — mixed, DSpark, and cross-node PD

### DIFF
--- a/examples/recipes/kimi-k3-optimized/README.md
+++ b/examples/recipes/kimi-k3-optimized/README.md
@@ -1,0 +1,166 @@
+# Kimi-K3 (optimized build)
+
+Kimi-K3 on 8× MI355X (TP8) using `johnqin2025/kimi-k3-dspark`, an image carrying an
+FP8 pre-route / shared-expert kernel cluster, an FP8 latent-MoE tail, a fused MLA
+output gate and a tri-projection dispatch.
+
+This is a **separate model entry** from [`kimi-k3/`](../kimi-k3/README.md) rather
+than a combo on it, because it is a different artifact. It is the same vLLM commit
+(`g5f76ae224`) as the stock `vllm/vllm-openai-rocm:kimi-k3`, so the delta is
+kernels, not engine version.
+
+## 1. Choose the combination
+
+| Combination | Manifest | Use it when |
+|---|---|---|
+| **mixed** | [`mixed/`](mixed/deploy.yaml) | concurrency above 8 — and it is the faster recipe there |
+| **mixed + DSpark** | [`mixed-dspark/`](mixed-dspark/deploy.yaml) | concurrency ≤ 8, where speculation is worth 1.9–2.2× |
+
+DSpark is speculative decoding with a block-diffusion draft model that drafts 7
+tokens in one parallel pass. The draft is a community checkpoint
+([`Inferact/Kimi-K3-DSpark`](https://huggingface.co/Inferact/Kimi-K3-DSpark)) —
+there is no official Moonshot draft for Kimi-K3.
+
+```{admonition} With DSpark, concurrency above 8 is an outage, not a slowdown
+:class: warning
+At `c>=16` the engine dies with
+
+    AssertionError: AiterMLA flattened verify requires a uniform decode query len
+
+"verify" is the tell — this is the speculative path only. The identical config
+without `--speculative-config` serves `c=16` at **426.51 tok/s**, which is also
+*faster* than the DSpark recipe's best result (359.72 at `c=8`). Above 8, use
+`mixed/`.
+```
+
+## 2. Prerequisites
+
+```bash
+# nodes must advertise amd.com/gpu
+kubectl get nodes -o custom-columns=NODE:.metadata.name,GPU:.status.allocatable.'amd\.com/gpu'
+
+# the operator (provides the InferaDeployment CRD)
+helm install infera-operator deploy/operator/helm/infera-operator -n infera-system --create-namespace
+```
+
+Both models go in one directory, mounted at `/models`:
+
+```bash
+hf download moonshotai/Kimi-K3      --local-dir <MODEL_DIR>/Kimi-K3
+hf download Inferact/Kimi-K3-DSpark --local-dir <MODEL_DIR>/Kimi-K3-DSpark   # DSpark only
+```
+
+**`<MODEL_DIR>` must be local NVMe.** Kimi-K3's 96 shards load in ~8 min from local
+disk and ~95 min from NFS with two nodes on the same mount — and the slow path does
+not merely run late, it exceeds the ready timeout, so the worker restarts mid-load
+and never finishes.
+
+First start is **10–14 min**: the image rebuilds its AITER JIT modules in-container
+on top of weight load and CUDA-graph capture. DSpark adds ~4 min over the baseline.
+
+## 3. Deploy
+
+```bash
+sed 's|<MODEL_DIR>|/your/local/nvme/models|' \
+  examples/recipes/kimi-k3-optimized/<combo>/deploy.yaml | kubectl apply -f -
+kubectl -n infera get pods -w
+```
+
+## 4. Smoke test
+
+```bash
+kubectl -n infera port-forward svc/kimi-k3-opt-<base|dspark>-server 8000:8000 &
+
+curl -s localhost:8000/v1/chat/completions -H 'Content-Type: application/json' \
+  -d '{"model":"kimi-k3","messages":[{"role":"user","content":"What is the capital of France?"}],
+       "max_tokens":200}' | jq -r '.choices[0].message.content'
+```
+
+Keep `max_tokens` generous: this model spends 70+ completion tokens on that
+sentence, so a tight cap truncates it into something that reads like a broken
+deployment.
+
+On the DSpark manifest, confirm speculation actually engaged rather than inferring
+it from throughput an hour later:
+
+```bash
+POD=$(kubectl -n infera get pod -o name \
+  -l infera.amd.com/deployment=kimi-k3-opt-dspark,infera.amd.com/service=worker | head -1)
+
+kubectl -n infera logs $POD -c main | grep -oE "cudagraph_mode': <CUDAGraphMode[^,]*"   # FULL_AND_PIECEWISE
+kubectl -n infera logs $POD -c main | grep -c 'running the draft eagerly'               # must be 0
+kubectl -n infera logs $POD -c main | grep -oE 'Mean acceptance length: [0-9.]+' | tail -1
+```
+
+`running the draft eagerly` means the draft fell back to Triton instead of being
+captured into CUDA graphs, which costs about 5% of decode throughput.
+
+## 5. Measured results
+
+8× MI355X, TP8, `--max-model-len 1048576`, BF16 KV, on k3s through the infera
+router. Every number below was measured on the manifests in this directory.
+
+**8K in / 1K out, batch 1** — read *step time* (median ITL), not TPOT: TPOT is step
+time ÷ tokens-per-step, so it flatters speculation and swings with acceptance.
+
+| | step time | acceptance |
+|---|---:|---|
+| mixed | 12.37 ms | — |
+| mixed + DSpark | 29.11 ms | 3.85 of 7 |
+
+A DSpark step costs 2.35× a baseline step and delivers ~3.85 tokens instead of 1.
+
+**1024 in / 128 out, output token throughput:**
+
+| concurrency | mixed | mixed + DSpark | speedup |
+|---:|---:|---:|---:|
+| 4 | 67.11 | **146.96** | 2.19× |
+| 8 | 187.17 | **359.72** | 1.92× |
+| 16 | **426.51** | crashes | — |
+| 32, 64 | not measured | crashes | — |
+
+The speedup decays with concurrency (2.19× → 1.92×) as the verify batch grows and
+acceptance drops (3.85 at batch 1 → 3.62 at `c=8`). Extrapolating that trend, even
+without the crash it is unlikely to still be winning at `c=16`.
+
+## 6. Settings that are not optional
+
+Each row is a failure that was hit and diagnosed on this hardware, not a preference.
+
+| Setting | Why |
+|---|---|
+| the `KIMI_K3_*` / `VLLM_ROCM_*` env block | these select the optimized kernels. Without them the MoE asks aiter for a kernel that was never generated: `ValueError: Invalid FlyDSL kernel name: flydsl_moe1_..._t16x64x256_...` — there is no Kimi-K3 `tuned_fmoe.csv`, while dsv3/dsv4/glm5 all have one |
+| `VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16=0` | must be `0`. The pre-route dispatch tries BF16 first and a `1` shadows the FP8 cluster entirely — silently, at ~40% of throughput |
+| `attention_backend: ROCM_AITER_MLA` | in the speculative config. The upstream quick-start says `FLASHINFER_MLA`, which is CUDA-only; **omitting the key entirely is not the fix** — this is its ROCm counterpart |
+| `--gpu-memory-utilization 0.88` | the draft's weights land after the KV budget is computed. At `0.95` the run dies with 998 MB free trying to allocate 2.32 GiB |
+| `INFERA_ENGINE_READY_TIMEOUT=7200` | infera's 1800 s default is generous for local NVMe and impossible for anything slower; the worker then kills itself mid-load and restarts forever, which reads as a crash loop rather than as slow storage |
+
+## 7. Validation status
+
+| What | Status |
+|---|---|
+| `mixed/deploy.yaml` as written | **validated end-to-end** — ready in ~10 min, correct answer, c=4/8/16 measured |
+| `mixed-dspark/deploy.yaml` as written | **validated end-to-end** — ready in ~14 min, correct answer, c=4/8 measured, c≥16 confirmed to crash |
+| PD / kvd combinations | not built for this image |
+| fp8 KV cache | not measured here |
+
+Against the upstream quick-start for this image, three of its numbers reproduce
+closely and three of its claims do not:
+
+| | upstream | measured here |
+|---|---|---|
+| baseline step time, 8K/1K | 12.39 ms | 12.37 ms |
+| DSpark step time, 8K/1K | 29.50 ms | 29.11 ms |
+| acceptance length | 4.00 | 3.85 |
+| concurrency assertion fires at | c=48 | **c=16** |
+| c=16 throughput | 315.7 tok/s | **crashes** |
+| c=32 throughput | 454.3 tok/s | **crashes** |
+
+The upstream document states its own concurrency table was measured on a sibling
+build (`kimi-k3-dspark:wvsplitk-fix`) and **not re-run on this image**. These
+measurements are that re-run: the concurrency fixes are not in this image.
+
+## Source
+
+[`examples/recipes/kimi-k3-optimized/`](.) in [AMD-AGI/Infera](https://github.com/AMD-AGI/Infera)
+· [all recipes](../README.md) · [stock Kimi-K3 recipe](../kimi-k3/README.md)

--- a/examples/recipes/kimi-k3-optimized/README.md
+++ b/examples/recipes/kimi-k3-optimized/README.md
@@ -15,6 +15,7 @@ kernels, not engine version.
 |---|---|---|
 | **mixed** | [`mixed/`](mixed/deploy.yaml) | concurrency above 8 — and it is the faster recipe there |
 | **mixed + DSpark** | [`mixed-dspark/`](mixed-dspark/deploy.yaml) | concurrency ≤ 8, where speculation is worth 1.9–2.2× |
+| **pd** | [`pd/`](pd/deploy.yaml) | you have two nodes on a routable RoCE fabric and want prefill and decode batched separately |
 
 DSpark is speculative decoding with a block-diffusion draft model that drafts 7
 tokens in one parallel pass. The draft is a community checkpoint
@@ -66,6 +67,17 @@ sed 's|<MODEL_DIR>|/your/local/nvme/models|' \
 kubectl -n infera get pods -w
 ```
 
+`pd/` takes four placeholders instead, because the two roles land on different
+nodes and each reads its **own local** copy — the paths do not have to match, and
+on this fleet they do not:
+
+```bash
+sed -e 's|<PREFILL_NODE>|chi2800|'      -e 's|<DECODE_NODE>|chi2866|' \
+    -e 's|<PREFILL_MODEL_DIR>|/mnt/k3local/models/moonshotai|' \
+    -e 's|<DECODE_MODEL_DIR>|/mnt/nvmeraid/models/moonshotai|' \
+    examples/recipes/kimi-k3-optimized/pd/deploy.yaml | kubectl apply -f -
+```
+
 ## 4. Smoke test
 
 ```bash
@@ -95,6 +107,24 @@ kubectl -n infera logs $POD -c main | grep -oE 'Mean acceptance length: [0-9.]+'
 `running the draft eagerly` means the draft fell back to Triton instead of being
 captured into CUDA graphs, which costs about 5% of decode throughput.
 
+On `pd`, the correct answer proves nothing on its own: if the KV handoff fails
+open, the decoder simply re-prefills locally and returns the same text. Check the
+**decode** side instead —
+
+```bash
+DEC=$(kubectl -n infera get pod -o name -l infera.amd.com/service=decode | head -1)
+kubectl -n infera logs $DEC -c main | grep 'Engine 000' | tail -2
+```
+
+```
+Avg prompt throughput: 0.1 tokens/s, Avg generation throughput: 7.8 tokens/s,
+  ... External prefix cache hit rate: 100.0%
+```
+
+`External prefix cache hit rate: 100.0%` with `Avg prompt throughput` near zero is
+the handoff working: the decoder computed no prefill and took the KV off the wire.
+The prefill pod is the mirror image — all prompt throughput, no generation.
+
 ## 5. Measured results
 
 8× MI355X, TP8, `--max-model-len 1048576`, BF16 KV, on k3s through the infera
@@ -110,7 +140,19 @@ time ÷ tokens-per-step, so it flatters speculation and swings with acceptance.
 
 A DSpark step costs 2.35× a baseline step and delivers ~3.85 tokens instead of 1.
 
-**1024 in / 128 out, output token throughput:**
+**pd, 2139 in / 127 out, 1P1D over two nodes — 16 GPUs:**
+
+| concurrency | output tok/s | P50 | P90 |
+|---:|---:|---:|---:|
+| 4 | 130.15 | 3.59 s | 4.27 s |
+| 8 | 229.61 | 4.34 s | 4.59 s |
+| 16 | 386.28 | 4.63 s | 6.09 s |
+
+These are deliberately **not** in the table below. `pd` uses 16 GPUs against
+`mixed`'s 8 *and* was measured at a 2139-token prompt against its 1024 — two
+differences at once, so any ratio between the two tables measures nothing.
+
+**mixed, 1024 in / 128 out, output token throughput — 8 GPUs:**
 
 | concurrency | mixed | mixed + DSpark | speedup |
 |---:|---:|---:|---:|
@@ -134,6 +176,8 @@ Each row is a failure that was hit and diagnosed on this hardware, not a prefere
 | `attention_backend: ROCM_AITER_MLA` | in the speculative config. The upstream quick-start says `FLASHINFER_MLA`, which is CUDA-only; **omitting the key entirely is not the fix** — this is its ROCm counterpart |
 | `--gpu-memory-utilization 0.88` | the draft's weights land after the KV budget is computed. At `0.95` the run dies with 998 MB free trying to allocate 2.32 GiB |
 | `INFERA_ENGINE_READY_TIMEOUT=7200` | infera's 1800 s default is generous for local NVMe and impossible for anything slower; the worker then kills itself mid-load and restarts forever, which reads as a crash loop rather than as slow storage |
+| `pd`: each node needs its **own local** copy of the weights | the `model` volume is a `hostPath`, so the two nodes need not use the same path — and on this fleet the tempting common name (`/mnt/shared`) is an NFS export of the *other* node's array. Mounting it on both sides turns one side's 8-minute load into ~95 minutes, which then exceeds the ready timeout and restarts forever. `df -hT <dir>` on each node and take the local device |
+| `pd`: never point a client at it that sends requests the engine will reject | the engine validates **after** prefill, so a rejected request has already had its KV computed and queued for transfer. 84 requests rejected for one bad field (`min_tokens` equal to `max_tokens`, which fails because the server silently decrements `max_tokens` by 1) left 424 aborted Mooncake transfers — 53 requests × 8 TP ranks — and stalled *valid* traffic behind the backlog for ~20 minutes. It presents as `MooncakeXferMetadata transfer failed: Resource temporarily unavailable` and reads exactly like a broken fabric |
 
 ## 7. Validation status
 
@@ -141,8 +185,30 @@ Each row is a failure that was hit and diagnosed on this hardware, not a prefere
 |---|---|
 | `mixed/deploy.yaml` as written | **validated end-to-end** — ready in ~10 min, correct answer, c=4/8/16 measured |
 | `mixed-dspark/deploy.yaml` as written | **validated end-to-end** — ready in ~14 min, correct answer, c=4/8 measured, c≥16 confirmed to crash |
-| PD / kvd combinations | not built for this image |
+| `pd/deploy.yaml` as written | **validated end-to-end across two nodes** — see below |
+| `pd` + DSpark | not attempted. Speculation is decode-side and its behaviour in the `kv_consumer` role is a separate unknown |
+| kvd combinations | not built for this image |
 | fp8 KV cache | not measured here |
+
+The `pd` run was 1P1D on chi2800 (prefill) and chi2866 (decode), 8 GPUs each:
+
+| | |
+|---|---|
+| both roles Ready | 790 s, 0 restarts |
+| RDMA devices | 8 on each side, via `ibv_get_device_list` |
+| handoff verified | decode at `External prefix cache hit rate: 100.0%` with ~0 prompt throughput; prefill at 2010.5 tok/s prompt and ~0 generation |
+| clean requests | 131 consecutive (47 correctness + 84 sweep), 0 failed transfers |
+
+`ibv_devices` is **not installed** in this image. Running it and reading `not
+found` as "no RDMA devices" is a mistake that cost two false TCP-fallback
+diagnoses here; `ibv_get_device_list` reported 8 the whole time:
+
+```bash
+kubectl -n infera exec <pod> -c main -- python3 -c '
+import ctypes; lib = ctypes.CDLL("libibverbs.so.1")
+lib.ibv_get_device_list.restype = ctypes.POINTER(ctypes.c_void_p)
+n = ctypes.c_int(0); lib.ibv_get_device_list(ctypes.byref(n)); print(n.value)'
+```
 
 Against the upstream quick-start for this image, three of its numbers reproduce
 closely and three of its claims do not:

--- a/examples/recipes/kimi-k3-optimized/mixed-dspark/deploy.yaml
+++ b/examples/recipes/kimi-k3-optimized/mixed-dspark/deploy.yaml
@@ -1,0 +1,254 @@
+# Kimi-K3 (optimized build) — mixed-dspark — Kubernetes recipe
+#
+# A separate model entry from `kimi-k3/` because it is a different artifact, not a
+# different setting: this uses johnqin2025/kimi-k3-dspark, which carries an FP8
+# pre-route / shared-expert kernel cluster, an FP8 latent-MoE tail, a fused MLA
+# output gate and a tri-projection dispatch. Same vLLM commit as the stock
+# kimi-k3 image (g5f76ae224), so the delta is kernels, not engine version.
+#
+#   base image   johnqin2025/kimi-k3-dspark:1.1.0-mi355x-rocm7.2.3-20260801
+#   overlay      inferaimage/infera-overlay v0.2.2
+#
+# Fill in <MODEL_DIR>: the directory holding Kimi-K3 and Kimi-K3-DSpark. Use LOCAL NVMe —
+# 96 shards load in ~8 min from local disk and ~95 min from NFS, and the slow path
+# does not merely run late, it exceeds the ready timeout and restarts forever.
+#
+# Deploy:  kubectl apply -f examples/recipes/kimi-k3-optimized/mixed-dspark/deploy.yaml
+#
+# MEASURED, this manifest, 8x MI355X TP8, 1M context (see README for the full set):
+#   8K in / 1K out, batch 1   step time 29.11 ms   acceptance 3.85 of 7 drafted
+#   1024 in / 128 out  c=4    146.96 tok/s  (2.19x the non-speculative recipe)
+#                      c=8    359.72 tok/s  (1.92x)
+#                      c>=16  CRASHES — see the concurrency note below.
+#
+# CONCURRENCY CEILING IS 8 WITH SPECULATION ON. At c>=16 the engine dies with
+#   AssertionError: AiterMLA flattened verify requires a uniform decode query len
+# The word "verify" is the tell: this is the speculative path only. The same
+# config without --speculative-config serves c=16 fine at 426.51 tok/s — which is
+# also *faster* than this manifest's best (359.72 at c=8). So speculation is a
+# low-concurrency optimisation here, and above c=8 it is not a tradeoff, it is an
+# outage. Use ../mixed/ for concurrent serving.
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: kimi-k3-opt-dspark
+  namespace: infera
+spec:
+  backendFramework: vllm
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        initContainers:
+        - name: infera-overlay
+          image: inferaimage/infera-overlay@sha256:6918eff34f201548a738dd592d2a1ece0627354d2e88f24a87cfa8f787a72a44
+          imagePullPolicy: IfNotPresent
+          command:
+          - sh
+          - -c
+          - cp -a /payload/. /overlay/
+          volumeMounts:
+          - name: overlay
+            mountPath: /overlay
+        containers:
+        - name: main
+          image: johnqin2025/kimi-k3-dspark:1.1.0-mi355x-rocm7.2.3-20260801@sha256:a3584d74f256ca7c33b1ac9e5598897123d28e9faf9860e188a2e82a9b5530e3
+          imagePullPolicy: IfNotPresent
+          command:
+          - /overlay/bin/infera-exec
+          - python3
+          - -m
+          - infera.server
+          - --host
+          - 0.0.0.0
+          - --port
+          - '8000'
+          - --router-tokenizer-path
+          - /models/Kimi-K3
+          - --request-transport
+          - http
+          - --kv-event-transport
+          - zmq
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          resources:
+            requests:
+              cpu: '8'
+              memory: 16Gi
+            limits:
+              cpu: '8'
+              memory: 16Gi
+          volumeMounts:
+          - name: overlay
+            mountPath: /overlay
+            readOnly: true
+          - name: model
+            mountPath: /models
+            readOnly: true
+        volumes:
+        - name: overlay
+          emptyDir: {}
+        - name: model
+          hostPath:
+            path: <MODEL_DIR>
+            type: Directory
+    worker:
+      componentType: worker
+      role: mixed
+      replicas: 1
+      extraPodSpec:
+        initContainers:
+        - name: infera-overlay
+          image: inferaimage/infera-overlay@sha256:6918eff34f201548a738dd592d2a1ece0627354d2e88f24a87cfa8f787a72a44
+          imagePullPolicy: IfNotPresent
+          command:
+          - sh
+          - -c
+          - cp -a /payload/. /overlay/
+          volumeMounts:
+          - name: overlay
+            mountPath: /overlay
+        containers:
+        - name: main
+          image: johnqin2025/kimi-k3-dspark:1.1.0-mi355x-rocm7.2.3-20260801@sha256:a3584d74f256ca7c33b1ac9e5598897123d28e9faf9860e188a2e82a9b5530e3
+          imagePullPolicy: IfNotPresent
+          command:
+          - /overlay/bin/infera-exec
+          - python3
+          - -m
+          - infera.engine.vllm
+          - --host
+          - 0.0.0.0
+          - --port
+          - '30000'
+          - --model
+          - /models/Kimi-K3
+          - --served-model-name
+          - kimi-k3
+          - --tensor-parallel-size
+          - '8'
+          - --gpu-memory-utilization
+          - '0.88'
+          - --trust-remote-code
+          - --load-format
+          - auto
+          - --mm-encoder-tp-mode
+          - data
+          - --kv-cache-dtype
+          - auto
+          - --enable-prefix-caching
+          - --max-num-seqs
+          - '64'
+          - --max-num-batched-tokens
+          - '4096'
+          - --enable-auto-tool-choice
+          - --tool-call-parser
+          - kimi_k3
+          - --reasoning-parser
+          - kimi_k3
+          - --kv-event-transport
+          - zmq
+          - --request-transport
+          - http
+          - --max-model-len
+          - '1048576'
+          - --enable-prefix-caching
+          - --speculative-config
+          - '{"method": "dspark", "model": "/models/Kimi-K3-DSpark", "num_speculative_tokens": 7, "attention_backend": "ROCM_AITER_MLA"}'
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: VLLM_ROCM_USE_AITER
+            value: '1'
+          - name: VLLM_ROCM_USE_AITER_FP4BMM
+            value: '1'
+          - name: AITER_SITUV2_A8W4
+            value: '1'
+          - name: AITER_BF16_FP8_MOE_BOUND
+            value: '0'
+          - name: HIP_FORCE_DEV_KERNARG
+            value: '1'
+          - name: HSA_NO_SCRATCH_RECLAIM
+            value: '1'
+          - name: HSA_ENABLE_IPC_MODE_LEGACY
+            value: '1'
+          - name: SAFETENSORS_FAST_GPU
+            value: '1'
+          - name: VLLM_USE_BREAKABLE_CUDAGRAPH
+            value: '0'
+          - name: VLLM_ENABLE_K3_LATENT_MOE_TAIL_FUSION
+            value: '1'
+          - name: VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16
+            value: '0'
+          - name: VLLM_ROCM_USE_KIMI_K3_PREROUTE_FP8
+            value: '1'
+          - name: VLLM_ROCM_USE_KIMI_K3_LATENT_TAIL_FP8
+            value: '1'
+          - name: KIMI_K3_DUAL_PROJ_FP8_WEIGHT_CACHE_MODIFIER
+            value: '2'
+          - name: KIMI_K3_SHARED_DOWN_FP8_WEIGHT_CACHE_MODIFIER
+            value: '2'
+          - name: INFERA_ENGINE_READY_TIMEOUT
+            value: '7200'
+          - name: HF_HUB_OFFLINE
+            value: '1'
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 30000
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 300
+          resources:
+            requests:
+              cpu: '32'
+              memory: 512Gi
+              amd.com/gpu: 8
+            limits:
+              cpu: '32'
+              memory: 512Gi
+              amd.com/gpu: 8
+          volumeMounts:
+          - name: overlay
+            mountPath: /overlay
+            readOnly: true
+          - name: model
+            mountPath: /models
+            readOnly: true
+          - name: dshm
+            mountPath: /dev/shm
+        volumes:
+        - name: overlay
+          emptyDir: {}
+        - name: model
+          hostPath:
+            path: <MODEL_DIR>
+            type: Directory
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 32Gi

--- a/examples/recipes/kimi-k3-optimized/mixed/deploy.yaml
+++ b/examples/recipes/kimi-k3-optimized/mixed/deploy.yaml
@@ -1,0 +1,247 @@
+# Kimi-K3 (optimized build) — mixed — Kubernetes recipe
+#
+# A separate model entry from `kimi-k3/` because it is a different artifact, not a
+# different setting: this uses johnqin2025/kimi-k3-dspark, which carries an FP8
+# pre-route / shared-expert kernel cluster, an FP8 latent-MoE tail, a fused MLA
+# output gate and a tri-projection dispatch. Same vLLM commit as the stock
+# kimi-k3 image (g5f76ae224), so the delta is kernels, not engine version.
+#
+#   base image   johnqin2025/kimi-k3-dspark:1.1.0-mi355x-rocm7.2.3-20260801
+#   overlay      inferaimage/infera-overlay v0.2.2
+#
+# Fill in <MODEL_DIR>: the directory holding Kimi-K3. Use LOCAL NVMe —
+# 96 shards load in ~8 min from local disk and ~95 min from NFS, and the slow path
+# does not merely run late, it exceeds the ready timeout and restarts forever.
+#
+# Deploy:  kubectl apply -f examples/recipes/kimi-k3-optimized/mixed/deploy.yaml
+#
+# MEASURED, this manifest, 8x MI355X TP8, 1M context:
+#   8K in / 1K out, batch 1   step time 12.37 ms
+#   1024 in / 128 out  c=4     67.11 tok/s
+#                      c=8    187.17 tok/s
+#                      c=16   426.51 tok/s
+#
+# This is the recipe to use above c=8. ../mixed-dspark/ is 1.9-2.2x faster at c<=8
+# but crashes at c>=16, and its best result (359.72) is below this one's c=16.
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: kimi-k3-opt-base
+  namespace: infera
+spec:
+  backendFramework: vllm
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        initContainers:
+        - name: infera-overlay
+          image: inferaimage/infera-overlay@sha256:6918eff34f201548a738dd592d2a1ece0627354d2e88f24a87cfa8f787a72a44
+          imagePullPolicy: IfNotPresent
+          command:
+          - sh
+          - -c
+          - cp -a /payload/. /overlay/
+          volumeMounts:
+          - name: overlay
+            mountPath: /overlay
+        containers:
+        - name: main
+          image: johnqin2025/kimi-k3-dspark:1.1.0-mi355x-rocm7.2.3-20260801@sha256:a3584d74f256ca7c33b1ac9e5598897123d28e9faf9860e188a2e82a9b5530e3
+          imagePullPolicy: IfNotPresent
+          command:
+          - /overlay/bin/infera-exec
+          - python3
+          - -m
+          - infera.server
+          - --host
+          - 0.0.0.0
+          - --port
+          - '8000'
+          - --router-tokenizer-path
+          - /models/Kimi-K3
+          - --request-transport
+          - http
+          - --kv-event-transport
+          - zmq
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          resources:
+            requests:
+              cpu: '8'
+              memory: 16Gi
+            limits:
+              cpu: '8'
+              memory: 16Gi
+          volumeMounts:
+          - name: overlay
+            mountPath: /overlay
+            readOnly: true
+          - name: model
+            mountPath: /models
+            readOnly: true
+        volumes:
+        - name: overlay
+          emptyDir: {}
+        - name: model
+          hostPath:
+            path: <MODEL_DIR>
+            type: Directory
+    worker:
+      componentType: worker
+      role: mixed
+      replicas: 1
+      extraPodSpec:
+        initContainers:
+        - name: infera-overlay
+          image: inferaimage/infera-overlay@sha256:6918eff34f201548a738dd592d2a1ece0627354d2e88f24a87cfa8f787a72a44
+          imagePullPolicy: IfNotPresent
+          command:
+          - sh
+          - -c
+          - cp -a /payload/. /overlay/
+          volumeMounts:
+          - name: overlay
+            mountPath: /overlay
+        containers:
+        - name: main
+          image: johnqin2025/kimi-k3-dspark:1.1.0-mi355x-rocm7.2.3-20260801@sha256:a3584d74f256ca7c33b1ac9e5598897123d28e9faf9860e188a2e82a9b5530e3
+          imagePullPolicy: IfNotPresent
+          command:
+          - /overlay/bin/infera-exec
+          - python3
+          - -m
+          - infera.engine.vllm
+          - --host
+          - 0.0.0.0
+          - --port
+          - '30000'
+          - --model
+          - /models/Kimi-K3
+          - --served-model-name
+          - kimi-k3
+          - --tensor-parallel-size
+          - '8'
+          - --gpu-memory-utilization
+          - '0.88'
+          - --trust-remote-code
+          - --load-format
+          - auto
+          - --mm-encoder-tp-mode
+          - data
+          - --kv-cache-dtype
+          - auto
+          - --enable-prefix-caching
+          - --max-num-seqs
+          - '64'
+          - --max-num-batched-tokens
+          - '4096'
+          - --enable-auto-tool-choice
+          - --tool-call-parser
+          - kimi_k3
+          - --reasoning-parser
+          - kimi_k3
+          - --kv-event-transport
+          - zmq
+          - --request-transport
+          - http
+          - --max-model-len
+          - '1048576'
+          - --enable-prefix-caching
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: VLLM_ROCM_USE_AITER
+            value: '1'
+          - name: VLLM_ROCM_USE_AITER_FP4BMM
+            value: '1'
+          - name: AITER_SITUV2_A8W4
+            value: '1'
+          - name: AITER_BF16_FP8_MOE_BOUND
+            value: '0'
+          - name: HIP_FORCE_DEV_KERNARG
+            value: '1'
+          - name: HSA_NO_SCRATCH_RECLAIM
+            value: '1'
+          - name: HSA_ENABLE_IPC_MODE_LEGACY
+            value: '1'
+          - name: SAFETENSORS_FAST_GPU
+            value: '1'
+          - name: VLLM_USE_BREAKABLE_CUDAGRAPH
+            value: '0'
+          - name: VLLM_ENABLE_K3_LATENT_MOE_TAIL_FUSION
+            value: '1'
+          - name: VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16
+            value: '0'
+          - name: VLLM_ROCM_USE_KIMI_K3_PREROUTE_FP8
+            value: '1'
+          - name: VLLM_ROCM_USE_KIMI_K3_LATENT_TAIL_FP8
+            value: '1'
+          - name: KIMI_K3_DUAL_PROJ_FP8_WEIGHT_CACHE_MODIFIER
+            value: '2'
+          - name: KIMI_K3_SHARED_DOWN_FP8_WEIGHT_CACHE_MODIFIER
+            value: '2'
+          - name: INFERA_ENGINE_READY_TIMEOUT
+            value: '7200'
+          - name: HF_HUB_OFFLINE
+            value: '1'
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 30000
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 300
+          resources:
+            requests:
+              cpu: '32'
+              memory: 512Gi
+              amd.com/gpu: 8
+            limits:
+              cpu: '32'
+              memory: 512Gi
+              amd.com/gpu: 8
+          volumeMounts:
+          - name: overlay
+            mountPath: /overlay
+            readOnly: true
+          - name: model
+            mountPath: /models
+            readOnly: true
+          - name: dshm
+            mountPath: /dev/shm
+        volumes:
+        - name: overlay
+          emptyDir: {}
+        - name: model
+          hostPath:
+            path: <MODEL_DIR>
+            type: Directory
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 32Gi

--- a/examples/recipes/kimi-k3-optimized/pd/deploy.yaml
+++ b/examples/recipes/kimi-k3-optimized/pd/deploy.yaml
@@ -1,0 +1,279 @@
+# Kimi-K3 (optimized build) — pd — Kubernetes recipe
+#
+#   base image   johnqin2025/kimi-k3-dspark:1.1.0-mi355x-rocm7.2.3-20260801
+#   overlay      inferaimage/infera-overlay v0.2.2
+#   engine       infera.engine.vllm   TP8 per role, 1P1D
+#
+# Deploy:  kubectl apply -f examples/recipes/kimi-k3-optimized/pd/deploy.yaml
+# Docs:    examples/recipes/kimi-k3-optimized/README.md
+#
+# NO SPECULATION HERE. DSpark is a decode-side draft and its interaction with the
+# kv_consumer role is a separate unknown; ../mixed-dspark/ is the speculative
+# recipe and it is mixed-only. Do not graft --speculative-config onto this file
+# without validating it — at c>=16 it fails even without PD.
+#
+# PD REQUIRES the two nodes to sit on a MUTUALLY ROUTABLE RoCE fabric. The KV
+# handoff is RDMA and there is no TCP fallback. Set <PREFILL_NODE>/<DECODE_NODE>.
+#
+# MEASURED, this manifest, 1P1D over 2x 8x MI355X = 16 GPUs, 1M context:
+#   ready              790 s both roles, 0 restarts
+#   2139 in / 127 out  c=4    130.15 tok/s   P50 3.59 s  P90 4.27 s
+#                      c=8    229.61 tok/s   P50 4.34 s  P90 4.59 s
+#                      c=16   386.28 tok/s   P50 4.63 s  P90 6.09 s
+#
+# DO NOT compare those to ../mixed/ as a speedup. This is 16 GPUs against its 8,
+# and the prompt is 2139 tokens against its 1024 — two differences at once, so
+# the ratio measures nothing.
+#
+# The tell that the handoff is real is on the DECODE side, and it is not
+# throughput: `External prefix cache hit rate: 100.0%` with `Avg prompt
+# throughput` near zero means the decoder computed no prefill and took the KV
+# from the wire. A correct answer proves nothing here — if the handoff fails
+# open, the decoder just re-prefills locally and returns the same text.
+#
+# THE WEIGHTS ARE A hostPath, SO EACH NODE NEEDS ITS OWN COPY — and the paths do
+# not have to match, which is why there are two placeholders. Both must be LOCAL
+# storage. On the fleet this was validated on, the obvious "shared" mount is an
+# NFS export of the other node's RAID: using it on both sides turns an 8-minute
+# weight load into a ~95-minute one on the NFS side, which then exceeds the ready
+# timeout and restarts forever. Check with `df -hT <dir>` on each node and take
+# the local device, not the convenient common name.
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: kimi-k3-opt-pd
+  namespace: infera
+spec:
+  backendFramework: vllm
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+    server:
+      componentType: server
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        initContainers:
+        - name: infera-overlay
+          image: inferaimage/infera-overlay@sha256:6918eff34f201548a738dd592d2a1ece0627354d2e88f24a87cfa8f787a72a44
+          imagePullPolicy: IfNotPresent
+          command: ["sh","-c","cp -a /payload/. /overlay/"]
+          volumeMounts:
+          - {name: overlay, mountPath: /overlay}
+        containers:
+        - name: main
+          image: johnqin2025/kimi-k3-dspark:1.1.0-mi355x-rocm7.2.3-20260801@sha256:a3584d74f256ca7c33b1ac9e5598897123d28e9faf9860e188a2e82a9b5530e3
+          imagePullPolicy: IfNotPresent
+          command: ["/overlay/bin/infera-exec","python3","-m","infera.server",
+                    "--host","0.0.0.0","--port","8000",
+                    "--router-tokenizer-path","/models/Kimi-K3",
+                    "--request-transport","http","--kv-event-transport","zmq"]
+          env:
+          - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+          - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+          - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+          resources:
+            requests: {cpu: '8', memory: 16Gi}
+            limits: {cpu: '8', memory: 16Gi}
+          volumeMounts:
+          - {name: overlay, mountPath: /overlay, readOnly: true}
+          - {name: model, mountPath: /models, readOnly: true}
+        volumes:
+        - {name: overlay, emptyDir: {}}
+        - name: model
+          hostPath: {path: <PREFILL_MODEL_DIR>, type: Directory}
+
+    prefill:
+      componentType: worker
+      role: prefill
+      replicas: 1
+      port: 30000
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        # hostNetwork is REQUIRED: the RDMA rails are host interfaces and the
+        # flannel pod network cannot reach them, so Mooncake has no path to the
+        # peer while the engine looks perfectly healthy.
+        hostNetwork: true
+        dnsPolicy: ClusterFirstWithHostNet
+        initContainers:
+        - name: infera-overlay
+          image: inferaimage/infera-overlay@sha256:6918eff34f201548a738dd592d2a1ece0627354d2e88f24a87cfa8f787a72a44
+          imagePullPolicy: IfNotPresent
+          command: ["sh","-c","cp -a /payload/. /overlay/"]
+          volumeMounts:
+          - {name: overlay, mountPath: /overlay}
+        containers:
+        - name: main
+          image: johnqin2025/kimi-k3-dspark:1.1.0-mi355x-rocm7.2.3-20260801@sha256:a3584d74f256ca7c33b1ac9e5598897123d28e9faf9860e188a2e82a9b5530e3
+          imagePullPolicy: IfNotPresent
+          command: ["/overlay/bin/infera-exec",
+                    "python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
+                    "--model","/models/Kimi-K3",
+                    "--served-model-name","kimi-k3",
+                    "--tensor-parallel-size","8",
+                    # 0.88, not the 0.95 the stock kimi-k3 recipe uses: 0.88 is the
+                    # value validated on THIS image at 1M context. Carrying a number
+                    # over from a different base is how the mixed-dspark run OOMed.
+                    "--gpu-memory-utilization","0.88",
+                    "--trust-remote-code","--load-format","auto",
+                    "--mm-encoder-tp-mode","data","--kv-cache-dtype","auto",
+                    "--enable-prefix-caching",
+                    "--max-num-seqs","64","--max-num-batched-tokens","4096",
+                    "--max-model-len","1048576",
+                    "--enable-auto-tool-choice","--tool-call-parser","kimi_k3",
+                    "--reasoning-parser","kimi_k3",
+                    # Mooncake's bootstrap server BINDS 0.0.0.0 (fine) but ADVERTISES
+                    # parallel_config.data_parallel_master_ip. With the usual 0.0.0.0
+                    # the prefiller registers "http://0.0.0.0:8998" and the decoder
+                    # cannot reach it:
+                    #   Failed to connect to bootstrap server http://0.0.0.0:8998
+                    #   Failed to find remote engine_id ...
+                    # while both workers look healthy and the request just hangs to a
+                    # 480 s connector timeout.
+                    "--data-parallel-address","$(POD_IP)",
+                    "--kv-transfer-config","{\"kv_connector\":\"MooncakeConnector\",\"kv_role\":\"kv_producer\"}",
+                    "--kv-event-transport","zmq","--request-transport","http"]
+          env:
+          - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+          - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+          - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+          # PD's KV transport is Mooncake, which lives in the overlay's native tree.
+          # Name it so a payload lacking it fails at startup instead of warning and
+          # quietly serving with no KV transfer at all.
+          - {name: INFERA_REQUIRE_NATIVE, value: mooncake}
+          - {name: INFERA_ENGINE_READY_TIMEOUT, value: '7200'}
+          - {name: HF_HUB_OFFLINE, value: '1'}
+          - {name: SAFETENSORS_FAST_GPU, value: '1'}
+          # --- the optimized-kernel cluster. Identical to ../mixed/. Without it the
+          # MoE asks aiter for a kernel that was never generated:
+          #   ValueError: Invalid FlyDSL kernel name: flydsl_moe1_..._t16x64x256_...
+          - {name: VLLM_ROCM_USE_AITER, value: '1'}
+          - {name: VLLM_ROCM_USE_AITER_FP4BMM, value: '1'}
+          - {name: AITER_SITUV2_A8W4, value: '1'}
+          - {name: AITER_BF16_FP8_MOE_BOUND, value: '0'}
+          - {name: HIP_FORCE_DEV_KERNARG, value: '1'}
+          - {name: HSA_NO_SCRATCH_RECLAIM, value: '1'}
+          - {name: HSA_ENABLE_IPC_MODE_LEGACY, value: '1'}
+          - {name: VLLM_USE_BREAKABLE_CUDAGRAPH, value: '0'}
+          - {name: VLLM_ENABLE_K3_LATENT_MOE_TAIL_FUSION, value: '1'}
+          # Must be 0. The pre-route dispatch tries BF16 first, so a 1 here shadows
+          # the FP8 cluster entirely — silently, at ~40% of throughput.
+          - {name: VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16, value: '0'}
+          - {name: VLLM_ROCM_USE_KIMI_K3_PREROUTE_FP8, value: '1'}
+          - {name: VLLM_ROCM_USE_KIMI_K3_LATENT_TAIL_FP8, value: '1'}
+          - {name: KIMI_K3_DUAL_PROJ_FP8_WEIGHT_CACHE_MODIFIER, value: '2'}
+          - {name: KIMI_K3_SHARED_DOWN_FP8_WEIGHT_CACHE_MODIFIER, value: '2'}
+          # RDMA needs the device nodes and pinned memory. Without these the engine
+          # starts, registers, and only fails when KV actually moves.
+          securityContext:
+            privileged: true
+            capabilities: {add: ["IPC_LOCK","SYS_PTRACE"]}
+          startupProbe:
+            httpGet: {path: /health, port: 30000}
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 300     # weight load is slow; do not use a readinessProbe here
+          resources:
+            requests: {cpu: '32', memory: 512Gi, amd.com/gpu: 8}
+            limits: {cpu: '32', memory: 512Gi, amd.com/gpu: 8}
+          volumeMounts:
+          - {name: overlay, mountPath: /overlay, readOnly: true}
+          - {name: model, mountPath: /models, readOnly: true}
+          # The vendor base's libionic must match the host ionic kernel ABI, or
+          # libibverbs rejects every device ("No RDMA devices found") and Mooncake
+          # falls back to HIP IPC — which cannot open a peer NODE's handle, so PD
+          # dies while a single-node smoke test passes.
+          - {name: host-libionic, mountPath: /host-libionic/libionic.so, readOnly: true}
+          - {name: ib, mountPath: /dev/infiniband}
+          - {name: dshm, mountPath: /dev/shm}
+        volumes:
+        - {name: overlay, emptyDir: {}}
+        - name: model
+          hostPath: {path: <PREFILL_MODEL_DIR>, type: Directory}
+        - name: host-libionic
+          hostPath: {path: /usr/lib/x86_64-linux-gnu/libionic.so.1, type: File}
+        - {name: ib, hostPath: {path: /dev/infiniband, type: Directory}}
+        - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 64Gi}}
+
+    decode:
+      componentType: worker
+      role: decode
+      replicas: 1
+      port: 30000
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <DECODE_NODE>}
+        hostNetwork: true
+        dnsPolicy: ClusterFirstWithHostNet
+        initContainers:
+        - name: infera-overlay
+          image: inferaimage/infera-overlay@sha256:6918eff34f201548a738dd592d2a1ece0627354d2e88f24a87cfa8f787a72a44
+          imagePullPolicy: IfNotPresent
+          command: ["sh","-c","cp -a /payload/. /overlay/"]
+          volumeMounts:
+          - {name: overlay, mountPath: /overlay}
+        containers:
+        - name: main
+          image: johnqin2025/kimi-k3-dspark:1.1.0-mi355x-rocm7.2.3-20260801@sha256:a3584d74f256ca7c33b1ac9e5598897123d28e9faf9860e188a2e82a9b5530e3
+          imagePullPolicy: IfNotPresent
+          command: ["/overlay/bin/infera-exec",
+                    "python3","-m","infera.engine.vllm","--host","0.0.0.0","--port","30000",
+                    "--model","/models/Kimi-K3",
+                    "--served-model-name","kimi-k3",
+                    "--tensor-parallel-size","8",
+                    "--gpu-memory-utilization","0.88",
+                    "--trust-remote-code","--load-format","auto",
+                    "--mm-encoder-tp-mode","data","--kv-cache-dtype","auto",
+                    "--max-num-seqs","64","--max-num-batched-tokens","4096",
+                    "--max-model-len","1048576",
+                    "--enable-auto-tool-choice","--tool-call-parser","kimi_k3",
+                    "--reasoning-parser","kimi_k3",
+                    "--data-parallel-address","$(POD_IP)",
+                    "--kv-transfer-config","{\"kv_connector\":\"MooncakeConnector\",\"kv_role\":\"kv_consumer\"}",
+                    "--kv-event-transport","zmq","--request-transport","http"]
+          env:
+          - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+          - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+          - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+          - {name: INFERA_REQUIRE_NATIVE, value: mooncake}
+          - {name: INFERA_ENGINE_READY_TIMEOUT, value: '7200'}
+          - {name: HF_HUB_OFFLINE, value: '1'}
+          - {name: SAFETENSORS_FAST_GPU, value: '1'}
+          - {name: VLLM_ROCM_USE_AITER, value: '1'}
+          - {name: VLLM_ROCM_USE_AITER_FP4BMM, value: '1'}
+          - {name: AITER_SITUV2_A8W4, value: '1'}
+          - {name: AITER_BF16_FP8_MOE_BOUND, value: '0'}
+          - {name: HIP_FORCE_DEV_KERNARG, value: '1'}
+          - {name: HSA_NO_SCRATCH_RECLAIM, value: '1'}
+          - {name: HSA_ENABLE_IPC_MODE_LEGACY, value: '1'}
+          - {name: VLLM_USE_BREAKABLE_CUDAGRAPH, value: '0'}
+          - {name: VLLM_ENABLE_K3_LATENT_MOE_TAIL_FUSION, value: '1'}
+          - {name: VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16, value: '0'}
+          - {name: VLLM_ROCM_USE_KIMI_K3_PREROUTE_FP8, value: '1'}
+          - {name: VLLM_ROCM_USE_KIMI_K3_LATENT_TAIL_FP8, value: '1'}
+          - {name: KIMI_K3_DUAL_PROJ_FP8_WEIGHT_CACHE_MODIFIER, value: '2'}
+          - {name: KIMI_K3_SHARED_DOWN_FP8_WEIGHT_CACHE_MODIFIER, value: '2'}
+          securityContext:
+            privileged: true
+            capabilities: {add: ["IPC_LOCK","SYS_PTRACE"]}
+          startupProbe:
+            httpGet: {path: /health, port: 30000}
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 300
+          resources:
+            requests: {cpu: '32', memory: 512Gi, amd.com/gpu: 8}
+            limits: {cpu: '32', memory: 512Gi, amd.com/gpu: 8}
+          volumeMounts:
+          - {name: overlay, mountPath: /overlay, readOnly: true}
+          - {name: model, mountPath: /models, readOnly: true}
+          - {name: host-libionic, mountPath: /host-libionic/libionic.so, readOnly: true}
+          - {name: ib, mountPath: /dev/infiniband}
+          - {name: dshm, mountPath: /dev/shm}
+        volumes:
+        - {name: overlay, emptyDir: {}}
+        - name: model
+          hostPath: {path: <DECODE_MODEL_DIR>, type: Directory}
+        - name: host-libionic
+          hostPath: {path: /usr/lib/x86_64-linux-gnu/libionic.so.1, type: File}
+        - {name: ib, hostPath: {path: /dev/infiniband, type: Directory}}
+        - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 64Gi}}

--- a/manual/examples/k8s_glm5.2_sglang.md
+++ b/manual/examples/k8s_glm5.2_sglang.md
@@ -61,7 +61,7 @@ one **mixed SGLang worker** at **TP8**, both mounting the model read-only.
 - The SGLang engine image (`rocm/infera:sglang-v0.1.1`, SGLang 0.5.15+) present
   in the node's containerd (`k3s ctr images import` for a local image).
 - The GLM-5.2-MXFP4 checkpoint reachable inside the pod — a `hostPath` (as in the
-  manifest) or the [model-cache](k8s_kimi_k3.md#1-model-cache-pvc-download-job) PVC.
+  manifest) or the {ref}`model-cache <model-cache-pvc-download-job>` PVC.
 
 ## Deploy & verify
 

--- a/manual/examples/k8s_kimi_k3.md
+++ b/manual/examples/k8s_kimi_k3.md
@@ -85,6 +85,7 @@ PVC read-only.
   sudo k3s ctr images import /mnt/<big-disk>/img.tar
   ```
 
+(model-cache-pvc-download-job)=
 ## 1. Model cache (PVC + download Job)
 
 The [`model-cache/`](https://github.com/AMD-AGI/Infera/tree/main/examples/k8s-deployments/model-cache)

--- a/manual/recipes/index.md
+++ b/manual/recipes/index.md
@@ -35,7 +35,7 @@ Multimodal, ~1.5 TB of weights, hybrid Mamba.
 vLLM · TP8 · MI355X
 
 Same engine commit, optimized FP8 kernels. Optional DSpark speculation: 1.9–2.2×
-below concurrency 8, and it crashes above it.
+below concurrency 8, and it crashes above it. Cross-node PD validated.
 :::
 
 ::::
@@ -53,9 +53,10 @@ Each recipe comes in the same four shapes, composing two independent choices:
 | `pd + kvd` | prefill and decode on separate nodes | plus kvd on each role | both of the above |
 
 One recipe carries an extra axis rather than a fifth combination: **Kimi-K3
-optimized** ships `mixed` and `mixed-dspark`, because speculative decoding is a
-property of that image's draft model, not a serving topology. It composes with the
-four above in principle; only `mixed` was built for it.
+optimized** ships `mixed`, `mixed-dspark` and `pd`, because speculative decoding is
+a property of that image's draft model, not a serving topology. `pd` is the same
+combination as everywhere else; `mixed-dspark` is the extra axis, and it was not
+combined with `pd`.
 
 ```{admonition} PD needs a routable RoCE fabric
 :class: warning

--- a/manual/recipes/index.md
+++ b/manual/recipes/index.md
@@ -28,6 +28,16 @@ vLLM · TP8 · MI355X
 Multimodal, ~1.5 TB of weights, hybrid Mamba.
 :::
 
+:::{grid-item-card} Kimi-K3 optimized (DSpark)
+:link: kimi-k3-optimized
+:link-type: doc
+
+vLLM · TP8 · MI355X
+
+Same engine commit, optimized FP8 kernels. Optional DSpark speculation: 1.9–2.2×
+below concurrency 8, and it crashes above it.
+:::
+
 ::::
 
 ## The four combinations
@@ -41,6 +51,11 @@ Each recipe comes in the same four shapes, composing two independent choices:
 | `mixed + kvd` | one worker does prefill and decode | plus L2 host RAM and L3 on a PVC | requests share long prefixes — a common system prompt, multi-turn chat, RAG |
 | `pd` | prefill and decode on separate nodes | GPU only | prefill and decode want different batching |
 | `pd + kvd` | prefill and decode on separate nodes | plus kvd on each role | both of the above |
+
+One recipe carries an extra axis rather than a fifth combination: **Kimi-K3
+optimized** ships `mixed` and `mixed-dspark`, because speculative decoding is a
+property of that image's draft model, not a serving topology. It composes with the
+four above in principle; only `mixed` was built for it.
 
 ```{admonition} PD needs a routable RoCE fabric
 :class: warning

--- a/manual/recipes/kimi-k3-optimized.md
+++ b/manual/recipes/kimi-k3-optimized.md
@@ -1,0 +1,135 @@
+# Kimi-K3 (optimized build)
+
+Kimi-K3 on 8× MI355X (TP8) using `johnqin2025/kimi-k3-dspark` — an image carrying an
+FP8 pre-route / shared-expert kernel cluster, an FP8 latent-MoE tail, a fused MLA
+output gate and a tri-projection dispatch.
+
+A separate entry from [Kimi-K3](kimi-k3) rather than a combination on it, because it
+is a different artifact. Same vLLM commit (`g5f76ae224`) as the stock image, so the
+delta is kernels, not engine version.
+
+## 1. Choose the combination
+
+::::{tab-set}
+
+:::{tab-item} Mixed
+:sync: mixed
+
+No speculative decoding. **The right choice above concurrency 8**, where it is also
+the faster of the two.
+
+```bash
+kubectl apply -f examples/recipes/kimi-k3-optimized/mixed/deploy.yaml
+```
+
+| 1024 in / 128 out | tok/s |
+|---:|---:|
+| c=4 | 67.11 |
+| c=8 | 187.17 |
+| c=16 | **426.51** |
+:::
+
+:::{tab-item} Mixed + DSpark
+:sync: mixed-dspark
+
+Speculative decoding with a block-diffusion draft that produces 7 tokens per
+parallel pass. Worth **1.9–2.2×** at concurrency ≤ 8.
+
+```bash
+kubectl apply -f examples/recipes/kimi-k3-optimized/mixed-dspark/deploy.yaml
+```
+
+| 1024 in / 128 out | tok/s | vs mixed |
+|---:|---:|---:|
+| c=4 | 146.96 | 2.19× |
+| c=8 | 359.72 | 1.92× |
+| c≥16 | crashes | — |
+
+```{admonition} Above concurrency 8 this is an outage, not a slowdown
+:class: warning
+At `c>=16` the engine dies with
+
+    AssertionError: AiterMLA flattened verify requires a uniform decode query len
+
+"verify" is the tell — the speculative path only. The identical config without
+`--speculative-config` serves `c=16` at 426.51 tok/s, which is also *faster* than
+this manifest's best result (359.72 at `c=8`).
+```
+:::
+
+::::
+
+## 2. Prerequisites
+
+```bash
+kubectl get nodes -o custom-columns=NODE:.metadata.name,GPU:.status.allocatable.'amd\.com/gpu'
+helm install infera-operator deploy/operator/helm/infera-operator -n infera-system --create-namespace
+
+hf download moonshotai/Kimi-K3      --local-dir <MODEL_DIR>/Kimi-K3
+hf download Inferact/Kimi-K3-DSpark --local-dir <MODEL_DIR>/Kimi-K3-DSpark   # DSpark only
+```
+
+**`<MODEL_DIR>` must be local NVMe.** Kimi-K3's 96 shards load in ~8 min from local
+disk and ~95 min from NFS — and the slow path does not merely run late, it exceeds
+the ready timeout, so the worker restarts mid-load and never finishes.
+
+First start is 10–14 min: the image rebuilds its AITER JIT modules in-container on
+top of weight load and CUDA-graph capture.
+
+## 3. Smoke test
+
+```bash
+kubectl -n infera port-forward svc/kimi-k3-opt-<base|dspark>-server 8000:8000 &
+curl -s localhost:8000/v1/chat/completions -H 'Content-Type: application/json' \
+  -d '{"model":"kimi-k3","messages":[{"role":"user","content":"What is the capital of France?"}],
+       "max_tokens":200}' | jq -r '.choices[0].message.content'
+```
+
+Keep `max_tokens` generous — this model spends 70+ tokens on that sentence, and a
+tight cap truncates it into something that reads like a broken deployment.
+
+On the DSpark manifest, confirm speculation engaged rather than inferring it from
+throughput later:
+
+```bash
+kubectl -n infera logs <worker-pod> -c main | grep -c 'running the draft eagerly'   # must be 0
+kubectl -n infera logs <worker-pod> -c main | grep -oE 'Mean acceptance length: [0-9.]+' | tail -1
+```
+
+## 4. Settings that are not optional
+
+| Setting | Why |
+|---|---|
+| the `KIMI_K3_*` / `VLLM_ROCM_*` env block | selects the optimized kernels. Without them the MoE asks aiter for a kernel that was never generated — `Invalid FlyDSL kernel name: flydsl_moe1_..._t16x64x256_...` — because there is no Kimi-K3 `tuned_fmoe.csv`, while dsv3/dsv4/glm5 all have one |
+| `VLLM_ROCM_USE_KIMI_K3_PREROUTE_BF16=0` | must be `0`; a `1` shadows the FP8 cluster silently, at ~40% of throughput |
+| `attention_backend: ROCM_AITER_MLA` | the ROCm counterpart of the upstream quick-start's `FLASHINFER_MLA`. Dropping the key instead of translating it is not the fix |
+| `--gpu-memory-utilization 0.88` | the draft's weights land after the KV budget is computed; `0.95` dies with 998 MB free trying to allocate 2.32 GiB |
+| `INFERA_ENGINE_READY_TIMEOUT=7200` | the 1800 s default is impossible on slow storage, and the worker then restarts mid-load forever — which reads as a crash loop, not as slow storage |
+
+## 5. Validation status
+
+Both manifests were **run end-to-end as written** on k3s (MI355X, 8 GPUs, 1M
+context, BF16 KV), through the infera router.
+
+Against the upstream quick-start for this image, three numbers reproduce and three
+claims do not:
+
+| | upstream | measured here |
+|---|---|---|
+| baseline step time, 8K/1K | 12.39 ms | 12.37 ms |
+| DSpark step time, 8K/1K | 29.50 ms | 29.11 ms |
+| acceptance length | 4.00 | 3.85 |
+| concurrency assertion fires at | c=48 | **c=16** |
+| c=16 throughput | 315.7 tok/s | **crashes** |
+| c=32 throughput | 454.3 tok/s | **crashes** |
+
+The upstream document states its concurrency table was measured on a sibling build
+(`kimi-k3-dspark:wvsplitk-fix`) and not re-run on this image. These measurements are
+that re-run: the concurrency fixes are not in this image.
+
+PD and kvd combinations are not built for this image.
+
+## Source
+
+[`examples/recipes/kimi-k3-optimized/`](https://github.com/AMD-AGI/Infera/tree/main/examples/recipes/kimi-k3-optimized)
+· [all recipes](index)

--- a/manual/recipes/kimi-k3-optimized.md
+++ b/manual/recipes/kimi-k3-optimized.md
@@ -57,6 +57,34 @@ this manifest's best result (359.72 at `c=8`).
 ```
 :::
 
+:::{tab-item} PD
+:sync: pd
+
+Prefill and decode on separate nodes, KV handed over RDMA. **16 GPUs**, not 8.
+
+```bash
+sed -e 's|<PREFILL_NODE>|nodeA|' -e 's|<DECODE_NODE>|nodeB|' \
+    -e 's|<PREFILL_MODEL_DIR>|/local/nvme/models|' \
+    -e 's|<DECODE_MODEL_DIR>|/local/nvme/models|' \
+    examples/recipes/kimi-k3-optimized/pd/deploy.yaml | kubectl apply -f -
+```
+
+| 2139 in / 127 out | tok/s | P50 | P90 |
+|---:|---:|---:|---:|
+| c=4 | 130.15 | 3.59 s | 4.27 s |
+| c=8 | 229.61 | 4.34 s | 4.59 s |
+| c=16 | 386.28 | 4.63 s | 6.09 s |
+
+```{admonition} Do not read these against the Mixed tab
+:class: warning
+This is 16 GPUs against Mixed's 8, measured at a 2139-token prompt against its
+1024. Two differences at once — the ratio between the tabs measures nothing.
+```
+
+No speculation here: DSpark is decode-side and its behaviour in the `kv_consumer`
+role is a separate unknown. Do not graft `--speculative-config` onto this manifest.
+:::
+
 ::::
 
 ## 2. Prerequisites
@@ -108,8 +136,27 @@ kubectl -n infera logs <worker-pod> -c main | grep -oE 'Mean acceptance length: 
 
 ## 5. Validation status
 
-Both manifests were **run end-to-end as written** on k3s (MI355X, 8 GPUs, 1M
-context, BF16 KV), through the infera router.
+All three manifests were **run end-to-end as written** on k3s (MI355X, 1M context,
+BF16 KV), through the infera router — `mixed` and `mixed-dspark` on 8 GPUs, `pd` as
+1P1D across two nodes.
+
+For `pd`, a correct answer proves nothing on its own: if the KV handoff fails open,
+the decoder re-prefills locally and returns the same text. The tell is on the decode
+side — `External prefix cache hit rate: 100.0%` with `Avg prompt throughput` near
+zero, against the prefill side's 2010.5 tok/s prompt and ~0 generation. That held
+for 131 consecutive requests with zero failed transfers.
+
+```{admonition} Do not point a misbehaving client at a PD deployment
+:class: warning
+The engine validates **after** prefill, so a request it rejects has already had its
+KV computed and queued for transfer. 84 requests rejected for a single bad field
+left 424 aborted Mooncake transfers — 53 requests × 8 TP ranks — and stalled valid
+traffic behind the backlog for ~20 minutes, with
+
+    MooncakeXferMetadata transfer failed: Resource temporarily unavailable
+
+which reads exactly like a broken fabric. It was a broken client.
+```
 
 Against the upstream quick-start for this image, three numbers reproduce and three
 claims do not:

--- a/manual/sphinx/_toc.yml.in
+++ b/manual/sphinx/_toc.yml.in
@@ -62,6 +62,8 @@ subtrees:
             title: GLM-5.2-MXFP4 (SGLang)
           - file: recipes/kimi-k3.md
             title: Kimi-K3 (vLLM)
+          - file: recipes/kimi-k3-optimized.md
+            title: Kimi-K3 optimized (DSpark)
 
   - caption: Examples
     entries:


### PR DESCRIPTION
Adds a recipe for `johnqin2025/kimi-k3-dspark` — a separate model entry rather than a combination on `kimi-k3`, because it is a different artifact (same vLLM commit as the stock base; the delta is kernels).

**All three manifests were run end-to-end as written**, on MI355X (TP8, 1M context, BF16 KV) through the router.

### mixed vs mixed-dspark — 8 GPUs, 1024 in / 128 out

| combo | c=4 | c=8 | c=16 |
|---|---:|---:|---:|
| `mixed` | 67.11 | 187.17 | **426.51** |
| `mixed-dspark` | **146.96** | **359.72** | crashes |

DSpark is worth 1.9–2.2× at concurrency ≤ 8. Above that it is an outage:

```
AssertionError: AiterMLA flattened verify requires a uniform decode query len
```

"verify" is the tell — the speculative path only. The identical config without `--speculative-config` serves c=16 at 426.51 tok/s, which also beats DSpark's own best. The pages recommend `mixed` above c=8 and lead with the ceiling rather than the speedup.

### pd — 1P1D across two nodes, 16 GPUs, 2139 in / 127 out

| c | tok/s | P50 | P90 |
|---:|---:|---:|---:|
| 4 | 130.15 | 3.59 s | 4.27 s |
| 8 | 229.61 | 4.34 s | 4.59 s |
| 16 | 386.28 | 4.63 s | 6.09 s |

Kept in its own table on purpose: this is **16 GPUs against mixed's 8** *and* a 2139-token prompt against its 1024 — two differences at once, so a ratio between the tables measures nothing. Both pages say so where the numbers appear.

Both roles Ready in 790 s, 0 restarts, 8 RDMA devices each side, 131 consecutive requests with zero failed transfers. The handoff is verified on the **decode** side rather than inferred from throughput: `External prefix cache hit rate: 100.0%` with ~0 prompt throughput, against prefill's 2010.5 tok/s prompt and ~0 generation. A correct answer proves nothing on its own — a handoff that fails open just re-prefills locally and returns the same text.

### Against the upstream quick-start for this image

Three numbers reproduce within 0.2–3.8%; three claims do not.

| | upstream | measured |
|---|---|---|
| baseline step time, 8K/1K | 12.39 ms | 12.37 ms |
| DSpark step time, 8K/1K | 29.50 ms | 29.11 ms |
| acceptance length | 4.00 | 3.85 |
| assertion fires at | c=48 | **c=16** |
| c=16 throughput | 315.7 | **crashes** |
| c=32 throughput | 454.3 | **crashes** |

That document states its concurrency table was measured on a sibling build (`kimi-k3-dspark:wvsplitk-fix`) and not re-run on this image. This is that re-run.

### Two PD gotchas worth reviewing closely

- **Each node needs its own local copy of the weights, and the paths need not match** — hence four placeholders in `pd/deploy.yaml`. On this fleet the tempting common name (`/mnt/shared`) is an NFS export of the *other* node's array; using it on both sides turns one side's 8-minute load into ~95 minutes, which then exceeds the ready timeout and restarts forever.
- **Never point a client at PD that sends requests the engine will reject.** The engine validates *after* prefill, so a rejected request has already had its KV computed and queued. 84 requests rejected for one bad field left 424 aborted Mooncake transfers (53 × 8 TP ranks) and stalled valid traffic for ~20 minutes with `MooncakeXferMetadata transfer failed: Resource temporarily unavailable` — which reads exactly like a broken fabric. It was a broken client.

`pd` + DSpark was **not** attempted and is not claimed: speculation is decode-side and its behaviour in the `kv_consumer` role is a separate unknown.

### Notes for review

- Combos are `mixed`, `mixed-dspark`, `pd`. `mixed-dspark` is an extra axis rather than a fifth combination — speculation is a property of the image's draft model, not a serving topology — and `recipes/index.md` says so.
- All three manifests pin base and overlay by digest and pass `kubectl apply --dry-run=server`.
- Documents that `ibv_devices` is **not installed** in this image; reading its "not found" as "no RDMA devices" produced two false TCP-fallback diagnoses here. The README carries a one-liner that asks `ibv_get_device_list` instead.

### Drive-by

`make -C manual html` (warnings-as-errors) was **already failing on main**: the `k8s_kimi_k3` "1. Model cache" heading is numbered, so docutils strips the digit from the id while myst keeps it in the slug, and the cross-link from `k8s_glm5.2_sglang` matched neither spelling. Fixed with an explicit target plus a `{ref}` role — the build is now clean.
