### PR TITLE
fix(router): register the block size vLLM resolved, not the one requested

### DIFF
--- a/infera/engine/vllm/worker.py
+++ b/infera/engine/vllm/worker.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -84,10 +85,65 @@ class VllmEngine(BaseEngine):
             disagg_mode=self.disagg_mode,
             disagg_meta=dict(self.disagg_meta),
             kv_events_endpoint=self.kv_events_endpoint,
-            kv_block_size=self.kv_block_size,
+            kv_block_size=await self._resolve_block_size(),
             dp_rank=self.dp_rank,
             dp_size=self.dp_size,
         )
+
+    async def _resolve_block_size(self) -> int | None:
+        """The block size vLLM actually ended up using, not the one asked for.
+
+        ``--block-size`` defaults to None and the platform resolves it after the
+        model is loaded, so the value parsed off the command line is frequently
+        not the value in force. Kimi-K3 makes this loud: it is a hybrid Mamba
+        model, so vLLM logs
+
+            Setting attention block size to 768 tokens to ensure that attention
+            page size is >= mamba page size
+
+        and the CLI namespace still says None. Registering that None left the
+        router with no block size, which it read as 1 — and a router hashing per
+        token against an engine paging per 768 produced an empty KV view and
+        kv-aware routing that silently did nothing.
+
+        ``vllm:cache_config_info`` carries the resolved value as a label and is
+        the only endpoint that does; ``/v1/models`` does not, and scraping the
+        log line is hostage to its wording. If the metric is missing (older
+        vLLM), fall back to the CLI value — wrong is still better than absent,
+        because absent disables kv-aware routing outright.
+        """
+        probe_host = "127.0.0.1" if self.host in ("0.0.0.0", "") else self.host
+        url = f"http://{probe_host}:{self.port}/metrics"
+        try:
+            async with httpx.AsyncClient() as client:
+                r = await client.get(url, timeout=10)
+            if r.status_code != 200:
+                raise RuntimeError(f"HTTP {r.status_code}")
+            m = re.search(r'vllm:cache_config_info\{[^}]*\bblock_size="(\d+)"', r.text)
+            if m is None:
+                raise RuntimeError("no vllm:cache_config_info{block_size=...} in /metrics")
+            resolved = int(m.group(1))
+        except Exception as exc:
+            logger.warning(
+                "could not read the resolved block size from %s (%s); falling back to the "
+                "command-line value %r. If that is None, kv-aware routing stays off for "
+                "this worker.",
+                url,
+                exc,
+                self.kv_block_size,
+            )
+            return self.kv_block_size
+
+        if self.kv_block_size is not None and resolved != self.kv_block_size:
+            logger.info(
+                "vLLM resolved block_size=%d, overriding the requested %d; registering the "
+                "resolved value so the router pages the same way the engine does",
+                resolved,
+                self.kv_block_size,
+            )
+        else:
+            logger.info("vLLM resolved block_size=%d", resolved)
+        return resolved
 
     async def stop(self) -> None:
         logger.info("vLLM engine stopping")

--- a/infera/router/kv_event/client.py
+++ b/infera/router/kv_event/client.py
@@ -68,6 +68,9 @@ class WorkerSubscription:
     views: dict[int, set[int]] = field(default_factory=dict)
     maps: dict[int, dict[int, int]] = field(default_factory=dict)  # worker_hash -> router_hash
     tasks: list[asyncio.Task] = field(default_factory=list)
+    # Latched: the block-size mismatch is per-subscription, not per-event, so
+    # logging it on every event would bury the fact under thousands of copies.
+    block_size_mismatch_logged: bool = False
 
     def view_for(self, rank: int | None) -> set[int]:
         return self.views.setdefault(rank or 0, set())
@@ -101,10 +104,25 @@ class KvEventClient:
     def on_worker_added(self, w: WorkerInfo) -> None:
         if not w.kv_events_endpoint or w.worker_id in self._subs:
             return
+        # No block size means we cannot reproduce the engine's paging, and 1 is not
+        # a safe stand-in: it is a wrong answer that looks like an answer. Hashing
+        # per token against an engine paging per 768 yields a view that never
+        # matches, so kv-aware routing degrades to nothing while the logs show a
+        # healthy subscription. Refuse loudly instead — the policy already skips
+        # workers without a block size, so this only makes the two agree.
+        if not w.kv_block_size:
+            logger.error(
+                "kv events: NOT subscribing to %s — it registered no kv_block_size, so "
+                "its KV view cannot be reproduced and kv-aware routing is off for this "
+                "worker. On vLLM this means the resolved block size could not be read "
+                "from /metrics at startup.",
+                w.worker_id,
+            )
+            return
         sub = WorkerSubscription(
             worker_id=w.worker_id,
             endpoint=w.kv_events_endpoint,
-            block_size=w.kv_block_size or 1,
+            block_size=w.kv_block_size,
             # vLLM and SGLang serialize kv-events differently (map vs array); pick
             # the decoder matching THIS worker's engine or every event fails to
             # decode and the view stays empty.
@@ -216,7 +234,39 @@ class KvEventClient:
                 # query misses by one block.
                 return
         bs = sub.block_size
-        n = len(ev.token_ids) // bs
+        # Both engines put the engine-side block size on the event itself. If it
+        # disagrees with what the worker registered, every hash we compute is
+        # against the wrong chunking and the view can never match — so say that,
+        # once, instead of leaving it to be inferred from a routing hit rate of
+        # zero. This is the check that would have named the Kimi-K3 failure
+        # immediately: events said 768, the registration said nothing, and the
+        # subscriber assumed 1.
+        ev_bs = getattr(ev, "block_size", None)
+        if ev_bs and ev_bs != bs and not sub.block_size_mismatch_logged:
+            sub.block_size_mismatch_logged = True
+            logger.error(
+                "kv events from %s are paged at block_size=%d but this worker registered "
+                "%d; the router's KV view cannot match the engine's and kv-aware routing "
+                "will report no hits for it",
+                sub.worker_id,
+                ev_bs,
+                bs,
+            )
+        # Bound by BOTH sequences. The count was derived from token_ids alone and
+        # then used to index block_hashes, so any disagreement between them was an
+        # IndexError — surfacing as "list index out of range", a message that points
+        # nowhere near the block size.
+        n = min(len(ev.token_ids) // bs, len(ev.block_hashes))
+        if n * bs != len(ev.token_ids) or n != len(ev.block_hashes):
+            logger.warning(
+                "kv event from %s covers %d tokens and %d block hashes, which do not "
+                "agree at block_size=%d; indexing %d block(s) and dropping the rest",
+                sub.worker_id,
+                len(ev.token_ids),
+                len(ev.block_hashes),
+                bs,
+                n,
+            )
         for i in range(n):
             chunk = ev.token_ids[i * bs : (i + 1) * bs]
             parent = hash_chunk(parent, chunk)

--- a/infera/router/kv_event/nats_client.py
+++ b/infera/router/kv_event/nats_client.py
@@ -55,16 +55,25 @@ class NatsKvEventClient(KvEventClient):
         # somewhere to write. Ingestion is the single global NATS sub.
         if w.worker_id in self._subs:
             return
+        # Same rule as the ZMQ client: a missing block size is not a 1. See the
+        # comment there — 1 produces a view that never matches and hides the fault.
+        if not w.kv_block_size:
+            logger.error(
+                "kv events (nats): NOT tracking %s — it registered no kv_block_size, so "
+                "kv-aware routing is off for this worker.",
+                w.worker_id,
+            )
+            return
         self._subs[w.worker_id] = WorkerSubscription(
             worker_id=w.worker_id,
             endpoint="(nats)",
-            block_size=w.kv_block_size or 1,
+            block_size=w.kv_block_size,
             multiplexed=is_rank_multiplexed(w),
         )
         logger.info(
             "kv events (nats): tracking %s (block_size=%d)",
             w.worker_id,
-            w.kv_block_size or 1,
+            w.kv_block_size,
         )
         # Lazily bring up the broker subscription on first worker.
         asyncio.create_task(self._ensure_started(), name="kv-nats-start")

--- a/tests/unit/engine/test_vllm_resolved_block_size.py
+++ b/tests/unit/engine/test_vllm_resolved_block_size.py
@@ -1,0 +1,123 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""The block size a vLLM worker registers must be the one the engine resolved,
+not the one that was on the command line.
+
+``--block-size`` defaults to None and the platform picks the real value after
+the model loads. Kimi-K3 is the loud case: a hybrid Mamba model, so vLLM logs
+"Setting attention block size to 768 tokens to ensure that attention page size
+is >= mamba page size" while the parsed namespace still says None. Registering
+that None left the router with no block size at all, and kv-aware routing
+reported cache_hits=0 on every decision.
+
+The metrics line below is copied verbatim from a running Kimi-K3 worker, so the
+parser is pinned against the real format rather than an idealised one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from infera.engine.vllm.worker import VllmEngine
+
+# Verbatim from `curl localhost:30000/metrics` on kimi-k3-opt-pd-prefill.
+REAL_METRICS = (
+    "# HELP vllm:cache_config_info Information of the LLMEngine CacheConfig\n"
+    "# TYPE vllm:cache_config_info gauge\n"
+    'vllm:cache_config_info{_block_size_resolved="True",block_size="768",'
+    'cache_dtype="auto",calculate_kv_scales="False",enable_prefix_caching="True",'
+    'engine="0",gpu_memory_utilization="0.88",is_attention_free="False",'
+    'mamba_block_size="16",num_gpu_blocks="2169",'
+    'user_specified_block_size="False"} 1.0\n'
+)
+
+
+def _engine(cli_block_size):
+    return VllmEngine(
+        vllm_argv=[],
+        model_name="m",
+        host="0.0.0.0",
+        port=30000,
+        kv_block_size=cli_block_size,
+    )
+
+
+class _Resp:
+    def __init__(self, text, status_code=200):
+        self.text = text
+        self.status_code = status_code
+
+
+def _patch_get(monkeypatch, result):
+    """Stub httpx.AsyncClient.get; ``result`` is a _Resp or an exception."""
+
+    async def fake_get(self, url, **kw):
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    import httpx
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+
+async def test_reads_the_resolved_value_not_the_cli_one(monkeypatch):
+    _patch_get(monkeypatch, _Resp(REAL_METRICS))
+    # None on the command line is exactly the Kimi-K3 case.
+    assert await _engine(None)._resolve_block_size() == 768
+
+
+async def test_resolved_value_overrides_an_explicit_one(monkeypatch):
+    """vLLM may override what the user asked for; the router has to page the way
+    the engine actually pages, not the way it was requested."""
+    _patch_get(monkeypatch, _Resp(REAL_METRICS))
+    assert await _engine(16)._resolve_block_size() == 768
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        _Resp("", 500),
+        _Resp("vllm:num_requests_running 0.0\n"),  # metric absent (older vLLM)
+        RuntimeError("connection refused"),
+    ],
+)
+async def test_falls_back_to_the_cli_value(monkeypatch, result):
+    """Wrong beats absent: absent disables kv-aware routing for the worker."""
+    _patch_get(monkeypatch, result)
+    assert await _engine(16)._resolve_block_size() == 16
+
+
+async def test_fallback_of_none_stays_none(monkeypatch):
+    """No metric and no CLI value means we genuinely do not know — registering a
+    made-up number would be worse, so None propagates and the router refuses to
+    subscribe rather than guessing 1."""
+    _patch_get(monkeypatch, RuntimeError("boom"))
+    assert await _engine(None)._resolve_block_size() is None
+
+
+async def test_start_registers_the_resolved_value(monkeypatch):
+    """Pins the wiring, not just the parser.
+
+    Testing ``_resolve_block_size`` alone would still pass if ``start()`` went
+    back to putting ``self.kv_block_size`` in the EngineConfig — which is the
+    original bug, and a one-word edit away.
+    """
+    _patch_get(monkeypatch, _Resp(REAL_METRICS))
+
+    class _Proc:
+        def poll(self):
+            return None
+
+    monkeypatch.setattr("subprocess.Popen", lambda *a, **kw: _Proc())
+
+    async def noop_ready(self, timeout=None):
+        return None
+
+    monkeypatch.setattr(VllmEngine, "_wait_ready", noop_ready)
+
+    cfg = await _engine(None).start()
+    assert cfg.kv_block_size == 768, "start() must register what the engine resolved"

--- a/tests/unit/router/test_kv_block_size_mismatch.py
+++ b/tests/unit/router/test_kv_block_size_mismatch.py
@@ -1,0 +1,138 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""A worker that registers no kv_block_size must not be subscribed, and events
+whose token_ids and block_hashes disagree must not raise.
+
+Both of these shipped broken and neither was caught, because every existing
+router test builds events where the two agree — block_size=4 with four tokens
+per hash. The failure needs the disagreement.
+
+What it cost: Kimi-K3 is a hybrid Mamba model, so vLLM resolves the attention
+block size to 768 after load while ``--block-size`` on the command line is still
+None. infera registered the None, the router read it as ``or 1``, and
+``_on_block_stored`` then derived its loop count from token_ids (768) and used it
+to index block_hashes (1). Every event raised IndexError, the subscriber
+reconnected forever, and 234 consecutive routing decisions reported
+cache_hits=0 — kv-aware routing silently off, with a healthy-looking log.
+
+These use the real ``BlockStored`` struct, not a stand-in. An earlier draft of
+this file used a duck-typed class and every assertion passed vacuously:
+``_handle_event`` dispatches on ``isinstance``, so the stand-in matched no branch
+and the handler under test never ran.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from infera.common.worker_pool import EngineType, WorkerInfo
+from infera.router.kv_event.client import KvEventClient
+from infera.router.kv_event.events import BlockStored
+
+
+def _worker(block_size):
+    return WorkerInfo(
+        worker_id="w1:30000",
+        url="http://w1:30000",
+        model_name="m",
+        engine=EngineType.VLLM,
+        kv_events_endpoint="tcp://w1:5555",
+        kv_block_size=block_size,
+    )
+
+
+def _stored(tokens, hashes, block_size, parent=None):
+    return BlockStored(
+        block_hashes=[bytes([i]) for i in range(hashes)],
+        parent_block_hash=parent,
+        token_ids=list(range(tokens)),
+        block_size=block_size,
+        lora_id=None,
+    )
+
+
+async def _subscribed(client, block_size):
+    """Add a worker and hand back its subscription, tasks cancelled on teardown."""
+    client.on_worker_added(_worker(block_size))
+    sub = client._subs["w1:30000"]
+    for t in sub.tasks:
+        t.cancel()
+    return sub
+
+
+def test_worker_without_block_size_is_not_subscribed(caplog):
+    """``or 1`` used to accept these, then hash per token against an engine
+    paging per 768 — a view that can never match, reported as a healthy sub."""
+    client = KvEventClient()
+    with caplog.at_level(logging.ERROR):
+        client.on_worker_added(_worker(None))
+
+    assert client._subs == {}, "a worker with no block size must not be subscribed"
+    assert any("kv_block_size" in r.getMessage() for r in caplog.records), (
+        "refusing to subscribe has to say why, or it looks like the worker was missed"
+    )
+
+    # 0 is the same defect wearing a different value.
+    client.on_worker_added(_worker(0))
+    assert client._subs == {}
+
+
+async def test_mismatched_event_does_not_raise_and_indexes_what_it_can():
+    """The real shape of the bug: 768 tokens, 1 block hash, subscriber at 1.
+
+    Before the fix this raised IndexError on i=1 and killed the subscriber.
+    """
+    client = KvEventClient()
+    sub = await _subscribed(client, 1)
+
+    client._handle_event(sub, _stored(tokens=768, hashes=1, block_size=768), rank=0)
+
+    assert len(sub.map_for(0)) == 1, "only the hashes actually supplied may be indexed"
+    assert len(sub.view_for(0)) == 1
+
+
+async def test_block_size_disagreement_is_reported_once(caplog):
+    """The event carries the engine's block size; a mismatch names the fault
+    directly instead of leaving it to be inferred from a zero hit rate."""
+    client = KvEventClient()
+    sub = await _subscribed(client, 1)
+
+    with caplog.at_level(logging.ERROR):
+        for _ in range(3):
+            client._handle_event(sub, _stored(tokens=768, hashes=1, block_size=768), rank=0)
+
+    hits = [r for r in caplog.records if "paged at block_size" in r.getMessage()]
+    assert len(hits) == 1, "latched: three events must not produce three copies"
+    assert "768" in hits[0].getMessage()
+
+
+async def test_agreeing_event_is_unaffected():
+    """The bound must not truncate the normal case."""
+    client = KvEventClient()
+    sub = await _subscribed(client, 4)
+
+    client._handle_event(sub, _stored(tokens=12, hashes=3, block_size=4), rank=0)
+
+    assert len(sub.map_for(0)) == 3
+    assert len(sub.view_for(0)) == 3
+
+
+@pytest.mark.parametrize(
+    "tokens,hashes,expect",
+    [
+        (8, 1, 1),  # more tokens than hashes cover — the observed failure
+        (4, 3, 1),  # fewer tokens than hashes — the mirror case
+        (0, 0, 0),  # empty event
+    ],
+)
+async def test_bound_is_the_minimum_of_both(tokens, hashes, expect):
+    client = KvEventClient()
+    sub = await _subscribed(client, 4)
+
+    client._handle_event(sub, _stored(tokens=tokens, hashes=hashes, block_size=4), rank=0)
+    assert len(sub.map_for(0)) == expect


### PR DESCRIPTION
kv-aware routing was **silently off** for Kimi-K3: 234 consecutive routing decisions reported `cache_hits=0 request_blocks=0 active_blocks=0`, while the router logged a healthy subscription to both workers. Found while validating cross-node PD; the bug is on `main` and is not specific to any feature branch.

### The chain, from the visible end to the actual cause

```
policy:  if not t.worker.kv_block_size: continue      → worker skipped entirely
client:  subscriber dies on every event with
         "list index out of range", reconnects forever → KV view stays empty
client:  _on_block_stored takes its loop count from
         len(token_ids)//bs and indexes block_hashes   → unguarded
client:  w.kv_block_size or 1                          → missing becomes 1
engine:  registers kv_block_size=None
args:    block_size=vllm_args.block_size, read at PARSE time
vllm:    --block-size defaults to None; the platform resolves it after load
```

Kimi-K3 is a **hybrid Mamba** model, so vLLM resolves the attention block size to **768**:

```
Setting attention block size to 768 tokens to ensure that attention page size is >= mamba page size
```

768 does not exist at parse time. This is not a missing flag, and defaulting to 16 would be equally wrong.

### The fixes

1. **Read the resolved value.** `VllmEngine._resolve_block_size()` scrapes `vllm:cache_config_info` from `/metrics` after the engine is ready — it carries `block_size` as a label and is the only endpoint that does (`/v1/models` does not, and scraping the log line is hostage to its wording). A missing metric falls back to the CLI value: wrong beats absent, because absent disables kv-aware routing outright.

2. **`or 1` is gone**, in both the ZMQ and NATS clients. 1 is not a safe default — it is a wrong answer that looks like an answer. Hashing per token against an engine paging per 768 gives a view that can never match, so had it not crashed it would have degraded silently. A worker with no block size is now refused with an error naming the reason, which also makes the client agree with the policy (which already skipped such workers).

3. **The loop is bounded by both sequences**, and disagreement is logged. Separately, `BlockStored` carries the engine's own `block_size` on the wire, so a mismatch against the registered value is now reported once per subscription — that is the check that would have named this immediately, instead of `list index out of range`, a message that points nowhere near a block size.

### On the tests

Both defects were verified to **reproduce by reverting each fix in place** — the revert produces the original `IndexError`.

Every existing router test builds events where `token_ids` and `block_hashes` agree (`block_size=4`, four tokens per hash), which is exactly why neither defect was caught. The new tests use the real `BlockStored` struct: an earlier draft with a duck-typed stand-in passed **vacuously**, because `_handle_event` dispatches on `isinstance` and the stand-in matched no branch, so the handler under test never ran.

The engine test pins the **wiring** as well as the parser — testing `_resolve_block_size` alone still passes if `start()` goes back to `self.kv_block_size`, which is the original bug and a one-word edit away. The metrics fixture is copied verbatim from a running Kimi-K3 worker.

1156 unit tests pass. The 5 failures in `tests/unit/kv/test_sglang_wiring.py` are a missing `transformers` in my environment and predate this change.

### Not addressed here

SGLang registers `page_size` directly, which is a real parsed value, so it is not affected. I have not checked whether any other engine reads a config value before the engine resolves it.
