### PR TITLE
ci(release): get the overlay into the compliant publishing pipeline

### DIFF
--- a/.github/scripts/build_test_push.sh
+++ b/.github/scripts/build_test_push.sh
@@ -6,7 +6,8 @@
 #   build|push|ship <sglang|vllm|atom|kvd|server|overlay>
 #
 # `overlay` builds the base-agnostic payload (deploy/overlay/). It consumes the
-# vllm and sglang images, so it must run AFTER them — release.yml gates it.
+# vllm and sglang images, so it must run AFTER them — release.yml gates it, and
+# it publishes to two repos from one build (see the `refs` array below).
 set -euo pipefail
 
 cmd="${1:-}"
@@ -29,6 +30,39 @@ elif [ -n "${PR:-}" ]; then tag="${engine}-pr${PR}"
 else                        tag="${engine}-local"
 fi
 ref="${IMAGE}:${tag}"
+
+# The overlay ships to two places from one build, and the two have different
+# lifetimes -- this is a transition, not a permanent design.
+#
+#   ${IMAGE}:overlay-<id>   The point of this change. Engine images publish to
+#                           the private staging repo and are promoted to the
+#                           public docker.io/rocm/infera after review; the
+#                           overlay never entered that pipeline, so it had no
+#                           reviewed public home. Same tag shape as the engines
+#                           (<component>-<id>), so promotion is the same
+#                           mechanical retag rather than a special case.
+#
+#   ${IMAGE}-overlay:<id>   Temporary. A public repo under the staging
+#                           namespace, currently the only published overlay and
+#                           what every recipe in this tree pulls. It goes away
+#                           once a promoted rocm/infera:overlay-<id> exists and
+#                           the manifests point at it.
+#
+# Deriving the second name from IMAGE rather than hard-coding it means
+# overriding IMAGE moves both together, instead of silently publishing half a
+# release to the wrong place.
+#
+# One build, two tags -- never two builds. The overlay harvests compiled pieces
+# out of the engine images, so a rebuild is both expensive (~80 min) and not
+# guaranteed to reproduce the same bits; tagging one image twice makes the two
+# refs provably the same artefact, which matters when one of them is the thing
+# that gets reviewed and the other is what users are already running.
+refs=("$ref")
+if [ "$engine" = overlay ]; then
+  overlay_id="${ID:-${PR:+pr$PR}}"
+  overlay_id="${overlay_id:-local}"
+  refs+=("${IMAGE}-overlay:${overlay_id}")
+fi
 
 cd "$(dirname "$0")/../.."
 
@@ -78,12 +112,16 @@ case "$cmd" in
   build)
     # --network=host: RUN steps need DNS, and these nodes resolve via 127.0.0.1
     # which a default bridge build netns can't reach.
+    tag_args=(); for r in "${refs[@]}"; do tag_args+=(-t "$r"); done
     docker build --network=host ${build_args[@]+"${build_args[@]}"} \
-                 -f "$dockerfile" -t "$ref" .
+                 "${tag_args[@]}" -f "$dockerfile" .
     ;;
 
   push)
-    docker push "$ref"
+    for r in "${refs[@]}"; do
+      echo "pushing $r"
+      docker push "$r"
+    done
     ;;
 
   ship)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,13 @@ name: Build & publish images
 #
 # The `overlay` image (deploy/overlay/) is built in its own job after the engine
 # images, because it harvests their compiled pieces — see the `overlay` job.
-#   inferaimage/infera:overlay-v0.1.0
+# It is published to BOTH repos from a single build, same image, two names:
+#   inferaimage/infera:overlay-v0.1.0   staging, alongside the engine images,
+#                                       so it promotes to rocm/infera the same
+#                                       way they do
+#   inferaimage/infera-overlay:v0.1.0   transitional public repo — what the
+#                                       recipes pull today, retired once a
+#                                       promoted rocm/infera:overlay-* exists
 #
 # Target repo defaults to docker.io/inferaimage/infera; override per-run with
 # the `image_repo` dispatch input, or repo-wide with the IMAGE_REPO Actions


### PR DESCRIPTION
## The gap

Engine images publish to the private staging repo `inferaimage/infera` and are
promoted to public `docker.io/rocm/infera` after review. **The overlay never
entered that pipeline.**

What is actually true today:

| repo | visibility | contents |
|---|---|---|
| `inferaimage/infera` | private (staging) | engines |
| `rocm/infera` | public (promoted) | `sglang-`, `vllm-`, `atom-`, `kvd-`, `server-` — **no overlay** |
| `inferaimage/infera-overlay` | **public** | `v0.2.0/1/2` — the only published overlay |

So the artefact **13 recipes pin by digest** lives in a public repo under the
*staging* namespace, reached by some route outside this workflow, with no
reviewed public home and no path to one.

## The change

The overlay now ships to both names from a single build:

- **`${IMAGE}:overlay-<id>`** — staging, same tag shape as the engines
  (`<component>-<id>`), so promotion to `rocm/infera` is the same mechanical
  retag rather than a special case. This is the point of the change.
- **`${IMAGE}-overlay:<id>`** — transitional. The only published overlay today
  and what every recipe pulls; retired once a promoted
  `rocm/infera:overlay-<id>` exists and the manifests move to it.

**One build, two tags — never two builds.** The overlay harvests compiled pieces
out of the engine images, so rebuilding is both expensive (~80 min) and not
guaranteed to reproduce the same bits. Tagging one image twice makes the two
refs provably the same artefact — which matters when one of them is what gets
reviewed and the other is what users are already running.

The second name is derived from `IMAGE` rather than hard-coded, so overriding
`IMAGE` moves both together instead of publishing half a release to the wrong
place.

## Verification

Stub build on real docker (throwaway repo, cleaned up):

| | |
|---|---|
| release (`ID=v9.9.9`) | `infera:overlay-v9.9.9` + `infera-overlay:v9.9.9` |
| PR (`PR=42`) | `infera:overlay-pr42` + `infera-overlay:pr42` |
| local (neither) | `infera:overlay-local` + `infera-overlay:local` |
| same artefact | both tags → image ID `72971b27d3a1` |
| push | loop iterates over both refs |
| non-overlay engines | unchanged, still one tag |

## Follow-ups, not in this PR

- **Docs still point at `inferaimage/infera-overlay`** (13 files by `@sha256`
  digest, 10 more by `:v0.2.2` tag). They cannot move to `rocm/infera` until a
  promoted `overlay-*` tag exists there. Worth doing as one change right after
  the first promotion.
- **Nothing in the repo says those digests must be re-pinned at release time** —
  no check, no note in `.github/`, `docs/` or `manual/`. Today it depends on
  someone remembering.
