### PR TITLE
fix(glm5.2): the remaining fixes for agentic serving — DSA indexer, ROCm hicache, PD/kvd wiring

### DIFF
--- a/deploy/docker/Dockerfile.sglang
+++ b/deploy/docker/Dockerfile.sglang
@@ -146,6 +146,28 @@ RUN set -eu; \
     for f in /tmp/sglang-disagg-patches/*.py; do echo "[sglang-patch] $f"; python "$f"; done; \
     rm -rf /tmp/sglang-disagg-patches
 
+# ---- sglang ROCm patches (hierarchical-cache host allocator) ----------------
+# REQUIRED FOR CORRECTNESS on ROCm whenever hierarchical cache / kvd is enabled:
+# hipHostRegister maps host pages at a device VA that differs from the host VA,
+# but sglang's hicache stores raw host data_ptr()s in device-side pointer tables
+# that a GPU kernel dereferences. The kernel then dereferences an unmapped
+# address and the process aborts with "Memory access fault by GPU node-N on
+# address <host VA>". gfx950 is xnack-, so there is no page-migration fallback.
+# Routes ALLOC_MEMORY_FUNCS to pin_memory (hipHostMalloc) on HIP, exactly as the
+# "npu" and "musa" entries already do for the same reason.
+#
+# Order-independent w.r.t. everything above: it touches
+# mem_cache/pool_host/common.py, which no other patch here does.
+#
+# NOT tolerant, like the disagg loop above: an image that GPU-faults the moment
+# kvd writes back is worse than a failed build. Self-locating, idempotent, and
+# it plants a real module-level string literal so the fix can be proven in the
+# BYTECODE rather than in the source.
+COPY deploy/docker/patches/sglang_rocm/ /tmp/sglang-rocm-patches/
+RUN set -eu; \
+    for f in /tmp/sglang-rocm-patches/*.py; do echo "[sglang-patch] $f"; python "$f"; done; \
+    rm -rf /tmp/sglang-rocm-patches
+
 # ---- Rust router (multi-core data plane; --router-backend rust) ----
 # The ROCm base ships cargo; use it (install a minimal toolchain only if
 # absent). Needs cc for linking and libclang (onig_sys/bindgen). Removes

--- a/deploy/docker/Dockerfile.sglang.gfx942
+++ b/deploy/docker/Dockerfile.sglang.gfx942
@@ -72,13 +72,16 @@ COPY infera ./infera
 RUN pip install --no-cache-dir ".[sglang]"
 
 # ---- GLM-5.2 DSA indexer rows (patch 01 of the sglang_dsa set) --------------
-# REQUIRED for DP-attention here: the aiter (HIP) paged-MQA branch sizes its
-# logits from the DP-PADDED row count while `lengths` carries the real one, so
-# top-k dies with "Expected lengths.size(0) == B" as soon as concurrency > 1.
+# REQUIRED for DP-attention here: the aiter (HIP) paged-MQA row count and
+# `lengths` disagree -- in BOTH directions -- so top-k dies with "Expected
+# lengths.size(0) == B" as soon as concurrency > 1.
 # ROCm-specific and independent of IndexShare, so nothing at runtime substitutes
 # for it. Same fix Dockerfile.sglang applies; it is an anchor script rather than
-# a pinned diff precisely so both bases can share one source of truth, and its
-# two edit sites are byte-identical on v0.5.15.post1 and v0.5.16.
+# a pinned diff precisely so both bases can share one source of truth. Its
+# `GLM52_P1V2` edit sites are byte-identical on v0.5.15.post1 and v0.5.16; the
+# later `GLM52_P1V3` anchor has been re-read against v0.5.15.post1 only (see the
+# anchor note in the script's header). A drifted anchor writes nothing and exits
+# non-zero, so this build fails rather than shipping a half-applied fix.
 #
 # ONLY patch 01 (DSA_PATCH_SET=indexer). Patches 02 and 04 are `--fuzz=0` context
 # diffs cut against v0.5.15.post1 and do not apply to this v0.5.16 base:

--- a/deploy/docker/patch.upstream.status.md
+++ b/deploy/docker/patch.upstream.status.md
@@ -5,9 +5,11 @@ project it patches. Kept here so "why do we still carry this?" has one answer
 per row, and so a patch that upstream has since merged gets dropped instead of
 quietly outliving its reason.
 
-**Verified with `gh` on 2026-08-01.** State drifts; re-check before relying on a
-row. `gh search` matches titles and bodies, **not diff content**, so "no upstream
-PR" means "none found by search", not "none exists".
+**Verified with `gh` on 2026-08-01**, except the `patches/sglang_rocm/` section,
+verified 2026-08-03. State drifts; re-check before relying on a row. `gh search`
+matches titles and bodies, **not diff content**, so "no upstream PR" means "none
+found by search", not "none exists" — where a row could be checked by reading
+upstream source instead, it says so.
 
 Column meanings:
 
@@ -27,6 +29,7 @@ not address 02a at all — `patches/sglang_dsa/README.md` carries the reasoning.
 |---|---|---|---|---|---|
 | `sglang_dsa/patch_dsa_indexer_hip_dp_padded_rows.py` | HIP/aiter paged-MQA sizes its output from DP-padded rows while `lengths` is sized to real rows → `Expected lengths.size(0) == B` | none found | [sglang#33059](https://github.com/sgl-project/sglang/pull/33059) | **yes** (`dorado269`) | OPEN, `REVIEW_REQUIRED` |
 | ″ (same bug class, other platform) | — | none found | [sglang#32762](https://github.com/sgl-project/sglang/pull/32762) `[NPU] Fix DSA eager padding mismatch` — our diff is written in its shape | no (`stellaxcpeng`) | OPEN |
+| ″ (anchor collision, **not** a fix) | — | — | [sglang#32738](https://github.com/sgl-project/sglang/pull/32738) pads heads for DeepGEMM at the same two aiter call sites; [#31480](https://github.com/sgl-project/sglang/pull/31480) extracts the paged-MQA backend and restructures the `is_aiter()` dispatch | no | both OPEN (re-read 2026-08-03) |
 | `sglang_dsa/dsa_backend_dp_sync_and_page_table_rows.diff` (2a) | `seq_lens.max().item()` is a host sync on a branch only *some* DP ranks take → DP collectives desync → deadlock | none found | none found | — | — |
 | `sglang_dsa/dsa_backend_dp_sync_and_page_table_rows.diff` (2b) | page table has one row per **request**, top-k one per **token** under MTP → `assert page_table.shape[0] == topk_indices.shape[0]` | none found | [sglang#32209](https://github.com/sgl-project/sglang/pull/32209) solves the same row mismatch by **trimming q/top-k**; porting that half here fails at conc=32 and is unresolved | no (`HZY-Wade`) | OPEN, `REVIEW_REQUIRED` |
 | `sglang_dsa/draft_cuda_graph_dp_vote.diff` | draft graph/eager choice is per-rank and diverges on the PD decode leg → group deadlock | [sglang#32527](https://github.com/sgl-project/sglang/issues/32527) (independent report, 8× Blackwell) | [sglang#32209](https://github.com/sgl-project/sglang/pull/32209) — same defect, same strategy; **this diff adopts its placement** | no (`HZY-Wade`) | OPEN, `REVIEW_REQUIRED` |
@@ -67,6 +70,26 @@ PD + DP-attention + MTP, i.e. **no CI covers this topology today**.
 > Unlike the rest of this page, this row was **not** verified with `gh`: the issue
 > state was read from the web UI on 2026-08-03, and no upstream PR search was run.
 > "none found" here is weaker than elsewhere on the page.
+
+## sglang ROCm — `patches/sglang_rocm/` (baked by `Dockerfile.sglang`)
+
+| patch | fixes | upstream issue | upstream PR | ours? | PR state |
+|---|---|---|---|---|---|
+| `sglang_rocm/patch_hicache_rocm_host_alloc.py` | hicache allocates host pools with `mmap` + `hipHostRegister`, which on ROCm maps the pages at a device address ≠ the host VA, but the pools hand raw host `data_ptr()`s to GPU kernels via device-side pointer tables → `Memory access fault by GPU node-N on address <host VA>` on the first kvd write-back | none found | none found | — | — |
+
+> Verified on 2026-08-03 by **reading upstream `main` directly** (contents API,
+> `pool_host/common.py`): `ALLOC_MEMORY_FUNCS` still overrides only `"npu"` and
+> `"musa"`, with no HIP entry — so main is affected too, and this is stronger
+> than the usual "no search hit". [sglang#23361](https://github.com/sgl-project/sglang/pull/23361)
+> (**MERGED**, MUSA) is the same one-line dispatch override for the same reason
+> and is the shape this patch copies.
+>
+> **No PR of ours has been filed** — it should be. **Drop this patch** when a
+> base sglang routes HIP to `alloc_with_pin_memory`; the anchor stops matching
+> and the script exits non-zero, so the drop is not silent. Note
+> [#32503](https://github.com/sgl-project/sglang/pull/32503) /
+> [#32792](https://github.com/sgl-project/sglang/pull/32792) (OPEN, Intel XPU
+> HiCache) touch this same dict — expect an anchor conflict, not a fix.
 
 ## Mooncake C++ — `patches/mooncake_cpp/` (built by `Dockerfile.sglang`, `Dockerfile.vllm`, `Dockerfile.atom`)
 

--- a/deploy/docker/patches/sglang_dsa/README.md
+++ b/deploy/docker/patches/sglang_dsa/README.md
@@ -15,16 +15,21 @@ same arm of the set — see [Applying](#applying):
 
 | # | patch | fixes |
 |---|---|---|
-| 01 | `patch_dsa_indexer_hip_dp_padded_rows.py` | HIP/aiter paged-MQA sizes its output from **DP-padded** rows while `lengths` is sized to **real** rows → `Expected lengths.size(0) == B` |
+| 01 | `patch_dsa_indexer_hip_dp_padded_rows.py` | the HIP/aiter paged-MQA row count and `lengths` disagree — **in both directions** → `Expected lengths.size(0) == B` |
 | 02 | `dsa_backend_dp_sync_and_page_table_rows.diff` | (a) a host sync on a branch only *some* DP ranks take → collectives desync → deadlock; (b) page table has one row per **request**, top-k one per **token** under MTP → assert |
 | 04 | `draft_cuda_graph_dp_vote.diff` | the draft graph/eager choice is made **per rank** from rank-dependent inputs and diverges on the PD decode leg → deadlock |
 
 Patch 01 is a **script** and 02/04 are **context diffs**, and that is the whole
 reason the two images can differ: 02 and 04 are `--fuzz=0` against
-v0.5.15.post1, while 01 anchors on source text and its two edit sites are
-byte-identical on both releases. On v0.5.15.post1 the script's output is
-byte-identical to the `dsa_indexer_hip_dp_padded_rows.diff` it replaced, which
-is why that diff is gone rather than kept as a second source of truth.
+v0.5.15.post1, while 01 anchors on source text. Its `GLM52_P1V2` edit sites are
+byte-identical on both releases; its later `GLM52_P1V3` anchor (the bare
+`topk_transform` call) has been re-read against v0.5.15.post1 only — see the
+anchor note in the script's header.
+
+The script replaced a `dsa_indexer_hip_dp_padded_rows.diff` that carried the
+same `GLM52_P1V2` edits; the diff is gone rather than kept as a second source of
+truth. It is **no longer equivalent to that diff**: `GLM52_P1V3` was added after
+the replacement, and only the script has it.
 
 **Each patch's own header is the record**: what it fixes, why, how it was
 established, the upstream issue / third-party PR / our own PR, how it differs
@@ -93,6 +98,89 @@ re-cut for v0.5.16, and the failure it prevents (a host sync on a branch only
 some DP ranks take) was not observed there — FP8, `dp8`, concurrency up to 128.
 Absence of the symptom is not a fix; if a gfx942 run deadlocks with IndexShare
 already off, 02a is the first thing to port.
+
+### Patch 01: the row count diverges in BOTH directions (`GLM52_P1V3`)
+
+Patch 01 originally guarded one direction only — `real < padded`, i.e. it
+assumed DP padding always makes `q_fp8` **longer** than the real row count. On a
+DP-attention **IDLE** rank under MTP draft-extend the inequality inverts.
+Captured live with the patch's own `SGLANG_DEBUG_DSA_ROWS=1`:
+
+    mode=IDLE q_fp8=(1,32,128) q_offset=2 ntnp=0 agree=False lengths=(2,) -> mqa_q=(1,32,128)
+
+`q_offset` (= `sum(dsa_extend_len_cpu)`) is **2** while only **1** row is
+materialized in `q_fp8`. `2 < 1` is false, so no trim runs; aiter sizes its
+`logits` from `q_fp8.shape[0] = 1`, and `fast_topk_v2` gets 1 score row against
+2 lengths entries — killing the scheduler rank (`deepseek_nextn.py` →
+`dsa_backend.py` → `top_k.py`) and dropping the router to `active_workers: 1`.
+
+**A trim cannot fix this direction** — there are *fewer* query rows than lengths
+entries, so there is nothing to cut. Both sides reconcile down to
+`min(real, padded)`:
+
+| | `real < padded` | `real > padded` |
+|---|---|---|
+| cause | DP padding (the #32762 case) | IDLE rank, MTP draft-extend |
+| `_p1v2_trim` | **True** — slice `q`/`weights` | False |
+| `_p1v2_clip` | False | **True** — clip the lengths |
+| restore | re-pad by `padded - rows` | nothing to restore |
+
+`_p1v2_rows = min(_p1v2_real, _p1v2_padded)` is the single source of truth and
+both flags derive from it, which is what keeps them from disagreeing. The
+lengths side is clipped by passing `ke_offset=metadata.get_seqlens_expanded()
+[:rows]` — an **existing** parameter of `DSAIndexerMetadata.topk_transform` whose
+sole effect is to override `seq_lens_topk`, so the fix rides an intended
+extension point rather than mutating shared (possibly graph-captured) metadata.
+
+Two details worth keeping in view when reading the script:
+
+* `_p1v2_clip` and `_p1v2_rows` are bound **before** the `is_aiter()` branch.
+  `_p1v2_clip` is read unconditionally at the `topk_transform` call, so a
+  branch-local binding is a `NameError` on any non-aiter backend. (aiter is
+  unconditional on ROCm, so this never fired in practice — but a build-time patch
+  should not depend on that.)
+* the restore assert keys off `_p1v2_rows`, not `_p1v2_real`: under the clip case
+  the two differ, and it is `_p1v2_rows` the kernel actually ran over.
+
+**This half is what makes the patch survive an *agentic* workload.** The bug
+needs MTP **and** DP-attention **and** an idle rank simultaneously. An 8-round
+fixed-shape sweep ran MTP + DPA for 660 requests without hitting it, because
+`--random-range-ratio 1.0` keeps every request in a round the same length —
+batch shapes stay homogeneous and ranks rarely go idle mid-flight. An agentic
+workload's breathing session population produces ragged batches constantly, and
+the one-directional revision crashed the decode leg roughly 13 minutes into an
+agentic benchmark. Over the last 400 indexer calls before one crash, 2 had the
+fatal shape.
+
+**Validated.** Reproduced twice under that workload (125 s and 766 s into two
+independent runs on the same stock image). With the fix: **0** occurrences of
+`Expected lengths.size` across a full ~4,000 s window, 0 scheduler exceptions, 0
+retractions, `active_workers: 2` throughout — and independently over a second
+~4,000 s window on a different cluster.
+
+> **Provenance.** Second-hand for the reader: this half was first validated as a
+> runtime script applied inside the decode container, *not* as part of patch 01.
+> Folding it in here is a re-shaping of an already-measured fix, and the fold was
+> checked for equivalence: the two forms differ only in the two pre-branch
+> bindings noted above. The runtime script, both crash logs and both clean-window
+> logs are in the internal reproduction kit — ask the patch author.
+
+**Upstream status.** Not filed, and it is not in our own PR #33059 either, which
+carries the `real < padded` half only. It should be — this repository already
+ships the instrumentation that proves the bug (`SGLANG_DEBUG_DSA_ROWS`) and, before
+this revision, a comment conceding the two bookkeeping sources had never been
+measured to agree on the MTP draft-extend path. They do not; that is the bug.
+
+Re-searched 2026-08-03 for the P1V3 half specifically ("DSA idle rank MTP draft
+extend", "q_offset dsa_extend_len", "fast_topk_v2 lengths"): no issue, no PR.
+But searching for the *function* rather than the symptom surfaces two OPEN PRs
+that rewrite what patch 01 anchors on — neither fixes this defect:
+[#32738](https://github.com/sgl-project/sglang/pull/32738) pads heads for
+DeepGEMM at the same two aiter call sites (`q_fp8` → `q_fp8_padded`), and
+[#31480](https://github.com/sgl-project/sglang/pull/31480) (updated the same day)
+extracts the paged-MQA backend, restructuring the `is_aiter()` dispatch this
+patch hangs off. Either landing in a future base drifts the anchors, which fails
+the build rather than mis-applying — but re-cut patch 01 when bumping past them.
 
 ### Prerequisite
 

--- a/deploy/docker/patches/sglang_dsa/patch_dsa_indexer_hip_dp_padded_rows.py
+++ b/deploy/docker/patches/sglang_dsa/patch_dsa_indexer_hip_dp_padded_rows.py
@@ -5,30 +5,97 @@
 
 WHAT: the aiter (HIP) paged-MQA branch sizes its `logits` output from the
 DP-PADDED row count while `lengths` is sized to the REAL count, so top-k dies
-with "Expected lengths.size(0) == B to be true, but got false". Slice q/weights
-to the real count (the contract every CUDA backend already honours), then
-restore the padding after `topk_transform`.
+with "Expected lengths.size(0) == B to be true, but got false". Reconcile the
+two counts to `min(real, padded)`: trim q/weights when q_fp8 is the longer side
+(the contract every CUDA backend already honours) and restore the padding after
+`topk_transform`, or clip the lengths when q_fp8 is the SHORTER side. See
+"THE ROW COUNT DIVERGES BOTH WAYS" below.
 
 WHY: without it, DP-attention + EAGLE MTP for GLM-5.2 DSA crashes as soon as
 more than one request is in flight -- on gfx950 at the very first batch, and on
 gfx942 at conc > 1. CUDA was never affected: those backends take `q_offset=` and
 slice internally. ROCm-specific.
 
+THE ROW COUNT DIVERGES BOTH WAYS (`GLM52_P1V3`)
+  An earlier revision of this fix guarded one direction only, `real < padded`,
+  i.e. it assumed DP padding always makes `q_fp8` LONGER. On a DP-attention IDLE
+  rank under MTP draft-extend the inequality inverts. Captured live with this
+  patch's own SGLANG_DEBUG_DSA_ROWS=1:
+
+      mode=IDLE q_fp8=(1,32,128) q_offset=2 ntnp=0 agree=False lengths=(2,)
+                -> mqa_q=(1,32,128)
+
+  `q_offset` (= sum of dsa_extend_len_cpu) is 2 while only 1 row is materialized
+  in q_fp8, so `2 < 1` is false, no trim runs, aiter sizes its logits from
+  q_fp8.shape[0] = 1, and fast_topk_v2 gets 1 score row against 2 lengths
+  entries -- killing the scheduler rank and dropping the router to
+  `active_workers: 1`. A trim cannot fix this direction: there are FEWER query
+  rows than lengths entries, so there is nothing to cut. The LENGTHS side is
+  clipped instead, through `topk_transform`'s existing `ke_offset` parameter.
+
+  The two directions, and what each does:
+
+    real < padded  the #32762 case: q_fp8 carries DP padding, so TRIM q/weights
+                   down to the real count, then re-pad after topk_transform.
+                   Trim at _p1v2_real == 0 too -- a DP-IDLE rank has no requests,
+                   so the real count is 0 while q_fp8 still carries padding.
+                   q_fp8[:0] is a legal empty slice and is what an idle rank
+                   should pass; the CUDA path likewise slices unconditionally.
+                   DO NOT reintroduce a `0 < q_offset` lower bound here: an
+                   earlier revision had one and it made fast_topk_v2 assert on
+                   exactly those idle ranks.
+    real > padded  the P1V3 case above: nothing to trim, so CLIP the lengths.
+
+  BOUND BEFORE THE BRANCH. `_p1v2_clip` and `_p1v2_rows` are bound before the
+  `is_aiter()` test, not inside it. `_p1v2_clip` is read unconditionally at the
+  topk_transform call, so a branch-local binding would be a NameError on any
+  non-aiter backend; `_p1v2_rows` defaults to `_p1v2_padded`, making the restore
+  a no-op if it is ever reached without the branch having run. aiter is
+  unconditional on ROCm so neither has fired in practice, but a build-time patch
+  should not depend on that.
+
+  This half is what makes the patch survive an AGENTIC workload. The bug needs
+  MTP AND DP-attention AND an idle rank at once: an 8-round fixed-shape sweep
+  ran MTP + DPA for 660 requests without hitting it, because
+  `--random-range-ratio 1.0` keeps batch shapes homogeneous and ranks rarely go
+  idle mid-flight. A breathing session population produces ragged batches
+  constantly, and the one-directional revision crashed the decode leg roughly
+  13 minutes into an agentic benchmark.
+
+  Reproduced twice under that workload (125 s and 766 s into two independent
+  runs). With the fix: 0 occurrences of `Expected lengths.size` across two full
+  ~4,000 s windows on two different clusters, 0 scheduler exceptions,
+  `active_workers: 2` throughout. Second-hand for the reader: it was validated
+  as a runtime script before being folded in here, so this is a re-shaping of an
+  already-measured fix rather than a fresh one. Evidence in the internal
+  reproduction kit -- ask the patch author.
+
 WHY A SCRIPT AND NOT A DIFF. Patches 02 and 04 are `--fuzz=0` context diffs
 pinned to v0.5.15.post1, the mi35x base. This fix is needed on BOTH engine
 bases, and `dsa_indexer.py` drifts between them: v0.5.16 adds `_is_xpu` beside
 the platform flags and calls `_mask_init_and_local_tokens` right before
-`topk_transform`, which fails 2 of the diff's 4 hunks. Both of this patch's own
-edit sites are byte-identical across the two releases, so anchoring on source
-text instead of line numbers covers both from one source of truth. On
-v0.5.15.post1 the result is byte-identical to the diff this replaces.
+`topk_transform`. Anchoring on source text instead of line numbers covers both
+from one source of truth.
 
-UPSTREAM STATUS (queried with `gh` on 2026-08-01, re-read from the web UI on
-2026-08-03 -- all still OPEN, none merged)
-  issue          NONE. No upstream issue reports this. Searched sgl-project/
-                 sglang for "Expected lengths.size", "DSA padding DP attention"
-                 and the GLM-5.2 MTP crash text: no match. Weak evidence --
-                 `gh search` matches titles and bodies, not diff content.
+  NOTE on the P1V3 anchor. It is the bare `topk_transform(logits,
+  self.index_topk)` call, which v0.5.16's added `_mask_init_and_local_tokens`
+  call sits BEFORE rather than inside -- so the anchor text itself is untouched.
+  That has not been re-verified against a v0.5.16 checkout since P1V3 was added.
+  If the drift is worse than expected the uniqueness check below writes NOTHING
+  and exits 1, which is the intended failure: a half-applied fix crashes in the
+  same place the unpatched tree does.
+
+UPSTREAM STATUS (queried with `gh` on 2026-08-01; re-queried and each PR state
+re-read 2026-08-03)
+  issue          NONE, for either half. Searched sgl-project/sglang for
+                 "Expected lengths.size", "DSA padding DP attention" and the
+                 GLM-5.2 MTP crash text (P1V2); and for "DSA idle rank MTP draft
+                 extend", "q_offset dsa_extend_len", "fast_topk_v2 lengths"
+                 (P1V3): no match either time. Weak evidence -- `gh search`
+                 matches titles and bodies, not diff content, so an upstream
+                 change to this same function that never names the symptom would
+                 not surface. The anchor-collision PRs below were found only by
+                 searching for the FUNCTION name, not the symptom.
   third-party PR #32762 "[NPU] Fix DSA eager padding mismatch in PD MTP warm-up"
                  (stellaxcpeng, OPEN). SAME BUG CLASS on a different platform,
                  and this patch is written in its shape: one boolean gates both
@@ -42,33 +109,52 @@ UPSTREAM STATUS (queried with `gh` on 2026-08-01, re-read from the web UI on
                  #30378 / #30427 (both MERGED, in both bases) clamp padded-row
                  seq_lens VALUES in triton_ops/pad.py. This fixes the HIP-side
                  row COUNT -- a different defect in the same area.
+  anchor risk    Two OPEN PRs rewrite the code this patch anchors on. Neither
+                 fixes this defect; both would make the anchors drift, which
+                 fails the build loudly rather than mis-applying.
+                 #32738 "[Fix] DSA Indexer: pad heads for DeepGEMM paged MQA
+                 logits on decode/target-verify" -- edits _get_topk_paged at the
+                 SAME two aiter call sites, replacing `q_fp8` with a
+                 `q_fp8_padded` from a new `_pad_heads_for_deep_gemm`. Head-dim
+                 padding, orthogonal to our row-count fix, but a direct textual
+                 collision with the P1V2 anchor.
+                 #31480 "[DSA] Add an arch-independent torch paged-MQA-logits
+                 backend" (updated 2026-08-03) -- extracts the backend into
+                 paged_mqa_logits_backend.py, i.e. restructures the
+                 `is_aiter()` dispatch this whole patch hangs off.
   own PR         #33059 "Fix DSA indexer aiter (HIP) padding mismatch under
                  DP-attention" (dorado269, OPEN, REVIEW_REQUIRED, against main,
                  1 file +16/-4). CI is red only at `pr-gate`, which blocks on a
                  missing `run-ci` label, not on code.
 
-THIS PATCH vs OUR OWN PR #33059. Same defect, same two edits. They differ
+THIS PATCH vs OUR OWN PR #33059. Same defect, overlapping edits. They differ
 deliberately:
-  base       here: whatever base carries the anchors (v0.5.15.post1 and v0.5.16
-             verified). #33059: sglang `main`, whose `_get_topk_paged` has
+  base       here: whatever base carries the anchors (v0.5.15.post1 verified for
+             all edits; v0.5.16 verified for the P1V2 edits, see the anchor note
+             above for P1V3). #33059: sglang `main`, whose `_get_topk_paged` has
              drifted further (cutedsl / dg_native branches,
              `_mask_init_and_local_tokens`).
-  form       here: explicit `_p1v2_trim` / `_p1v2_real` / `_p1v2_padded` locals
+  scope      #33059 carries the `real < padded` half ONLY. The P1V3 clip is NOT
+             in it and has not been filed upstream at all -- it should be, and
+             this repo already ships the instrumentation that proves the bug.
+  form       here: explicit `_p1v2_rows` / `_p1v2_trim` / `_p1v2_clip` locals
              with a post-kernel row-count ASSERT, following #32762's shape.
              #33059: the minimal `q_fp8[:q_offset]` / `weights[:q_offset]` slice
              and a plain `if q_offset < q_fp8.shape[0]` restore.
-  local-only Stripped for upstream: the `GLM52_P1V2` markers (the build script
-             greps them out of the BYTECODE to prove the patch landed), the
-             `_p1v2_*` naming, and the `SGLANG_DEBUG_DSA_ROWS` logging block.
-             All three are scaffolding for this repo's verification loop and
-             carry no upstream value.
+  local-only Stripped for upstream: the `GLM52_P1V2` / `GLM52_P1V3` markers (the
+             build script greps `_p1v2_trim` and `_p1v2_rows` out of the
+             BYTECODE to prove the patch landed), the `_p1v2_*` naming, and the
+             `SGLANG_DEBUG_DSA_ROWS` logging block. All three are scaffolding
+             for this repo's verification loop and carry no upstream value.
   trade-off  The upstream form is smaller and easier to review. Ours fails
              LOUDER: on a shape drift the assert crashes instead of silently
-             returning a short tensor. Prefer upstream's once it merges and the
-             base carries it -- then delete this script.
-  validation Ours: 4/4 probe, conc=64 1k/1k 256/256, plus 2540/2540 in the PD
-             set, all on gfx950 / v0.5.15.post1. #33059's port to `main` was NOT
-             re-run on hardware.
+             returning a short tensor -- and it handles a direction #33059 does
+             not. Do NOT delete this script when #33059 merges; the clip half
+             would go with it.
+  validation Ours: 4/4 probe, conc=64 1k/1k 256/256, 2540/2540 in the PD set,
+             plus two full ~4,000 s agentic windows on two clusters for the
+             P1V3 half -- all on gfx950 / v0.5.15.post1. #33059's port to
+             `main` was NOT re-run on hardware.
 
 RELATION TO THE INDEXSHARE WORKAROUND. NOT substituted.
 `--json-model-override-args '{"index_share_for_mtp_iteration":false}'` removes
@@ -130,27 +216,30 @@ _DSA_DEBUG_ROWS = os.environ.get("SGLANG_DEBUG_DSA_ROWS", "0") == "1"
 """,
         """        weights = weights.squeeze(2)
 
-        # GLM52_P1V2: bound before the branch so the restore gates on the same
-        # boolean. Only aiter sets it; the CUDA branches slice internally.
+        # GLM52_P1V2/P1V3: bound BEFORE the branch, not inside it -- _p1v2_clip is
+        # read unconditionally below, so a branch-local binding is a NameError on
+        # any non-aiter backend. See "BOUND BEFORE THE BRANCH" in the header.
         _p1v2_trim = False
+        _p1v2_clip = False
         _p1v2_real = q_offset
         _p1v2_padded = q_fp8.shape[0]
+        _p1v2_rows = _p1v2_padded
         if self.paged_mqa_logits_backend.is_aiter():
-            # WHY: DP-attention pads q_fp8 past `lengths` and aiter (unlike CUDA)
-            # sizes logits from q_fp8.shape[0] -> "Expected lengths.size(0) == B".
-            # HOW: slice to the real count -- the contract CUDA already honours.
-
-            # Trim at _p1v2_real == 0 too: q_fp8[:0] is what a DP-idle rank should
-            # pass. An earlier `0 < q_offset` bound asserted on exactly those ranks.
-            _p1v2_trim = _p1v2_real < _p1v2_padded
+            # WHY aiter sizes logits from q_fp8.shape[0], which disagrees with
+            # `lengths` BOTH ways. HOW reconcile to min(): trim when longer, clip
+            # when shorter. Cases: "DIVERGES BOTH WAYS" in the header.
+            _p1v2_rows = min(_p1v2_real, _p1v2_padded)
+            _p1v2_trim = _p1v2_rows < _p1v2_padded
+            _p1v2_clip = _p1v2_rows < _p1v2_real
             _q_mqa, _w_mqa = q_fp8, weights
             if _p1v2_trim:
-                _q_mqa = q_fp8[:_p1v2_real]
-                _w_mqa = weights[:_p1v2_real]
+                _q_mqa = q_fp8[:_p1v2_rows]
+                _w_mqa = weights[:_p1v2_rows]
             if _DSA_DEBUG_ROWS:
                 # Cross-check against the padding bookkeeping #32762 keys off.
-                # Logged, not asserted: it has never been measured to agree with
-                # q_offset on the MTP draft-extend path.
+                # NOT an assert: it does NOT agree with q_offset on the MTP
+                # draft-extend path -- that disagreement is the P1V3 case above,
+                # and this log is how it was caught.
                 _p1v2_ntnp = getattr(forward_batch, "_original_num_tokens", None)
                 if _p1v2_ntnp is None:
                     _p1v2_ntnp = forward_batch.num_token_non_padded_cpu
@@ -171,6 +260,26 @@ _DSA_DEBUG_ROWS = os.environ.get("SGLANG_DEBUG_DSA_ROWS", "0") == "1"
                 _w_mqa,
 """,
     ),
+    # GLM52_P1V3: clip the lengths when the rows were clipped rather than trimmed.
+    # Anchored on the bare call, which occurs once; the `if` wrapper is the
+    # already-applied marker.
+    (
+        """        topk_result = metadata.topk_transform(logits, self.index_topk)
+""",
+        """        # GLM52_P1V3: rows were CLIPPED (real > padded), so the lengths this
+        # indexes must be clipped to match. Via topk_transform's existing
+        # `ke_offset` -- an extension point that only overrides seq_lens_topk --
+        # NOT by mutating shared, possibly graph-captured metadata.
+        if _p1v2_clip:
+            topk_result = metadata.topk_transform(
+                logits,
+                self.index_topk,
+                ke_offset=metadata.get_seqlens_expanded()[:_p1v2_rows],
+            )
+        else:
+            topk_result = metadata.topk_transform(logits, self.index_topk)
+""",
+    ),
     # Restore the trimmed padding, gated on the SAME boolean.
     (
         """        # Restore possible padding exist in the hidden states.
@@ -182,15 +291,18 @@ _DSA_DEBUG_ROWS = os.environ.get("SGLANG_DEBUG_DSA_ROWS", "0") == "1"
         """        # GLM52_P1V2: restore the trimmed padding -- gate on the SAME boolean and
         # assert the row count. BEFORE, a re-derived condition skipped the restore
         # on a shape drift, returning a short tensor instead of crashing.
+        #
+        # Keyed off _p1v2_rows, not _p1v2_real: under P1V3's clip case the two
+        # differ, and it is _p1v2_rows that the kernel actually ran over.
         if _p1v2_trim:
-            assert topk_result.shape[0] == _p1v2_real, (
-                "GLM52_P1V2: paged-MQA top-k returned "
-                f"{topk_result.shape[0]} rows for {_p1v2_real} trimmed query "
-                f"rows (padded={_p1v2_padded}); refusing to pad a mis-shaped "
-                "result."
+            assert topk_result.shape[0] == _p1v2_rows, (
+                "GLM52_P1V3: paged-MQA top-k returned "
+                f"{topk_result.shape[0]} rows for {_p1v2_rows} trimmed query "
+                f"rows (real={_p1v2_real}, padded={_p1v2_padded}); refusing to "
+                "pad a mis-shaped result."
             )
             padding = torch.full(
-                (_p1v2_padded - _p1v2_real, topk_result.shape[1]),
+                (_p1v2_padded - _p1v2_rows, topk_result.shape[1]),
 """,
     ),
 ]

--- a/deploy/docker/patches/sglang_rocm/patch_hicache_rocm_host_alloc.py
+++ b/deploy/docker/patches/sglang_rocm/patch_hicache_rocm_host_alloc.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Fix the hicache host-pool allocator on ROCm: use hipHostMalloc, not
+mmap + hipHostRegister.
+
+THE BUG
+-------
+SGLang allocates every hierarchical-cache host pool through
+
+    ALLOC_MEMORY_FUNCS[device] -> alloc_with_host_register(...)
+        buffer = alloc_mmap(dims, dtype)          # anonymous mmap
+        cudaHostRegister(buffer.data_ptr(), n, 0) # page-lock it
+
+and then stores the resulting **host** virtual addresses in a device-side
+pointer table that a GPU kernel dereferences:
+
+    memory_pool_host.py :: DSAIndexerPoolHost.init_kv_buffer
+        self.index_k_data_ptrs = torch.tensor(
+            [x.data_ptr() for x in self.index_k_data_refs],  # HOST VAs
+            dtype=torch.uint64, device=<gpu>)
+    ... -> transfer_kv_all_layer_mla(dst_layers=self.index_k_data_ptrs, ...)
+
+On CUDA that is fine: cudaHostRegister maps the pages at the *same* address in
+the device address space, so a host VA is directly dereferenceable from a kernel.
+
+On ROCm it is not. hipHostRegister maps the pages at a **different** device
+address, which you must obtain with hipHostGetDevicePointer. Measured on this
+stack (MI355X / gfx950 / ROCm 7.2.0), 8 MiB buffer:
+
+    [pin_memory]            host=0x7d7c2f600000  devPtr=0x7d7c2f600000  same=True
+    [mmap + hipHostRegister]host=0x7d3bee790000  devPtr=0x7d3bede00000  same=False
+    [+hipHostRegisterMapped]host=0x7d3bed600000  devPtr=0x7d3becc00000  same=False
+    [+Portable|Mapped]      host=0x7d3bec400000  devPtr=0x7d3a97600000  same=False
+    [MAP_PRIVATE]           host=0x7d3a96e00000  devPtr=0x7d3a96400000  same=False
+
+So the kernel is handed an address that is not mapped on the device, and the
+first write-back aborts the process with
+
+    Memory access fault by GPU node-2 (Agent handle: ...) on address <host VA>.
+    Reason: Unknown.
+
+The fault address equals the host pointer exactly, which is the fingerprint.
+gfx950 reports `xnack-`, so there is no page-migration path to paper over it.
+
+THE FIX
+-------
+Register ROCm in ALLOC_MEMORY_FUNCS to use `alloc_with_pin_memory`, i.e.
+torch's `pin_memory=True` (hipHostMalloc underneath), which returns memory whose
+device pointer *is* the host pointer. Exactly what the "npu" and "musa" entries
+already do for the same reason.
+
+This is the smallest change that makes the existing pointer-table design correct
+on ROCm. The alternative -- translate every host pointer through
+hipHostGetDevicePointer before building the tables -- touches ~10 call sites in
+memory_pool_host.py and is the right upstream shape, but it is not a patch to
+apply blind to a running container.
+
+Cost: the hugepage path in alloc_mmap (SGLANG_HUGEPAGE_SIZE) is bypassed on
+ROCm. That env var is unset here.
+
+VERIFIED
+--------
+Standalone repro of the exact write-back kernel, 78 layers, 7.33 GB host indexer
+buffer, page ranges head / tail / last:
+  * mmap+hipHostRegister -> Memory access fault, every variant
+  * pin_memory           -> ALL OK, no fault
+The repro and its logs are in the internal reproduction kit -- ask the patch
+author.
+
+UPSTREAM STATUS (queried with `gh` on 2026-08-03)
+  issue          NONE FOUND. Searched sgl-project/sglang issues for
+                 "hipHostRegister", "hicache ROCm host" and "Memory access fault
+                 by GPU node". The last returns AMD faults from unrelated areas
+                 (#23784 EAGLE3 at high concurrency, #23288 HiSparse page_size,
+                 #10195 EP on MI300) -- none is this allocator. Weak evidence:
+                 `gh search` matches titles and bodies, not diff content, so an
+                 upstream change to this same dispatch that never names it would
+                 not show up. The direct read below is the stronger check.
+  upstream code  Read `pool_host/common.py` on sgl-project/sglang `main` via the
+                 contents API on 2026-08-03: ALLOC_MEMORY_FUNCS still defaults to
+                 `alloc_with_host_register` with only "npu" and "musa" overridden.
+                 No HIP entry. So the defect is live on main, not just on our base.
+  third-party PR #23361 "[MUSA][19/N] Support HiCache with pin_memory allocator"
+                 (MERGED 2026-04-22). NOT this fix, but it is the SHAPE this
+                 patch copies: same one-line dispatch override, same reason
+                 (host VA is not the device VA on that platform). #32503 /
+                 #32792 (both OPEN) add Intel XPU HiCache and will touch the same
+                 dict -- a merge conflict risk for this anchor, not a fix for it.
+  own PR         NONE. Not filed. It should be: upstream main is affected, the
+                 one-line form matches an already-merged precedent (#23361), and
+                 the device-pointer measurements above are the evidence. Blocked
+                 only on someone opening it.
+
+Idempotent and self-locating. Run inside the container, then delete stale .pyc.
+"""
+
+import importlib.util
+import os
+import re
+import sys
+
+MARKER = "GLM52_ROCM_HOST_ALLOC"
+
+
+def find_common_py() -> str:
+    spec = importlib.util.find_spec("sglang")
+    if spec is None or not spec.submodule_search_locations:
+        sys.exit("cannot locate the sglang package")
+    root = list(spec.submodule_search_locations)[0]
+    path = os.path.join(root, "srt", "mem_cache", "pool_host", "common.py")
+    if not os.path.isfile(path):
+        sys.exit(f"not found: {path}")
+    return path
+
+
+OLD_IMPORT = "from sglang.srt.mem_cache.mmap_allocator import alloc_mmap"
+NEW_IMPORT = (
+    "from sglang.srt.mem_cache.mmap_allocator import alloc_mmap\n"
+    f"from sglang.srt.utils import is_hip  # {MARKER}"
+)
+
+OLD = """ALLOC_MEMORY_FUNCS = defaultdict(
+    lambda: alloc_with_host_register,
+    {
+        "npu": alloc_with_pin_memory,
+        "musa": alloc_with_pin_memory,
+    },
+)"""
+
+NEW = f"""# {MARKER}: WHY hipHostRegister's device address != the host VA, but these
+# pools pass host data_ptr()s to GPU kernels -> "Memory access fault". HOW use
+# hipHostMalloc, as "npu"/"musa". See infera patch_hicache_rocm_host_alloc.py.
+
+# A real literal, not a comment: `strings *.pyc` must prove this reached the
+# BYTECODE, and the compiler discards comments.
+{MARKER} = "applied"
+
+_ALLOC_MEMORY_FUNCS_OVERRIDES = {{
+    "npu": alloc_with_pin_memory,
+    "musa": alloc_with_pin_memory,
+}}
+if is_hip():
+    _ALLOC_MEMORY_FUNCS_OVERRIDES["cuda"] = alloc_with_pin_memory
+
+ALLOC_MEMORY_FUNCS = defaultdict(
+    lambda: alloc_with_pin_memory if is_hip() else alloc_with_host_register,
+    _ALLOC_MEMORY_FUNCS_OVERRIDES,
+)"""
+
+
+def main() -> int:
+    path = find_common_py()
+    src = open(path).read()
+
+    if MARKER in src:
+        print(f"[patch] already applied: {path}")
+        return 0
+
+    if OLD not in src:
+        print(
+            "[patch] ERROR: ALLOC_MEMORY_FUNCS block not found in the expected "
+            "shape. Refusing to guess -- inspect the file:"
+        )
+        print(f"        {path}")
+        for m in re.finditer(r"ALLOC_MEMORY_FUNCS.*", src):
+            print("        |", m.group(0))
+        return 1
+
+    # common.py does NOT import is_hip today (it only pulls in alloc_mmap), so
+    # the import has to be added alongside the dispatch change.
+    if "is_hip" not in src:
+        if OLD_IMPORT not in src:
+            print("[patch] ERROR: mmap_allocator import line not found; aborting.")
+            return 1
+        src = src.replace(OLD_IMPORT, NEW_IMPORT, 1)
+
+    open(path, "w").write(src.replace(OLD, NEW))
+    print(f"[patch] applied to {path}")
+
+    pyc = os.path.join(os.path.dirname(path), "__pycache__")
+    n = 0
+    if os.path.isdir(pyc):
+        for f in os.listdir(pyc):
+            if f.startswith("common."):
+                os.remove(os.path.join(pyc, f))
+                n += 1
+    print(f"[patch] removed {n} stale .pyc")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/docker/scripts/apply_sglang_dsa_patches.sh
+++ b/deploy/docker/scripts/apply_sglang_dsa_patches.sh
@@ -11,9 +11,10 @@
 #         patch 01 + 02 + 04.  02 and 04 are `--fuzz=0` context diffs pinned to
 #         that one release, so this arm only works on that base.
 #   DSA_PATCH_SET=indexer  (Dockerfile.sglang.gfx942, mi30x / v0.5.16)
-#         patch 01 only.  It is an anchor script, not a pinned diff, and its two
-#         edit sites are byte-identical on both releases.  02b and 04 are instead
-#         substituted at RUNTIME on this base by
+#         patch 01 only -- an anchor script, not a pinned diff, which is what
+#         lets both bases share it.  Anchor coverage per base: patch 01's header.
+#
+#         02b and 04 are instead substituted at RUNTIME on this base by
 #         `--json-model-override-args '{"index_share_for_mtp_iteration":false}'`
 #         -- see patches/sglang_dsa/README.md; the gfx942 recipe MUST pass it.
 #         02a has no substitute and is not carried here: its diff does not apply
@@ -62,7 +63,10 @@ PATCHES=(
 )
 
 # module basename : identifier that must be present in the compiled bytecode
-MARKERS=("dsa_indexer.py:_p1v2_trim")
+#
+# Patch 01 needs TWO markers: `_p1v2_trim` alone is also satisfied by the earlier
+# one-directional revision; only `_p1v2_rows` proves real > padded is handled.
+MARKERS=("dsa_indexer.py:_p1v2_trim" "dsa_indexer.py:_p1v2_rows")
 if [ "$DSA_PATCH_SET" = "full" ]; then
   MARKERS+=(
     "dsa_backend.py:_glm52_match_page_table_rows"

--- a/infera/common/net.py
+++ b/infera/common/net.py
@@ -5,11 +5,17 @@
 ###############################################################################
 from __future__ import annotations
 
+import itertools
 import logging
 import os
+import random
 import socket
 
 logger = logging.getLogger(__name__)
+
+# How many randomly-chosen bases _scan_free_port_block tries before falling back
+# to an exhaustive scan.
+_PORT_BLOCK_TRIES = 64
 
 # Kubernetes' default --service-node-port-range. A port in this window can be
 # claimed cluster-wide by any Service at any time; kube-proxy in IPVS mode then
@@ -68,12 +74,33 @@ def _probe_ephemeral_port() -> int:
 
 
 def _scan_free_port_block(count: int, reserved: tuple[int, int] | None) -> int:
-    """Lowest base below the ephemeral range with ``count`` free ports."""
+    """A base below the ephemeral range with ``count`` free ports.
+
+    The scan start is **randomised**. The probe must release the block before
+    returning (the caller's real listener binds ``0.0.0.0``, and a retained
+    ``127.0.0.1`` reservation would shut its own child out), so the reservation
+    cannot be exclusive. With a fixed start (``low - count``) that made
+    collisions deterministic rather than merely possible: two engines launched
+    on one host -- e.g. the prefill and decode legs of a PD pair -- both scanned
+    from the same place, both saw the same free block, and the second died with
+    ``ZMQError: Address already in use`` on ``base + rank``. Randomising spreads
+    the picks so concurrent callers land on different blocks.
+
+    A bounded number of random probes comes first, then the exhaustive downward
+    scan, so we still never fail while a block is available.
+    """
     try:
         low = int(open("/proc/sys/net/ipv4/ip_local_port_range").read().split()[0])
     except (OSError, ValueError, IndexError):
         low = 32768
-    for base in range(low - count, 1024, -1):
+    # Candidate window [1024, low - count] is empty on a host whose ephemeral
+    # range was widened down to the reserved ports. Bail out as the exhaustive
+    # scan does -- randint() would raise ValueError on the inverted range.
+    highest = low - count
+    if highest < 1024:
+        raise RuntimeError(f"could not find {count} contiguous free TCP ports")
+    randomised = [random.randint(1024, highest) for _ in range(_PORT_BLOCK_TRIES)]
+    for base in itertools.chain(randomised, range(highest, 1024, -1)):
         # A block inside the NodePort range binds and answers on loopback here,
         # so only skipping it up front keeps it out of the advertised endpoint.
         if reserved and base + count - 1 >= reserved[0] and base <= reserved[1]:
@@ -120,14 +147,16 @@ def free_tcp_port() -> int:
 
 
 def free_tcp_port_block(count: int) -> int:
-    """Lowest base such that ``base .. base+count-1`` are all free TCP ports.
+    """A base such that ``base .. base+count-1`` are all free TCP ports.
 
     SGLang binds one KV-event publisher per DP rank at ``base + attn_dp_rank``,
-    so a single free base is not enough. We scan downward from just below the OS
-    ephemeral range: a base there won't be handed out to any ``bind(("", 0))``
-    caller (ours or SGLang's internal sockets), so the whole block survives the
-    window until the engine binds it. The scan also skips the Kubernetes
-    NodePort range, which a loopback bind probe cannot rule out on its own.
+    so a single free base is not enough. We scan below the OS ephemeral range: a
+    base there won't be handed out to any ``bind(("", 0))`` caller (ours or
+    SGLang's internal sockets), so the whole block survives the window until the
+    engine binds it. The scan also skips the Kubernetes NodePort range, which a
+    loopback bind probe cannot rule out on its own, and starts from a randomised
+    base so two engines on one host do not pick the same block -- see
+    :func:`_scan_free_port_block`.
     """
     if count <= 1:
         return free_tcp_port()

--- a/infera/engine/sglang/args.py
+++ b/infera/engine/sglang/args.py
@@ -260,7 +260,20 @@ def parse_sglang_args(argv: list[str] | None = None) -> SglangWorkerArgs:
         and getattr(sglang_parsed, "disaggregation_transfer_backend", None) == "mooncake"
         and "--disaggregation-decode-enable-radix-cache" not in remaining
     ):
-        remaining.append("--disaggregation-decode-enable-radix-cache")
+        # SGLang rejects this flag under speculative decoding, so appending it
+        # kills an EAGLE/MTP decode leg at parse time. Skipping it costs only the
+        # decode-side KV view; prefix-aware routing runs on the prefill one.
+        if getattr(sglang_parsed, "speculative_algorithm", None) is not None:
+            logger.info(
+                "kv-events on, but --disaggregation-decode-enable-radix-cache is "
+                "incompatible with --speculative-algorithm %s; not appending it. "
+                "The decode leg will use SGLang's chunk cache and contribute "
+                "little to the router KV view; prefix-aware routing runs on the "
+                "prefill-side view.",
+                sglang_parsed.speculative_algorithm,
+            )
+        else:
+            remaining.append("--disaggregation-decode-enable-radix-cache")
 
     # infera product default: fp8 KV cache (fp8_e4m3) unless the operator passed
     # --kv-cache-dtype explicitly. fp8 halves the KV footprint -> ~2x the KV that

--- a/infera/engine/sglang/kvd_wiring.py
+++ b/infera/engine/sglang/kvd_wiring.py
@@ -171,10 +171,34 @@ def _finish_wiring(args: Any, socket_path: str) -> None:
     logger.info("infera-kvd HiCacheStorage backend ready (socket=%s)", socket_path)
 
 
+def _skip_kvd_on_decode_leg(args: Any) -> bool:
+    """True if this is a PD decode leg, where kvd would be write-only.
+
+    SGLang only prefetches from hicache storage on the aggregated and PREFILL
+    branches of ``Scheduler._add_request_to_queue``; the DECODE branch has no
+    ``_prefetch_kvcache`` call, and that method is the sole caller of
+    ``prefetch_from_storage``. The backup path still runs, so a decode leg fills
+    L3 and never reads it -- measured at 180 sets / 0 gets against a prefill
+    leg's 102 sets / 102 gets on the same run.
+    """
+    mode = getattr(getattr(args, "server_args", None), "disaggregation_mode", None)
+    if str(mode) != "decode":
+        return False
+    logger.info(
+        "PD decode leg: not wiring infera-kvd. SGLang issues no storage prefetch "
+        "on the decode branch (scheduler._add_request_to_queue), so L3 here would "
+        "be write-only -- host memory and D2H bandwidth for zero reads. kvd stays "
+        "on the prefill leg, which is where prefix reuse is decided."
+    )
+    return True
+
+
 async def awire_infera_kvd_backend(args: Any) -> None:
     """Async variant for callers already inside an event loop."""
     socket_path = args.infera_kvd_socket
     if not socket_path:
+        return
+    if _skip_kvd_on_decode_leg(args):
         return
 
     # The adapter (constructed later by SGLang) reads this env var;

--- a/infera/kvd/storage_classify.py
+++ b/infera/kvd/storage_classify.py
@@ -162,6 +162,12 @@ def _findmnt(path: Path) -> tuple[str, str] | None:
         return None
     fstype = parts[-1]
     source = " ".join(parts[:-1])
+    # A bind mount prints SOURCE as `/dev/md0[/sub/path]`; only the part before
+    # '[' names the device. The whole string makes lsblk say "not a block
+    # device", silently downgrading an O_DIRECT-capable kvd L3 to buffered.
+    bracket = source.find("[")
+    if bracket > 0:
+        source = source[:bracket]
     return source, fstype
 
 

--- a/rust/router/tests/kv_event_zmq.rs
+++ b/rust/router/tests/kv_event_zmq.rs
@@ -37,6 +37,23 @@ fn block_stored(block_hashes: &[u64], parent: Option<u64>, token_ids: &[u32], bs
     ])
 }
 
+/// The same event as SGLang emits it under EAGLE/MTP: `token_ids` carries the
+/// overlapping bigrams `(t[i], t[i+1])` that key the radix tree, not bare ints.
+fn block_stored_bigram(block_hashes: &[u64], parent: Option<u64>, flat: &[u32], bs: i64) -> Mv {
+    let pairs: Vec<Mv> = flat
+        .windows(2)
+        .map(|w| Mv::Array(vec![Mv::from(w[0]), Mv::from(w[1])]))
+        .collect();
+    Mv::Array(vec![
+        Mv::String("BlockStored".into()),
+        Mv::Array(block_hashes.iter().map(|&h| Mv::from(h)).collect()),
+        parent.map(Mv::from).unwrap_or(Mv::Nil),
+        Mv::Array(pairs),
+        Mv::from(bs),
+        Mv::Nil, // lora_id
+    ])
+}
+
 /// Encode a KVEventBatch: array_like `[ts, events, attn_dp_rank?]`.
 fn batch(events: Vec<Mv>) -> Vec<u8> {
     let v = Mv::Array(vec![Mv::from(0.0_f64), Mv::Array(events)]);
@@ -87,6 +104,58 @@ fn subscriber_decodes_real_zmq_msgpack_into_view() {
     // A divergent second block breaks the prefix at 1 (same chain semantics).
     let q2 = hash_request(&[1, 2, 3, 4, 9, 9, 9, 9], 4);
     assert_eq!(client.prefix_hits("w", None, &q2), 1);
+
+    client.shutdown();
+}
+
+/// The MTP shape, over the same real socket.
+///
+/// This is the wire-level twin of the in-crate `decodes_sglang_bigram_batch_under_mtp`
+/// unit test, and the one that would have caught the original bug in a live
+/// deployment: a `--router-backend rust` router subscribed to an MTP-enabled
+/// SGLang leg received pairs, decoded every element to `None`, and kept an empty
+/// view forever. Nothing errored — kv-aware simply degraded to load balancing.
+///
+/// The assertion is that the bigram view hashes to *the same blocks* the query
+/// side computes over the flat tokens, not merely that it is non-empty.
+#[test]
+fn subscriber_decodes_bigram_tokens_under_mtp() {
+    let ctx = zmq::Context::new();
+    let pub_sock = ctx.socket(zmq::PUB).unwrap();
+    pub_sock.bind("tcp://127.0.0.1:*").unwrap();
+    let endpoint = pub_sock.get_last_endpoint().unwrap().unwrap();
+
+    let client = KvEventClient::new();
+    client.on_worker_added(&worker("w", &endpoint, 4));
+
+    // Flat tokens 1..=9 -> 8 bigrams -> two blocks of 4 whose first elements are
+    // [1,2,3,4] and [5,6,7,8]: exactly the slice the query side chunks.
+    let payload = batch(vec![block_stored_bigram(
+        &[333, 444],
+        None,
+        &[1, 2, 3, 4, 5, 6, 7, 8, 9],
+        4,
+    )]);
+    let query = hash_request(&[1, 2, 3, 4, 5, 6, 7, 8], 4);
+    assert_eq!(query.len(), 2);
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut hits = 0;
+    while Instant::now() < deadline {
+        pub_sock
+            .send_multipart([b"kv-events".as_ref(), payload.as_ref()], 0)
+            .unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+        hits = client.prefix_hits("w", None, &query);
+        if hits == 2 {
+            break;
+        }
+    }
+    assert_eq!(
+        hits, 2,
+        "bigram token_ids must mirror to the same blocks as the flat slice; \
+         0 here is the original bug (every pair dropped, view stays empty)"
+    );
 
     client.shutdown();
 }

--- a/tests/unit/common/test_net_ports.py
+++ b/tests/unit/common/test_net_ports.py
@@ -80,6 +80,35 @@ def test_block_is_contiguous_and_bindable(count):
             s.close()
 
 
+def _ephemeral_low() -> int:
+    try:
+        return int(open("/proc/sys/net/ipv4/ip_local_port_range").read().split()[0])
+    except (OSError, ValueError, IndexError):
+        return 32768
+
+
+def test_block_sits_below_the_ephemeral_range():
+    # A base inside the ephemeral range could be handed out by bind(("", 0))
+    # between the probe releasing it and the engine binding it.
+    count = 4
+    base = free_tcp_port_block(count)
+    assert 1024 <= base
+    assert base + count - 1 < _ephemeral_low()
+
+
+def test_repeated_calls_do_not_all_collide():
+    """Consecutive callers must not deterministically get the same base.
+
+    The probe releases the block before returning, so the reservation is not
+    exclusive. With the old fixed scan start every call returned an identical
+    base while nothing held the ports: the prefill and decode legs of a PD pair
+    launched on one host both picked it, and the second leg's sglang subprocess
+    died with ``ZMQError: Address already in use`` on ``base + attn_dp_rank``.
+    """
+    bases = [free_tcp_port_block(4) for _ in range(10)]
+    assert len(set(bases)) > 1, f"all calls returned the same base: {bases[0]}"
+
+
 def test_single_port_delegates_to_ephemeral_helper():
     # count<=1 lets the kernel choose, which on a default ip_local_port_range
     # lands above the NodePort range anyway.

--- a/tests/unit/kvd/test_storage_classify.py
+++ b/tests/unit/kvd/test_storage_classify.py
@@ -358,6 +358,59 @@ def test_sas_ssd_picks_o_direct(fake_run):
     assert "sas-ssd" in rationale
 
 
+def test_bind_mount_source_strips_subpath(monkeypatch):
+    """A bind mount makes findmnt print SOURCE as ``/dev/md0[/sub/path]``.
+
+    That bracketed suffix is not part of the device name. Passing the raw
+    string to lsblk gets ``not a block device``, so the probe silently
+    degrades to buffered even on hardware that qualifies for O_DIRECT.
+
+    Observed on a real deployment: kvd's L3 bind-mounted into a container
+    reported ``devices = [(none)]``, ``rationale: unknown device,
+    conservative buffered``, on an ext4-on-md0 mount.
+
+    This test models the *real* lsblk contract — it errors on a bracketed
+    argument — rather than a fake that accepts anything, which is what
+    lets the bug through.
+    """
+
+    def run(cmd, timeout=2.0):
+        class R:
+            returncode = 0
+            stdout = ""
+
+        r = R()
+        if cmd[0] == "findmnt":
+            r.stdout = "/dev/nvme0n1p1[/kvd-long] ext4\n"
+        elif cmd[0] == "lsblk":
+            target = cmd[-1]
+            if "[" in target:  # what real lsblk does
+                r.returncode = 32
+                r.stdout = ""
+            else:
+                r.stdout = "nvme0n1 nvme 0\n"
+        return r
+
+    monkeypatch.setattr(storage_classify, "_run", run)
+    o_direct, rationale = pick_io_mode(Path("/kvd-long"))
+    assert o_direct is True, f"bind mount misclassified: {rationale}"
+    assert "nvme-ssd" in rationale
+
+
+def test_bind_mount_classify_reports_clean_source(fake_run):
+    """The bracketed subpath must not leak into the reported mount source
+    either — operators read this field to sanity-check the probe."""
+    fake_run(
+        {
+            "findmnt": "/dev/sda1[/some/where] ext4\n",
+            "lsblk": "sda sata 0\n",
+        }
+    )
+    info = classify_storage(Path("/some/where"))
+    assert info.mount_source == "/dev/sda1"
+    assert info.devices, "bind-mounted device should still be resolved"
+
+
 def test_findmnt_missing_falls_back_to_buffered(monkeypatch, caplog):
     """When findmnt isn't installed (minimal containers), we don't
     raise — we just default to buffered and log a WARN. The classifier


### PR DESCRIPTION
## What this is

Everything still missing from `main` that GLM-5.2 needs to run
**Optimus-AgenticBench Case A** with kvaware + kvd + MTP + PD + DP-attention all
on at once. The fixes were established across several debugging runs on two
clusters; this branch is the formalised subset, cut fresh off `main`.

Much of that work has already reached `main` by other routes — PR #58 (the DSA
set, since evolved by `1380228`), PR #56, and the individual fixes `786f238`,
`05841f9`, `b398268`+`c178b69`, `e190d65`, `2c31a3f`. **None of it is
re-carried here.** In particular `main`'s NodePort guard and ready-timeout are
*stronger* than the versions that existed on the experiment branch, and its
`args.py` fp8 ordering is the correct one — all three were left alone.

**Supersedes #59**, which carried items 6–9 below against an older `main` plus
experiment packups. Close that one when this merges.

## The commits, by kind

### Engine correctness — the image crashes without these (2)

Both patch vendor SGLang inside the image at build time; neither touches infera
runtime code. Both are ROCm-only defects where the CUDA path is correct by
accident of a platform difference, which is why upstream CI cannot see them.

| commit | fix | symptom without it |
|---|---|---|
| `9929c94` | `GLM52_P1V3` — the DSA indexer row count diverges in **both** directions | `Expected lengths.size(0) == B` kills a decode scheduler rank, router drops to `active_workers: 1`. Reproducible ~13 min into Case A |
| `b1d8103` | ROCm hicache host allocator → `hipHostMalloc` | `Memory access fault by GPU node-N on address <host VA>` the moment kvd writes back; gfx950 is `xnack-`, so a hard abort |

### infera correctness — startup failure or silent degradation (3)

| commit | fix | symptom without it |
|---|---|---|
| `7e9cf0d` | don't append the decode radix cache under speculative decoding | SGLang rejects the flag outright: the MTP decode leg **dies during argument parsing**, before loading a weight |
| `30300ad` | randomise the free-port-block scan start | two PD legs on one host deterministically pick the same base; the second dies with `ZMQError: Address already in use` |
| `f0c328d` | strip the bind-mount `[subpath]` from the findmnt source | `lsblk` says "not a block device", so kvd's L3 **silently** degrades to buffered on hardware that qualifies for O_DIRECT |

### Behavioural optimisation — not a bug fix (1)

`4b14403` — skip kvd wiring on a PD decode leg. SGLang issues no storage
prefetch on the decode branch, so L3 there is write-only: measured at 180 sets /
0 gets against a prefill leg's 102/102 on the same run. Saves host memory and
D2H bandwidth.

### Tests for fixes already on `main` (2)

Neither carries production code.

| commit | covers |
|---|---|
| `fc11a73` | `main`'s `05841f9` Python bigram decode — 175 lines of behavioural coverage |
| `618bfec` | `main`'s Rust `as_u32_any`. `main` has the in-crate unit test but not the real-socket path, which is where a live deployment meets it — and the failure is **silent** (view stays empty, `cache_hits` pinned at 0, nothing errors) |

### Docs and patch bookkeeping (5)

`157d535` kvd is no longer vLLM-only in the feature matrix, plus the SGLang
section · `aabcb0c` a 276-line operator guide for KV-aware + kvd · `7909361` a
README for `deploy/docker/`, which had none · `21a860b` corrects a stale
portability claim about patch 01 · `28319cf` gives the ROCm allocator patch the
upstream-status block and index row that `deploy/docker/README.md` requires of
every patch · `e995e07` compresses over-long inline comments, scrubs cluster
identifiers, and records two upstream PRs that collide with patch 01's anchors
(see *Review follow-ups*).

### Added then dropped (2)

`4f9834d` added `Dockerfile.sglang.kvaware-kvd`; `97c2ff5` removed it again
along with its two doc references. It was contents-identical to
`Dockerfile.sglang`, so it bought a second file to keep in sync and nothing
else. Net effect on the tree is zero — left as two commits rather than a
rewrite, since the branch is already under review.

## Size

22 files, +1565/−69. Under `infera/` the whole change is **4 files, +87 lines**;
the two engine patches plus their README are +428 but live entirely in
`deploy/docker/patches/`. The remaining ~1000 lines are tests (514) and docs.
No experiment packups.

## Verification

**Patch 01 applies to the pinned base, and the build script proves it.** Run
end-to-end against a clean `v0.5.15.post1` `dsa_indexer.py` exported from a real
SGLang checkout (not `--dry-run`, not `git apply --check`):
`apply_sglang_dsa_patches.sh` with `DSA_PATCH_SET=indexer` applies the patch,
byte-compiles it, finds both markers in the **bytecode**, and exits 0. A second
run reports "already present" — idempotent.

**The second marker discriminates.** `21a860b`'s companion change (already in
`9929c94`) added `_p1v2_rows` beside `_p1v2_trim` because the latter alone could
not tell the one-directional revision from the fixed one. Confirmed by applying
`main`'s *pre-P1V3* patch 01 and running the same verification: `_p1v2_trim`
pyc=1 — it would have passed — while `_p1v2_rows` pyc=0 fails the build. The
extra marker is load-bearing, not decorative.

**The `ke_offset` route is a real, precedented API.** Read against the pinned
base: `ke_offset` is an existing parameter of `DSAIndexerMetadata.topk_transform`
whose sole effect is to override `seq_lens_topk` (`dsa_backend.py:310-311`), it
is already used that way at `dsa_indexer.py:1217`, and `DSAIndexerMetadata` is
the only concrete implementation — so no third-party subclass can hit a
`TypeError` on the added kwarg.

**Both new infera fixes fail without the fix.** Verified with a revert harness
rather than by inspection, since a test that passes on the pre-fix code proves
nothing: removing the decode-leg guard makes
`test_decode_leg_gets_no_hicache_flags` fail; removing the randomisation makes
10 consecutive `free_tcp_port_block(4)` calls return the identical base 29996
and fails `test_repeated_calls_do_not_all_collide`. Restored, 73 tests pass.

**Upstream status re-queried 2026-08-03**, not taken from the header: #33059,
#32762, #31683 OPEN; #30378, #30427 MERGED — all matching what the patch header
claims. For the ROCm allocator, upstream `main`'s `pool_host/common.py` was read
directly: `ALLOC_MEMORY_FUNCS` still overrides only `"npu"` and `"musa"`, no HIP
entry, so main is affected too.

The two ROCm engine patches were each measured on hardware before being
formalised here — the allocator by a standalone micro-repro of the exact kernel
that faults and un-faults on the allocator alone, and `GLM52_P1V3` by two
independent Case A crashes followed by two clean ~4,000 s windows on two
different clusters.

## Review follow-ups

Found reviewing this branch against the repo's own conventions. All
documentation-only, all fixed in-branch:

- `21a860b` — the build script and the gfx942 recipe still described patch 01 as
  having "two edit sites, byte-identical on both releases". It has five, and only
  the `GLM52_P1V2` ones were re-read against v0.5.16. The gfx942 image is the one
  arm that depends on that claim, so the two files a reader consults before
  bumping that base were the two still asserting the stronger version.
- `28319cf` — `deploy/docker/README.md`, added in *this* branch, requires every
  patch to carry its upstream issue/PR and a row in `patch.upstream.status.md`.
  The `sglang_rocm` patch added in this same branch had neither.
- `e995e07` — three things at once, since they touched the same text:
  **(a)** nine inline comment blocks ran over the 3-line limit, up to 29 lines.
  Compressed to what/why/how, with the case analysis and the rejected
  `0 < q_offset` variant moved to the patch header and README rather than
  deleted — that variant passes every functional test, so losing the note
  invites a retry. **(b)** two cluster names, three pointers to scripts that
  exist only in a private workspace, and an internal workload name were still
  in files headed for a public repo; replaced with this README's existing
  "internal reproduction kit, ask the patch author" convention, keeping the
  evidence-strength qualifiers. **(c)** searching for the *function* rather than
  the symptom surfaced two OPEN upstream PRs that rewrite what patch 01 anchors
  on — [#32738](https://github.com/sgl-project/sglang/pull/32738) (pads heads at
  the same two aiter call sites) and
  [#31480](https://github.com/sgl-project/sglang/pull/31480) (extracts the
  paged-MQA backend, restructuring the `is_aiter()` dispatch). Neither fixes
  this defect; both drift the anchors, which fails the build rather than
  mis-applying. This is precisely the `gh search` blind spot the header warns
  about, and the P1V3 half had never been searched on its own terms before —
  it now has been: still no upstream issue or PR.

## What is NOT established yet

**Patch 01's `GLM52_P1V3` anchor on the gfx942 v0.5.16 base.** Verified on
`v0.5.15.post1` (above); on v0.5.16 it has been *reasoned about* — the added
`_mask_init_and_local_tokens` call sits before rather than inside the anchored
`topk_transform` call — but not measured, because there is no v0.5.16 checkout
here. A drift writes nothing and exits 1, so the failure mode is a failed build,
not a mis-applied patch. The patch header, the build script and the README all
now say this rather than claiming both bases are covered.

**The Rust wire-level test (`618bfec`) has not been compiled.** The dev
workstation's cargo is 1.75 and cannot read this repo's v4 `Cargo.lock`
(`-Znext-lockfile-bump`). It is purely additive and `rust/router/src/` is
untouched, but neither its compilation nor its own pre-fix failure has been
demonstrated. CI is the gate.

**`test_decode_radix_vs_speculative.py` did not execute here** — it is
`importorskip("sglang")` and skips outside the engine image. Its third case
depends on SGLang's own `ServerArgs.__post_init__` raising, which is external
behaviour.

Cluster acceptance — build, kvd/kvaware feature proofs, Case A — runs next; I
will post results on this PR.

## Deliberately out of scope

Prefill `--mem-fraction-static` 0.88 → 0.80 (an experiment-environment value,
not a defect — it stays in the reproduction kits) and the kvd `--long-bytes`
512G → 64G value (a single node's disk artefact, verified inapplicable
elsewhere).
