### PR TITLE
docs(recipes): GLM-5.2 PD is validated, and its PVC cannot work for PD

### DIFF
--- a/examples/recipes/glm5.2/README.md
+++ b/examples/recipes/glm5.2/README.md
@@ -148,7 +148,10 @@ rocm-smi --showpids
 |---|---|
 | **`aggregated/deploy.yaml` exactly as written** | **validated end-to-end on k3s (MI355X, 8×`amd.com/gpu`)** — see below |
 | kvd sidecar + PVC L3 under SGLang | validated (3674 entries / 421 MB), on Qwen3-0.6B — but see the py310 native-tree note above |
-| pd / pd-kvd for this model | the PD path itself is validated cross-node (SGLang + Mooncake over RoCE, chi2800→chi2866); not yet run with these GLM-5.2 settings |
+| `disaggregated/deploy.yaml`, `model-cache` swapped for per-node hostPath | **validated cross-node** — both roles Ready in ~4 min, 0 restarts, correct answer, and the decode side logged only `Decode batch` (never `Prefill batch`), so the KV handoff was real rather than failing open |
+| `disaggregated` + decode-side DP attention | **validated** — `--dp-size 2 --enable-dp-attention` on the decode role only, Ready in ~3 min, 3/3 requests, both attention ranks active, 0 port collisions |
+| `disaggregated/deploy.yaml` **as shipped** | **cannot work** — its `model-cache` PVC is ReadWriteOnce on `local-path`, so it is pinned to one node and the other role cannot mount it. See the manifest header |
+| `disaggregated-kvd` | not run |
 
 The `aggregated` run used the **stock `lmsysorg/sglang` image** with the overlay
 mounted in — no infera-built engine image anywhere in the Pod:

--- a/examples/recipes/glm5.2/disaggregated/deploy.yaml
+++ b/examples/recipes/glm5.2/disaggregated/deploy.yaml
@@ -13,8 +13,35 @@
 #
 # PD REQUIRES the prefill and decode nodes to sit on a MUTUALLY ROUTABLE RoCE
 # fabric — the KV transfer is RDMA, not TCP, and there is no fallback. Set
-# <PREFILL_NODE>/<DECODE_NODE> to two such nodes. Not validated for this model;
-# examples/k8s-deployments/pd-1p1d-mooncake.yaml is the validated reference.
+# <PREFILL_NODE>/<DECODE_NODE> to two such nodes.
+#
+# THE `model-cache` PVC BELOW CANNOT WORK FOR PD AS SHIPPED. It is provisioned
+# ReadWriteOnce on the `local-path` storage class, which pins the volume to one
+# node -- so the role scheduled on the other node cannot mount it and the Pod
+# never starts. PD needs each node to hold the weights itself. Replace both
+# `model` volumes with a hostPath per node:
+#
+#   prefill:  - {name: model, hostPath: {path: <PREFILL_MODEL_DIR>, type: Directory}}
+#   decode:   - {name: model, hostPath: {path: <DECODE_MODEL_DIR>,  type: Directory}}
+#
+# The two paths need not match, and on a mixed fleet they usually do not. Each
+# must be LOCAL storage on its own node: the obvious shared-looking mount may be
+# an NFS export of the peer's array, which turns an 8-minute weight load into a
+# ~95-minute one, exceeds the ready timeout, and restarts forever.
+#
+# VALIDATED cross-node on k3s (MI355X, chi2800 prefill / chi2866 decode) with
+# amd/GLM-5.2-MXFP4 (282 shards, 408 GB per node) and the hostPath substitution
+# above: both roles Ready in ~4 min, 0 restarts, correct answer. The KV handoff
+# was confirmed rather than inferred -- the decode side logged only `Decode
+# batch` and never a `Prefill batch`, so it did not recompute the prompt locally.
+#
+# DECODE-SIDE DP ATTENTION WORKS. Adding `--dp-size 2 --enable-dp-attention` to
+# the decode role only (keeping `--tp-size 8`, since SGLang's tp-size stays the
+# total) came up in ~3 min with 0 restarts, served 3/3 requests, kept the same
+# `Decode batch`-only signature, and exercised both attention ranks (DP0 and DP1
+# both logged). No `Address already in use` -- but note that the port-block
+# collision that `free_tcp_port_block` guards against needs two engines on ONE
+# host, which this cross-node topology does not exercise.
 ---
 apiVersion: infera.amd.com/v1alpha1
 kind: InferaDeployment


### PR DESCRIPTION
Two findings from running the GLM-5.2 disaggregated recipe cross-node for the first time.

## It works, and the header no longer says otherwise

`amd/GLM-5.2-MXFP4` (282 shards, 408 GB per node) on k3s, chi2800 prefill / chi2866 decode: **both roles Ready in ~4 min, 0 restarts, correct answer.**

The KV handoff was **confirmed rather than inferred**. A correct answer proves nothing here — a handoff that fails open just re-prefills locally and returns the same text — so the check is that the decode side logged only `Decode batch` and never a `Prefill batch`.

## Decode-side DP attention works

`--dp-size 2 --enable-dp-attention` on the **decode role only**, keeping `--tp-size 8`. SGLang's `tp-size` stays the total, so this still fits 8 GPUs — unlike vLLM, where the equivalent needs TP reduced and Kimi-K3's latent-MoE tail fusion then refuses outright:

```
ValueError: Kimi-K3 ROCm latent-MoE tail fusion requires TP=8, got TP=4.
```

Ready in ~3 min, 0 restarts, **3/3 requests**, the same `Decode batch`-only signature, and **both attention ranks logging** (DP0 and DP1). Three requests rather than one on purpose: DP attention spreads them across ranks, so a single request only exercises one path.

## The manifest as shipped cannot work for PD

This is the more useful finding. All three roles mount the `model-cache` PVC, and that PVC is **ReadWriteOnce on `local-path`** — pinned to a single node, so whichever role lands on the other node cannot mount it and never starts.

The header now says so and shows the hostPath substitution, with the warning that the two paths need not match and **each must be local storage**: the obvious shared-looking mount can be an NFS export of the peer's array, which turns an 8-minute load into ~95 minutes, exceeds the ready timeout, and restarts forever.

The validation table distinguishes **what was run** from **what ships** — the runs used the hostPath substitution, and the committed file still carries the PVC.

## On port collisions

0 `Address already in use`. That is **not** evidence that the fixed-start scan in `free_tcp_port_block` (the fix in #59) is harmless: that collision needs two engines on **one** host, and a cross-node PD pair does not exercise it. Recorded with the limit attached rather than as a clean bill of health.
