### PR TITLE
fix(sglang-rocm): make kvd hicache work on the gfx942 v0.5.16 base — one crash, two wrong diagnostics

### DIFF
--- a/deploy/docker/Dockerfile.sglang
+++ b/deploy/docker/Dockerfile.sglang
@@ -146,7 +146,7 @@ RUN set -eu; \
     for f in /tmp/sglang-disagg-patches/*.py; do echo "[sglang-patch] $f"; python "$f"; done; \
     rm -rf /tmp/sglang-disagg-patches
 
-# ---- sglang ROCm patches (hierarchical-cache host allocator) ----------------
+# ---- sglang ROCm patches (hicache host allocator, staged write-back) --------
 # REQUIRED FOR CORRECTNESS on ROCm whenever hierarchical cache / kvd is enabled:
 # hipHostRegister maps host pages at a device VA that differs from the host VA,
 # but sglang's hicache stores raw host data_ptr()s in device-side pointer tables
@@ -163,6 +163,14 @@ RUN set -eu; \
 # kvd writes back is worse than a failed build. Self-locating, idempotent, and
 # it plants a real module-level string literal so the fix can be proven in the
 # BYTECODE rather than in the source.
+#
+# The directory also carries patch_hicache_rocm_staged_write_back.py, which
+# resyncs two gates that disagree about the staged write-back JIT on ROCm. This
+# base is not affected: every gate here is still _is_cuda, so they agree on False
+# and the non-JIT kernel runs — sglang#28534 introduced the disagreement after
+# this tag. That script exits 0 on the absent mem_cache/pool_host/mla.py. Kept in
+# the shared directory so a base bump picks the fix up rather than rediscovering
+# it as a scheduler crash.
 COPY deploy/docker/patches/sglang_rocm/ /tmp/sglang-rocm-patches/
 RUN set -eu; \
     for f in /tmp/sglang-rocm-patches/*.py; do echo "[sglang-patch] $f"; python "$f"; done; \

--- a/deploy/docker/Dockerfile.sglang.gfx942
+++ b/deploy/docker/Dockerfile.sglang.gfx942
@@ -120,6 +120,42 @@ RUN set -eu; \
     for f in /tmp/sglang-disagg-patches/*.py; do echo "[sglang-patch] $f"; python "$f"; done; \
     rm -rf /tmp/sglang-disagg-patches
 
+# ---- sglang ROCm patches (hicache host allocator, staged write-back) --------
+# Two independent hicache-on-ROCm fixes, both needed once kvd is enabled.
+#
+# (1) host allocator. hicache allocates its host pools with mmap +
+# hipHostRegister and then hands the raw host data_ptr()s to GPU kernels through
+# device-side pointer tables, which is only correct while hipHostRegister happens
+# to map the pages at the host VA. The patch moves ROCm to hipHostMalloc, whose
+# device pointer IS the host pointer by contract.
+#
+# PREVENTIVE ON THIS BASE, not a fix for a crash seen here. On gfx950 the two
+# addresses differ and the first kvd write-back aborts the process with "Memory
+# access fault by GPU node-N"; on gfx942 they were measured equal (MI300X, amdgpu
+# 6.14.14, ROCm 7.2.0, this base image: 8 MiB / 512 MiB / 4 GiB and 78 sequential
+# registrations totalling 7.3 GB, 0 mismatches). That identity is an accident of
+# the driver rather than an API guarantee, gfx942 is `xnack-` too so a regression
+# would fault rather than migrate, and the switch costs nothing measurable while
+# SGLANG_HUGEPAGE_SIZE is unset -- both allocators then hand out 4 KiB pages.
+#
+# (2) staged write-back JIT. NOT preventive: without it this base kills the
+# prefill scheduler (exit -3, "Tensor match failed ... device=rocm:0") on the
+# first page written back to the host tier, i.e. on the first request that reuses
+# a prefix. pool_host/mla.py opts HIP into a JIT kernel whose ROCm build wants
+# host-resident indices while the caller passes a GPU tensor; the patch gates it
+# on CUDA like every other host pool does. v0.5.15.post1 has no pool_host/mla.py,
+# so the same script is a no-op on the mi35x image.
+#
+# Order-independent w.r.t. everything above: they touch
+# mem_cache/pool_host/{common,mla}.py, which no other patch here does. NOT
+# tolerant, like the disagg loop: a non-zero exit means the base drifted, and
+# either fix half-applied is worse than a failed build. The one tolerated miss
+# is an absent pool_host/mla.py, which means the base predates the JIT path.
+COPY deploy/docker/patches/sglang_rocm/ /tmp/sglang-rocm-patches/
+RUN set -eu; \
+    for f in /tmp/sglang-rocm-patches/*.py; do echo "[sglang-patch] $f"; python "$f"; done; \
+    rm -rf /tmp/sglang-rocm-patches
+
 # ---- Rust router (multi-core data plane; --router-backend rust) ----
 # The ROCm base ships cargo; use it (install a minimal toolchain only if
 # absent). Needs cc for linking and libclang (onig_sys/bindgen). Removes

--- a/deploy/docker/patch.upstream.status.md
+++ b/deploy/docker/patch.upstream.status.md
@@ -5,8 +5,9 @@ project it patches. Kept here so "why do we still carry this?" has one answer
 per row, and so a patch that upstream has since merged gets dropped instead of
 quietly outliving its reason.
 
-**Verified with `gh` on 2026-08-01**, except the `patches/sglang_rocm/` section,
-verified 2026-08-03. State drifts; re-check before relying on a row. `gh search`
+**Verified with `gh` on 2026-08-01**, except the `patches/sglang_rocm/` section:
+2026-08-03 for the host allocator, 2026-08-04 for the staged write-back.
+State drifts; re-check before relying on a row. `gh search`
 matches titles and bodies, **not diff content**, so "no upstream PR" means "none
 found by search", not "none exists" — where a row could be checked by reading
 upstream source instead, it says so.
@@ -71,11 +72,17 @@ PD + DP-attention + MTP, i.e. **no CI covers this topology today**.
 > state was read from the web UI on 2026-08-03, and no upstream PR search was run.
 > "none found" here is weaker than elsewhere on the page.
 
-## sglang ROCm — `patches/sglang_rocm/` (baked by `Dockerfile.sglang`)
+## sglang ROCm — `patches/sglang_rocm/` (baked by `Dockerfile.sglang`, `Dockerfile.sglang.gfx942`)
 
 | patch | fixes | upstream issue | upstream PR | ours? | PR state |
 |---|---|---|---|---|---|
 | `sglang_rocm/patch_hicache_rocm_host_alloc.py` | hicache allocates host pools with `mmap` + `hipHostRegister`, which on ROCm maps the pages at a device address ≠ the host VA, but the pools hand raw host `data_ptr()`s to GPU kernels via device-side pointer tables → `Memory access fault by GPU node-N on address <host VA>` on the first kvd write-back | none found | none found | — | — |
+| `sglang_rocm/patch_hicache_rocm_staged_write_back.py` | `pool_host/mla.py` enables the staged write-back JIT on HIP while `DSAIndexerPoolHost` — in the same `HostPoolGroup` for any DSA model — still gates it on `_is_cuda`. The group ANDs the flag, so the controller puts the destination indices on the GPU; the anchor MLA pool then reads its own flag and launches the JIT anyway → `Tensor match failed … device=rocm:0 … allowed options: [cpu, rocm_host]`, scheduler exit −3 on the first write-back | none found | [sglang#28534](https://github.com/sgl-project/sglang/pull/28534) `[AMD] Enable JIT staged HiCache write-back and fix CPU-index crash` — added the HIP enablement and aligned `cache_controller.py`, `memory_pool_host.py`, `pool_host/mha.py`; **never touched `pool_host/mla.py`** | no (`AMD-yanfeiwang`) | **MERGED** 2026-07-09 |
+
+**`patch_hicache_rocm_host_alloc.py`** — the fault is **gfx950-only so far**: MI300X
+(amdgpu 6.14.14, ROCm 7.2.0) measures the two addresses equal, so
+`Dockerfile.sglang.gfx942` carries this one preventively rather than to fix a crash.
+Don't read its row above as evidence the fault was seen on both arches.
 
 > Verified on 2026-08-03 by **reading upstream `main` directly** (contents API,
 > `pool_host/common.py`): `ALLOC_MEMORY_FUNCS` still overrides only `"npu"` and
@@ -90,6 +97,54 @@ PD + DP-attention + MTP, i.e. **no CI covers this topology today**.
 > [#32503](https://github.com/sgl-project/sglang/pull/32503) /
 > [#32792](https://github.com/sgl-project/sglang/pull/32792) (OPEN, Intel XPU
 > HiCache) touch this same dict — expect an anchor conflict, not a fix.
+
+**`patch_hicache_rocm_staged_write_back.py`** — **not** preventive: without it the
+v0.5.16 gfx942 base kills the prefill scheduler on the first reused prefix, so that
+image needs it to run kvd at all. A **no-op on the mi35x image**, which has nothing to
+fix — every `can_use_write_back_jit` gate at v0.5.15.post1 is still `_is_cuda` (MHA,
+MLA, both V4 pools and `DSAIndexerPoolHost`, all in `memory_pool_host.py` before
+MLA/MHA moved into `pool_host/`), and `_is_hip` appears only in the kernel import
+guard, so the group's AND and its anchor agree on False. #28534 introduced the
+disagreement after that tag; the absent `pool_host/mla.py` is only how the script
+notices. Both `_is_cuda or _is_hip` in `pool_host/mla.py` and the CUDA-only gates on
+the other pools are still on upstream `main` (read from the raw files, so stronger
+than a search miss), i.e. **main is affected** — and #28534's own reasoning argues for
+the opposite repair, teaching the remaining pools the JIT rather than gating MLA down,
+so expect upstream to close this differently than we did.
+
+> **That repair is already in flight (checked 2026-08-04):**
+> [sglang#30350](https://github.com/sgl-project/sglang/pull/30350) `Add HiCache JIT
+> test and benchmark for ROCm/HIP CI support` (**OPEN**, `Emmanuel0612`) adds
+> `_is_cuda_alike = _is_cuda or _is_hip` and flips exactly the three CUDA-only gates
+> (`DSAIndexerPoolHost`, `DeepSeekV4PagedHostPool`, `DeepSeekV4StateHostPool`), so the
+> group AND stops reading False on ROCm — **including the V4 stack our patch does not
+> cover**. It also teaches `staged_write_back.cuh` to accept kDLROCM/kDLROCMHost (the
+> TensorMatcher check that emits our crash) and adds an AMD CI lane for the HiCache
+> JIT; the author reports 47/47 on MI355X. Stalled rather than rejected: amd-bot
+> called its AMD suites green on 07-09 alongside a merge conflict, conflicts were
+> cleared 07-13, nothing since 07-16, and #28534 landed in between. **Our leverage is
+> a gfx942 reproduction on that thread, not a competing PR** — it has no MI300X
+> datapoint.
+>
+> **Anchor drift cannot be the drop signal.** #30350 never touches
+> `pool_host/mla.py`, so our anchor would keep matching and the patch would keep
+> applying on top of the fix — not a crash, since both gates read False again, but a
+> silent forfeit of the staged kernel #30350 enables. `check_group_still_poisoned()`
+> checks the *precondition* instead: once `DSAIndexerPoolHost` stops gating on
+> `_is_cuda` alone, the script refuses and exits 1 telling the operator to drop it.
+>
+> **Exercised 2026-08-04** against the v0.5.16 *and* current-`main` copies of both
+> files, on throwaway trees. Stock: applies, exit 0. Re-run: "already applied", exit
+> 0. #30350 simulated by flipping the three CUDA-only gates: refuses, exit 1, with
+> `mla.py` byte-identical to pristine. `pool_host/mla.py` removed (the v0.5.15.post1
+> shape): tolerated, exit 0. Anchor or pool renamed: exit 1.
+>
+> Scope: `DSAIndexerPoolHost` is not the only CUDA-only member that can poison the
+> group's AND, and `build_deepseek_v4_hicache_stack` puts `DeepSeekV4PagedHostPool`
+> in a group anchored by `LogicalHostPool` (flag unconditionally True). Expect the
+> same crash on a V4 hicache stack on gfx942; **this patch gates `mla.py` only**. No
+> V4 stack runs on this branch, so that gate would be untested — the script's SCOPE
+> section records it for whoever gets there.
 
 ## Mooncake C++ — `patches/mooncake_cpp/` (built by `Dockerfile.sglang`, `Dockerfile.vllm`, `Dockerfile.atom`)
 
@@ -165,8 +220,10 @@ Mooncake diffs), `sglang_dsa/README.md`, `sglang_disagg/README.md` and
 ## Maintenance
 
 A row is ready to delete when its upstream PR is **merged and present in the
-pinned base**. Merged-but-not-in-base still needs the local patch — the two
-`MERGED` rows above (sglang#30265, Mooncake#2644) are exactly that case.
+pinned base**. Merged-but-not-in-base still needs the local patch — sglang#30265
+and Mooncake#2644 are exactly that case. The staged write-back row is the
+exception: its `MERGED` PR (sglang#28534) is what *introduced* the defect, so that
+patch drops on sglang#30350 instead.
 
 When adding a patch, add its row here in the same commit, and put the full
 argument — evidence, alternatives, how it differs from our own upstream PR — in

--- a/deploy/docker/patches/sglang_rocm/patch_hicache_rocm_host_alloc.py
+++ b/deploy/docker/patches/sglang_rocm/patch_hicache_rocm_host_alloc.py
@@ -66,6 +66,26 @@ buffer, page ranges head / tail / last:
 The repro and its logs are in the internal reproduction kit -- ask the patch
 author.
 
+NOT REPRODUCIBLE ON gfx942 -- and the patch is applied there anyway
+------------------------------------------------------------------
+Re-measured on MI300X (gfx942:sramecc+:xnack-, amdgpu 6.14.14, ROCm 7.2.0,
+lmsysorg/sglang:v0.5.16-rocm720-mi30x): hipHostRegister returns a device pointer
+EQUAL to the host VA for 8 MiB / 512 MiB / 4 GiB, with and without
+hipHostRegisterMapped, and across 78 sequential registrations totalling 7.3 GB --
+0 mismatches. So the stock allocator does not fault there, and this patch fixes
+nothing observable on that arch today. Re-check on a new arch or after a driver
+bump by comparing `data_ptr()` with hipHostGetDevicePointer for each strategy
+`alloc_mmap` can take; do not assume either outcome.
+
+`Dockerfile.sglang.gfx942` applies it regardless. The identity above is a
+property of that driver, not of the API -- hipHostRegister's contract is that you
+call hipHostGetDevicePointer -- and gfx950 already breaks it on the same ROCm
+release. gfx942 is `xnack-` too, so a driver bump that diverged would fault
+rather than migrate, and the failure lands on the kvd write-back path where it is
+expensive to diagnose. The switch costs nothing measurable on either arch while
+SGLANG_HUGEPAGE_SIZE is unset: alloc_mmap then takes its plain-page branch, so
+both allocators hand out 4 KiB pages.
+
 UPSTREAM STATUS (queried with `gh` on 2026-08-03)
   issue          NONE FOUND. Searched sgl-project/sglang issues for
                  "hipHostRegister", "hicache ROCm host" and "Memory access fault

--- a/deploy/docker/patches/sglang_rocm/patch_hicache_rocm_staged_write_back.py
+++ b/deploy/docker/patches/sglang_rocm/patch_hicache_rocm_staged_write_back.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Stop the hicache staged write-back JIT kernel from being used on ROCm.
+
+THE BUG
+-------
+Two gates decide one thing and disagree on ROCm.
+
+`mem_cache/pool_host/mla.py` opts HIP into the staged (layer_first -> page_first)
+write-back JIT kernel:
+
+    self.can_use_write_back_jit = (
+        _is_cuda or _is_hip
+    ) and can_use_write_back_jit_kernel(...)
+
+`pool_host/mha.py` carries the identical HIP enablement -- sglang#28534 did both --
+but the pools that can share a `HostPoolGroup` with them do not. Three still gate
+the flag on `_is_cuda` alone and therefore read False on ROCm: `DSAIndexerPoolHost`,
+which a DSA model such as GLM-5.2 always instantiates alongside the MLA pool, plus
+`DeepSeekV4PagedHostPool` and `DeepSeekV4StateHostPool`. `HostPoolGroup` ANDs the
+flag over its entries, so one CUDA-only member makes the group's flag False on ROCm
+while its anchor entry -- the MLA pool -- still says True.
+
+The two gates feed different decisions:
+
+  * `hybrid_cache/hybrid_cache_controller.py :: start_writing()` reads the GROUP
+    flag. False means "the JIT is not going to run", so it calls
+    `move_hybrid_indices()` and the destination host indices end up on the GPU.
+  * `HostPoolGroup.backup_from_device_all_layer()` delegates to the ANCHOR pool,
+    whose own flag is True, so the MLA pool launches the JIT kernel after all.
+
+The JIT kernel is then handed GPU-resident `dst_indices` where it requires
+host-resident ones, and the first write-back after the first reusable prefix
+aborts the scheduler:
+
+    File "mem_cache/pool_host/mla.py", line 403, in backup_from_device_all_layer
+      jit_transfer_hicache_all_layer_mla_staged_lf_pf(
+    tvm.error.InternalError: Tensor match failed for
+      Tensor<1152>[strides=<1>, dtype=int64, device=rocm:0]
+      at jit_kernel/csrc/kvcacheio/staged_write_back.cuh:248
+    - Root cause: Device value [rocm:0] not in the allowed options: [cpu, rocm_host]
+    Subprocess scheduler_0 crashed with exit code -3
+
+Measured on MI300X (gfx942, ROCm 7.2.0, sglang v0.5.16) with GLM-5.2-FP8, DSA
+attention, dp8, `--hicache-mem-layout page_first --hicache-io-backend kernel`
+(both defaults). Not specific to kvd: any hierarchical cache on this path dies the
+moment it writes a page back, so the engine survives startup and then crashes on
+the first real request.
+
+THE FIX
+-------
+Make the anchor agree with the group: gate the staged JIT on CUDA only, exactly as
+the three CUDA-only pools above already spell it. The MLA pool then falls through
+to `transfer_kv_all_layer_mla_lf_pf` -- the non-JIT kernel in the same branch,
+which asserts its destination indices ARE on the GPU, which is where the controller
+just put them. Both gates now read False on ROCm and the two decisions match.
+
+On any model that reaches this crash the fix costs nothing that worked before:
+`DSAIndexerPoolHost` is CUDA-gated, so the group flag was already False on ROCm for
+every DSA model and the staged JIT was unreachable regardless -- the `_is_hip` in
+mla.py bought no faster path, it only desynchronized the two gates. It is not free
+everywhere, though. An MLA model grouped only with pools that set the flag True
+unconditionally (`MambaPoolHost`, `LogicalHostPool`) had both gates reading True on
+ROCm and really did run the staged kernel; this patch moves it back to the non-JIT
+one. That is a throughput question on the write-back path, not a correctness one --
+the non-JIT kernel is what ROCm ran before #28534 -- and no such model is deployed
+here.
+
+Two launch flags dodge the crash instead and neither is a good trade:
+`--hicache-io-backend direct` leaves the kernel branch altogether for per-layer
+`transfer_kv_direct` copies, and `--hicache-mem-layout layer_first` trips the
+`layout != "page_first"` early return that zeroes the flag. Both change how every
+transfer is done in order to route around one mis-set boolean, and both leave the
+disagreement in place for the next model to find.
+
+SCOPE -- WHAT THIS DOES NOT FIX
+-------------------------------
+The disagreement is a property of the group, not of MLA, so gating one pool closes
+one instance of it. The other instance reachable today is the DeepSeek-V4 hicache
+stack: `build_deepseek_v4_hicache_stack` anchors on `LogicalHostPool`, whose flag is
+an unconditional True, and hangs `DeepSeekV4PagedHostPool` (CUDA-only, False on
+ROCm) off the same group -- same AND, same False group flag, same True anchor, so
+expect the same crash there on gfx942. Left alone deliberately: no V4 stack runs on
+this branch, so a gate here would be untested code guarding an untested path. Named
+so the next person recognizes the failure instead of re-deriving it.
+
+UPSTREAM STATUS (2026-08-04)
+  The `_is_cuda or _is_hip` gate is still on `main` (read from the raw file), so
+  main is affected, not just this base.
+
+  It comes from sglang#28534 "[AMD] Enable JIT staged HiCache write-back and fix
+  CPU-index crash" (MERGED 2026-07-09), which fixed the mirror image of this crash
+  -- CPU indices reaching a kernel that wanted GPU ones -- and deliberately chose
+  parity with CUDA. That PR taught `cache_controller.py`, `memory_pool_host.py` and
+  `pool_host/mha.py` to agree; it never touched `pool_host/mla.py`, and it predates
+  `DSAIndexerPoolHost` joining the same pool group. So this is #28534 left
+  incomplete on the MLA + DSA path rather than a fresh defect.
+
+  A fix is in flight and it is the parity repair done thoroughly: sglang#30350 "Add
+  HiCache JIT test and benchmark for ROCm/HIP CI support" (OPEN, Emmanuel0612) adds
+  `_is_cuda_alike = _is_cuda or _is_hip` and flips exactly the three CUDA-only gates
+  named above, so the group AND stops reading False on ROCm. It also teaches
+  `staged_write_back.cuh` to accept kDLROCM / kDLROCMHost -- the TensorMatcher check
+  that emits the crash above -- and adds an AMD CI lane (author reports 47/47 on
+  MI355X). It therefore also covers the V4 stack that SCOPE leaves open. Stalled
+  rather than rejected: amd-bot called its AMD suites green on 07-09 alongside a
+  merge conflict, the author cleared conflicts on 07-13, nothing since 07-16, and
+  #28534 landed in between. So the useful contribution is a gfx942 reproduction on
+  that thread, not a competing PR; file our own only if #30350 dies.
+
+  Anchor drift cannot be the drop signal, which is why this script checks a
+  precondition instead. #30350 repairs the OTHER pools and never touches
+  `pool_host/mla.py`, so the anchor would keep matching and this patch would keep
+  applying on top of the fix -- without crashing, because both gates read False
+  again, and therefore without anyone noticing that the staged kernel #30350 enabled
+  on ROCm had been given back. `check_group_still_poisoned` closes that: it reads
+  `DSAIndexerPoolHost` in `memory_pool_host.py` and refuses to apply once that pool
+  stops gating on `_is_cuda` alone (line 1777 at v0.5.16, 1830 on main).
+
+THE TWO IMAGES THAT RUN THIS
+  `Dockerfile.sglang.gfx942` (MI300X / MI325X, base v0.5.16) is the one that needs
+  it: mla.py carries the `_is_cuda or _is_hip` gate and `DSAIndexerPoolHost` is
+  still CUDA-only, so both checks below find what they expect.
+
+  `Dockerfile.sglang` (MI355X, base v0.5.15.post1) exits 0 at the first check and
+  has no bug to exit from. Every write-back gate on that base is still `_is_cuda` --
+  MHA (196), MLA (1405), both V4 pools (2478, 2887) and `DSAIndexerPoolHost` (3387),
+  all in `memory_pool_host.py` before MLA and MHA moved into `pool_host/` -- and
+  `_is_hip` appears only in the kernel import guard. So the group's AND and its
+  anchor both read False, they agree, and the non-JIT kernel runs. #28534 introduced
+  the disagreement after that tag; the absent `pool_host/mla.py` is just how this
+  script notices.
+
+EXIT CODES
+  0  applied; already applied; or nothing to gate -- no `pool_host/mla.py`, or an
+     mla.py with no `can_use_write_back_jit` (a base predating the staged
+     write-back). Those are the ONLY tolerated misses.
+  1  everything else, all of it meaning "a human has to look":
+       * the anchor is present but in an unexpected shape -- the crashing path IS on
+         this base and the gate would silently not be applied;
+       * `DSAIndexerPoolHost` no longer gates on `_is_cuda` alone -- upstream fixed
+         it, so this patch must be dropped rather than applied;
+       * that pool, or `memory_pool_host.py`, cannot be found to check at all.
+
+Idempotent and self-locating. Run inside the container, then delete stale .pyc.
+"""
+
+import importlib.util
+import os
+import sys
+
+MARKER = "GLM52_ROCM_STAGED_WRITE_BACK"
+
+# Swallows upstream's comment as well as the assignment: it argues for the HIP
+# enablement this patch removes, so leaving it behind would contradict the code.
+OLD = """        # The staged write-back JIT kernel builds with hipcc and has a ROCm
+        # path, so enable it on HIP too (consistent with the CUDA path).
+        self.can_use_write_back_jit = (
+            _is_cuda or _is_hip
+        ) and can_use_write_back_jit_kernel("""
+
+NEW = f"""        # {MARKER}: WHY the ROCm build of this kernel wants
+        # host-resident dst_indices while the caller passes a GPU tensor ->
+        # "Tensor match failed ... device=rocm:0" kills the scheduler on the
+        # first write-back. HOW gate on CUDA like every other host pool; HIP
+        # falls through to transfer_kv_all_layer_mla_lf_pf. See infera
+        # patch_hicache_rocm_staged_write_back.py.
+        {MARKER} = "applied"  # a literal, so `strings *.pyc` can prove it
+        self.can_use_write_back_jit = _is_cuda and can_use_write_back_jit_kernel("""
+
+# The precondition this patch exists for: a CUDA-only pool in the same
+# HostPoolGroup dragging the group's AND to False on ROCm. Checked against the
+# pool that does it for every DSA model, in the file it lives in.
+MPH_REL = ("srt", "mem_cache", "memory_pool_host.py")
+GROUP_MEMBER = "class DSAIndexerPoolHost"
+POISON_GATE = "self.can_use_write_back_jit = _is_cuda and can_use_write_back_jit_kernel("
+
+
+def find_pkg_root() -> str:
+    spec = importlib.util.find_spec("sglang")
+    if spec is None or not spec.submodule_search_locations:
+        sys.exit("cannot locate the sglang package")
+    return list(spec.submodule_search_locations)[0]
+
+
+def find_mla_py(root: str) -> str:
+    path = os.path.join(root, "srt", "mem_cache", "pool_host", "mla.py")
+    if not os.path.isfile(path):
+        print(f"[patch] no {path} on this base — no staged write-back to gate")
+        raise SystemExit(0)
+    return path
+
+
+def check_group_still_poisoned(root: str) -> int:
+    """Verify the disagreement this patch resolves is still there.
+
+    The OLD anchor cannot be the drop signal on its own: sglang#30350 repairs the
+    other side and never touches `pool_host/mla.py`, so the anchor would keep
+    matching and this patch would keep applying on top of the fix. That does not
+    crash; it silently gates the anchor back down, makes the group read False
+    again, and forfeits the staged kernel #30350 just enabled on ROCm.
+    """
+    path = os.path.join(root, *MPH_REL)
+    if not os.path.isfile(path):
+        print(
+            "[patch] ERROR: mla.py carries the staged write-back but there is no\n"
+            f"        {path}\n"
+            "        to check the group's other members against. Refusing to\n"
+            "        apply a gate whose precondition cannot be verified."
+        )
+        return 1
+
+    src = open(path).read()
+    start = src.find(GROUP_MEMBER)
+    if start < 0:
+        print(
+            f"[patch] ERROR: no `{GROUP_MEMBER}` to check. It has moved or been\n"
+            "        renamed, so whether the HostPoolGroup AND still reads False on\n"
+            "        ROCm is unknown. Re-derive before shipping — see this script's\n"
+            "        UPSTREAM STATUS section.\n"
+            f"        Checked: {path}"
+        )
+        return 1
+
+    end = src.find("\nclass ", start + 1)
+    block = src[start:] if end < 0 else src[start:end]
+    if POISON_GATE not in block:
+        print(
+            "[patch] ERROR: DSAIndexerPoolHost no longer gates can_use_write_back_jit\n"
+            "        on _is_cuda alone, so it no longer forces the HostPoolGroup AND\n"
+            "        to False on ROCm and the two gates already agree without us.\n"
+            "        This is what sglang#30350 does.\n"
+            "\n"
+            "        DROP THIS PATCH — remove it from Dockerfile.sglang.gfx942.\n"
+            "\n"
+            "        Do NOT re-anchor it instead. #30350 leaves pool_host/mla.py\n"
+            "        alone, so the anchor below still matches and applying it would\n"
+            "        gate the anchor back down, put the group at False again, and\n"
+            "        silently give up the staged write-back kernel on ROCm.\n"
+            f"        Checked: {path}"
+        )
+        return 1
+
+    return 0
+
+
+def main() -> int:
+    root = find_pkg_root()
+    path = find_mla_py(root)
+    src = open(path).read()
+
+    if "can_use_write_back_jit" not in src:
+        print(f"[patch] {path} has no staged write-back JIT — nothing to gate")
+        return 0
+
+    # Checked only once the two exits above have established there is something
+    # to patch, so a base without the JIT path never reports a drifted anchor.
+    rc = check_group_still_poisoned(root)
+    if rc:
+        return rc
+
+    if MARKER in src:
+        print(f"[patch] already applied: {path}")
+        return 0
+
+    if OLD not in src:
+        print(
+            "[patch] ERROR: the can_use_write_back_jit assignment is not in the "
+            "expected shape. It is present, so this base DOES have the path that "
+            "crashes on ROCm -- refusing to guess. Inspect:"
+        )
+        print(f"        {path}")
+        for i, line in enumerate(src.splitlines(), 1):
+            if "can_use_write_back_jit" in line:
+                print(f"        {i}: {line}")
+        return 1
+
+    open(path, "w").write(src.replace(OLD, NEW, 1))
+    print(f"[patch] applied to {path}")
+
+    pyc = os.path.join(os.path.dirname(path), "__pycache__")
+    n = 0
+    if os.path.isdir(pyc):
+        for f in os.listdir(pyc):
+            if f.startswith("mla."):
+                os.remove(os.path.join(pyc, f))
+                n += 1
+    print(f"[patch] removed {n} stale .pyc")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/sglang_1p1d_glm5.2/README.md
+++ b/examples/sglang_1p1d_glm5.2/README.md
@@ -37,7 +37,7 @@ on two different fabrics, is in [`results/`](results/README.md).
 node-P                                        node-D
 ├─ etcd                    ◀── discovery ──▶
 ├─ infera router  :8100    ◀── clients
-├─ kvd daemon                                 
+├─ kvd daemon
 └─ prefill leg    :30000   ══ KV over RDMA ══▶ decode leg :30001
    TP8, DPA off,                                TP8, DPA on (dp8),
    kvd L2/L3                                    MTP (EAGLE)

--- a/infera/engine/sglang/hicache_validate.py
+++ b/infera/engine/sglang/hicache_validate.py
@@ -28,8 +28,12 @@ logger = logging.getLogger(__name__)
 #
 # 0.5.15 changed it to `int(0.5 * host_pool)` (still so on main), which is
 # positive for any host pool, so there the low-ratio failure is a hit-rate loss —
-# an L2 that evicts as fast as the L1 it shadows — rather than prefetch being
+# an L2 that evicts about as fast as the L1 it shadows — rather than prefetch being
 # switched off. Worth guarding on both; only the older base loses reads entirely.
+#
+# 1.5 rather than 1.0: the limit is 0 only exactly at 1.0 on the old formula, but a
+# host pool under 1.5× the device pool is too thin a margin to be worth an L3 round
+# trip on either formula, and it is never what an operator meant to configure.
 HICACHE_RATIO_DANGER_THRESHOLD = 1.5
 
 
@@ -38,11 +42,11 @@ def warn_if_hicache_prefetch_disabled(server_args: Any) -> bool:
 
     Returns True iff a warning was emitted (for testability).
 
-    A ratio near 1.0 sizes the host pool at the device pool, which on older
-    SGLang caps `prefetch_capacity_limit` at 0 outright and on current SGLang
-    leaves an L2 that evicts as fast as the L1 it shadows — see the threshold
-    constant above. This is the infera-side guard so operators don't ship a
-    config that looks like "kvd is wired up" but never reads from it.
+    A ratio below the threshold above sizes the host pool close to the device
+    pool, which at exactly 1.0 caps `prefetch_capacity_limit` at 0 on older
+    SGLang and otherwise leaves an L2 too small to be worth reading. This is the
+    infera-side guard so operators don't ship a config that looks like "kvd is
+    wired up" but never reads from it.
     """
     enable_hicache = bool(getattr(server_args, "enable_hierarchical_cache", False))
     storage_backend = getattr(server_args, "hicache_storage_backend", None)

--- a/infera/engine/sglang/hicache_validate.py
+++ b/infera/engine/sglang/hicache_validate.py
@@ -17,31 +17,32 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-# Threshold below which SGLang's prefetch becomes effectively disabled.
-# Derivation: cache_controller.py:462 computes
+# Threshold below which a host pool stops being a useful L2.
+#
+# On sglang <= 0.5.14 it is worse than useless — cache_controller computes
 #     prefetch_capacity_limit = max(0, int(0.8 * (host_pool - device_pool)))
-# In token units this evaluates to
-#     0.8 * device_pool_tokens * (hicache_ratio - 1)
-# So when hicache_ratio == 1.0 the limit is 0 — every prefetch attempt is
-# rate-limited → kvd / mooncake / nixl L3 storage never gets queried.
-# Empirically observed on MiniMax-M2.5 TP=1 with --hicache-ratio 1.0:
-# 0 EXISTS, 0 GET to kvd across a 5-minute bench, while the same workload
-# at ratio=2.0 produced 35 EXISTS + 2048 GET calls.
+# which in token units is 0.8 * device_pool_tokens * (hicache_ratio - 1), so at
+# ratio 1.0 the limit is 0, every prefetch is rate-limited, and L3 storage is
+# never queried. Empirically on MiniMax-M2.5 TP=1 at ratio 1.0: 0 EXISTS and
+# 0 GET to kvd across a 5-minute bench, versus 35 EXISTS + 2048 GET at 2.0.
+#
+# 0.5.15 changed it to `int(0.5 * host_pool)` (still so on main), which is
+# positive for any host pool, so there the low-ratio failure is a hit-rate loss —
+# an L2 that evicts as fast as the L1 it shadows — rather than prefetch being
+# switched off. Worth guarding on both; only the older base loses reads entirely.
 HICACHE_RATIO_DANGER_THRESHOLD = 1.5
 
 
 def warn_if_hicache_prefetch_disabled(server_args: Any) -> bool:
-    """Log a CRITICAL warning if the server_args config will silently
-    disable SGLang's L3 prefetch path.
+    """Log a CRITICAL warning when server_args leaves L3 prefetch useless.
 
     Returns True iff a warning was emitted (for testability).
 
-    See `--hicache-ratio` documentation in SGLang's server_args; the
-    `prefetch_capacity_limit` formula scales with `(host - device)`,
-    so values near 1.0 produce a 0-limit cap and silently disable
-    prefetch. Upstream fix tracked separately; this is the
-    infera-side guard so operators don't ship configs that look
-    like "kvd is wired up" but never actually fetch from it.
+    A ratio near 1.0 sizes the host pool at the device pool, which on older
+    SGLang caps `prefetch_capacity_limit` at 0 outright and on current SGLang
+    leaves an L2 that evicts as fast as the L1 it shadows — see the threshold
+    constant above. This is the infera-side guard so operators don't ship a
+    config that looks like "kvd is wired up" but never reads from it.
     """
     enable_hicache = bool(getattr(server_args, "enable_hierarchical_cache", False))
     storage_backend = getattr(server_args, "hicache_storage_backend", None)
@@ -61,17 +62,17 @@ def warn_if_hicache_prefetch_disabled(server_args: Any) -> bool:
 
     logger.critical(
         "infera: --hicache-ratio=%g with --hicache-storage-backend=%s "
-        "will silently DISABLE SGLang L3 prefetch. "
-        "Inside SGLang's cache_controller.py the formula "
-        "prefetch_capacity_limit = 0.8 * (host_pool - device_pool) "
-        "evaluates to ~0 when ratio is close to 1.0, which makes "
-        "prefetch_rate_limited() return True on every attempt. "
-        "Net effect: kvd / mooncake / nixl backend receives writes "
-        "but never any reads, even when GPU cache overflows. "
+        "cripples SGLang's L3 prefetch. On sglang <= 0.5.14 it DISABLES it: "
+        "cache_controller's prefetch_capacity_limit = "
+        "0.8 * (host_pool - device_pool) evaluates to ~0 as the ratio "
+        "approaches 1.0, so prefetch_rate_limited() returns True on every "
+        "attempt and the kvd / mooncake / nixl backend takes writes but is "
+        "never read, even when the GPU cache overflows. From 0.5.15 the limit "
+        "is 0.5 * host_pool, so prefetch still runs but against a host pool "
+        "that evicts as fast as the GPU pool it shadows. "
         "Recommended: --hicache-ratio >= 2.0 (the SGLang default), "
-        "or use --hicache-size=<GB> to override the ratio-based "
-        "computation. See infera PD design §5.4 for empirical "
-        "evidence on MI355X TP=1.",
+        "or --hicache-size=<GB> to size the host pool outright. "
+        "See infera PD design §5.4 for the MI355X TP=1 measurement.",
         ratio,
         storage_backend,
     )

--- a/infera/engine/sglang/kvd_wiring.py
+++ b/infera/engine/sglang/kvd_wiring.py
@@ -131,9 +131,11 @@ def _finish_wiring(args: Any, socket_path: str) -> None:
     # the override, prompts under 256 tokens never trigger L3 prefetch
     # → `gets_total = 0` and operators see no cache reuse.
     #
-    # Try common field names across SGLang versions and lower the
-    # default; if none match (older SGLang), log a clear WARNING with
-    # the override the operator should pass via extra-config.
+    # Try common field names across SGLang versions and lower the default. Not
+    # finding one is normal rather than a problem: on bases where the threshold
+    # lives in the backend's extra config instead of ServerArgs,
+    # `_append_sglang_hicache_argv` below carries the same 64 on the argv, which
+    # is the copy the subprocess actually reads.
     _PREFETCH_FIELDS = (
         "hicache_storage_prefetch_threshold",
         "hicache_prefetch_threshold",
@@ -159,11 +161,10 @@ def _finish_wiring(args: Any, socket_path: str) -> None:
             overridden = True
             break
     if not overridden:
-        logger.warning(
-            "SGLang version has no recognized prefetch_threshold field "
-            "(tried %s). Prompts under 256 tokens may not trigger L3 "
-            "prefetch. Pass an explicit override via --hicache-storage-"
-            'config / extra-config JSON: {"prefetch_threshold":64}.',
+        logger.info(
+            "No prefetch_threshold field on this SGLang's ServerArgs (tried %s); the "
+            "backend extra config appended below carries prefetch_threshold=64, which "
+            "is the copy the engine subprocess reads.",
             ", ".join(_PREFETCH_FIELDS),
         )
 

--- a/infera/engine/sglang/kvd_wiring.py
+++ b/infera/engine/sglang/kvd_wiring.py
@@ -32,6 +32,10 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Named because two places have to agree on it: the appender below, and the
+# prefetch_threshold fallback in `_finish_wiring` that only holds if we append.
+_EXTRA_CONFIG_FLAG = "--hicache-storage-backend-extra-config"
+
 
 def _has_cli_flag(argv: list[str], flag: str) -> bool:
     return flag in argv or any(item.startswith(f"{flag}=") for item in argv)
@@ -59,14 +63,14 @@ def _append_sglang_hicache_argv(args: Any) -> None:
         argv += ["--hicache-storage-backend", "dynamic"]
         logger.info("--infera-kvd-socket appends --hicache-storage-backend dynamic")
 
-    if not _has_cli_flag(argv, "--hicache-storage-backend-extra-config"):
+    if not _has_cli_flag(argv, _EXTRA_CONFIG_FLAG):
         cfg = {
             "backend_name": "infera-kvd",
             "module_path": "infera.engine.sglang.kvd_adapter",
             "class_name": "InferaKvdBackend",
             "prefetch_threshold": 64,
         }
-        argv += ["--hicache-storage-backend-extra-config", json.dumps(cfg)]
+        argv += [_EXTRA_CONFIG_FLAG, json.dumps(cfg)]
         logger.info("--infera-kvd-socket appends dynamic backend extra config")
 
 
@@ -161,12 +165,25 @@ def _finish_wiring(args: Any, socket_path: str) -> None:
             overridden = True
             break
     if not overridden:
-        logger.info(
-            "No prefetch_threshold field on this SGLang's ServerArgs (tried %s); the "
-            "backend extra config appended below carries prefetch_threshold=64, which "
-            "is the copy the engine subprocess reads.",
-            ", ".join(_PREFETCH_FIELDS),
-        )
+        # `_append_sglang_hicache_argv` only adds its extra config when the operator
+        # supplied none, so whether the 64 still reaches the engine depends on that.
+        if _has_cli_flag(getattr(args, "sglang_argv", None) or [], _EXTRA_CONFIG_FLAG):
+            logger.warning(
+                "No prefetch_threshold field on this SGLang's ServerArgs (tried %s) "
+                "and %s is already on the argv, so infera cannot supply the default. "
+                'Add {"prefetch_threshold": 64} to that JSON yourself, or prompts '
+                "under 256 tokens will not trigger L3 prefetch.",
+                ", ".join(_PREFETCH_FIELDS),
+                _EXTRA_CONFIG_FLAG,
+            )
+        else:
+            logger.info(
+                "No prefetch_threshold field on this SGLang's ServerArgs (tried %s); "
+                "the %s appended below carries prefetch_threshold=64, which is the "
+                "copy the engine subprocess reads.",
+                ", ".join(_PREFETCH_FIELDS),
+                _EXTRA_CONFIG_FLAG,
+            )
 
     _append_sglang_hicache_argv(args)
     logger.info("infera-kvd HiCacheStorage backend ready (socket=%s)", socket_path)

--- a/infera/kvd/server.py
+++ b/infera/kvd/server.py
@@ -1169,6 +1169,11 @@ async def _main_async(args) -> None:
             "region shards over TablespaceLongRegion instances; the "
             "legacy LongStorageRegion is not supported)."
         )
+    # The io_mode the long region below resolves, so the startup self-check can
+    # report the mount under the mode kvd will actually use. None means no region,
+    # or a region that only resolves it at start() — the self-check then classifies
+    # for itself, which is its own default.
+    resolved_o_direct: bool | None = None
     if args.long_paths:
         # Striped long region — N shards, one per mount point, hash-routed.
         from infera.kvd.striped_long_region import StripedLongRegion
@@ -1193,6 +1198,7 @@ async def _main_async(args) -> None:
             # that all striping shards live on similar devices (typical:
             # 8× NVMe under /mnt/nvme{0..7}); the auto-probe is a guide.
             o_direct, _ = _resolve_io_mode(args, paths[0])
+        resolved_o_direct = o_direct
         if args.tablespace_flush_interval_ms is not None:
             flush_interval_ms = args.tablespace_flush_interval_ms
         elif args.tablespace_auto_detect_fs:
@@ -1252,6 +1258,7 @@ async def _main_async(args) -> None:
                 o_direct = None
             else:
                 o_direct, _ = _resolve_io_mode(args, args.long_path)
+            resolved_o_direct = o_direct
 
             if args.tablespace_flush_interval_ms is not None:
                 flush_interval_ms = args.tablespace_flush_interval_ms
@@ -1294,6 +1301,10 @@ async def _main_async(args) -> None:
                     flush_interval_ms=flush_interval_ms,
                 )
         else:
+            # The file-per-block region never opens with O_DIRECT, so say so rather
+            # than leaving the self-check to probe: on NVMe the probe answers
+            # `direct` and would report that mode's GB/s for buffered writes.
+            resolved_o_direct = False
             long_region = LongStorageRegion(args.long_path, args.long_bytes)
         long_region.start()
 
@@ -1308,7 +1319,11 @@ async def _main_async(args) -> None:
         try:
             from infera.kvd.storage_selfcheck import run_storage_selfcheck
 
-            run_storage_selfcheck(_sc_path)
+            # Pass the region's resolved io_mode; left to classify on its own the
+            # self-check reports GB/s for a mode kvd is not using whenever
+            # --io-mode was explicit or its device walk dead-ends (in a container
+            # it stops at a /dev/mapper node outside the namespace).
+            run_storage_selfcheck(_sc_path, o_direct=resolved_o_direct)
         except Exception as _sc_exc:  # pragma: no cover — never block startup
             logger.warning("[kvd] storage self-check wiring error (non-fatal): %s", _sc_exc)
 

--- a/infera/kvd/server.py
+++ b/infera/kvd/server.py
@@ -1087,6 +1087,31 @@ def _resolve_io_mode(args, probe_path: str | Path) -> tuple[bool, str]:
     return o_direct, "auto"
 
 
+def _resolve_region_io_mode(args, probe_path: str | Path) -> bool | None:
+    """``o_direct`` for a tablespace long region, or None to leave it undecided.
+
+    The order is NOT the one ``_resolve_io_mode``'s docstring implies on its own,
+    because the two legacy flags are checked before it ever runs:
+
+      1. ``--tablespace-buffered-io`` short-circuits to buffered, as its own help
+         text promises. It therefore also shadows ``INFERA_KVD_IO_MODE``, which
+         overrides ``--io-mode`` and not this flag.
+      2. ``--tablespace-auto-detect-fs`` returns None, deferring to the region's
+         own fstype probe at ``start()``.
+      3. Otherwise ``_resolve_io_mode``: env var, then ``--io-mode``, then the
+         storage-classifier probe.
+
+    One helper for both the striped and single-path branches, so that order is
+    stated once instead of drifting between two copies of it.
+    """
+    if args.tablespace_buffered_io:
+        logger.info("[kvd] L3 io_mode: BUFFERED (explicit --tablespace-buffered-io)")
+        return False
+    if args.tablespace_auto_detect_fs:
+        return None
+    return _resolve_io_mode(args, probe_path)[0]
+
+
 async def _main_async(args) -> None:
     # Optional SSD tiers — wired only when the operator provides paths.
     # Either or both can be enabled independently.
@@ -1182,22 +1207,10 @@ async def _main_async(args) -> None:
         paths = [p.strip() for p in args.long_paths.split(",") if p.strip()]
         if not paths:
             raise SystemExit("kvd: --long-paths must be a non-empty comma-separated list")
-        # Resolution order: INFERA_KVD_IO_MODE > --io-mode (non-auto)
-        # > legacy --tablespace-buffered-io > --tablespace-auto-detect-fs
-        # > --io-mode auto (storage_classify probe).
-        if args.tablespace_buffered_io:
-            o_direct = False
-            logger.info("[kvd] L3 io_mode: BUFFERED (explicit --tablespace-buffered-io)")
-        elif args.tablespace_auto_detect_fs:
-            # Defer to TablespaceLongRegion's fstype-based auto-detect
-            # (legacy behavior — kept for backward compat with deploy
-            # manifests that already use this flag).
-            o_direct = None
-        else:
-            # Classify on the first shard's path. The expectation is
-            # that all striping shards live on similar devices (typical:
-            # 8× NVMe under /mnt/nvme{0..7}); the auto-probe is a guide.
-            o_direct, _ = _resolve_io_mode(args, paths[0])
+        # Probed on the first shard's path: the expectation is that all striping
+        # shards live on similar devices (typical: 8× NVMe under /mnt/nvme{0..7}),
+        # so the auto-probe is a guide rather than a per-shard measurement.
+        o_direct = _resolve_region_io_mode(args, paths[0])
         resolved_o_direct = o_direct
         if args.tablespace_flush_interval_ms is not None:
             flush_interval_ms = args.tablespace_flush_interval_ms
@@ -1237,27 +1250,10 @@ async def _main_async(args) -> None:
             # append-only journal. Bounded file count, scales better
             # past ~100K entries than the file-per-block layout.
 
-            # Resolution order for o_direct + flush_interval_ms:
-            #   1. INFERA_KVD_IO_MODE env var — operator escape hatch.
-            #   2. Explicit --tablespace-buffered-io flag — legacy
-            #      backward-compat; treated as "I really mean buffered".
-            #   3. --tablespace-auto-detect-fs — pass None down, let the
-            #      region probe fstype at start() and pick per-backend
-            #      defaults.
-            #   4. --io-mode (default `auto`) — call storage_classify
-            #      to pick based on the underlying device transport.
-            #      Explicit `--io-mode direct/buffered` short-circuits.
-            #
-            # The `--io-mode auto` default is intentional (May 2026
-            # rebrand): O_DIRECT was the unconditional choice and lost
-            # to buffered on SATA + NFS-low-nconnect.
-            if args.tablespace_buffered_io:
-                o_direct = False
-                logger.info("[kvd] L3 io_mode: BUFFERED (explicit --tablespace-buffered-io)")
-            elif args.tablespace_auto_detect_fs:
-                o_direct = None
-            else:
-                o_direct, _ = _resolve_io_mode(args, args.long_path)
+            # `--io-mode auto` is the default on purpose (May 2026 rebrand):
+            # O_DIRECT used to be the unconditional choice and lost to buffered on
+            # SATA and on NFS with low nconnect.
+            o_direct = _resolve_region_io_mode(args, args.long_path)
             resolved_o_direct = o_direct
 
             if args.tablespace_flush_interval_ms is not None:

--- a/infera/kvd/storage_selfcheck.py
+++ b/infera/kvd/storage_selfcheck.py
@@ -103,6 +103,11 @@ def run_storage_selfcheck(
         d = Path(long_path) / ".kvd_selfcheck"
         d.mkdir(parents=True, exist_ok=True)
         r_od, r_workers, r_chunk, why = _resolve(Path(long_path))
+        if o_direct is not None and bool(o_direct) != r_od:
+            # Otherwise the log line reads `io_mode=direct` next to the probe's
+            # reason for picking buffered, and looks self-contradictory.
+            probed = "direct" if r_od else "buffered"
+            why = f"io_mode from the caller, not the probe (probe wanted {probed}: {why})"
         o_direct = r_od if o_direct is None else bool(o_direct)
         chunk = r_chunk if chunk_bytes is None else int(chunk_bytes)
         w_workers = int(write_workers) if write_workers else r_workers

--- a/tests/engine/sglang/test_hicache_warning.py
+++ b/tests/engine/sglang/test_hicache_warning.py
@@ -6,11 +6,13 @@
 """Unit tests for `warn_if_hicache_prefetch_disabled`.
 
 The function lives in `infera.engine.sglang.hicache_validate` and exists
-to flag SGLang configs where `--hicache-ratio` leaves the host pool no
-bigger than the device pool: on sglang <= 0.5.14 `prefetch_capacity_limit`
-then rounds to 0 and silently disables L3 prefetch, and from 0.5.15 the L2
-evicts as fast as the L1 it shadows. Background: see PD design §5.4 + the
-2026-05-23 TP=1 debugging session.
+to flag SGLang configs where `--hicache-ratio` leaves the host pool close
+to the device pool — the guard fires below 1.5, so at 1.0 the two are
+equal and above it the margin is too thin to matter. On sglang <= 0.5.14
+`prefetch_capacity_limit` then rounds to 0 and silently disables L3
+prefetch; from 0.5.15 the L2 instead evicts about as fast as the L1 it
+shadows. Background: see PD design §5.4 + the 2026-05-23 TP=1 debugging
+session.
 
 These tests don't depend on SGLang being installed — they pass a
 SimpleNamespace masquerading as `ServerArgs`.

--- a/tests/engine/sglang/test_hicache_warning.py
+++ b/tests/engine/sglang/test_hicache_warning.py
@@ -5,11 +5,12 @@
 ###############################################################################
 """Unit tests for `warn_if_hicache_prefetch_disabled`.
 
-The function lives in `infera.engine.sglang.args` and exists to flag
-SGLang configs where `--hicache-ratio` is small enough that
-`prefetch_capacity_limit` rounds to 0 and silently disables L3
-prefetch. Background: see PD design §5.4 + the 2026-05-23 TP=1
-debugging session.
+The function lives in `infera.engine.sglang.hicache_validate` and exists
+to flag SGLang configs where `--hicache-ratio` leaves the host pool no
+bigger than the device pool: on sglang <= 0.5.14 `prefetch_capacity_limit`
+then rounds to 0 and silently disables L3 prefetch, and from 0.5.15 the L2
+evicts as fast as the L1 it shadows. Background: see PD design §5.4 + the
+2026-05-23 TP=1 debugging session.
 
 These tests don't depend on SGLang being installed — they pass a
 SimpleNamespace masquerading as `ServerArgs`.
@@ -60,8 +61,8 @@ def test_no_warning_when_no_storage_backend(caplog):
 
 
 def test_no_warning_at_default_ratio(caplog):
-    """ratio=2.0 (SGLang default) is fine; capacity_limit = 0.8 * 1.0 *
-    device_pool which is plenty of prefetch budget."""
+    """ratio=2.0 (SGLang default) is fine: the host pool is twice the device
+    pool, so either capacity_limit formula leaves real prefetch budget."""
     from infera.engine.sglang.hicache_validate import warn_if_hicache_prefetch_disabled
 
     args = _fake_server_args(hicache_ratio=2.0)


### PR DESCRIPTION
# Description

Three fixes that stand between a GLM-5.2-FP8 PD deployment on gfx942 and a working
kvd L3 tier. The load-bearing one is a scheduler crash; the other two are
diagnostics that told operators something untrue.

**Enabling kvd on the v0.5.16 gfx942 base crashes on the first reused prefix.**
Startup, weight load and a single-shot request all succeed, then the prefill
scheduler dies with exit -3:

```
tvm.error.InternalError: Tensor match failed for
  Tensor<1152>[strides=<1>, dtype=int64, device=rocm:0]
- Root cause: Device value [rocm:0] not in the allowed options: [cpu, rocm_host]
```

Two gates for one decision disagree on ROCm. `pool_host/mla.py` opts HIP into the
staged write-back JIT kernel, while `DSAIndexerPoolHost` — the sidecar in the same
`HostPoolGroup` for any DSA model — still gates it on `_is_cuda`. The group ANDs
the flag over its entries, reads False, and moves the destination indices to the
GPU; it then delegates the write-back to its anchor, the MLA pool, which reads its
own flag, True, and launches the JIT kernel that needs those indices on the host.
The new patch gates MLA like every other host pool, so both sides read False and
the non-JIT kernel in the same branch takes over — which is what ROCm has always
run. It costs nothing that worked before: the group flag was already False here
regardless, so the `_is_hip` bought no faster path, it only desynchronized the two
gates.

Not specific to kvd — any hierarchical cache on this path dies the moment it writes
a page back. Upstream `main` is affected too. The proper repair is upstream's own
([sglang#30350](https://github.com/sgl-project/sglang/pull/30350), OPEN, stalled
since 07-16), which teaches the other pools the JIT instead; our patch only has to
stop the crash, and it refuses to apply once #30350 lands.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

**`fix(sglang-rocm): make hicache survive its first write-back on gfx942`**

- New `patches/sglang_rocm/patch_hicache_rocm_staged_write_back.py`: gates
  `can_use_write_back_jit` on CUDA in `pool_host/mla.py`. The anchor swallows
  upstream's comment along with the assignment, since that comment argues for the
  HIP enablement being removed — leaving it would contradict the patched code.
- Dropping the patch **cannot** be keyed on anchor drift: #30350 repairs the other
  pools and never touches `mla.py`, so the anchor would keep matching and the patch
  would keep gating the anchor back down, silently forfeiting the staged kernel
  #30350 enables. `check_group_still_poisoned()` checks that *precondition* instead
  and exits 1 once `DSAIndexerPoolHost` stops gating on `_is_cuda` alone.
- `Dockerfile.sglang.gfx942` now runs the shared `sglang_rocm/` loop, which also
  brings the existing hicache host-allocator patch to this image. That one is
  **preventive** there: MI300X was measured to return host VA == device VA from
  `hipHostRegister`, but that identity is a property of the driver rather than of
  the API, gfx942 is `xnack-` too, and the failure would land on the write-back
  path where it is expensive to diagnose.
- `Dockerfile.sglang` (mi35x, v0.5.15.post1) documents why the same script is a
  no-op there: every write-back gate on that base is still `_is_cuda`, so the group
  AND and its anchor agree. #28534 introduced the disagreement after that tag.
- `patch.upstream.status.md`: a row for the new patch, notes grouped per patch, and
  a `Maintenance` caveat — the new `MERGED` PR (#28534) is what *introduced* the
  defect, so the usual "upstream merged it, drop the row" rule does not apply.

**`fix(kvd): report the io_mode the L3 region actually resolved`**

- The startup self-check re-classified the mount instead of being told what the
  long region had settled on, so its GB/s line could describe a mode kvd is not
  using — either because `--io-mode` / `INFERA_KVD_IO_MODE` was explicit, or
  because the device walk dead-ends (in a container it stops at a `/dev/mapper`
  node outside the namespace).
- The file-per-block region now reports `False` outright, since it only ever opens
  buffered while the probe answers `direct` on NVMe. `None` still means "let the
  self-check classify" — the honest answer for `--tablespace-auto-detect-fs`, where
  the region resolves `o_direct` at `start()`.
- When caller and probe disagree, the self-check says so in the rationale it logs,
  so `io_mode=direct` no longer sits next to the probe's reason for picking
  buffered.

**`fix(sglang): correct two hicache diagnostics that misread current sglang`**

- The hicache-ratio guard attributed `prefetch_capacity_limit = 0.8 * (host_pool -
  device_pool)` to every sglang up to 0.5.15. That formula was replaced **in
  0.5.15** by `int(0.5 * host_pool)` — read from the raw `cache_controller.py` at
  v0.5.4 / 0.5.12 / 0.5.14 / 0.5.15.post1 / 0.5.16 / `main`. So the boundary is
  0.5.14, and above it a low ratio is a hit-rate loss (an L2 that evicts as fast as
  the L1 it shadows) rather than prefetch being switched off. The threshold constant
  does not move and the guard still fires on both; only the explanation an operator
  reads was wrong.
- `kvd_wiring` logged a WARNING when `ServerArgs` carried no `prefetch_threshold`
  field, telling the operator to pass an override that `_append_sglang_hicache_argv`
  already puts on the child argv a few lines later — and that argv copy is the one
  the engine subprocess reads. Demoted to INFO, and it now says where the 64 comes
  from.

## Verification

Both patch scripts were exercised against the **v0.5.16 and current-`main`** copies
of `pool_host/mla.py` + `memory_pool_host.py`, on throwaway trees:

| scenario | expected | result |
|---|---|---|
| stock v0.5.16 / `main` | apply, exit 0 | applies, patched file compiles, marker reaches the bytecode |
| re-run on a patched tree | exit 0 | `already applied` |
| #30350 simulated (three CUDA-only gates flipped) | refuse, exit 1 | refuses, `mla.py` byte-identical to pristine |
| no `pool_host/mla.py` (v0.5.15.post1 shape) | exit 0 | tolerated |
| anchor drifted / pool renamed / `memory_pool_host.py` absent | exit 1 | exit 1 with the offending lines printed |
| stale `__pycache__` | only `mla.*` / `common.*` removed | `mha.*` left in place |

kvd: a real daemon on a file-per-block long region now logs `io_mode=buffered`; a
caller/probe conflict logs `io_mode from the caller, not the probe (probe wanted
buffered: ...)`, and agreement adds no noise.

`ruff check` and `ruff format --check` clean. `tests/engine/sglang` +
`tests/unit/kvd`: 596 passed, 3 skipped. `tests/engine/vllm/test_mla_tp_dedup.py`
has 7 pre-existing failures on this machine (`PermissionError` on
`/nonexistent/model-for-test`) — reproduced identically on the untouched tree.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
