### PR TITLE
docs(preflight): how to run it on a cluster that has no SLURM

### DIFF
--- a/manual/tools/preflight.md
+++ b/manual/tools/preflight.md
@@ -92,8 +92,70 @@ preflight only, not production config.
 counting `*.json` in the directory, so a stale file makes it render early. The
 script clears the path for you.
 
-Without SLURM it falls back to a single node. The manual equivalent is
-`--collect-only` on each node, then one `--render-only` over the shared directory.
+### Two nodes without SLURM
+
+SLURM is convenient, not required. Rank, world size and node name come from plain
+environment variables — `SLURM_PROCID`, `SLURM_NNODES`, `PREFLIGHT_HOST` — and all
+coordination happens through files in the shared `--dump-path`. Setting those by
+hand works exactly the same.
+
+**The dump path must be the same directory on both nodes, on a shared filesystem.**
+That is not a convenience: it is how the nodes find each other. Each publishes its
+NIC information there, waits until every node has, then walks the pair matrix
+behind a file barrier. Two separate local directories give you two single-node runs
+that never measure anything cross-node.
+
+Run these on **node A** and **node B** at the same time, one shell each:
+
+```bash
+# --- node A ---
+export DUMP=/shared/preflight-run1          # the same path on both nodes
+mkdir -p "$DUMP"
+SLURM_PROCID=0 SLURM_NNODES=2 PREFLIGHT_HOST=$(hostname) \
+  infera-preflight --dump-path "$DUMP" --netperf --mooncake
+
+# --- node B, started at the same time ---
+SLURM_PROCID=1 SLURM_NNODES=2 PREFLIGHT_HOST=$(hostname) \
+  infera-preflight --dump-path "$DUMP" --netperf --mooncake
+```
+
+Ranks must be `0` and `1`. Rank 0 is the one that waits for the other node and
+renders `infera_preflight_report.html` into `$DUMP`, so exactly one node must have
+it; the other exits as soon as it has published its own results.
+
+```{admonition} Start them together
+:class: warning
+The nodes wait for each other, but not indefinitely: 120 s for the initial exchange
+of NIC information, and 300 s for rank 0 to see every node's JSON. Start the second
+node a few minutes late and you get a report with the cross-node sections missing
+and `WARN: only 1/2 node reports before timeout` on stderr — which looks like a
+fabric problem and is not one. The per-pair barrier is far more generous (30 min),
+because a single bandwidth measurement can legitimately take a while.
+```
+
+If you cannot mount a shared filesystem, collect separately and render once. This
+measures **per-node state only** — the cross-node probes have no way to coordinate,
+so there is no RoCE matrix and no Mooncake KV-transfer comparison:
+
+```bash
+# on each node, independently
+infera-preflight --collect-only --dump-path /local/preflight
+
+# copy every <host>.json into one directory, then on any one machine
+infera-preflight --render-only --dump-path /collected
+```
+
+```{admonition} Use a fresh dump path for every run
+:class: tip
+Rank 0 decides everyone has reported by counting `*.json` in the directory. A
+leftover file from an earlier run makes it render immediately, with one node's data
+silently coming from that earlier run. `run_preflight_slurm.sh` clears the path for
+you; by hand, you have to.
+```
+
+Either way, the full check set only runs **inside the engine container** — see the
+warning above.
+
 
 ## Report layout
 

--- a/manual/tools/preflight.md
+++ b/manual/tools/preflight.md
@@ -92,56 +92,136 @@ preflight only, not production config.
 counting `*.json` in the directory, so a stale file makes it render early. The
 script clears the path for you.
 
-### Two nodes without SLURM
+### Two nodes on a cluster without SLURM
 
 SLURM is convenient, not required. Rank, world size and node name come from plain
 environment variables — `SLURM_PROCID`, `SLURM_NNODES`, `PREFLIGHT_HOST` — and all
-coordination happens through files in the shared `--dump-path`. Setting those by
-hand works exactly the same.
+coordination happens through files in the shared `--dump-path`. Nothing consults a
+scheduler. The variables keep their SLURM names because that is where they came
+from; setting them by hand on a cluster that has never seen SLURM works the same.
 
-**The dump path must be the same directory on both nodes, on a shared filesystem.**
-That is not a convenience: it is how the nodes find each other. Each publishes its
-NIC information there, waits until every node has, then walks the pair matrix
-behind a file barrier. Two separate local directories give you two single-node runs
-that never measure anything cross-node.
+**The dump path must resolve to the same storage from both nodes.** That is not a
+convenience: that directory is *how the nodes find each other*. Each publishes its
+NIC information there, waits for the others, then walks the pair matrix behind a
+file barrier. Two unrelated local directories give you two single-node runs that
+measure nothing cross-node.
 
-Run these on **node A** and **node B** at the same time, one shell each:
+#### On Kubernetes
+
+Run one Pod per node, pinned with `nodeSelector`, both mounting the same shared
+storage at the same path inside the container. The two Pods differ in four places
+only: the node, the rank, the host name, and the host path that backs `/dump`.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata: {name: preflight-rank0, namespace: infera}
+spec:
+  nodeSelector: {kubernetes.io/hostname: <NODE_A>}
+  restartPolicy: Never
+  hostNetwork: true                    # RDMA rails are host interfaces
+  dnsPolicy: ClusterFirstWithHostNet
+  initContainers:                      # infera comes from the overlay payload
+  - name: infera-overlay
+    image: <overlay image>
+    command: ["sh","-c","cp -a /payload/. /overlay/"]
+    volumeMounts: [{name: overlay, mountPath: /overlay}]
+  containers:
+  - name: main
+    image: <the engine image you deploy with>
+    command: ["/overlay/bin/infera-exec","python3","-m","infera.tools.preflight",
+              "--dump-path","/dump","--mooncake"]
+    env:
+    - {name: SLURM_PROCID,   value: "0"}      # "1" on the other Pod
+    - {name: SLURM_NNODES,   value: "2"}
+    - {name: PREFLIGHT_HOST, value: "<NODE_A>"}
+    securityContext: {privileged: true, capabilities: {add: ["IPC_LOCK","SYS_PTRACE"]}}
+    volumeMounts:
+    - {name: overlay, mountPath: /overlay, readOnly: true}
+    - {name: dump,    mountPath: /dump}       # same mountPath on both Pods
+    - {name: ib,      mountPath: /dev/infiniband}
+    - {name: host-libionic, mountPath: /host-libionic/libionic.so, readOnly: true}
+  volumes:
+  - {name: overlay, emptyDir: {}}
+  - {name: dump, hostPath: {path: <SHARED_DIR_ON_THIS_NODE>, type: DirectoryOrCreate}}
+  - {name: ib,   hostPath: {path: /dev/infiniband, type: Directory}}
+  - name: host-libionic
+    hostPath: {path: /usr/lib/x86_64-linux-gnu/libionic.so.1, type: File}
+```
+
+Apply both, then read the report from the shared directory:
+
+```bash
+kubectl apply -f preflight-rank0.yaml -f preflight-rank1.yaml
+kubectl -n infera wait --for=jsonpath='{.status.phase}'=Succeeded   pod/preflight-rank0 pod/preflight-rank1 --timeout=20m
+# <shared-dir>/infera_preflight_report.html
+```
+
+Why each piece is there:
+
+| | |
+|---|---|
+| the overlay initContainer | `infera` is not in the engine image — it comes from the overlay payload, and `infera-exec` is what puts it on `PYTHONPATH` |
+| `privileged` + `/dev/infiniband` | without them the container sees **zero** RDMA devices, which is indistinguishable from the node having none |
+| the host `libionic.so` mount | the vendor image's libionic must match the host's ionic kernel ABI, or libibverbs rejects every device |
+| `hostNetwork: true` | the RDMA rails are host interfaces; the pod network cannot reach them |
+| `<SHARED_DIR_ON_THIS_NODE>` differing per Pod | the *container* path must match (`/dump`); the host paths only have to reach the same storage. On a fleet where one node mounts the array locally and the other over NFS, they will not look alike |
+
+```{admonition} netperf is skipped in the engine image
+:class: warning
+The cross-node `ib_write_bw` matrix needs the `perftest` package, which these
+engine images do not ship. You get
+
+    WARN: [netperf] netperf skipped (no ib_write_bw or RDMA device)
+
+That message names two causes and it is almost always the first one — verified on
+this fleet, where the same Pod reported **8** RDMA devices via
+`ibv_get_device_list` while `command -v ib_write_bw` came back empty. Do not read
+it as "no RDMA".
+
+`--mooncake` does **not** need `perftest` and does run, which is the more useful
+measurement anyway: it reports KV-move bandwidth over `rdma`, `rdma-default` and
+`tcp` separately, so a fabric that will silently serve at TCP speed shows up as a
+number.
+```
+
+#### On plain hosts over SSH
+
+Same idea without the Pod wrapper — two shells, started together:
 
 ```bash
 # --- node A ---
-export DUMP=/shared/preflight-run1          # the same path on both nodes
-mkdir -p "$DUMP"
+export DUMP=/shared/preflight-run1            # same storage, reachable from both
 SLURM_PROCID=0 SLURM_NNODES=2 PREFLIGHT_HOST=$(hostname) \
   infera-preflight --dump-path "$DUMP" --netperf --mooncake
 
-# --- node B, started at the same time ---
+# --- node B, at the same time ---
 SLURM_PROCID=1 SLURM_NNODES=2 PREFLIGHT_HOST=$(hostname) \
   infera-preflight --dump-path "$DUMP" --netperf --mooncake
 ```
 
-Ranks must be `0` and `1`. Rank 0 is the one that waits for the other node and
-renders `infera_preflight_report.html` into `$DUMP`, so exactly one node must have
-it; the other exits as soon as it has published its own results.
+Ranks must be `0` and `1`. Rank 0 waits for the others and renders
+`infera_preflight_report.html`; the rest exit once they have published.
 
 ```{admonition} Start them together
 :class: warning
 The nodes wait for each other, but not indefinitely: 120 s for the initial exchange
-of NIC information, and 300 s for rank 0 to see every node's JSON. Start the second
+of NIC information and 300 s for rank 0 to see every node's JSON. Start the second
 node a few minutes late and you get a report with the cross-node sections missing
-and `WARN: only 1/2 node reports before timeout` on stderr — which looks like a
+and `WARN: only 1/2 node reports before timeout` on stderr — which reads as a
 fabric problem and is not one. The per-pair barrier is far more generous (30 min),
-because a single bandwidth measurement can legitimately take a while.
+since a single bandwidth measurement can legitimately take a while.
 ```
 
-If you cannot mount a shared filesystem, collect separately and render once. This
-measures **per-node state only** — the cross-node probes have no way to coordinate,
-so there is no RoCE matrix and no Mooncake KV-transfer comparison:
+#### No shared filesystem at all
+
+Collect separately and render once. This measures **per-node state only** — the
+cross-node probes have no way to coordinate, so there is no RoCE matrix and no
+Mooncake comparison:
 
 ```bash
-# on each node, independently
-infera-preflight --collect-only --dump-path /local/preflight
-
-# copy every <host>.json into one directory, then on any one machine
+infera-preflight --collect-only --dump-path /local/preflight     # on each node
+# copy every <host>.json into one directory, then anywhere:
 infera-preflight --render-only --dump-path /collected
 ```
 
@@ -152,9 +232,6 @@ leftover file from an earlier run makes it render immediately, with one node's d
 silently coming from that earlier run. `run_preflight_slurm.sh` clears the path for
 you; by hand, you have to.
 ```
-
-Either way, the full check set only runs **inside the engine container** — see the
-warning above.
 
 
 ## Report layout


### PR DESCRIPTION
The preflight page treated SLURM as *the* multi-node path and gave the alternative one sentence. This adds the worked example for a cluster that has no scheduler.

## Kubernetes is the actual deployment target

Every recipe in this repo deploys to Kubernetes, so that is the worked example: one Pod per node, pinned with `nodeSelector`, both mounting the same storage at the same container path, **differing in four fields only** — node, rank, host name, and the host path backing `/dump`.

Each requirement is given with the failure it prevents:

| | |
|---|---|
| overlay initContainer | `infera` is not in the engine image — it comes from the overlay payload, and `infera-exec` is what puts it on `PYTHONPATH` |
| `privileged` + `/dev/infiniband` | without them the container sees **zero** RDMA devices, indistinguishable from the node having none |
| host `libionic.so` mount | the vendor libionic must match the host's ionic kernel ABI, or libibverbs rejects every device |
| `hostNetwork: true` | the RDMA rails are host interfaces |
| per-Pod host path | the **container** path must match (`/dump`); the host paths only have to reach the same storage — on a fleet where one node mounts an array locally and the other over NFS, they will not look alike |

The dump path requirement is stated as the reason it exists rather than as a rule: that directory is *how the nodes find each other*. Two unrelated local directories silently degrade to two single-node runs.

## Run end to end before documenting, which surfaced the one real caveat

**`netperf` is skipped in these engine images** — they do not ship `perftest`. The warning names two possible causes:

```
WARN: [netperf] netperf skipped (no ib_write_bw or RDMA device)
```

and it is the first one. The same Pod reported **8** RDMA devices through `ibv_get_device_list` while `command -v ib_write_bw` came back empty. Reading that warning as "no RDMA" is wrong, and the page now says so.

**`--mooncake` needs no `perftest`, does run, and is the more useful measurement anyway** — verified here reporting `RDMA: OK / RDMA(default): OK / TCP: OK` for both hosts. That is the row that matters for PD: a fabric that will silently serve at TCP speed shows up as a number rather than as a slow deployment.

## Also kept

The plain-SSH form (two shells, same variables), with the real waiting behaviour from the source — 120 s for the NIC-info exchange, 300 s for rank 0 to see every node's JSON, 30 min for the per-pair barrier — because starting the second node late produces a report with the cross-node sections missing and `WARN: only 1/2 node reports before timeout`, which reads as a fabric problem and is not one.

The no-shared-filesystem fallback is labelled for what it is: per-node state only, no RoCE matrix, no Mooncake comparison.
