### PR TITLE
docs(examples): add a GLM-5.2 1P1D SGLang deployment example

### DIFF
--- a/examples/sglang_1p1d_glm5.2/README.md
+++ b/examples/sglang_1p1d_glm5.2/README.md
@@ -1,0 +1,344 @@
+# GLM-5.2-MXFP4 — SGLang 1P1D + DP-attention + MTP on MI355X
+
+Runnable deployment kit for **GLM-5.2-MXFP4** served the infera way: one **prefill**
+node and one **decode** node, KV moved between them over **Mooncake RDMA**, fronted
+by the **infera router**, with **DP-attention**, **MTP** (EAGLE speculative decoding)
+and the **kvd** cache tiers all on.
+
+Two files in [`cluster/`](cluster/) hold everything site-specific. Fill in one of
+them and the deployment is three commands.
+
+```bash
+bash preflight_rdma.sh mode                  # which wrapper do I need?
+bash cluster/cluster.peermem.sh up           # (or cluster.dmabuf.sh) — bring it up
+bash cluster/cluster.peermem.sh smoke        # prove it works
+```
+
+Measured performance for this exact shape, under two independent agentic benchmarks
+on two different fabrics, is in [`results/`](results/README.md).
+
+## Contents
+
+| path | what |
+|---|---|
+| [`cluster/`](cluster/README.md) | **the only files you edit.** Two wrappers, one per RDMA fabric type |
+| `common.sh` | shared helpers — container, etcd, router, health polling, teardown |
+| `engine/leg.sh` | the real launcher for one PD leg. The tuned recipe lives here; no site values do |
+| `engine/up.sh` | bring up both nodes: containers → etcd + kvd → both legs → router |
+| `engine/smoke.sh` | service check **plus** positive evidence for each of the five features |
+| `engine/bench.sh` | reference throughput sweep using SGLang's own `bench_serving` |
+| `engine/down.sh` | tear down and wait for VRAM to actually free |
+| `preflight_rdma.sh` | RDMA preflight: registration-mode probe + cross-node fabric measurement |
+| [`results/`](results/README.md) | measured agentic-benchmark numbers at concurrency 8 |
+
+## Topology
+
+```
+node-P                                        node-D
+├─ etcd                    ◀── discovery ──▶
+├─ infera router  :8100    ◀── clients
+├─ kvd daemon                                 
+└─ prefill leg    :30000   ══ KV over RDMA ══▶ decode leg :30001
+   TP8, DPA off,                                TP8, DPA on (dp8),
+   kvd L2/L3                                    MTP (EAGLE)
+```
+
+The router discovers both legs through etcd and pairs them — there is no static
+worker list to maintain. Clients only ever talk to `:8100`.
+
+## 1. Prerequisites
+
+**Hardware.** Two nodes, 8× MI355X (gfx950) each, on a **mutually routable RoCE
+fabric**. The KV handoff is RDMA and there is no TCP fallback worth having — over TCP
+the pair is slower than a single node.
+
+**Weights.** GLM-5.2-MXFP4 (~400 GB) on **each** node.
+
+**Image.** An infera-sglang build **newer than 0.2.0**. `<infera-sglang-image>` is a
+placeholder wherever it appears below — substitute that tag. Both nodes must run the
+same image.
+
+**Docker with GPU + RDMA access**, and a way to run a command on each node
+(`ssh` by default — see [`cluster/README.md`](cluster/README.md#schedulers-where-ssh-node-does-not-work)
+if your scheduler blocks it).
+
+## 2. Verify the RDMA fabric first
+
+PD moves the KV cache across the fabric on **every request**, and every way that can
+go wrong is silent. A container that cannot see the RDMA devices does not raise —
+Mooncake falls back to a transport that works and is merely 5–20× slower. Run the
+preflight before the bring-up, not after the numbers disappoint you.
+
+### 2.1 Registration mode — this also picks your wrapper
+
+```bash
+IMAGE=<infera-sglang-image> bash preflight_rdma.sh mode
+```
+
+Per RDMA NIC it reports **vendor, link speed, ODP, PCI BDF, NUMA node and GID
+index**; per node it reports whether a **peer-memory module** is loaded and whether
+the image's Mooncake engine has dma-buf compiled in. It then enumerates the three
+registration modes, each marked viable or blocked **with the reason**, and prints the
+exact env and launch flags for the one it picks.
+
+| what it reports | which wrapper | why |
+|---|---|---|
+| `peermem: present` → **mode A** | [`cluster/cluster.peermem.sh`](cluster/cluster.peermem.sh) | bare `ibv_reg_mr` hands the NIC the GPU pages directly: nothing pinned, KV pool not duplicated, **every** rail carries KV |
+| `peermem: absent` + an ODP NIC → **mode B** | [`cluster/cluster.dmabuf.sh`](cluster/cluster.dmabuf.sh) | dma-buf is the only GPUDirect path without peer-mem, and it is only safe on an ODP NIC — so KV gets locked to that one NIC. A fallback, not a target: see below |
+| only **mode C**, or nothing viable | **stop and decide** | mode C pins and **doubles** the KV pool; it needs an explicit cap computed for your model/TP/VRAM. Preflight exits `2` here on purpose — it is a human decision, not a default |
+
+Then copy the reported `MC_GID_INDEX`, device list and dma-buf setting into the
+wrapper. The report is the source; do not guess these.
+
+**Mode B's single NIC is a constraint, not a design choice.** Locking KV to one
+card is what makes dma-buf *safe* without peer-mem — a non-ODP rail would pin the
+registration and duplicate the KV pool in VRAM. But it costs whatever bandwidth
+the node's other rails would have carried, and on a node with fast non-ODP rails
+that cost is large: preflight prints an explicit
+`*** PERFORMANCE REGRESSION ***` line naming both numbers when it picks this mode.
+Expect to see it, and read it as the price of the mode rather than as a
+misconfiguration.
+
+**If mode A is available, prefer it** — every rail carries KV, nothing is pinned.
+Mode B is what you run when no peer-memory module is loaded and loading one is not
+an option. Both wrappers configure the *same* deployment shape; only the transport
+differs, so switching later means editing the wrapper, not the recipe.
+
+Two of these values bite in ways worth knowing in advance:
+
+- **`MC_GID_INDEX` is per node, not per cluster.** Two identical machines routinely
+  expose the routable GID at different indices, because an empty slot on one shifts
+  everything after it. A wrong index fails loudly (`GID is NULL`, on every DP rank,
+  at init) — cheap to catch, expensive to assume. The link-local `fe80::` GID is
+  never the answer; it is not routable across the fabric.
+- **A down rail must not be listed.** Enumerate what is actually `PORT_ACTIVE` on
+  **each** node; the two can legitimately differ.
+- **A rail visible in `/sys` is not necessarily usable by the engine** — only the
+  vendor provider libraries the image ships can open one, so `ibv_devinfo` inside
+  the container may report far fewer cards than the host lists. Preflight runs
+  there for that reason; believe its verdict over the host's view.
+
+### 2.2 Cross-node fabric — the check that catches silent TCP
+
+Device visibility does not prove the two nodes can move KV between them. This does,
+one task per node into a shared directory:
+
+```bash
+export IMAGE=<infera-sglang-image> DUMP_PATH=<fresh-shared-dir>
+srun --nodelist=<node-P>,<node-D> -N2 --ntasks-per-node=1 bash preflight_rdma.sh fabric
+```
+
+It produces a cross-node RoCE bandwidth matrix (`ib_write_bw`) and — the rows that
+matter for PD — **Mooncake KV-transfer bandwidth measured separately over `rdma` and
+over `tcp`**. A fabric that will silently serve at TCP speed therefore appears as a
+number here, rather than as a deployment that is inexplicably slow later.
+
+Use a **fresh** `DUMP_PATH` each run: rank 0 decides everyone has reported by counting
+`*.json` files, so a stale file makes it render early.
+
+## 3. Configure
+
+Open the wrapper the preflight pointed you at and fill in the four blocks: nodes,
+image and weights, transport, deployment shape. [`cluster/README.md`](cluster/README.md)
+walks through every field.
+
+**Everything site-specific is in that one file.** `common.sh` and `engine/*.sh`
+contain no addresses, paths, NIC names or GID indices at all. If you find yourself
+editing an engine script to adapt to your cluster, something is wrong — say so, it is
+a bug in this kit.
+
+## 4. Deploy
+
+```bash
+bash cluster/cluster.peermem.sh up
+```
+
+That runs, in order: containers on both nodes → etcd and kvd on the prefill node →
+both legs concurrently → wait for both to serve → the router.
+
+**Cold start is minutes** — ~400 GB of weights plus CUDA-graph capture. Silence is
+not a hang; `up.sh` polls `/health` patiently and reports elapsed time as it goes.
+Both legs are launched before either is awaited, so they load in parallel.
+
+## 5. Verify
+
+```bash
+bash cluster/cluster.peermem.sh smoke
+```
+
+A green `/health` proves the process is alive — not that PD paired, that KV moved
+over RDMA, or that speculative decoding is doing anything. `smoke` checks each of
+those with a signal that would go **red** if the feature were silently absent:
+
+| feature | what is checked | healthy reading |
+|---|---|---|
+| **router + PD pairing** | `/v1/workers` | two workers, one prefill and one decode |
+| **serving + DSA correctness** | one chat completion | a correct, coherent answer |
+| **mooncake over RDMA** | `MC_FORCE_TCP` and `GID is NULL` counts in both leg logs | **0** and **0** |
+| **DP-attention** | resolved `dp_size` / `enable_dp_attention` per leg | matches what you configured |
+| **MTP** | `accept len` on the decode leg | roughly **2–3** |
+| **kv-aware / kvd** | router policy line; kvd adapter count and counters | one adapter per DP rank on the kvd leg |
+
+Two of those readings are counter-intuitive:
+
+- **Garbage or repeated tokens from the chat completion** is not a sampling problem.
+  It is the signature of the DSA-on-ROCm env block not taking effect — the model
+  serves, it just computes sparse attention on a path that is not ported to this
+  architecture.
+- **An MTP acceptance length of a steady 4.00 is bad news, not a good result.** It
+  means the draft model is predicting a repetition loop perfectly, i.e. the output has
+  degenerated. 2–3 is the healthy band.
+
+The completion check asks a one-line question but sends `max_tokens: 512`, which is
+deliberate. GLM-5.2 is a thinking model and the leg passes `--reasoning-parser glm45`,
+so the chain of thought lands in `reasoning_content` — but it is billed against the
+**same** budget. At a small value the model spends every token thinking, `content`
+comes back empty with `finish_reason: "length"`, and the check reads as a failure on a
+deployment that is serving correctly.
+
+### Reference sweep
+
+```bash
+bash cluster/cluster.peermem.sh bench 8 16 32
+```
+
+This uses SGLang's own `bench_serving`, which ships inside the image. Three of its
+flags are load-bearing in ways that are not obvious from the flag name:
+
+- **`--random-range-ratio 1.0`** pins every prompt to exactly `ISL`. The default draws
+  uniformly, and the percentiles then mix request sizes — a fixed-length sweep wants a
+  delta, not a distribution.
+- **`--temperature 1.0 --top-p 0.95`** are the checkpoint's own `generation_config`
+  defaults, and are deliberately *not* greedy. At temperature 0 this reasoning model
+  falls into repetition on a long prompt, MTP then predicts the loop perfectly,
+  acceptance length pins at 4.00, and the run reads like KV corruption.
+- **`--cache-report`** needs the server's `--enable-cache-report` (`engine/leg.sh`
+  passes it). Its column is nonetheless meaningless on this dataset: `--dataset-name
+  random` builds every prompt independently, so there is **no shared prefix by
+  construction** and any nonzero value is residue from the previous round. Prefix reuse
+  is an agentic-workload property — see [`results/`](results/README.md).
+
+`--num-prompts` is recomputed per concurrency (`10 × C`), so each arm of a sweep gets
+enough requests to reach steady state.
+
+**This kit ships no agentic benchmark client**, by design. `results/` documents what
+the agentic numbers look like and how to point the customer's harness at this
+deployment.
+
+## 6. Tear down
+
+```bash
+bash cluster/cluster.peermem.sh down
+```
+
+It removes the containers and then **waits** for VRAM to drain, printing
+`rocm-smi --showpids` so you can see it happen. Relaunching before that completes
+OOMs on a box that looks idle — the wait is the point, not the kill.
+
+## Recommended configuration
+
+The shipped defaults, and what each one is for:
+
+| knob | prefill | decode | why |
+|---|---|---|---|
+| `--tp-size` | 8 | 8 | one node each |
+| DP-attention | **off** | **on** (dp8) | see below |
+| MTP (EAGLE) | off | **on** | decode-only is the validated configuration |
+| `--ep-size` | 8 | 8 | **always**, independent of DP-attention |
+| `--mem-fraction-static` | **0.70** | 0.85 | see below |
+| `--chunked-prefill-size` | 65,536 global | — | a global budget, not per-rank |
+| `--context-length` | 262,144 | 262,144 | covers a 260K-token input clamp |
+| kvd (L2 host RAM + L3) | **on** | off | off on decode by design |
+| router policy | `kv-aware` (pw 20.0 / dw 2.0) | | |
+| custom all-reduce | **disabled** | **disabled** | see below |
+
+**Prefill DP-attention off.** In the measured pair, the arm with prefill DPA off
+carried 25 % more throughput at lower latency across every percentile. That
+comparison moved two variables at once (DPA *and* router policy) and cannot be split
+— but a separate single-variable comparison at concurrency 1 found DP-attention
+costing 1.65–1.93× on TTFT, and the direction agrees. Decode keeps DPA on: it is
+where the 8 attention ranks earn their keep.
+
+**Router policy and prefill memory are coupled**, which is documented nowhere else.
+Under `round-robin`, 4–5 DP ranks prefill concurrently — each holding its own chunk's
+activations — where `kv-aware` concentrates on 1–2. The round-robin arm **would not
+boot** at `--mem-fraction-static 0.80` and needed 0.70. **If you switch to
+`round-robin`, lower `GMU_PREFILL`.** That is why 0.70 is the shipped default rather
+than the higher value a kv-aware-only deployment could sustain.
+
+## Notes & gotchas
+
+**1. `--ep-size` and `--enable-dp-attention` are different parallelism axes.** Expert
+parallelism vs attention parallelism. Gating both on one condition means turning
+DP-attention off also collapses the MoE from ep8 to the TP default — so a deployment
+billed as "DPA off" differs in the expert-dispatch collective too, and no latency
+delta is attributable to either. `engine/leg.sh` emits `--ep-size` unconditionally.
+
+**2. `--chunked-prefill-size` is a GLOBAL budget, and DP-attention divides it.**
+SGLang divides it by `dp_size` **only** when DP-attention is on — a division, not a
+clamp, though the engine's own warning text reads like a clamp. At dp8 a requested
+65,536 resolves to 8,192 per rank while staying 65,536 machine-wide. One value serves
+both modes; hardcoding the per-rank number in a DPA-off branch cuts the global budget
+8×.
+
+**3. Prefill activation OOM is fixed by LOWERING `--mem-fraction-static`.** This is
+the opposite of the decode-side fix and it costs real debugging time to rediscover.
+Diagnose by phase:
+
+| phase | symptom | direction |
+|---|---|---|
+| decode | retract / `get_cpu_copy NotImplementedError` | **raise** |
+| prefill | `HSA_STATUS_ERROR_OUT_OF_RESOURCES` / `Aborted` at **low** token usage | **lower** |
+
+Low token usage at the moment of the abort is the tell: the KV pool is nearly empty,
+so it was never KV exhaustion — it is activation memory, which lives in the
+`1 - mem_fraction_static` remainder.
+
+**4. Custom all-reduce is disabled, and independently of MTP.** The aiter custom
+all-reduce kernel deadlocks on this architecture during speculative verify. Letting
+the switch follow MTP would make any "MTP on vs off" comparison a two-variable one.
+
+**5. The DSA-on-ROCm env block is mandatory on gfx950.** Without
+`SGLANG_OPT_USE_TILELANG_INDEXER=1`, `SGLANG_OPT_USE_TOPK_V2=0` and
+`SGLANG_OPT_USE_JIT_NORM=0` the model still serves and still returns 200s — it just
+returns garbage. `engine/leg.sh` sets them; `smoke` catches it if they did not take.
+
+**6. MTP and decode-side radix cache are mutually exclusive upstream.** SGLang raises
+on `--disaggregation-decode-enable-radix-cache` together with
+`--speculative-algorithm`. Consequence: `decode_prefix_len` is always 0, so **every
+turn re-transfers the entire prompt KV**, and a prefill-side cache hit saves *compute*,
+not *bytes*. This is why fabric bandwidth matters on long-prompt agentic workloads
+even at a 89 % cache-hit rate.
+
+**7. kvd's sizes are absolute on purpose.** `--hicache-size` is in GB, not a ratio:
+SGLang's ratio-based default sizes the host pool off `max_total_num_tokens` and can
+compute to hundreds of GB **per DP rank**, and a TB-scale pinned host allocation can
+wedge a node at kernel level. Likewise kvd's L3 `--long-bytes` — it writes to a
+container-local path, so an oversized budget fills the node's root filesystem, after
+which every `docker exec` fails with `no space left on device` and the node reads as
+broken rather than full.
+
+**8. `Ctrl-C` on a log tail does not stop anything.** Use `down`, and check
+`docker ps`.
+
+## Validation status
+
+Stated plainly rather than implied.
+
+| what | status |
+|---|---|
+| the deployment **shape** this kit encodes (1P1D + mooncake + DPA + MTP + kvd + kv-aware) | **validated end-to-end on two clusters**, both fabric types, with the agentic results in [`results/`](results/README.md) |
+| the tuned values (GMU, chunk, ctx, EAGLE settings, DSA env, router weights) | **validated** — each is carried over from a run that completed cleanly |
+| the three traps in Notes 1–3 | **first-hand**, each found by a run that failed or silently mis-measured |
+| **these scripts as written** | **validated** — `preflight_rdma.sh mode` → `up` → `smoke` → `bench` → `down` on a 2-node MI355X mode-B cluster, with no edits outside `cluster/cluster.dmabuf.sh`. Long context checked separately (needle, to 238K tokens) and under a real agentic workload at concurrency 8 |
+| `preflight_rdma.sh` | `mode` validated on both nodes and its verdict followed. `fabric` not exercised |
+| `cluster.peermem.sh`, `round-robin` routing | **not validated** — no peer-mem cluster was available, and the shipped `kv-aware` default is what ran |
+
+If you run this kit and it does not come up, that is worth reporting.
+
+## Source
+
+[`examples/sglang_1p1d_glm5.2/`](.) in [AMD-AGI/Infera](https://github.com/AMD-AGI/Infera)
+· [Kubernetes recipes for the same model](../recipes/glm5.2/README.md)
+· [PD disaggregation concepts](../../manual/features/pd_disaggregation.md)
+· [preflight reference](../../manual/reference/preflight.md)

--- a/examples/sglang_1p1d_glm5.2/cluster/README.md
+++ b/examples/sglang_1p1d_glm5.2/cluster/README.md
@@ -1,0 +1,140 @@
+# Adapt to your cluster — change things HERE
+
+Everything site-specific in this kit lives in one of the two wrapper files in this
+directory. `common.sh` and `engine/*.sh` carry the tuned recipe and contain no
+addresses, paths, NIC names or GID indices at all. **If you need to adapt the
+deployment to your cluster, edit a wrapper — not the engine scripts.**
+
+## Which wrapper?
+
+Run the mooncake-mode probe on one of your nodes first. It reads the node, not a
+config file, and prints which registration modes are viable:
+
+```bash
+bash preflight_rdma.sh mode
+```
+
+Then pick by what it says about **peer-mem**:
+
+| preflight says | wrapper | why |
+|---|---|---|
+| `peermem: present`, **mode A viable** | [`cluster.peermem.sh`](cluster.peermem.sh) | bare `ibv_reg_mr` hands the NIC the GPU pages directly — nothing pinned, KV pool not duplicated, **every** rail can carry KV |
+| `peermem: absent`, **mode B viable** (an ODP NIC exists) | [`cluster.dmabuf.sh`](cluster.dmabuf.sh) | dma-buf is the only GPUDirect path without peer-mem, and it is only safe on an ODP NIC; KV is locked to that one NIC |
+| **only mode C viable**, or nothing viable | *neither, yet* | mode C pins and **doubles** the KV pool and needs an explicit, model/TP/VRAM-specific cap. Preflight exits `2` in this case on purpose: it is a human decision, not a default. |
+
+The probe does not just classify — for the mode it picks it prints the exact env
+and launch flags. The wrapper fields below are a place to paste those values, not
+a puzzle to solve.
+
+## The fields you must fill in
+
+Both wrappers have the same four blocks. Placeholders read `<like-this>`.
+
+### 1. Nodes
+
+| var | what |
+|---|---|
+| `PREFILL_NODE` / `DECODE_NODE` | names the bring-up host can run a command on |
+| `PREFILL_IP` / `DECODE_IP` | each node's **data-plane** IP — the address on the KV network |
+| `KIT_DIR` | where this kit lives; must be the **same path on both nodes** |
+
+**The data-plane IP is not the management IP.** The legs advertise these addresses
+to each other and to the router for the KV handoff. A worker that advertises a
+non-routable address (`0.0.0.0`, `127.0.0.1`) is rejected at launch by infera's own
+config preflight, but a *wrong-but-routable* one is not — it just hangs.
+
+### 2. Image and weights
+
+| var | what |
+|---|---|
+| `INFERA_IMAGE` | the engine image — an infera-sglang build newer than 0.2.0. Ships as the placeholder `<infera-sglang-image>`. |
+| `MODEL_MOUNT` | host directory bind-mounted into the container |
+| `MODEL` | the checkpoint, which must live **under** `MODEL_MOUNT` |
+| `TOKENIZER` | usually the same path; the router loads it for kv-aware routing |
+| `HOST_RDMA_LIB` / `HOST_RDMA_MOUNT` / `ENTRYPOINT_KEEP` | only if your image injects a host RDMA provider library at entrypoint — see below |
+
+The checkpoint is ~400 GB and both legs read it during bring-up. Prefer local storage
+on both nodes: a slow mount can take an order of magnitude longer and blow the ready
+timeout — which presents as a crash loop, not as slow storage.
+
+**If your image injects a host RDMA provider library**, all three variables are
+required together. `HOST_RDMA_LIB` is the host path (point it at the *symlink*, so nodes
+carrying different provider builds both resolve); `HOST_RDMA_MOUNT` is the in-container
+path **that image's entrypoint reads**; `ENTRYPOINT_KEEP=1` keeps the entrypoint that
+does the injecting. Set only some of them and nothing happens — the library is mounted
+where nothing reads it, which is not an error. The failure is silent: the leg boots and
+serves, `ibv_devinfo` inside the container reports `does not support the kernel ABI` and
+finds **zero** devices, and mooncake moves KV over a 5-20× slower transport.
+`start_container` warns when the in-container device count is 0; that line is the check.
+
+### 3. Transport
+
+The block that differs between the two wrappers. Each field is a value to copy from
+the preflight report:
+
+| var | mode A | mode B |
+|---|---|---|
+| `RDMA_IB_DEVICES` | all `PORT_ACTIVE` rails, comma-separated | the single ODP NIC |
+| `MC_GID_INDEX` | the routable RoCEv2 GID index | same |
+| `MOONCAKE_DISABLE_HIP_DMABUF` | `1` | `0` |
+| `MC_MS_AUTO_DISC` / `MC_MS_FILTERS` | unset | `0` / the ODP NIC |
+| `RDMAV_FORK_SAFE` | `1` | only if non-ODP rails are also present |
+
+Two things about this block are worth knowing before you fill it in.
+
+**`MC_GID_INDEX` is per-node, not per-cluster.** Two identical nodes routinely expose
+the routable GID at different indices, because an empty slot on one shifts everything
+after it. A wrong index fails loudly (`GID is NULL, please check your GID index`, on
+every DP rank, at init) — cheap to catch, expensive to assume. If your nodes disagree,
+set it per node rather than once in the wrapper. The link-local `fe80::` GID (usually
+index 0) is never the answer; it is not routable across the fabric.
+
+**A down rail must not be listed.** `RDMA_IB_DEVICES` should enumerate what is
+actually `PORT_ACTIVE`, which is not always every card:
+
+```bash
+for d in /sys/class/infiniband/*; do
+  grep -q ACTIVE "$d/ports/1/state" && basename "$d"
+done | paste -sd,
+```
+
+Run it on **each** node — the two can legitimately differ.
+
+### 4. Deployment shape
+
+`TP`, `CTX`, `CHUNK`, the DPA/MTP/kvd switches, the router policy, and the two
+`mem-fraction-static` values. The defaults are the recommended production shape;
+the [main README](../README.md#recommended-configuration) explains what each one buys
+and which pairs are coupled.
+
+## Schedulers where `ssh <node>` does not work
+
+`engine/up.sh` reaches each node through `$SSH_CMD`, defaulting to
+`ssh -o StrictHostKeyChecking=no`. On a cluster where compute nodes are only
+reachable through the scheduler, point it at whatever does work:
+
+```bash
+export SSH_CMD="<your-scheduler> exec"
+```
+
+It is invoked as `$SSH_CMD <node> <command>`. If your scheduler's syntax does not
+fit that shape, run `engine/leg.sh` on each node yourself — it is a single command
+per leg and takes the same env vars.
+
+## What NOT to change
+
+`engine/leg.sh` encodes a recipe where several settings are coupled in ways that are
+not obvious, and where getting one wrong tends to produce a *plausible* result rather
+than an error:
+
+- `--ep-size` is emitted **unconditionally**, outside the DP-attention branch. They
+  are different parallelism axes (expert vs attention); coupling them means turning
+  DP-attention off silently collapses the MoE too.
+- `--chunked-prefill-size` is a **global** budget that SGLang divides by `dp_size`
+  only when DP-attention is on. One value serves both modes; a per-rank number
+  hardcoded in a DPA-off branch cuts the global budget 8×.
+- `--disable-custom-all-reduce` is on by default and **independent of MTP**, because
+  the custom all-reduce kernel deadlocks on this architecture during speculative
+  verify. Letting it follow MTP turns any MTP comparison into a two-variable one.
+- The DSA-on-ROCm env block is mandatory on gfx950. Without it the model still serves
+  — it just returns garbage.

--- a/examples/sglang_1p1d_glm5.2/cluster/cluster.dmabuf.sh
+++ b/examples/sglang_1p1d_glm5.2/cluster/cluster.dmabuf.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# ============================================================================
+#  EDIT THIS FILE. Nothing else in this kit needs changing for your cluster.
+# ============================================================================
+#
+# Wrapper B — NO PEER-MEMORY MODULE, GPUDirect VIA dma-buf ON AN ODP NIC.
+#
+# Use this when `python -m infera.tools.preflight.mooncake_mode` reports
+# **mode B viable** on your nodes, i.e.:
+#
+#     peermem : absent
+#     mode B  : VIABLE   ibv_reg_dmabuf_mr (GPUDirect dma-buf) on the ODP NIC (no-pin)
+#
+# Without a peer-mem module, dma-buf is the only GPUDirect path — and it is only
+# SAFE on a NIC with ODP (on-demand paging). On a NIC without ODP the driver PINS
+# the whole registered region, duplicating the KV pool in VRAM until a large pool
+# exhausts a KFD resource and the process dies. That is why KV is locked to the
+# ODP NIC below and not left to auto-discovery.
+#
+# Expect preflight to also print a `perf-regression` warning here if the ODP NIC
+# is slower or fewer than the node's fastest rails. That is the real cost of
+# no-pin dma-buf without peer-mem, and it is a fabric fact, not a misconfiguration.
+#
+# So: the one-NIC restriction is a FALLBACK, not a target. Mode A (peer-mem) uses
+# every rail and pins nothing; this mode exists for nodes where no peer-memory
+# module is loaded and loading one is not an option.
+#
+# If preflight instead reports "peer-mem present", use cluster.peermem.sh.
+# See cluster/README.md for the full mapping.
+#
+# Usage:  bash cluster/cluster.dmabuf.sh up | smoke | bench [conc...] | down
+set -euo pipefail
+KIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# 1. Nodes
+# ---------------------------------------------------------------------------
+# Each node's SSH-reachable name and its DATA-PLANE IP. Do NOT use the
+# management/public NIC — the legs advertise these to each other. If ssh to
+# compute nodes is blocked, set SSH_CMD (see cluster/README.md).
+export PREFILL_NODE="<prefill-host>"
+export DECODE_NODE="<decode-host>"
+export PREFILL_IP="<prefill-data-plane-ip>"
+export DECODE_IP="<decode-data-plane-ip>"
+
+# This kit must live at the SAME path on both nodes (a shared filesystem, or an
+# identical copy). up.sh runs engine/leg.sh from here on each node.
+export KIT_DIR="$KIT"
+
+# ---------------------------------------------------------------------------
+# 2. Image and weights
+# ---------------------------------------------------------------------------
+# Requires an infera-sglang build NEWER than 0.2.0. The default below is a placeholder.
+export INFERA_IMAGE="${INFERA_IMAGE:-<infera-sglang-image>}"
+
+# MODEL_MOUNT is bind-mounted into the container; MODEL must live under it.
+# Shared storage works but loads slowly — ~400 GB read by both legs at once.
+export MODEL_MOUNT="<host-dir-holding-the-weights>"
+export MODEL="$MODEL_MOUNT/GLM-5.2-MXFP4"
+export TOKENIZER="$MODEL"
+
+# ---------------------------------------------------------------------------
+# 3. Transport — mode B (dma-buf on the ODP NIC)
+# ---------------------------------------------------------------------------
+# Copy these straight out of the preflight report's mode-B block — it has
+# already checked ODP per card and confirmed dma-buf is compiled into the image.
+# ONE device, not a list, and both legs MUST name the same one.
+export RDMA_IB_DEVICES="<odp-nic-from-preflight>"          # e.g. mlx5_0
+
+# Lock mooncake to that device. With auto-discovery on, it would find the
+# non-ODP rails and register KV on one of them, which pins and doubles the pool.
+export MC_MS_AUTO_DISC=0
+export MC_MS_FILTERS="$RDMA_IB_DEVICES"
+
+# The RoCEv2 routable GID index for that NIC. Read it from preflight; the
+# link-local fe80:: GID is not routable across the fabric and is never the answer.
+export MC_GID_INDEX="<gid-index-from-preflight>"
+
+# dma-buf ON — the whole point of this mode.
+export MOONCAKE_DISABLE_HIP_DMABUF=0
+
+# Only needed when the node ALSO has non-ODP rails present. Uncomment if
+# preflight lists any.
+# export RDMAV_FORK_SAFE=1
+
+# ---------------------------------------------------------------------------
+# 4. Deployment shape — see the README's "Recommended configuration"
+# ---------------------------------------------------------------------------
+export TP=8
+export CTX=262144
+export CHUNK=65536                 # GLOBAL per-step prefill budget (see engine/leg.sh)
+
+export PREFILL_DPA=0               # prefill DP-attention: 0 = pure TP (recommended)
+export DECODE_DPA=1                # decode DP-attention:  1 = dp8
+export PREFILL_MTP=0               # MTP on prefill: leave off
+export DECODE_MTP=1                # MTP on decode: EAGLE speculative decoding
+
+export ROUTER_POLICY=kv-aware      # or round-robin — read the README first, the two
+                                   # are coupled to GMU_PREFILL
+export KVAWARE=1
+export PREFILL_KVD=1               # kvd L2/L3 on the prefill leg
+export DECODE_KVD=0                # off on decode by design
+
+export GMU_PREFILL=0.70
+export GMU_DECODE=0.85
+
+exec bash "$KIT/engine/${1:-up}.sh" "${@:2}"

--- a/examples/sglang_1p1d_glm5.2/cluster/cluster.peermem.sh
+++ b/examples/sglang_1p1d_glm5.2/cluster/cluster.peermem.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# ============================================================================
+#  EDIT THIS FILE. Nothing else in this kit needs changing for your cluster.
+# ============================================================================
+#
+# Wrapper A — MULTI-RAIL RDMA WITH A PEER-MEMORY MODULE.
+#
+# Use this when `python -m infera.tools.preflight.mooncake_mode` reports
+# **mode A viable** on your nodes, i.e.:
+#
+#     peermem : present
+#     mode A  : VIABLE   bare ibv_reg_mr + peer-mem (default, no-pin, every rail)
+#
+# In this mode registration hands the NIC the GPU pages directly: nothing is
+# pinned, the KV pool is not duplicated, and every active rail can carry KV.
+# dma-buf is therefore switched OFF — it would be strictly worse here.
+#
+# If preflight instead reports "no peer-mem module loaded", use
+# cluster.dmabuf.sh. See cluster/README.md for the full mapping.
+#
+# Usage:  bash cluster/cluster.peermem.sh up | smoke | bench [conc...] | down
+set -euo pipefail
+KIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# 1. Nodes
+# ---------------------------------------------------------------------------
+# Each node's SSH-reachable name and its DATA-PLANE IP. Do NOT use the
+# management/public NIC — the legs advertise these to each other for the KV
+# handoff. See cluster/README.md section 1.
+export PREFILL_NODE="<prefill-host>"
+export DECODE_NODE="<decode-host>"
+export PREFILL_IP="<prefill-data-plane-ip>"
+export DECODE_IP="<decode-data-plane-ip>"
+
+# Must be the SAME path on both nodes — up.sh runs engine/leg.sh from here.
+export KIT_DIR="$KIT"
+
+# ---------------------------------------------------------------------------
+# 2. Image and weights
+# ---------------------------------------------------------------------------
+# Requires an infera-sglang build NEWER than 0.2.0. The default below is a placeholder.
+export INFERA_IMAGE="${INFERA_IMAGE:-<infera-sglang-image>}"
+
+# MODEL_MOUNT is bind-mounted into the container; MODEL must live under it.
+# Prefer LOCAL storage on both nodes — a slow mount blows the ready timeout
+# (see cluster/README.md section 2).
+export MODEL_MOUNT="<host-dir-holding-the-weights>"
+export MODEL="$MODEL_MOUNT/GLM-5.2-MXFP4"
+export TOKENIZER="$MODEL"
+
+# If your image injects a host RDMA provider library at entrypoint, set all three: the
+# host library (the SYMLINK, so differing per-node builds resolve), the in-container path
+# THAT image reads, and the entrypoint. Any one alone silently does nothing — see §2.
+# export HOST_RDMA_LIB=/usr/lib/x86_64-linux-gnu/lib<provider>.so.1
+# export HOST_RDMA_MOUNT=/host-<provider>/lib<provider>.so ENTRYPOINT_KEEP=1
+
+# ---------------------------------------------------------------------------
+# 3. Transport — mode A (peer-mem, every rail)
+# ---------------------------------------------------------------------------
+# Copy these two values straight out of the preflight report's mode-A block.
+# RDMA_IB_DEVICES is every ACTIVE rail — a rail that is physically down must NOT
+# be listed, or every transfer targeting it fails. Enumerate per node; see §3.
+export RDMA_IB_DEVICES="<ionic_0,ionic_1,...>"
+
+# MC_GID_INDEX: the RoCEv2 GID index. It is NODE-dependent, not cluster-wide —
+# if your two nodes disagree, set it per node rather than here. The link-local
+# fe80:: GID (usually index 0) is NOT a fallback. Details: cluster/README.md §3.
+export MC_GID_INDEX="<gid-index-from-preflight>"
+
+# dma-buf OFF: with a peer-mem module loaded, bare ibv_reg_mr is the no-pin path.
+export MOONCAKE_DISABLE_HIP_DMABUF=1
+# Some providers need fork-safety enabled in libibverbs.
+export RDMAV_FORK_SAFE=1
+# MC_MS_FILTERS is deliberately unset: every rail is allowed to carry KV.
+
+# ---------------------------------------------------------------------------
+# 4. Deployment shape — see the README's "Recommended configuration"
+# ---------------------------------------------------------------------------
+export TP=8
+export CTX=262144
+export CHUNK=65536                 # GLOBAL per-step prefill budget (see engine/leg.sh)
+
+export PREFILL_DPA=0               # prefill DP-attention: 0 = pure TP (recommended)
+export DECODE_DPA=1                # decode DP-attention:  1 = dp8
+export PREFILL_MTP=0               # MTP on prefill: leave off
+export DECODE_MTP=1                # MTP on decode: EAGLE speculative decoding
+
+export ROUTER_POLICY=kv-aware      # or round-robin — read the README first, the two
+                                   # are coupled to GMU_PREFILL
+export KVAWARE=1
+export PREFILL_KVD=1               # kvd L2/L3 on the prefill leg
+export DECODE_KVD=0                # off on decode by design
+
+export GMU_PREFILL=0.70
+export GMU_DECODE=0.85
+
+exec bash "$KIT/engine/${1:-up}.sh" "${@:2}"

--- a/examples/sglang_1p1d_glm5.2/common.sh
+++ b/examples/sglang_1p1d_glm5.2/common.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+# what: shared helpers for the GLM-5.2 1P1D kit (env checks + container/etcd/router/smoke/reap).
+# why : one place for the infera-way bring-up so every script stays small and consistent.
+# how : sourced by engine/*.sh and preflight_rdma.sh; the cluster wrappers never source it.
+set -uo pipefail
+
+RED='\033[0;31m'; GRN='\033[0;32m'; YEL='\033[0;33m'; NC='\033[0m'
+log(){ echo -e "${GRN}[glm52]${NC} $*"; }
+warn(){ echo -e "${YEL}[glm52]${NC} $*" >&2; }
+die(){ echo -e "${RED}[glm52] ERROR:${NC} $*" >&2; exit 1; }
+
+# what: fail fast if a required env var is unset/empty. why: a 10-minute cold start is a
+# terrible place to discover a typo; every knob is set in cluster/<your-cluster>.sh.
+require_env(){ local v="$1" d="${2:-}"; [ -n "${!v:-}" ] || die "env '$v' is required${d:+ ($d)}. Set it in cluster/<wrapper>.sh — see cluster/README.md."; }
+
+# ---- defaults that are NOT cluster-specific ---------------------------------
+# Anything a site must change lives in cluster/*.sh, never here.
+: "${ETCD_PORT:=2379}"
+: "${ETCD_IMAGE:=quay.io/coreos/etcd:v3.5.14}"
+: "${ROUTER_PORT:=8100}"
+: "${PREFILL_PORT:=30000}"
+: "${DECODE_PORT:=30001}"
+: "${BOOTSTRAP_PORT:=8998}"
+: "${CTR:=glm52_pd}"
+: "${SERVED:=glm5.2-mxfp4}"
+: "${KVD_SOCK:=/tmp/kvd/kvd.sock}"
+
+# what: start the long-lived engine container (host net + GPU + IB), then sleep.
+# why : every infera command `docker exec`s into it, so a leg restart is cheap.
+# note: `--entrypoint ''` is deliberate — see ENTRYPOINT_KEEP in cluster/cluster.peermem.sh.
+start_container(){
+  require_env INFERA_IMAGE "the engine image"
+  require_env MODEL_MOUNT "host dir holding the weights, bind-mounted into the container"
+  local ep=(--entrypoint '')
+  if [ "${ENTRYPOINT_KEEP:-0}" = "1" ]; then ep=(); fi
+  local mounts=(-v "$MODEL_MOUNT:$MODEL_MOUNT")
+  # Only mount a host RDMA provider library if the site says it needs one.
+  # HOST_RDMA_MOUNT must be the in-container path YOUR image's entrypoint reads — mount it
+  # elsewhere and the injection silently no-ops: zero devices, and the leg still serves.
+  if [ -n "${HOST_RDMA_LIB:-}" ]; then
+    mounts+=(-v "$HOST_RDMA_LIB:${HOST_RDMA_MOUNT:-/host-rdma/$(basename "$HOST_RDMA_LIB")}:ro")
+  fi
+  docker rm -f "$CTR" >/dev/null 2>&1 || true
+  docker run -d --name "$CTR" --network=host --ipc=host --shm-size=32G \
+    --device=/dev/kfd --device=/dev/dri --device=/dev/infiniband \
+    --group-add video --group-add render --cap-add=SYS_PTRACE --cap-add=IPC_LOCK \
+    --security-opt seccomp=unconfined --ulimit memlock=-1:-1 \
+    "${mounts[@]}" "${ep[@]}" "$INFERA_IMAGE" sleep infinity >/dev/null \
+    || die "docker run failed for $CTR"
+  log "container '$CTR' up ($INFERA_IMAGE)"
+  docker exec "$CTR" python3 -c 'import torch;print("  gpu gate:", torch.cuda.is_available(), torch.cuda.device_count())' || true
+  # Zero devices is not an error — mooncake falls back to a 5-20x slower transport and the
+  # leg serves fine. Hence a warning, not a number to skim past.
+  # `grep -c` already prints 0 and exits 1; a `|| echo 0` would make the value read "00".
+  local nports
+  nports=$(docker exec "$CTR" bash -c 'ibv_devinfo 2>/dev/null | grep -c PORT_ACTIVE; true' | tr -d '\r\n')
+  echo "  RDMA PORT_ACTIVE visible in container: ${nports:-0}"
+  if [ "${nports:-0}" -eq 0 ]; then
+    warn "  NO RDMA device usable inside $CTR — KV will not move over RDMA."
+    warn "  docker exec $CTR ibv_devinfo; a 'does not support the kernel ABI' line means"
+    warn "  the provider mismatches the host driver — set HOST_RDMA_LIB + HOST_RDMA_MOUNT"
+    warn "  + ENTRYPOINT_KEEP=1 so the image's entrypoint injects the host build."
+  fi
+}
+
+# what: etcd on the prefill node. why: both legs and the router self-register here, so the
+# router pairs P and D with no static worker list.
+start_etcd(){
+  local ip="${1:?etcd advertise ip}" name="${2:-glm52-etcd}"
+  docker rm -f "$name" >/dev/null 2>&1 || true
+  docker run -d --name "$name" --network=host "$ETCD_IMAGE" etcd \
+    --advertise-client-urls "http://$ip:$ETCD_PORT" \
+    --listen-client-urls "http://0.0.0.0:$ETCD_PORT" >/dev/null || die "etcd start failed"
+  for _ in $(seq 1 30); do
+    curl -sf -m2 "http://$ip:$ETCD_PORT/health" >/dev/null 2>&1 && { log "etcd healthy ($ip:$ETCD_PORT)"; return 0; }
+    sleep 1
+  done
+  die "etcd not healthy in 30s"
+}
+
+# what: the infera router, inside $CTR on the prefill node.
+# why : the module is `infera.server`, NOT `infera.router` — the latter has no __main__.
+# how : POLICY=kv-aware|round-robin, coupled to GMU_PREFILL; kv-aware needs the tokenizer.
+start_router(){
+  local ip="${1:?router bind ip}"
+  require_env TOKENIZER "tokenizer path the router loads for kv-aware routing"
+  local policy="${ROUTER_POLICY:-kv-aware}" backend="${ROUTER_BACKEND:-rust}"
+  local kv_args=()
+  if [ "$policy" = "kv-aware" ]; then
+    # Cost = w * (request_blocks - hits) + active_blocks. Prefill is compute-bound and a hit
+    # skips an entire prefill pass, so its weight is high; decode is memory-bound on the KV
+    # transfer and gains little from a prefill-time hit, so route it by load.
+    kv_args=(--router-tokenizer-path "$TOKENIZER"
+             --kv-prefill-overlap-weight "${KV_PREFILL_W:-20.0}"
+             --kv-decode-overlap-weight "${KV_DECODE_W:-2.0}")
+  fi
+  # Kill a previous router by its own pid only. A bare `pkill -f infera.server` also matches
+  # the `docker exec bash -c ...` command string that CONTAINS that text — i.e. this shell.
+  docker exec "$CTR" bash -c "pgrep -f 'python3 -m infera.server' | xargs -r kill -9 2>/dev/null; true"
+  sleep 2
+  docker exec -d "$CTR" bash -c "nohup python3 -m infera.server \
+    --host 0.0.0.0 --port $ROUTER_PORT --router-backend $backend \
+    --discovery-backend etcd --etcd-endpoint $ip:$ETCD_PORT \
+    --request-transport http --kv-event-transport zmq \
+    --router-policy $policy ${kv_args[*]} > /tmp/router.log 2>&1"
+  wait_health "http://$ip:$ROUTER_PORT/health" 12 5 \
+    || { docker exec "$CTR" tail -30 /tmp/router.log; die "router did not come up"; }
+  log "router up on :$ROUTER_PORT (backend=$backend policy=$policy)"
+}
+
+# what: poll an HTTP endpoint until it answers. why: a leg's cold start is minutes and
+#       silence is NOT a hang. note: DO NOT grep the log for a ready line instead — logs
+#       are appended to across restarts, so a grep matches the PREVIOUS run and returns early.
+wait_health(){
+  local url="$1" tries="${2:-120}" gap="${3:-15}"
+  for i in $(seq 1 "$tries"); do
+    curl -sf -m5 "$url" >/dev/null 2>&1 && { log "$url serving after $((i * gap))s"; return 0; }
+    sleep "$gap"
+  done
+  warn "$url did NOT answer within $((tries * gap))s"
+  return 1
+}
+
+# what: kill engines in $CTR and wait for VRAM to drain. The WAIT is the point, not the kill.
+# why : the infera wrapper exits before its sglang child does, and that child keeps the KV
+#       event port block bound — the next leg dies with "port_base at N is not available".
+reap(){
+  docker exec "$CTR" bash -c '
+    pkill -9 -f "infera.engine.sglang" 2>/dev/null
+    pkill -9 -f "sglang.launch_server" 2>/dev/null
+    pkill -9 -f "multiprocessing.spawn" 2>/dev/null
+    for _ in $(seq 1 20); do
+      n=$(ps aux | grep -E "launch_server|infera.engine" | grep -v grep | wc -l)
+      [ "$n" -eq 0 ] && exit 0
+      sleep 2
+    done
+    echo "  WARNING: engines still present after 40s" >&2' 2>/dev/null || true
+  log "reaped engines in $CTR"
+}

--- a/examples/sglang_1p1d_glm5.2/engine/bench.sh
+++ b/examples/sglang_1p1d_glm5.2/engine/bench.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+# what: a REFERENCE throughput sweep against the router, using sglang's own bench_serving.
+# why : it ships inside the engine image, so there is nothing extra to install, and it is
+#       enough to confirm the deployment performs sanely. It is NOT the agentic benchmark —
+#       see results/ for what the agentic numbers look like and where those harnesses live.
+# how : bash cluster/<your-cluster>.sh bench [conc ...]
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; source "$DIR/../common.sh"
+
+require_env PREFILL_NODE; require_env PREFILL_IP; require_env MODEL
+SSH_CMD="${SSH_CMD:-ssh -o StrictHostKeyChecking=no}"
+URL="http://$PREFILL_IP:$ROUTER_PORT"
+ISL="${ISL:-8192}"
+OSL="${OSL:-1024}"
+CONCS="${*:-8}"
+OUT="${OUT:-/tmp/glm52_bench}"
+
+for C in $CONCS; do
+  # Recomputed per concurrency. A single $N reused across the sweep would leave the high
+  # arms with too few requests to reach steady state, and their percentiles unusable.
+  NPROMPTS="${N:-$((C * 10))}"
+  WARM=$([ "$C" -lt 8 ] && echo "$C" || echo 8)
+  TAG="glm52_isl${ISL}_osl${OSL}_c${C}"
+  log "=== $TAG ==="
+  # Three of the flags below are load-bearing in non-obvious ways (range-ratio, temperature,
+  # cache-report). Do not change them without reading "Reference sweep" in the README.
+  $SSH_CMD "$PREFILL_NODE" "docker exec $CTR bash -c 'mkdir -p $OUT && \
+    python3 -m sglang.bench_serving \
+      --backend sglang-oai-chat --base-url $URL \
+      --model $SERVED --tokenizer ${TOKENIZER:-$MODEL} \
+      --dataset-name random --random-input-len $ISL --random-output-len $OSL \
+      --random-range-ratio 1.0 \
+      --max-concurrency $C --num-prompts $NPROMPTS --request-rate inf \
+      --warmup-requests $WARM \
+      --cache-report --temperature 1.0 --top-p 0.95 \
+      --output-file $OUT/$TAG.jsonl --output-details 2>&1 | tail -30'"
+done
+
+log "bench done -> $PREFILL_NODE:$OUT/*.jsonl (per-request ttfts/itls are in the jsonl)"

--- a/examples/sglang_1p1d_glm5.2/engine/down.sh
+++ b/examples/sglang_1p1d_glm5.2/engine/down.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+# what: tear down the deployment on both nodes and wait for VRAM and ports to actually free.
+# why : relaunching before that drains OOMs on a box that looks idle. The WAIT is the point.
+# how : bash cluster/<your-cluster>.sh down
+set -uo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; source "$DIR/../common.sh"
+
+require_env PREFILL_NODE; require_env DECODE_NODE
+SSH_CMD="${SSH_CMD:-ssh -o StrictHostKeyChecking=no}"
+
+for h in "$PREFILL_NODE" "$DECODE_NODE"; do
+  [ -n "$h" ] || continue
+  # Removing the container kills its `sleep infinity` init, which reaps the engine children.
+  # Left alone they hold VRAM and the KV-event port block, and the next launch dies with
+  # "port_base at N is not available" — which reads as a bug, not as leftover state.
+  $SSH_CMD "$h" "docker rm -f $CTR glm52-etcd 2>/dev/null; \
+    pkill -9 -f 'infera.engine.sglang' 2>/dev/null; true" >/dev/null 2>&1 || true
+  log "torn down $h"
+done
+
+# Container removal returns before the GPU driver has released the memory.
+sleep 20
+log "checking VRAM released (a non-empty list means something is still holding it):"
+for h in "$PREFILL_NODE" "$DECODE_NODE"; do
+  echo "  --- $h ---"
+  $SSH_CMD "$h" "rocm-smi --showpids 2>/dev/null | tail -8" || true
+done
+log "teardown complete"

--- a/examples/sglang_1p1d_glm5.2/engine/leg.sh
+++ b/examples/sglang_1p1d_glm5.2/engine/leg.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+# what: launch ONE GLM-5.2 PD leg (prefill|decode) through the infera SGLang wrapper.
+# why : this is the real launcher. It carries the tuned recipe and NOTHING site-specific —
+#       every address, path, NIC name and GID comes in as an env var from
+#       cluster/<your-cluster>.sh. If you need to adapt to your cluster, edit THAT file,
+#       not this one.
+# how : runs ON the node, docker-execs into $CTR. Called by engine/up.sh.
+#
+# Feature switches (all default to the recommended production values):
+#   DPA=0|1     DP-attention on this leg
+#   MTP=0|1     EAGLE speculative decoding (decode leg only unless PREFILL_MTP=1)
+#   KVAWARE=0|1 publish KV events so the router can route by cache locality
+#   KVD=0|1     wire the infera-kvd HiCacheStorage backend (L2 host RAM + L3)
+set -uo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; source "$DIR/../common.sh"
+
+ROLE="${ROLE:?ROLE=prefill|decode}"
+require_env MY_IP   "this node's data-plane IP (the one peers and the router can reach)"
+require_env ETCD_IP "the node running etcd (by convention the prefill node)"
+require_env MODEL   "model directory, inside \$MODEL_MOUNT"
+require_env RDMA_IB_DEVICES "comma-separated RDMA device(s) mooncake may use, e.g. mlx5_0"
+
+TP="${TP:-8}"
+GPUS="${GPUS:-$(seq -s, 0 $((TP - 1)))}"
+CTX="${CTX:-262144}"
+MAX_RUNNING="${MAX_RUNNING:-2048}"
+CUDA_GRAPH_BS="${CUDA_GRAPH_BS:-128}"
+HICACHE_GB="${HICACHE_GB:-32}"
+KV_PUB_PORT="${KV_PUB_PORT:-5557}"
+KV_SNAP_PORT="${KV_SNAP_PORT:-8801}"
+
+if [ "$ROLE" = "prefill" ]; then
+  PORT="${PORT:-$PREFILL_PORT}"; DPA="${DPA:-0}"; MTP="${MTP:-0}"; KVD="${KVD:-1}"
+else
+  PORT="${PORT:-$DECODE_PORT}";  DPA="${DPA:-1}"; MTP="${MTP:-1}"; KVD="${KVD:-0}"
+fi
+KVAWARE="${KVAWARE:-1}"
+LOG="${LOG:-/tmp/glm52_${ROLE}.log}"
+
+# Role-asymmetric, and the direction is counter-intuitive: a prefill OOM is fixed by LOWERING
+# this, a decode retract by raising it. Also coupled to DPA and to the router policy.
+# 0.70/0.85 is safe across every combination measured on MI355X. Diagnosis: README note 3.
+GMU_PREFILL="${GMU_PREFILL:-0.70}"
+GMU_DECODE="${GMU_DECODE:-0.85}"
+[ "$ROLE" = "prefill" ] && GMU="${GMU:-$GMU_PREFILL}" || GMU="${GMU:-$GMU_DECODE}"
+
+# A GLOBAL budget that SGLang divides by dp_size only when DP-attention is on. One value
+# serves both modes; DO NOT hardcode a per-rank number in a DPA-off branch — that cuts the
+# global budget 8x, silently. Why the trap is expensive: README note 2.
+CHUNK="${CHUNK:-65536}"
+
+# ---- transport env ------------------------------------------------------------------------
+# All from cluster/<wrapper>.sh, filled in from the preflight report. Do not guess: a wrong
+# GID index fails loudly, but a wrong dma-buf/peer-mem choice fails SILENTLY — doubled KV
+# pool, or a 5-20x slower TCP fallback. See cluster/README.md section 3.
+export MOONCAKE_DISABLE_HIP_DMABUF="${MOONCAKE_DISABLE_HIP_DMABUF:-1}"
+export MC_GID_INDEX="${MC_GID_INDEX:?MC_GID_INDEX is required — read it off the preflight report}"
+export MC_DISABLE_HIP_TRANSPORT=1
+unset MC_ENABLE_HIP_TRANSPORT
+# MC_MS_FILTERS pins mooncake to named device(s). Required in the dma-buf mode so a non-ODP
+# rail is never picked (it would pin and double the KV pool); harmless to leave unset when a
+# peer-mem module is loaded and every rail can carry KV.
+[ -n "${MC_MS_FILTERS:-}" ] && { export MC_MS_FILTERS MC_MS_AUTO_DISC="${MC_MS_AUTO_DISC:-0}"; }
+[ "${RDMAV_FORK_SAFE:-0}" = "1" ] && export RDMAV_FORK_SAFE=1
+export NCCL_IB_DISABLE=1 NCCL_IGNORE_CPU_AFFINITY=1 HSA_NO_SCRATCH_RECLAIM=1
+
+# Bind the engine and its collectives to the data-plane NIC. NIC is derived from MY_IP rather
+# than named, so the same script works on a node whose interface has a different name.
+NIC="${NIC:-$(docker exec "$CTR" bash -c "ip -o -4 addr show | awk '\$4 ~ /^$MY_IP\// {print \$2; exit}'" 2>/dev/null | tr -d '\r')}"
+[ -n "$NIC" ] || die "could not derive the NIC holding $MY_IP inside $CTR — set NIC explicitly"
+export SGLANG_HOST_IP="$MY_IP" HOST_IP="$MY_IP"
+export SGLANG_LOCAL_IP_NIC="$NIC" GLOO_SOCKET_IFNAME="$NIC"
+# A 400 GB+ checkpoint over shared storage, two legs reading it at once: the defaults are tight.
+export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT="${BOOTSTRAP_TIMEOUT:-1800}"
+export SGLANG_DISAGGREGATION_WAITING_TIMEOUT="${BOOTSTRAP_TIMEOUT:-1800}"
+export INFERA_SGLANG_READY_TIMEOUT="${READY_TIMEOUT:-3600}"
+
+# ---- GLM-5.2 DSA-on-ROCm recipe (mandatory on gfx950) -----------------------------------
+# Without these the model still serves and still returns 200s — it just returns garbage,
+# because the sparse-attention indexer takes a path not ported to ROCm. See README note 5.
+export SGLANG_USE_AITER=1 SGLANG_ROCM_FUSED_DECODE_MLA=0
+export SGLANG_OPT_USE_TILELANG_INDEXER=1 SGLANG_OPT_USE_TOPK_V2=0 SGLANG_OPT_USE_JIT_NORM=0
+export SAFETENSORS_FAST_GPU=1 HIP_FORCE_DEV_KERNARG=1
+[ "$DPA" = "1" ] && export SGLANG_DP_USE_GATHERV=1
+# Stable block hashes -> stable kvd keys across restarts, so an L3 entry written by one run is
+# readable by the next.
+export PYTHONHASHSEED=0
+
+# ---- args --------------------------------------------------------------------------------
+ROLE_ARGS=(--disaggregation-mode "$ROLE"
+           --disaggregation-transfer-backend mooncake
+           --disaggregation-ib-device "$RDMA_IB_DEVICES")
+[ "$ROLE" = "prefill" ] && ROLE_ARGS+=(--disaggregation-bootstrap-port "$BOOTSTRAP_PORT")
+
+# --ep-size is passed UNCONDITIONALLY, outside the DPA branch: expert parallelism and
+# attention parallelism are different axes. DO NOT move it inside the `if` — that silently
+# collapses the MoE too whenever DPA is off. See README note 1.
+DP_ARGS=(--ep-size "$TP")
+if [ "$DPA" = "1" ]; then
+  DP_ARGS+=(--dp-size "$TP" --enable-dp-attention)
+  # The prefill delayer batches arrivals so a DP step is not wasted on one short request.
+  # It only makes sense where there are DP ranks to fill.
+  [ "$ROLE" = "prefill" ] && [ "${DELAYER:-1}" = "1" ] \
+    && DP_ARGS+=(--enable-prefill-delayer --prefill-delayer-max-delay-ms "${PREFILL_DELAY_MS:-5000}")
+fi
+
+# etcd discovery, so the router pairs the two legs with no static worker list.
+INFERA_ARGS=(--advertise-host "$MY_IP" --etcd-endpoint "$ETCD_IP:$ETCD_PORT"
+             --discovery-backend etcd --request-transport http --kv-event-transport zmq)
+
+if [ "$KVAWARE" = "1" ]; then
+  INFERA_ARGS+=(--kv-events-bind "tcp://0.0.0.0:$KV_PUB_PORT" --kv-snapshot-port "$KV_SNAP_PORT")
+else
+  # NOTE: this also disables kvd on the DECODE leg — the two switches are not independent.
+  # What legalises kvd there is --disaggregation-decode-enable-radix-cache, which infera
+  # appends only when KV events are on. See README note 6.
+  INFERA_ARGS+=(--no-enable-kv-events)
+fi
+
+# kvd: the wrapper probes the daemon, then appends --enable-hierarchical-cache,
+# --hicache-storage-backend and the backend's extra-config for you. --hicache-size is an
+# ABSOLUTE size in GB, deliberately — the ratio-based default can wedge a node. README note 7.
+[ "$KVD" = "1" ] && INFERA_ARGS+=(--infera-kvd-socket "$KVD_SOCK" --hicache-size "$HICACHE_GB")
+
+# MTP (EAGLE). Decode-only by default: that is the configuration these settings were
+# validated in. Acceptance length should land around 2-3; a steady 4.00 means the draft model
+# is predicting a repetition loop, not that speculation is working well.
+MTP_ARGS=()
+if [ "$MTP" = "1" ] && { [ "$ROLE" = "decode" ] || [ "${PREFILL_MTP:-0}" = "1" ]; }; then
+  MTP_ARGS=(--speculative-algorithm EAGLE
+            --speculative-num-steps "${SPEC_STEPS:-3}"
+            --speculative-eagle-topk 1
+            --speculative-num-draft-tokens "${SPEC_DRAFT:-4}"
+            --num-reserved-decode-tokens "${RESERVED_TOK:-256}")
+fi
+
+# Disabled by default and INDEPENDENTLY of MTP — the aiter kernel deadlocks on gfx942/gfx950
+# during EAGLE verify. DO NOT let this switch follow MTP: that makes any "MTP on vs off"
+# comparison two-variable. Set CUSTOM_AR=1 only if your image carries the fix. README note 4.
+CAR_ARGS=()
+[ "${CUSTOM_AR:-0}" = "1" ] || CAR_ARGS+=(--disable-custom-all-reduce)
+
+# --enable-cache-report populates usage.prompt_tokens_details.cached_tokens. Without it every
+# client-side cache-hit metric reads 0 and a prefix-reuse target cannot be checked at all.
+EXTRA_ARGS=(--enable-cache-report)
+
+log "$ROLE on $MY_IP:$PORT — tp=$TP dpa=$DPA mtp=$MTP kvaware=$KVAWARE kvd=$KVD gmu=$GMU chunk=$CHUNK ctx=$CTX nic=$NIC ib=$RDMA_IB_DEVICES"
+
+# Pass the transport/recipe env explicitly rather than relying on `docker exec`'s environment:
+# the variables above are exported in THIS shell, on the host, not inside the container.
+docker exec -d "$CTR" env \
+  HIP_VISIBLE_DEVICES="$GPUS" \
+  MOONCAKE_DISABLE_HIP_DMABUF="$MOONCAKE_DISABLE_HIP_DMABUF" \
+  MC_GID_INDEX="$MC_GID_INDEX" MC_DISABLE_HIP_TRANSPORT=1 \
+  ${MC_MS_FILTERS:+MC_MS_FILTERS="$MC_MS_FILTERS"} \
+  ${MC_MS_FILTERS:+MC_MS_AUTO_DISC="${MC_MS_AUTO_DISC:-0}"} \
+  ${RDMAV_FORK_SAFE:+RDMAV_FORK_SAFE="$RDMAV_FORK_SAFE"} \
+  NCCL_IB_DISABLE=1 NCCL_IGNORE_CPU_AFFINITY=1 HSA_NO_SCRATCH_RECLAIM=1 \
+  SGLANG_HOST_IP="$MY_IP" HOST_IP="$MY_IP" \
+  SGLANG_LOCAL_IP_NIC="$NIC" GLOO_SOCKET_IFNAME="$NIC" \
+  SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT="$SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT" \
+  SGLANG_DISAGGREGATION_WAITING_TIMEOUT="$SGLANG_DISAGGREGATION_WAITING_TIMEOUT" \
+  INFERA_SGLANG_READY_TIMEOUT="$INFERA_SGLANG_READY_TIMEOUT" \
+  SGLANG_USE_AITER=1 SGLANG_ROCM_FUSED_DECODE_MLA=0 \
+  SGLANG_OPT_USE_TILELANG_INDEXER=1 SGLANG_OPT_USE_TOPK_V2=0 SGLANG_OPT_USE_JIT_NORM=0 \
+  SAFETENSORS_FAST_GPU=1 HIP_FORCE_DEV_KERNARG=1 PYTHONHASHSEED=0 \
+  ${SGLANG_DP_USE_GATHERV:+SGLANG_DP_USE_GATHERV=1} \
+  bash -c "python3 -m infera.engine.sglang \
+    --model-path '$MODEL' --served-model-name '$SERVED' --tp-size $TP --trust-remote-code \
+    --host '$MY_IP' --port $PORT \
+    --nsa-prefill-backend tilelang --nsa-decode-backend tilelang \
+    --kv-cache-dtype fp8_e4m3 --mem-fraction-static $GMU --context-length $CTX \
+    --chunked-prefill-size $CHUNK --cuda-graph-max-bs $CUDA_GRAPH_BS \
+    --max-running-requests $MAX_RUNNING --watchdog-timeout ${WATCHDOG:-3600} \
+    --reasoning-parser glm45 \
+    ${INFERA_ARGS[*]} ${DP_ARGS[*]} ${MTP_ARGS[*]} ${CAR_ARGS[*]} \
+    ${ROLE_ARGS[*]} ${EXTRA_ARGS[*]} > '$LOG' 2>&1"
+
+log "$ROLE launching -> $LOG in $CTR (cold start is minutes: weights + graph capture)"

--- a/examples/sglang_1p1d_glm5.2/engine/smoke.sh
+++ b/examples/sglang_1p1d_glm5.2/engine/smoke.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+# what: prove the deployment is serving AND that each of the five features is actually on.
+# why : a green /health proves the process is alive, not that PD paired, that KV moved over
+#       RDMA, or that speculative decoding is doing anything. Every check below is one that
+#       would go RED if the corresponding feature were silently absent.
+# how : run through cluster/<your-cluster>.sh smoke.
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; source "$DIR/../common.sh"
+
+require_env PREFILL_NODE; require_env DECODE_NODE; require_env PREFILL_IP
+SSH_CMD="${SSH_CMD:-ssh -o StrictHostKeyChecking=no}"
+on(){ local h="$1"; shift; $SSH_CMD "$h" "$*"; }
+URL="http://$PREFILL_IP:$ROUTER_PORT"
+PLOG="${PLOG:-/tmp/glm52_prefill.log}"
+DLOG="${DLOG:-/tmp/glm52_decode.log}"
+
+echo "===== 1. router + workers ====="
+# active_workers must be 2, with one prefill and one decode. A single worker means the second
+# leg never registered in etcd — which a per-leg /health check cannot tell you.
+on "$PREFILL_NODE" "docker exec $CTR curl -s -m10 $URL/health" ; echo
+on "$PREFILL_NODE" "docker exec $CTR curl -s -m10 $URL/v1/workers" | python3 -m json.tool 2>/dev/null \
+  || on "$PREFILL_NODE" "docker exec $CTR curl -s -m10 $URL/v1/workers"
+
+echo
+echo "===== 2. a real completion through the router ====="
+# Expect a coherent answer; GARBAGE OR REPEATED TOKENS means the DSA-on-ROCm env block did
+# not take effect, and is not a sampling problem (README note 5). DO NOT lower max_tokens —
+# reasoning is billed against the SAME budget and `content` then comes back EMPTY (README §5).
+BODY=$(python3 -c "import json,os;print(json.dumps({
+  'model': os.environ.get('SERVED','glm5.2-mxfp4'),
+  'messages':[{'role':'user','content':'What is the capital of France? Answer in one short sentence.'}],
+  'max_tokens': 512}))")
+on "$PREFILL_NODE" "docker exec $CTR curl -s -m120 $URL/v1/chat/completions \
+  -H 'Content-Type: application/json' -d '$BODY'" \
+  | python3 -c "import sys,json
+d=json.load(sys.stdin)
+m=d['choices'][0]['message']
+print('  content  :', (m.get('content') or '').strip())
+r=(m.get('reasoning_content') or '').strip()
+print('  reasoning:', (r[:80]+'…') if len(r)>80 else r or '(none)')
+u=d.get('usage',{})
+print('  usage    :', u.get('prompt_tokens'), 'prompt /', u.get('completion_tokens'), 'completion',
+      '| cached', (u.get('prompt_tokens_details') or {}).get('cached_tokens'))" \
+  || die "no completion — check: docker exec $CTR tail -50 /tmp/router.log"
+
+echo
+echo "===== 3. feature evidence ====="
+
+echo "-- PD + mooncake: KV must move over RDMA, not TCP --"
+# MC_FORCE_TCP appearing in a leg log means mooncake fell back to TCP. That path WORKS and
+# looks fine; it is merely 5-20x slower, which is exactly why it has to be checked rather
+# than assumed. 'GID is NULL' means the GID index is wrong for this node.
+#
+# `strings` because these logs carry binary bytes and a bare grep then reports only
+# "binary file matches". Values go into variables first: an `echo -n "label="` followed by
+# output arriving over ssh interleaves, leaving a bare column of digits.
+#
+# The two counters being 0 does NOT prove the container can see an RDMA device — a
+# mismatched provider finds ZERO devices and prints neither string. Hence the device count.
+for pair in "$PREFILL_NODE:$PLOG" "$DECODE_NODE:$DLOG"; do
+  h="${pair%%:*}"; f="${pair#*:}"
+  n_tcp=$(on "$h" "docker exec $CTR bash -c \"strings $f 2>/dev/null | grep -c MC_FORCE_TCP; true\"" | tr -d '\r\n')
+  n_gid=$(on "$h" "docker exec $CTR bash -c \"strings $f 2>/dev/null | grep -c 'GID is NULL'; true\"" | tr -d '\r\n')
+  n_dev=$(on "$h" "docker exec $CTR bash -c \"ibv_devinfo 2>/dev/null | grep -c PORT_ACTIVE; true\"" | tr -d '\r\n')
+  printf '  %-10s MC_FORCE_TCP=%-4s GID-is-NULL=%-4s RDMA-devices-in-container=%s\n' \
+    "$h" "${n_tcp:-?}" "${n_gid:-?}" "${n_dev:-?}"
+done
+echo "  (the two counters must be 0; the device count must be > 0)"
+
+echo "-- DP-attention: resolved dp_size per leg --"
+# Read it off the engine's own resolved server_args, not off what was requested. A leg
+# launched with --dp-size that failed to enable DP-attention reports dp_size=1 here.
+for pair in "$PREFILL_NODE:$PLOG" "$DECODE_NODE:$DLOG"; do
+  h="${pair%%:*}"; f="${pair#*:}"
+  echo -n "  $h  "
+  on "$h" "docker exec $CTR bash -c \"strings $f 2>/dev/null | grep -o 'dp_size=[0-9]*' | head -1; strings $f 2>/dev/null | grep -o 'enable_dp_attention=[A-Za-z]*' | head -1\"" | tr '\n' ' '
+  echo
+done
+
+echo "-- MTP: acceptance length on the decode leg --"
+# Healthy is a MEDIAN of 2-3. Report the distribution, not the last few lines: a few
+# percent of batches sit at 4.00 even on a healthy leg (measured 4.7% at median 2.88), so
+# a `tail -5` routinely lands on them and reads as degenerate.
+on "$DECODE_NODE" "docker exec $CTR bash -c \"strings $DLOG 2>/dev/null \
+  | grep -o 'accept len: [0-9.]*' | awk '{print \\\$3}' | sort -n \
+  | awk '{a[NR]=\\\$1; if (\\\$1>=4) f++} END {if (!NR) exit 1;
+      printf \\\"  n=%d  p10=%s  MEDIAN=%s  p90=%s  at-4.00=%d (%.1f%%)\\n\\\",
+             NR, a[int(NR*0.1)+1], a[int(NR*0.5)+1], a[int(NR*0.9)+1], f, 100*f/NR}'\"" \
+  || echo "  (no accept-len lines yet — send more traffic)"
+echo "  (read the MEDIAN: 2-3 is healthy. A median at 4.00 is a repetition loop, not a win.)"
+
+echo "-- kv-aware / kvd --"
+# The Rust router prints `router_policy: "kv-aware"` inside a colourised Config{...} dump,
+# never `router-policy=<x>` — a hyphenated, unquoted, ANSI-naive pattern prints EMPTY
+# whatever the policy is. Strip ANSI, read the struct field, and `strings` for the binary bytes.
+r_pol=$(on "$PREFILL_NODE" "docker exec $CTR bash -c \"strings /tmp/router.log 2>/dev/null \
+  | sed -r 's/\\x1B\\[[0-9;]*[mK]//g' | grep -oE 'router_policy: \\\"[a-z-]+\\\"' | head -1\"" | tr -d '\r\n')
+# kv-aware silently degrades to load-only routing if the tokenizer did not load, so the
+# policy line alone is not enough.
+r_tok=$(on "$PREFILL_NODE" "docker exec $CTR bash -c \"strings /tmp/router.log 2>/dev/null \
+  | sed -r 's/\\x1B\\[[0-9;]*[mK]//g' | grep -c 'kv-aware: loaded tokenizer'\"" | tr -d '\r\n')
+printf '  router %s   tokenizer-loaded=%s (must be >0 for kv-aware to steer)\n' \
+  "${r_pol:-<not found>}" "${r_tok:-?}"
+# kvd 'adapter connected' should appear once per DP rank on a leg with kvd enabled, and zero
+# times on the decode leg — infera skips kvd there by design.
+n_kvd=$(on "$PREFILL_NODE" "docker exec $CTR bash -c \"strings $PLOG 2>/dev/null | grep -c 'kvd adapter connected'; true\"" | tr -d '\r\n')
+printf '  prefill kvd adapters connected: %s (expect one per DP rank on the kvd leg)\n' "${n_kvd:-?}"
+if [ "${PREFILL_KVD:-1}" = "1" ]; then
+  echo "  kvd counters:"
+  on "$PREFILL_NODE" "docker exec $CTR python3 -m infera.kvd.statctl --socket $KVD_SOCK 2>&1 | head -12" || true
+fi
+
+echo
+log "smoke complete — read the four blocks above, not just the exit code"

--- a/examples/sglang_1p1d_glm5.2/engine/up.sh
+++ b/examples/sglang_1p1d_glm5.2/engine/up.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+# what: bring up the whole 1P1D deployment — containers, etcd, kvd, router, both PD legs.
+# why : one command from the wrapper. The router pairs the two legs out of etcd, so there is
+#       no static worker list to keep in sync.
+# how : DO NOT run this directly — run it through cluster/<your-cluster>.sh, which supplies
+#       every site-specific value. Reaches each node via $SSH_CMD.
+set -euo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; source "$DIR/../common.sh"
+
+require_env PREFILL_NODE; require_env DECODE_NODE
+require_env PREFILL_IP;   require_env DECODE_IP
+require_env KIT_DIR "path to this kit, identical on both nodes"
+require_env INFERA_IMAGE; require_env MODEL; require_env MODEL_MOUNT
+require_env RDMA_IB_DEVICES; require_env MC_GID_INDEX
+
+# On a scheduler that blocks ssh to compute nodes, set SSH_CMD to whatever runs a command on
+# a node. Invoked as: $SSH_CMD <node> <command>.
+SSH_CMD="${SSH_CMD:-ssh -o StrictHostKeyChecking=no}"
+on(){ local h="$1"; shift; $SSH_CMD "$h" "$*"; }
+
+# The env every remote invocation needs. Kept in one string so the two legs cannot drift.
+# PREFILL_MTP is forwarded as well as consumed below: leg.sh reads it directly to decide
+# whether a prefill leg may emit MTP args, so passing only MTP= leaves that gate always shut.
+COMMON_ENV="CTR=$CTR INFERA_IMAGE=$INFERA_IMAGE MODEL=$MODEL MODEL_MOUNT=$MODEL_MOUNT \
+SERVED=$SERVED TOKENIZER=${TOKENIZER:-$MODEL} ETCD_IP=$PREFILL_IP ETCD_PORT=$ETCD_PORT \
+ROUTER_PORT=$ROUTER_PORT PREFILL_PORT=$PREFILL_PORT DECODE_PORT=$DECODE_PORT \
+BOOTSTRAP_PORT=$BOOTSTRAP_PORT KVD_SOCK=$KVD_SOCK TP=${TP:-8} CTX=${CTX:-262144} \
+CHUNK=${CHUNK:-65536} KVAWARE=${KVAWARE:-1} PREFILL_MTP=${PREFILL_MTP:-0} \
+RDMA_IB_DEVICES=$RDMA_IB_DEVICES MC_GID_INDEX=$MC_GID_INDEX \
+MOONCAKE_DISABLE_HIP_DMABUF=${MOONCAKE_DISABLE_HIP_DMABUF:-1} \
+${MC_MS_FILTERS:+MC_MS_FILTERS=$MC_MS_FILTERS} \
+${MC_MS_AUTO_DISC:+MC_MS_AUTO_DISC=$MC_MS_AUTO_DISC} \
+${RDMAV_FORK_SAFE:+RDMAV_FORK_SAFE=$RDMAV_FORK_SAFE} \
+${HOST_RDMA_LIB:+HOST_RDMA_LIB=$HOST_RDMA_LIB} \
+${ENTRYPOINT_KEEP:+ENTRYPOINT_KEEP=$ENTRYPOINT_KEEP} \
+${GMU_PREFILL:+GMU_PREFILL=$GMU_PREFILL} ${GMU_DECODE:+GMU_DECODE=$GMU_DECODE}"
+
+log "=== 1/4 containers ==="
+for h in "$PREFILL_NODE" "$DECODE_NODE"; do
+  on "$h" "$COMMON_ENV bash -c 'source $KIT_DIR/common.sh; start_container'"
+done
+
+log "=== 2/4 etcd (prefill node) + kvd ==="
+on "$PREFILL_NODE" "$COMMON_ENV bash -c 'source $KIT_DIR/common.sh; start_etcd $PREFILL_IP'"
+
+# kvd runs only where a leg enables it. Stage a script FILE and nohup it — a detached
+# `docker exec -d ... bash -lc '<cmd>'` login shell exits and takes the child with it, leaving
+# no process, no log, no error. --max-bytes/--long-bytes are absolute caps: README note 7.
+start_kvd(){
+  local h="$1"
+  on "$h" "docker exec $CTR bash -c \"mkdir -p /tmp/kvd /tmp/kvd-long && rm -f $KVD_SOCK && \
+printf '%s\\n' '#!/bin/bash' 'exec python3 -m infera.kvd --socket $KVD_SOCK \
+--max-bytes ${KVD_MAX_BYTES:-64G} --long-path /tmp/kvd-long --long-bytes ${KVD_LONG_BYTES:-64G} \
+--log-level INFO' > /run_kvd.sh && chmod +x /run_kvd.sh\""
+  on "$h" "docker exec -d $CTR bash -c 'nohup /run_kvd.sh > /tmp/kvd.log 2>&1'"
+  sleep 15
+  on "$h" "docker exec $CTR bash -c \"test -S $KVD_SOCK && echo '  kvd socket OK on $h' || { echo '  KVD FAILED on $h'; tail -20 /tmp/kvd.log; }\""
+}
+if [ "${PREFILL_KVD:-1}" = "1" ]; then start_kvd "$PREFILL_NODE"; fi
+if [ "${DECODE_KVD:-0}"  = "1" ]; then start_kvd "$DECODE_NODE"; fi
+
+log "=== 3/4 legs ==="
+# Launch both legs before waiting on either: they load ~400 GB of weights concurrently, and
+# serialising the waits doubles the bring-up for no reason.
+on "$PREFILL_NODE" "$COMMON_ENV ROLE=prefill MY_IP=$PREFILL_IP PORT=$PREFILL_PORT \
+  DPA=${PREFILL_DPA:-0} MTP=${PREFILL_MTP:-0} KVD=${PREFILL_KVD:-1} \
+  bash $KIT_DIR/engine/leg.sh"
+on "$DECODE_NODE" "$COMMON_ENV ROLE=decode MY_IP=$DECODE_IP PORT=$DECODE_PORT \
+  DPA=${DECODE_DPA:-1} MTP=${DECODE_MTP:-1} KVD=${DECODE_KVD:-0} \
+  bash $KIT_DIR/engine/leg.sh"
+
+# Poll /health from INSIDE each node's container. Never curl a PD leg's port from another
+# host — and never grep the log for a ready line, because the logs are appended to across
+# restarts and a grep matches the PREVIOUS run's line within seconds.
+log "waiting for both legs (cold start is minutes — silence is not a hang)"
+wait_leg(){
+  local h="$1" ip="$2" port="$3" tries="${LEG_TRIES:-120}"
+  for i in $(seq 1 "$tries"); do
+    if on "$h" "docker exec $CTR curl -sf -m5 http://$ip:$port/health >/dev/null 2>&1"; then
+      log "  $h ($ip:$port) serving after $((i * 15))s"; return 0
+    fi
+    sleep 15
+  done
+  warn "  $h ($ip:$port) did NOT come up in $((tries * 15))s"; return 1
+}
+wait_leg "$PREFILL_NODE" "$PREFILL_IP" "$PREFILL_PORT" || die "prefill leg never became ready"
+wait_leg "$DECODE_NODE"  "$DECODE_IP"  "$DECODE_PORT"  || die "decode leg never became ready"
+
+log "=== 4/4 router (prefill node) ==="
+# The router last: it registers the workers it finds in etcd, and starting it after both legs
+# are serving means its first health check already reflects a paired deployment.
+on "$PREFILL_NODE" "$COMMON_ENV ROUTER_POLICY=${ROUTER_POLICY:-kv-aware} \
+  ROUTER_BACKEND=${ROUTER_BACKEND:-rust} \
+  ${KV_PREFILL_W:+KV_PREFILL_W=$KV_PREFILL_W} ${KV_DECODE_W:+KV_DECODE_W=$KV_DECODE_W} \
+  bash -c 'source $KIT_DIR/common.sh; start_router $PREFILL_IP'"
+
+log "up. endpoint: http://$PREFILL_IP:$ROUTER_PORT"
+log "verify with:  bash cluster/<your-cluster>.sh smoke"

--- a/examples/sglang_1p1d_glm5.2/preflight_rdma.sh
+++ b/examples/sglang_1p1d_glm5.2/preflight_rdma.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+# what: run infera's RDMA preflight inside the engine container. Two subcommands:
+#         mode    per-node registration-mode probe -> tells you WHICH cluster wrapper to use
+#         fabric  cross-node RoCE bandwidth + mooncake KV transfer measured over rdma AND tcp
+# why : PD moves the KV cache over the fabric on every request, and every way it can go wrong
+#       is SILENT. A container that cannot see the RDMA devices does not raise — mooncake
+#       falls back to a transport that works and is merely 5-20x slower. This turns that into
+#       a number you can read before you deploy.
+# how : both probes must run INSIDE the engine container: the mooncake engine library, the
+#       GPU-side checks and ib_write_bw only exist there.
+#
+#   IMAGE=<engine image> bash preflight_rdma.sh mode
+#   IMAGE=<engine image> DUMP_PATH=<shared dir> srun -N2 --ntasks-per-node=1 \
+#       bash preflight_rdma.sh fabric
+set -euo pipefail
+
+: "${IMAGE:?set IMAGE=<the infera-sglang engine image>}"
+CMD="${1:-mode}"
+
+# Do NOT pass --entrypoint '' here if your image's entrypoint bind-maps a host RDMA provider
+# library: skipping it leaves the container's provider mismatched with the host driver, the
+# device count reads 0, and the report is measuring the wrong thing.
+DOCKER_ARGS=(--rm --network host
+             --device=/dev/kfd --device=/dev/dri --device=/dev/infiniband
+             --group-add video --group-add render --cap-add=IPC_LOCK
+             --ulimit memlock=-1:-1 --security-opt seccomp=unconfined --ipc=host)
+# HOST_RDMA_MOUNT must be the in-container path your image's entrypoint reads, or the
+# injection silently no-ops and this probe measures a container whose provider does not
+# match the host driver — it then reports zero devices and the report means nothing.
+[ -n "${HOST_RDMA_LIB:-}" ] && DOCKER_ARGS+=(-v "$HOST_RDMA_LIB:${HOST_RDMA_MOUNT:-/host-rdma/$(basename "$HOST_RDMA_LIB")}:ro")
+
+case "$CMD" in
+mode)
+  # Per-node registration-mode probe; prints the env and launch flags for the mode it picks.
+  # Read the peer-mem line first — present -> cluster.peermem.sh, absent+ODP -> dmabuf.sh.
+  # Exit 2 means only the KV-pool-CAPPED mode C is left: a human decision, not a default.
+  echo "[preflight] registration-mode probe on $(hostname -s)"
+  exec docker run "${DOCKER_ARGS[@]}" "$IMAGE" \
+    python3 -m infera.tools.preflight.mooncake_mode
+  ;;
+fabric)
+  # Cross-node. One task per node writing into a SHARED dump path; rank 0 renders the report.
+  # For PD, read the mooncake rows: they report KV-move bandwidth over rdma and over tcp
+  # SEPARATELY, which turns a silent TCP fallback into a number you can read before deploying.
+  : "${DUMP_PATH:?set DUMP_PATH=<a directory shared by all nodes>}"
+  : "${SLURM_PROCID:?rank — srun sets this; otherwise set it per node by hand (0..N-1)}"
+  : "${SLURM_NNODES:?node count — srun sets this}"
+  export SLURMD_NODENAME="${SLURMD_NODENAME:-$(hostname -s)}"
+  # Use a FRESH dump path each run: rank 0 decides everyone has reported by counting the
+  # *.json files in the directory, so a stale file from a previous run makes it render early.
+  echo "[preflight] fabric check: rank $SLURM_PROCID/$SLURM_NNODES on $SLURMD_NODENAME -> $DUMP_PATH"
+  exec docker run "${DOCKER_ARGS[@]}" \
+    -e SLURM_PROCID -e SLURM_NNODES -e SLURMD_NODENAME \
+    -e PREFLIGHT_HOST="$SLURMD_NODENAME" -e PREFLIGHT_IMAGE="$IMAGE" \
+    -v "$DUMP_PATH:$DUMP_PATH" "$IMAGE" \
+    python3 -m infera.tools.preflight --dump-path "$DUMP_PATH" --netperf --mooncake
+  ;;
+*)
+  echo "usage: IMAGE=<image> bash preflight_rdma.sh {mode|fabric}" >&2
+  exit 1
+  ;;
+esac

--- a/examples/sglang_1p1d_glm5.2/results/README.md
+++ b/examples/sglang_1p1d_glm5.2/results/README.md
@@ -1,0 +1,88 @@
+# Measured results — GLM-5.2 1P1D at concurrency 8
+
+What this deployment actually did, under **two independent agentic benchmarks**, on
+**two clusters with different RDMA fabrics**. Every number here comes from a
+completed run against the deployment shape this kit ships; nothing is projected.
+
+| file | what |
+|---|---|
+| [`infera_agenticbench_conc8.md`](infera_agenticbench_conc8.md) | infera's own agentic benchmark — closed-loop session driver, ~67-minute window, both clusters |
+| [`customer_agentx_caseA_conc8.md`](customer_agentx_caseA_conc8.md) | the customer's AgentX Case-A — frozen-trace replay, 900 s window, both clusters |
+
+## Read this before comparing any two numbers here
+
+Three axes vary across these runs, and only one of them is the deployment.
+
+**1. The two benchmarks apply load differently, so their concurrency numbers are
+not the same operating point.**
+
+Both are **closed-loop** — a request is not issued until the previous one on that
+session/worker has returned, so a slower server reduces offered load in either. What
+differs is what "8" counts:
+
+| | infera AgenticBench | customer AgentX Case-A |
+|---|---|---|
+| what "conc 8" means | 8 *initial sessions*, population **grows** to a cap of 32; in-flight is emergent and lands wherever the server allows (mean 12.1) | 8 *fixed workers*; in-flight is bounded by 8 and lands below it (mean 5.1) |
+| requests | built live by the driver | frozen in 200 session files, byte-identical every replay |
+| window | ramp 400 s + sustain 3,600 s | 900 s |
+
+So the two ran at very different occupancies on the same server, and a TTFT gap
+between them is expected — it is **not** evidence about the deployment.
+
+The two agree where the load model does not matter: **ITL/TPOT p50 ≈ 14–16 ms** and
+**prefix cache ≈ 88 %**, measured independently by both drivers on both clusters.
+
+**2. The two clusters differ in the fabric, and in two configuration values that
+follow from it.** See [Cross-cluster](#cross-cluster-why-the-single-rail-cluster-looks-slower)
+below — the short version is that the cross-cluster rows are **context, not a
+measurement**, because more than one variable moves.
+
+**3. The workload shape is the same in both benches, and reproduces.** Both are
+built from the same Case-A profile — ISL p50/p90/p99 ≈ 74K/155K/235K, OSL p50/p90 ≈
+320/3,300, ~89 % prefix reuse — and the realised distributions land within ~7 % of
+each other on every axis. Workload shape is therefore never the explanation for a
+latency difference between them. The one axis where the customer harness's corpus
+does *not* meet the spec is the prefix-reuse rate, which it hits per turn but not
+overall; see
+[the construction analysis](customer_agentx_caseA_conc8.md#the-harnesss-cache-hit-construction-does-not-meet-the-workload-spec).
+
+## Cross-cluster: why the single-rail cluster looks slower
+
+Running the same workload on both clusters, the single-rail one is **~1.6× slower on
+TTFT p50** while matching on TPOT, cache hit rate and success rate.
+
+| | multi-rail cluster | single-rail cluster |
+|---|---|---|
+| RDMA | 8 rails, peer-mem loaded (mode A) | 1 ODP rail, no peer-mem, dma-buf (mode B) |
+| aggregate KV bandwidth (preflight's own metric) | ~3,200 Gb/s | ~200 Gb/s |
+| TTFT p50 (infera bench, sustain) | 1,365 ms | 2,239 ms |
+| TTFT p90 | 4,903 ms | 6,389 ms |
+| TPOT p50 | 14.8 ms | 16.1 ms |
+| cache hit | 88.8 % | 88.7 % |
+
+**No single-variable experiment separates these causes.** Four candidates, with the
+evidence behind each stated honestly:
+
+| # | candidate | evidence | what would settle it |
+|---|---|---|---|
+| 1 | **Fabric.** 1 rail vs 8, and dma-buf vs peer-mem registration. | First-hand node facts on both clusters. **No controlled experiment.** | Not separable — the fabric is the cluster. |
+| 2 | **`--chunked-prefill-size` differs**: 65,536 global on the single-rail runs, 16,384 on the multi-rail ones — 4× the per-forward prefill work. | First-hand from both runs' resolved args. The two source recipes genuinely disagreed on this value and the disagreement was recorded rather than resolved. | Re-run one cluster at the other's chunk. Cheapest of the four. |
+| 3 | **`--mem-fraction-static` differs**: 0.70 vs 0.80 on prefill → a smaller KV pool (−19 % measured when this was changed within one cluster). | First-hand. Forced, not chosen: 0.80 does not boot the single-rail cluster's prefill leg. | Only separable if 0.80 can be made to boot there. |
+| 4 | **MTP and decode-side radix cache are mutually exclusive upstream**, so `decode_prefix_len` is always 0 and **every turn re-transfers the entire prompt KV**. A prefill-side cache hit saves *compute*, not *bytes*. | First-hand: SGLang raises on `--disaggregation-decode-enable-radix-cache` together with `--speculative-algorithm`. | This does not act alone — it **amplifies** #1, by putting a full-prompt KV transfer on every turn's critical path. |
+
+Candidate 4 is the reason to expect #1 to matter *on this workload specifically*: at
+~86K mean input tokens and ~89 % prefix reuse, the deployment re-sends the whole
+prompt's KV every turn regardless of how well the cache is working. A workload with
+short prompts would be far less fabric-sensitive.
+
+**None of the four is confirmed.** The honest summary is that the single-rail cluster
+is slower on TTFT by a factor that is consistent with its fabric, and that two
+configuration deltas ride along with the fabric and are not controlled for.
+
+## Provenance
+
+Numbers are recomputed from raw per-request records where those exist, not copied
+from a summary line. The customer-bench ladders come from aiperf's
+`profile_export.jsonl`; the infera-bench ladders from the driver's own
+`summary.json` sustain-phase block, with the ramp window excluded exactly as that
+driver defines it.

--- a/examples/sglang_1p1d_glm5.2/results/customer_agentx_caseA_conc8.md
+++ b/examples/sglang_1p1d_glm5.2/results/customer_agentx_caseA_conc8.md
@@ -1,0 +1,212 @@
+# Customer benchmark — AgentX Case-A at concurrency 8
+
+The customer-supplied agentic benchmark from
+[ROCm/MAD PR #173](https://github.com/ROCm/MAD/pull/173) (`scripts/AgentX_CaseA/`),
+replayed **unmodified** against exactly the deployment shape this kit ships.
+
+**This kit ships no runner for it.** The harness is the customer's, lives upstream,
+and is configured entirely through environment variables — see
+[Pointing it at this deployment](#pointing-it-at-this-deployment) at the bottom.
+
+## What the benchmark is
+
+A **deterministic, spec-constructed replay trace** plus a generic driver:
+
+- `gen_caseA_conformance.py` synthesises 200 sessions / 1,778 requests from the
+  Case-A parameters at a fixed seed, so the corpus is byte-identical every run.
+- The corpus records **demand only** — per-request input/output token counts, turn
+  structure, think-times, KV prefix reuse. Nothing engine- or topology-specific.
+- `replay_caseA.sh` replays it via **aiperf** (a SemiAnalysis fork, scenario
+  `inferencex-agentx-mvp`, `--custom-dataset-type weka_trace`) against any
+  OpenAI-compatible endpoint.
+
+It is **closed-loop**, like the infera bench: `--concurrency N` runs N workers, and a
+worker does not issue its next request until the previous one has returned. Offered
+load is therefore bounded by the server, not pushed at it — which the measurement
+confirms, in-flight sitting at mean 5.13 against a cap of 8. What differs from the
+infera bench is not the loop but *what N counts*: N is a fixed worker population here,
+where the infera bench starts 8 sessions and lets the population grow.
+
+The frozen trace is what makes this benchmark useful: replaying it against a
+different deployment changes exactly one variable.
+
+## Results at c8
+
+Both clusters, the same frozen trace, the same deployment shape:
+
+| | multi-rail cluster | single-rail cluster |
+|---|---|---|
+| profiling requests | 231 | 231 |
+| window | 901 s | 907 s |
+| **errors / cancelled / context overflows** | **0 / 0 / 0** | **2 / 0 / 0** |
+| in-flight max / mean | 8 / 5.13 | 8 / 4.98 |
+| request rate | 0.256 req/s | 0.255 req/s |
+| output token rate | 268 tok/s | 265 tok/s |
+| **TTFT p50** | **5,146 ms** | 6,698 ms |
+| TTFT p90 | 19,780 ms | 23,871 ms |
+| TTFT p99 | 31,014 ms | 33,972 ms |
+| **E2E p50** | **12,556 ms** | 13,874 ms |
+| E2E p90 | 44,522 ms | 42,501 ms |
+| **ITL p50** | **13.81 ms** | 13.26 ms |
+| ITL p90 | 27.43 ms | 18.52 ms |
+| ISL p50 / mean | 70,624 / 80,989 | 69,911 / 80,811 |
+| OSL p50 / mean | 223 / — | 230 / 1,050 |
+| **server-reported cache hit** (per-request p50) | **88.1 %** | **88.1 %** |
+
+Ladders are recomputed from aiperf's raw per-request records
+(`profile_export.jsonl`), not copied from a summary line.
+
+**The two clusters agree closely at this concurrency** — TTFT p50 within 1.3×, ITL
+within 4 %. That is a narrower gap than the infera bench shows between the same two
+clusters, which is consistent with this driver's fixed worker population holding
+in-flight at ~5 on both, where the infera bench's growing session population let the
+faster cluster run at higher occupancy.
+
+### The harness's cache-hit construction does not meet the workload spec
+
+The Case-A spec asks for a **~88–89 % prefix-cache hit rate**. The corpus generator
+aims at that number per turn and reaches it *as a per-turn median* — but the corpus it
+produces does not deliver it as a workload property. Measured over all 200 sessions /
+1,778 requests of the shipped corpus:
+
+| how the corpus's own `hash_ids` are counted | hit rate |
+|---|---|
+| per-turn ratio, median | 88.0 % |
+| per-turn ratio, median, excluding turn 0 | 88.2 % |
+| per-turn ratio, **mean** | 66.0 % |
+| **token-weighted over the whole corpus** | **59.7 %** |
+
+Three things in `gen_caseA_conformance.py` drive the gap, and each is worth reporting
+upstream:
+
+1. **Cold start is inside the target.** Turn 0 is all-miss by construction and is
+   11.2 % of requests. The generator applies its 0.88–0.90 draw only from turn 1, so
+   the corpus can hit the target per-turn and still miss it overall.
+2. **No token weighting.** The target is drawn per *turn*, uniformly, but turns differ
+   by two orders of magnitude in input size (ISL is sampled lognormal per turn,
+   independently of the reuse draw). Cheap turns and 240K-token turns count equally
+   toward a rate whose cost is entirely token-proportional.
+3. **The reuse accounting does not survive a shrinking turn.** Reuse is
+   `min(len(prefix_blocks), int(total_blocks × uniform(0.88, 0.90)))` against a
+   `total_blocks` resampled independently each turn, and the surviving prefix is then
+   *overwritten* with this turn's `hash_ids` (`prefix_blocks = hash_ids`). Because
+   consecutive ISL draws are independent, **51 % of turns are shorter than their
+   predecessor**, and every one of those truncates the accumulated prefix permanently.
+   A real agentic session's context grows; this one random-walks.
+
+The consequence for reading the results below: the harness's own summary line reports
+**`Theoretical Prefix Cache Hit` ≈ 50.8 %**, and that figure is *not* a deployment
+measurement — it is computed from the trace file's `hash_ids` and never asks the
+server, so it reads the same on both clusters regardless of how the cache performs.
+Its closeness to the corpus's own 59.7 % token-weighted rate is the point: both are
+properties of the corpus.
+
+The server-side number aiperf does record is `usage_prompt_cache_read_tokens`. Taken
+as a per-request ratio it is **88.1 % p50 / 89.4 % p90 on both clusters** — but that
+median is over the 177 of 231 records that carry the field, and the 54 that do not are
+exactly the `turn_index == 0` requests, i.e. the cold ones. Counted with those in at
+0 % it is 72.4 %; token-weighted over all requests, 50.3 %. **All three are real
+numbers about different populations**, and the deployment comparison in this document
+uses the first because it is the one that holds the population fixed across clusters.
+
+A second, unrelated defect is worth reporting with the above: `replay_caseA.sh`
+silently loses results when `OUT` is set outside the script's own directory, because
+the container mounts only that directory — the sweep then prints `FAILED` for a run
+that actually succeeded.
+
+## What this benchmark establishes that the infera one cannot
+
+**1. Per-turn attribution — the prefix cache is worth 2.5× on TTFT.** aiperf tags
+every record with `turn_index`, so first-turn (cold) and later-turn (cached) requests
+can be split at matched input size:
+
+| | n | ISL p50 | TTFT p50 |
+|---|---|---|---|
+| first turn (cold) | 54 | 69,907 | **8,981 ms** |
+| turn ≥ 1 (cached) | 177 | 70,998 | **3,568 ms** |
+
+2.5× faster for a 1.6 % *larger* prompt. That is the prefix cache priced directly.
+The infera bench has no turn index and cannot produce this.
+
+**2. Independent confirmation of the cache rate.** 88.1 % measured from the server's
+own usage field, by a third-party driver, on a third-party trace, on **both**
+clusters — against the infera bench's 88.9 %. Same population caveat as above: this is
+the median over the warm requests.
+
+**3. A structurally clean input distribution.** `max(in + out) = 258,303` by
+construction, below the 262,144 context, so context overflow is impossible. The
+infera bench samples input and output independently with no joint clamp, which is
+where its 0.5 % error rate comes from.
+
+**4. TTFT-by-input-size, and what changes with concurrency.** Comparing c8 against a
+c16 run on the same deployment, the curve changes *shape*:
+
+| | 0–50K | 50–100K | 100–160K | 160–220K | 220–300K | spread |
+|---|---|---|---|---|---|---|
+| **c8** TTFT p50 | 3,177 | 6,161 | 11,305 | 20,674 | 22,639 | **7.1×** |
+| **c16** TTFT p50 | 14,425 | 18,594 | 22,723 | 33,162 | 40,192 | **2.8×** |
+
+*(single-rail cluster; the multi-rail cluster shows the same transition, 10.0× → 2.3×)*
+
+At c8 the curve is **prefill-shaped** — monotone and super-linear, the deployment is
+computing. At c16 it **flattens** and the smallest bucket already costs 14 s: a 40K
+request cannot take that long to prefill on a leg that serves 240K in 40 s, so that
+time is queueing rather than compute.
+
+TTFT here is entirely server-side: `http_req_sending` p50 is 0.2 ms.
+
+## Why its TTFT is higher than the infera bench's
+
+At c8 the customer bench reads TTFT p50 5,146 ms against the infera bench's 1,365 ms
+on the same cluster, **against the same server processes in the same hour**.
+
+Part of it is the load model — but not all of it, and the residual is honestly
+unexplained. At c8 the customer bench's mean in-flight is **5.1, less than half** the
+infera bench's 12.1, and its TTFT is still 3.8× worse. Lower offered load with worse
+latency is not explained by queueing.
+
+Candidates, none of which the available data discriminates between:
+
+| candidate | what would settle it |
+|---|---|
+| the 900 s window is too short for the prefill radix tree to reach the steady state the 3,600 s run measures | run the customer bench at c8 for 3,600 s; compare its first 900 s against its last |
+| the scenario injects a unique marker into every trajectory's first turn, deliberately defeating cross-trajectory prefix sharing the other driver allows | run with the scenario's cache-bust disabled |
+| the driver may not honour the trace's `think_time`, so turns arrive far denser than the session profile specifies | compare measured inter-arrival per conversation against the trace's think-time field |
+| measurement definition — first *token* vs first *chunk* | inspect the first streamed chunk of a known request under both drivers |
+
+**Do not pick one of these without running the experiment.**
+
+## The right posture: run both
+
+The two benchmarks answer different questions and should not be collapsed into one
+number.
+
+- The **infera bench** discovers capacity: its session population grows, so it finds
+  the concurrency the workload naturally sustains, runs a long steady-state window,
+  and captures router and KV internals. The customer bench must be *told* a worker
+  count, so it measures the point you chose.
+- The **customer bench** compares deployments: the frozen trace means replaying it
+  against a different topology changes exactly one variable. It also models real
+  per-turn structure and applies no client timeout.
+
+They agree where they should — ITL ≈ 14 ms, cache ≈ 88 % — and diverge exactly where
+the load model differs.
+
+## Pointing it at this deployment
+
+Get the harness from upstream ([ROCm/MAD PR #173](https://github.com/ROCm/MAD/pull/173),
+`scripts/AgentX_CaseA/`) and configure it by environment only — no code change is
+needed, and none should be made.
+
+| var | set it to |
+|---|---|
+| `URL` | this deployment's router: `http://<prefill-data-plane-ip>:8100` |
+| `SERVED` | the served-model-name this kit launches with (`glm5.2-mxfp4`), **not** the harness default |
+| `TOK` | a tokenizer path the harness's container can see |
+| `CONCS` | `8` for the numbers above |
+| `DUR` | `900` — the scenario enforces this as its minimum and rejects the script's own default |
+| `OUT` | a path **inside the harness's own directory** — see the defect noted above |
+
+Two prerequisites the deployment side must satisfy, both of which this kit already
+does: `--enable-cache-report` on the engine (or every cache-hit column reads 0), and a
+context length that covers the trace's 258,303-token maximum.

--- a/examples/sglang_1p1d_glm5.2/results/infera_agenticbench_conc8.md
+++ b/examples/sglang_1p1d_glm5.2/results/infera_agenticbench_conc8.md
@@ -1,0 +1,145 @@
+# infera AgenticBench — Case-A request shape at concurrency 8
+
+infera's own agentic benchmark, run against exactly the deployment shape this kit
+ships. **Closed-loop**: each session issues one request, waits for the response,
+sleeps its inter-turn delay, then issues the next. Offered load is therefore set by
+the live-session population, not by a QPS target.
+
+## Workload
+
+The Case-A agentic profile at reduced load. Long inputs, a heavy output tail,
+realistic think-time, and a large shared prefix:
+
+| axis | value |
+|---|---|
+| input tokens | p50 74,000 · p90 155,000 · p99 235,000 (clamped at 260,000) |
+| output tokens | p50 320 · p90 3,300 · p99 17,000 |
+| turns per session | p50 3 · p90 20 · p99 103 |
+| inter-turn delay | p50 4 s · p90 31 s · p99 240 s |
+| target prefix-cache hit | 0.89 |
+| initial sessions / max sessions / max in-flight | 8 / 32 / 24 |
+| window | ramp 400 s (excluded) + sustain 3,600 s |
+
+All figures below are the **sustain phase only**; the ramp is a warm-up exclusion
+window, sized so the synchronised start cohort has died off and the shared prefix is
+resident before measurement begins.
+
+## Results
+
+Three runs. All three ran the workload byte-identical; they differ in the cluster
+and in the deployment shape.
+
+| | **multi-rail cluster**<br>prefill DPA off + kv-aware | **single-rail cluster**<br>prefill DPA off + kv-aware | **single-rail cluster**<br>prefill DPA on + round-robin |
+|---|---|---|---|
+| requests sent / completed | 2,884 / 2,850 | 2,907 / 2,861 | 2,323 / 2,289 |
+| success rate | 0.988 | 0.984 | 0.985 |
+| QPS (sustain) | 0.74 | **0.75** | 0.60 |
+| **TTFT p50** | **1,365 ms** | 2,239 ms | 3,504 ms |
+| **TTFT p90** | **4,903 ms** | 6,389 ms | 7,079 ms |
+| TTFT p99 | 9,066 ms | 10,606 ms | 16,602 ms |
+| **TPOT p50** | **14.8 ms** | 16.1 ms | 16.5 ms |
+| TPOT p90 | 17.7 ms | 21.1 ms | 23.3 ms |
+| cache hit (actual / ideal) | 88.9 % / 89.0 % | 88.7 % / 89.0 % | 88.2 % / 89.0 % |
+| cache efficiency | 100.0 % | 99.6 % | 99.1 % |
+| MTP acceptance length | 2.02 (per-request) | 2.79 (engine) | 2.72 (engine) |
+| engine faults | 0 | 0 | 0 |
+| prefill `--mem-fraction-static` | 0.80 | 0.70 | 0.70 |
+| `--chunked-prefill-size` (global) | 16,384 | 65,536 | 65,536 |
+
+### Against the workload's own SLA block
+
+| bar | target | multi-rail | single-rail (DPA off) | single-rail (DPA on) |
+|---|---|---|---|---|
+| success rate | ≥ 0.97 | 0.988 **PASS** | 0.984 **PASS** | 0.985 **PASS** |
+| TTFT p90 | < 30,000 ms | 4,903 **PASS** (6.1×) | 6,389 **PASS** (4.7×) | 7,079 **PASS** (4.2×) |
+| E2E p50 | < 4,500 ms | 7,400 ms **FAIL** | not recorded | not recorded |
+| in-flight not pinned at cap | — | max 22 / 24 **PASS** | not pinned **PASS** | brushed 24 on 0.8 % of ticks **PASS** |
+
+The E2E miss is not a regression. `e2e_p50_ms: 4500` is a **latency-floor** spec that
+is met only at concurrency 1; at ~12 mean in-flight it is the wrong bar, and it fails
+identically in every loaded run on this stack. It is reported rather than quietly
+dropped.
+
+## What these runs establish
+
+**1. Prefill scales with input size, with no pathology.** On the multi-rail run,
+TTFT p50 by input-size bucket:
+
+| input | 0–50K | 50–100K | 100–160K | 160–220K | 220–300K |
+|---|---|---|---|---|---|
+| TTFT p50 | 623 ms | 1,036 ms | 1,815 ms | 3,411 ms | 5,863 ms |
+
+Monotone, 9.4× across a 4.5× size span, **no stall bucket**. The deployment is
+computing, not queueing, at this load.
+
+**2. Decode is not the bottleneck.** TPOT p99/p50 = 1.45 on the multi-rail run — an
+exceptionally tight ladder. A contended decode leg shows a fat upper tail.
+
+**3. The prefix cache works as specified.** 88.2–88.9 % actual against an ideal of
+89.0 %, i.e. 99–100 % cache efficiency and 0.2–0.9 % eviction. The workload nests
+every request inside the same prefix, so this verifies cache *accounting* under load;
+it does not exercise eviction pressure.
+
+**4. MTP is healthy, not degenerate.** Acceptance length 2.02–2.79. **A steady 4.00
+would be bad news**, not a better result — it means the draft model is predicting a
+repetition loop perfectly.
+
+**5. The load cap never bound**, so the workload set the offered load rather than
+backpressure, and the measurement window is valid.
+
+## The two things this data cannot tell you
+
+**The DPA/routing comparison is two-variable.** The two single-rail arms differ in
+*both* prefill DP-attention *and* router policy, because that is how they were
+specified. Arm B (DPA off + kv-aware) is faster on every latency percentile and
+carries 25 % more throughput, but that gap is the **combined** effect and this data
+cannot split it. The 2×2 is missing its other two cells.
+
+One prior controlled result bears on the DPA half alone: at **concurrency 1**, in a
+single-variable comparison, prefill DP-attention cost 1.65–1.93× on TTFT. The
+direction is consistent with the gap above; the load there is 24× lower and nothing
+licenses transferring the magnitude.
+
+**Routing policy and a memory knob are coupled, and it is not documented anywhere
+else.** The DPA-on + round-robin arm **would not boot** at `--mem-fraction-static
+0.80`; it aborted 60 s in with `HSA_STATUS_ERROR_OUT_OF_RESOURCES` while token usage
+read 0.05 — an empty KV pool, so activation memory, not KV exhaustion. The mechanism
+is the spreading itself: under round-robin 4–5 DP ranks prefill concurrently, each
+holding its own chunk's activations, where kv-aware concentrates on 1–2. At 0.70 it
+ran the full 4,007 s with zero faults, at a cost of 19 % of the KV pool — which, at a
+peak token usage of ~0.05, was never the binding resource.
+
+**If you switch this kit to `ROUTER_POLICY=round-robin`, lower `GMU_PREFILL`.** That
+is why the shipped default is 0.70 rather than the higher value a kv-aware-only
+deployment could sustain.
+
+## One structural finding worth knowing before you tune
+
+**kv-aware routing performed no cache steering in these runs, on either leg.** Not a
+misconfiguration — a consequence of the deployment:
+
+- **Prefill**: with DP-attention off, `dp_size=1`, so the router has exactly one
+  target to choose between.
+- **Decode**: MTP forces `ChunkCache` instead of a radix tree, because SGLang raises
+  on `--disaggregation-decode-enable-radix-cache` together with
+  `--speculative-algorithm`. The router's KV view of that worker is therefore
+  permanently empty and the cost function's overlap term cancels, leaving pure
+  least-loaded routing. Verified on the wire: the decode leg's kv-event socket
+  emitted 0 messages in 15 s while prefill's emitted 30.
+
+The consequence is the one in the [cross-cluster analysis](README.md#cross-cluster-why-the-single-rail-cluster-looks-slower):
+`decode_prefix_len` is always 0, so **every turn re-transfers the entire prompt KV**.
+A prefill-side cache hit saves compute, not bytes.
+
+This does not make kv-aware pointless — it steers prefill whenever DP-attention is on
+there, which the round-robin arm demonstrated by contrast (round-robin spread picks
+±4 % across all 8 ranks; kv-aware concentrated on 2 of 8 and left the other six at one
+batch each for an entire run, because the concentration is self-reinforcing: no
+traffic → empty cache view → never the cheapest candidate → no traffic).
+
+## Running it yourself
+
+This kit deliberately ships **no agentic bench client** — only the service self-check
+(`smoke`) and a reference sweep with SGLang's own `bench_serving` (`bench`). The
+agentic harness above is a separate internal tool. What this kit gives you is the
+deployment those numbers were measured against.


### PR DESCRIPTION
# Description

Adds a runnable deployment example for **GLM-5.2-MXFP4** under `examples/sglang_1p1d_glm5.2/`:
one prefill node and one decode node, KV moved between them over Mooncake RDMA, fronted by the
infera router, with DP-attention, MTP (EAGLE speculative decoding) and the kvd cache tiers on.

Everything site-specific lives in one of two files under `cluster/` — one per RDMA registration
mode, picked by the preflight probe rather than by autodetection at launch. `common.sh` and
`engine/*.sh` carry the tuned recipe and contain no addresses, paths, NIC names or GID indices,
so adapting to a cluster means editing a wrapper, never an engine script.

Directory shape mirrors `examples/deepseek_v4` (`common.sh` + an `engine/` subdirectory).

## Type of change

- [x] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- `cluster/` — two wrappers, the only files a user edits: `cluster.peermem.sh` (multi-rail
  with a peer-memory module) and `cluster.dmabuf.sh` (single ODP NIC, no peer-mem). No
  autodetection: `preflight_rdma.sh mode` tells you which one to use.
- `engine/leg.sh` — the launcher for one PD leg. Carries the tuned recipe and nothing
  site-specific.
- `engine/up.sh` / `down.sh` — bring up both nodes (containers → etcd + kvd → both legs →
  router) and tear down, waiting for VRAM to actually drain.
- `engine/smoke.sh` — service check **plus** positive evidence for each of the five features.
  A green `/health` proves the process is alive, not that PD paired or that speculation is
  doing anything; every check here goes red if its feature is silently absent.
- `engine/bench.sh` — reference throughput sweep using SGLang's own `bench_serving`.
- `preflight_rdma.sh` — registration-mode probe and cross-node fabric measurement.
- `results/` — concurrency-8 numbers from two independent agentic benchmarks on two clusters.

### Three couplings that fail quietly

Each of these produces a plausible result rather than an error when got wrong, so each is
commented at the point of use and written up in the README's "Notes & gotchas":

- **`--ep-size` is emitted unconditionally**, outside the DP-attention branch. Expert and
  attention parallelism are different axes; gating both on one condition collapses the MoE
  from ep8 to the TP default whenever DP-attention is off, so a run billed as "DPA off"
  differs in the expert-dispatch collective too and no latency delta is attributable.
- **`--chunked-prefill-size` is a global budget** that SGLang divides by `dp_size` only when
  DP-attention is on. One value serves both modes; hardcoding the per-rank number in a DPA-off
  branch cuts the global budget 8×.
- **Prefill activation OOM is fixed by *lowering* `--mem-fraction-static`** — the opposite of
  the decode-side retract fix. Low token usage at the moment of the abort is the tell: the KV
  pool is nearly empty, so it was never KV exhaustion.

### On `results/`

Numbers are recomputed from raw per-request records, not copied from summary lines. The
cross-cluster comparison is presented as **context, not a measurement**: more than one variable
moves between those clusters, four candidate causes are listed with the evidence behind each,
and none is confirmed. Where a benchmark's own summary metric is misleading it is called out —
the customer harness's `Theoretical Prefix Cache Hit` is computed from the trace file and never
asks the server, so it is invariant to the deployment under test.

The customer's benchmark is **referenced by URL, not vendored**; this kit ships no agentic bench
client, only the service self-check and the `bench_serving` reference sweep.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

**No tests.** This is a documentation/example change: shell scripts that drive a two-node GPU
deployment, with no unit-testable surface and no CI cluster to run them against. What was done
instead is recorded below.

## Validation status

Stated plainly rather than implied — the README carries the same table.

| what | status |
|---|---|
| the deployment shape (1P1D + mooncake + DPA + MTP + kvd + kv-aware) | **validated end-to-end on two clusters**, both fabric types |
| the tuned values (GMU, chunk, ctx, EAGLE settings, DSA env, router weights) | **validated** — each carried over from a run that completed cleanly |
| **these scripts as written** | **validated** — `preflight mode` → `up` → `smoke` → `bench` → `down` on a 2-node MI355X mode-B cluster, no edits outside the wrapper. Long context checked separately (needle, to 238K tokens) and under a real agentic workload at concurrency 8 |
| `preflight_rdma.sh fabric` | **not validated** — only `mode` was exercised |
| `cluster.peermem.sh`, `round-robin` routing | **not validated** — no peer-mem cluster was available; the shipped `kv-aware` default is what ran |

Static checks: `bash -n` on all 9 scripts; every infera flag grepped against `infera/**/args.py`
on `main`; the deliverable grepped for leaked local information (host names, absolute paths,
scheduler identifiers, credentials) before submission.

## Known placeholder

The image tag `inferaimage/infera-sglang:0.2.0` is a **placeholder**, flagged as such in the
README. It needs replacing with the released infera-sglang tag before this is useful to a
reader.
