### PR TITLE
docs(recipes): correct the port-collision note — the fix landed on main

### DIFF
--- a/examples/recipes/glm5.2/README.md
+++ b/examples/recipes/glm5.2/README.md
@@ -149,7 +149,7 @@ rocm-smi --showpids
 | **`aggregated/deploy.yaml` exactly as written** | **validated end-to-end on k3s (MI355X, 8×`amd.com/gpu`)** — see below |
 | kvd sidecar + PVC L3 under SGLang | validated (3674 entries / 421 MB), on Qwen3-0.6B — but see the py310 native-tree note above |
 | `disaggregated/deploy.yaml`, `model-cache` swapped for per-node hostPath | **validated cross-node** — both roles Ready in ~4 min, 0 restarts, correct answer, and the decode side logged only `Decode batch` (never `Prefill batch`), so the KV handoff was real rather than failing open |
-| `disaggregated` + decode-side DP attention | **validated** — `--dp-size 2 --enable-dp-attention` on the decode role only, Ready in ~3 min, 3/3 requests, both attention ranks active, 0 port collisions |
+| `disaggregated` + decode-side DP attention | **validated** — `--dp-size 2 --enable-dp-attention` on the decode role only, Ready in ~3 min, 3/3 requests, both attention ranks active. It saw no port collision, but the run predates the randomised scan start in `free_tcp_port_block` and a cross-node pair cannot produce that collision anyway — it needs two engines on one host |
 | `disaggregated/deploy.yaml` **as shipped** | **cannot work** — its `model-cache` PVC is ReadWriteOnce on `local-path`, so it is pinned to one node and the other role cannot mount it. See the manifest header |
 | `disaggregated-kvd` | not run |
 

--- a/examples/recipes/glm5.2/disaggregated/deploy.yaml
+++ b/examples/recipes/glm5.2/disaggregated/deploy.yaml
@@ -39,9 +39,11 @@
 # the decode role only (keeping `--tp-size 8`, since SGLang's tp-size stays the
 # total) came up in ~3 min with 0 restarts, served 3/3 requests, kept the same
 # `Decode batch`-only signature, and exercised both attention ranks (DP0 and DP1
-# both logged). No `Address already in use` -- but note that the port-block
-# collision that `free_tcp_port_block` guards against needs two engines on ONE
-# host, which this cross-node topology does not exercise.
+# both logged). No `Address already in use`, though that run predates the fix in
+# `free_tcp_port_block` and so proves less than it looks: the collision that
+# function guards against needs two engines on ONE host, and a cross-node PD pair
+# never exercises it. The scan start is randomised on main now, so the risk is
+# retired either way.
 ---
 apiVersion: infera.amd.com/v1alpha1
 kind: InferaDeployment


### PR DESCRIPTION
The GLM-5.2 header recorded "No `Address already in use`" from the DP-attention run, worded so it reads as *"main has this bug and we did not trip it"*. Two things are wrong with that now.

**The run predates #79**, which landed the randomised scan start in `free_tcp_port_block` on main — the same fix #59 carried. The risk is retired, not merely untriggered.

**And the observation proved less than the wording implied even at the time.** That collision needs two engines on **one** host; a cross-node PD pair cannot produce it. Recording a clean result from a topology that cannot fail the test reads as evidence when it is not.

Both the manifest header and the README table now say so.
