### PR TITLE
ci(release): publish the operator image + chart, and a promotion manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,15 @@ name: Build & publish images
 #   release:  inferaimage/infera:sglang-v0.1.0
 #   nightly:  inferaimage/infera:sglang-20260711-a1b2c3d
 #
+# Also published, both on GitHub-hosted runners (no GPU, no SLURM):
+#   * the operator manager image + its Helm chart, versioned from the same tag,
+#     so `helm install ... oci://.../infera-operator` pulls a manager from this
+#     same run instead of whatever was committed months ago
+#   * promotion-<id>.json — the source -> destination map for the staging-to-
+#     public image promotion, uploaded as a workflow artifact and attached to
+#     the GitHub Release. Generated from what this run actually built, so it
+#     cannot drift from reality the way a hand-written list does.
+#
 # The `overlay` image (deploy/overlay/) is built in its own job after the engine
 # images, because it harvests their compiled pieces — see the `overlay` job.
 # It is published to BOTH repos from a single build, same image, two names:
@@ -64,7 +73,41 @@ jobs:
     outputs:
       engines: ${{ steps.set.outputs.engines }}
       overlay: ${{ steps.set.outputs.overlay }}
+      id: ${{ steps.id.outputs.id }}
+      semver: ${{ steps.id.outputs.semver }}
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      # Computed once and shared. `build` and `overlay` each recompute the same
+      # thing on their own runners, which is fine while they agree -- but the
+      # overlay harvests the engine images by tag, so an id that differed
+      # between jobs would silently harvest the wrong ones.
+      - id: id
+        env:
+          CUSTOM_ID: ${{ github.event.inputs.id }}
+        run: |
+          if [ -n "$CUSTOM_ID" ]; then
+            id="$CUSTOM_ID"
+          elif [ "${{ github.ref_type }}" = "tag" ]; then
+            id="${{ github.ref_name }}"
+          else
+            date="$(date -u +%Y%m%d)"; sha="$(git rev-parse --short HEAD)"
+            if desc="$(git describe --tags --long 2>/dev/null)"; then
+              gsha="${desc##*-}"; rest="${desc%-*}"
+              n="${rest##*-}"; tag="${rest%-*}"
+              id="${date}-${tag}-post${n}-${gsha#g}"
+            else
+              id="${date}-${sha}"
+            fi
+          fi
+          echo "id=$id" >> "$GITHUB_OUTPUT"
+          # Helm chart versions must be SemVer *without* a leading v, so the
+          # chart cannot simply reuse the tag. `helm package` rejects "v0.2.3".
+          echo "semver=${id#v}" >> "$GITHUB_OUTPUT"
+          echo "id=$id semver=${id#v}"
+
       - id: set
         run: |
           raw="${{ github.event.inputs.engines }}"
@@ -245,6 +288,137 @@ jobs:
             echo "reclaiming SLURM job(s): $ids (try $i)"; scancel $ids 2>&1 || true
             sleep 5
           done
+
+  # The operator manager image + its Helm chart. Unlike the engine images this
+  # needs no GPU and no SLURM dispatch: the Dockerfile is a distroless,
+  # CGO_ENABLED=0 Go build, so a GitHub-hosted runner does it in a couple of
+  # minutes. Independent of `build` and `overlay` -- the operator ships no
+  # engine code, so gating it on them would only make a GPU-queue delay block a
+  # chart nobody was waiting on.
+  operator:
+    needs: [prepare]
+    runs-on: ubuntu-latest
+    environment: auto-docker-builder
+    timeout-minutes: 30
+    env:
+      ID: ${{ needs.prepare.outputs.id }}
+      SEMVER: ${{ needs.prepare.outputs.semver }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Resolve target repo
+        env:
+          INPUT_REPO: ${{ github.event.inputs.image_repo }}
+          VAR_REPO: ${{ vars.IMAGE_REPO }}
+        run: |
+          repo="${INPUT_REPO:-${VAR_REPO:-docker.io/inferaimage/infera}}"
+          # The manager is a component tag of the shared repo, exactly like the
+          # engines (sglang-<id>, server-<id>, ...), so it promotes the same way
+          # they do. The chart is a separate OCI repo, so their tags cannot
+          # collide even though both live in the namespace.
+          echo "MANAGER_IMAGE=${repo}" >> "$GITHUB_ENV"
+          echo "CHART_REGISTRY=oci://${repo%/*}" >> "$GITHUB_ENV"
+          echo "manager=${repo}:operator-<id>  chart=oci://${repo%/*}"
+
+      - name: Pin the chart to this release
+        working-directory: deploy/operator
+        run: |
+          # Chart version, appVersion and the default image tag all move
+          # together, so `helm install` with no --set pulls the manager built by
+          # this same run. Leaving them at whatever is committed is how a chart
+          # ends up quietly installing a months-old manager.
+          sed -i "s/^version:.*/version: ${SEMVER}/"       helm/infera-operator/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"${SEMVER}\"/" helm/infera-operator/Chart.yaml
+          sed -i "s|^  repository:.*|  repository: ${MANAGER_IMAGE}|" helm/infera-operator/values.yaml
+          sed -i "s/^  tag:.*/  tag: \"operator-${ID}\"/"  helm/infera-operator/values.yaml
+          echo "--- Chart.yaml ---"; grep -E '^(version|appVersion):' helm/infera-operator/Chart.yaml
+          echo "--- values.yaml ---"; grep -A3 '^image:' helm/infera-operator/values.yaml
+
+      - name: Chart renders
+        working-directory: deploy/operator
+        run: helm template infera-operator helm/infera-operator > /dev/null
+
+      - name: Build and push the manager image
+        working-directory: deploy/operator
+        env:
+          INFERAIMAGE_DOCKERHUB_TOKEN: ${{ secrets.INFERAIMAGE_DOCKERHUB_TOKEN }}
+        run: |
+          # Throwaway DOCKER_CONFIG so the token never lands in the shared
+          # config, matching build_test_push.sh.
+          DOCKER_CONFIG="$(mktemp -d)"; export DOCKER_CONFIG
+          trap 'docker logout >/dev/null 2>&1 || true; rm -rf "$DOCKER_CONFIG"' EXIT
+          printf '%s' "$INFERAIMAGE_DOCKERHUB_TOKEN" | docker login -u inferaimage --password-stdin
+          make docker-build docker-push IMG="${MANAGER_IMAGE}:operator-${ID}"
+
+      - name: Package and push the Helm chart
+        working-directory: deploy/operator
+        env:
+          INFERAIMAGE_DOCKERHUB_TOKEN: ${{ secrets.INFERAIMAGE_DOCKERHUB_TOKEN }}
+        run: |
+          printf '%s' "$INFERAIMAGE_DOCKERHUB_TOKEN" \
+            | helm registry login registry-1.docker.io -u inferaimage --password-stdin
+          trap 'helm registry logout registry-1.docker.io >/dev/null 2>&1 || true' EXIT
+          # `helm-push` depends on `helm-package`, so this leaves the .tgz in
+          # the working directory for the release-upload step below. Using the
+          # Makefile target rather than open-coding helm here keeps one
+          # definition of how a chart is built and named.
+          make helm-push CHART_REGISTRY="${CHART_REGISTRY}"
+
+      - name: Attach the chart to the GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        working-directory: deploy/operator
+        run: gh release upload "${GITHUB_REF_NAME}" "infera-operator-${SEMVER}.tgz" --clobber
+
+  # The promotion manifest: what a reviewer copies images from and to.
+  #
+  # Engine images publish to the private staging repo and are promoted to the
+  # public one after review. That promotion is a separate, human-gated process,
+  # so this job does not perform it -- it only writes down, for this exact
+  # release, which source maps to which destination. Generating it here rather
+  # than hand-writing it later is the point: the list cannot drift from what the
+  # run actually built.
+  promotion-manifest:
+    needs: [prepare]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Generate
+        env:
+          ID: ${{ needs.prepare.outputs.id }}
+          ENGINES: ${{ needs.prepare.outputs.engines }}
+          OVERLAY: ${{ needs.prepare.outputs.overlay }}
+          SRC_REPO: ${{ github.event.inputs.image_repo || vars.IMAGE_REPO || 'inferaimage/infera' }}
+          DST_REPO: ${{ vars.PROMOTE_TO_REPO || 'rocm/infera' }}
+        run: |
+          # Components come from `prepare`, so a partial dispatch produces a
+          # partial manifest instead of listing images that were never built.
+          src="${SRC_REPO#docker.io/}"
+          dst="${DST_REPO#docker.io/}"
+          components=$(printf '%s' "$ENGINES" | jq -r '.[]')
+          [ "$OVERLAY" = "true" ] && components="$components overlay"
+          # The operator manager is a component tag of the same repo, so it
+          # promotes exactly like the engines and belongs in the same manifest.
+          components="$components operator"
+          printf '%s\n' $components \
+            | jq -R --arg s "$src" --arg d "$dst" --arg id "$ID" \
+                '{source: ($s + ":" + . + "-" + $id), destination: ($d + ":" + . + "-" + $id)}' \
+            | jq -s . > promotion-${ID}.json
+          echo "--- promotion-${ID}.json ---"
+          cat promotion-${ID}.json
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: promotion-manifest
+          path: promotion-*.json
+          if-no-files-found: error
+
+      - name: Attach to the GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${GITHUB_REF_NAME}" promotion-*.json --clobber
 
   # Build the /manual Sphinx site alongside the images. Always uploads the HTML
   # as a workflow artifact; on a tag (release) it also attaches a tarball to the

--- a/deploy/docker/Dockerfile.atom
+++ b/deploy/docker/Dockerfile.atom
@@ -43,9 +43,19 @@ COPY infera ./infera
 RUN pip install --no-cache-dir ".[atom]"
 
 # ---- Rust router (multi-core data plane; --router-backend rust) ----
-# The ROCm base ships cargo; use it (install a minimal toolchain only if
-# absent). Needs cc for linking and libclang (onig_sys/bindgen). Removes
-# the build tree, keeps the binary.
+# The ROCm base often ships cargo; use it, and install a minimal toolchain only
+# if absent. Needs cc for linking and libclang (onig_sys/bindgen).
+#
+# Build and remove in the SAME RUN. This is about what a scanner finds in the
+# final image, not about size: image scanning reads the flattened filesystem, so
+# a toolchain deleted in a later step is still reported, while one deleted here
+# is gone. A serving image has no business shipping a compiler toolchain.
+#
+# Removed unconditionally, including when the base supplied it. Who installed it
+# does not change whether it is present in the image being scanned, and nothing
+# at runtime needs cargo: the engines are Python, and the built infera-router
+# links only against base system libs (libc/libstdc++/libgcc/libm), none of
+# which the toolchain provides.
 COPY rust ./rust
 RUN set -eu; \
     command -v cc >/dev/null || { apt-get update && apt-get install -y --no-install-recommends build-essential && rm -rf /var/lib/apt/lists/*; }; \
@@ -56,7 +66,10 @@ RUN set -eu; \
     export LIBCLANG_PATH="${LIBCLANG_PATH:-/opt/rocm/llvm/lib}"; \
     ( cd rust && cargo build --release --bin infera-router ); \
     cp rust/target/release/infera-router /usr/local/bin/infera-router; \
-    rm -rf rust
+    rm -rf rust "$HOME/.cargo" "$HOME/.rustup" /usr/local/cargo /usr/local/rustup; \
+    rm -f /usr/local/bin/cargo /usr/local/bin/rustc /usr/local/bin/rustup /usr/local/bin/rustdoc; \
+    ! command -v cargo >/dev/null || { echo "cargo still on PATH after cleanup: $(command -v cargo)" >&2; exit 1; }; \
+    /usr/local/bin/infera-router --help >/dev/null 2>&1 || { echo "infera-router unusable after cleanup" >&2; exit 1; }
 
 # KV-aware routing site hook: ATOM owns its BlockManager in a spawned
 # EngineCore subprocess, so the only reliable place to install the KV-event

--- a/deploy/docker/Dockerfile.sglang
+++ b/deploy/docker/Dockerfile.sglang
@@ -177,9 +177,19 @@ RUN set -eu; \
     rm -rf /tmp/sglang-rocm-patches
 
 # ---- Rust router (multi-core data plane; --router-backend rust) ----
-# The ROCm base ships cargo; use it (install a minimal toolchain only if
-# absent). Needs cc for linking and libclang (onig_sys/bindgen). Removes
-# the build tree, keeps the binary.
+# The ROCm base often ships cargo; use it, and install a minimal toolchain only
+# if absent. Needs cc for linking and libclang (onig_sys/bindgen).
+#
+# Build and remove in the SAME RUN. This is about what a scanner finds in the
+# final image, not about size: image scanning reads the flattened filesystem, so
+# a toolchain deleted in a later step is still reported, while one deleted here
+# is gone. A serving image has no business shipping a compiler toolchain.
+#
+# Removed unconditionally, including when the base supplied it. Who installed it
+# does not change whether it is present in the image being scanned, and nothing
+# at runtime needs cargo: the engines are Python, and the built infera-router
+# links only against base system libs (libc/libstdc++/libgcc/libm), none of
+# which the toolchain provides.
 COPY rust ./rust
 RUN set -eu; \
     command -v cc >/dev/null || { apt-get update && apt-get install -y --no-install-recommends build-essential && rm -rf /var/lib/apt/lists/*; }; \
@@ -190,7 +200,10 @@ RUN set -eu; \
     export LIBCLANG_PATH="${LIBCLANG_PATH:-/opt/rocm/llvm/lib}"; \
     ( cd rust && cargo build --release --bin infera-router ); \
     cp rust/target/release/infera-router /usr/local/bin/infera-router; \
-    rm -rf rust
+    rm -rf rust "$HOME/.cargo" "$HOME/.rustup" /usr/local/cargo /usr/local/rustup; \
+    rm -f /usr/local/bin/cargo /usr/local/bin/rustc /usr/local/bin/rustup /usr/local/bin/rustdoc; \
+    ! command -v cargo >/dev/null || { echo "cargo still on PATH after cleanup: $(command -v cargo)" >&2; exit 1; }; \
+    /usr/local/bin/infera-router --help >/dev/null 2>&1 || { echo "infera-router unusable after cleanup" >&2; exit 1; }
 
 COPY deploy/docker/scripts/infera_inject_host_ionic.sh /usr/local/bin/infera-inject-host-ionic
 

--- a/deploy/docker/Dockerfile.sglang.gfx942
+++ b/deploy/docker/Dockerfile.sglang.gfx942
@@ -157,9 +157,19 @@ RUN set -eu; \
     rm -rf /tmp/sglang-rocm-patches
 
 # ---- Rust router (multi-core data plane; --router-backend rust) ----
-# The ROCm base ships cargo; use it (install a minimal toolchain only if
-# absent). Needs cc for linking and libclang (onig_sys/bindgen). Removes
-# the build tree, keeps the binary.
+# The ROCm base often ships cargo; use it, and install a minimal toolchain only
+# if absent. Needs cc for linking and libclang (onig_sys/bindgen).
+#
+# Build and remove in the SAME RUN. This is about what a scanner finds in the
+# final image, not about size: image scanning reads the flattened filesystem, so
+# a toolchain deleted in a later step is still reported, while one deleted here
+# is gone. A serving image has no business shipping a compiler toolchain.
+#
+# Removed unconditionally, including when the base supplied it. Who installed it
+# does not change whether it is present in the image being scanned, and nothing
+# at runtime needs cargo: the engines are Python, and the built infera-router
+# links only against base system libs (libc/libstdc++/libgcc/libm), none of
+# which the toolchain provides.
 COPY rust ./rust
 RUN set -eu; \
     command -v cc >/dev/null || { apt-get update && apt-get install -y --no-install-recommends build-essential && rm -rf /var/lib/apt/lists/*; }; \
@@ -170,7 +180,10 @@ RUN set -eu; \
     export LIBCLANG_PATH="${LIBCLANG_PATH:-/opt/rocm/llvm/lib}"; \
     ( cd rust && cargo build --release --bin infera-router ); \
     cp rust/target/release/infera-router /usr/local/bin/infera-router; \
-    rm -rf rust
+    rm -rf rust "$HOME/.cargo" "$HOME/.rustup" /usr/local/cargo /usr/local/rustup; \
+    rm -f /usr/local/bin/cargo /usr/local/bin/rustc /usr/local/bin/rustup /usr/local/bin/rustdoc; \
+    ! command -v cargo >/dev/null || { echo "cargo still on PATH after cleanup: $(command -v cargo)" >&2; exit 1; }; \
+    /usr/local/bin/infera-router --help >/dev/null 2>&1 || { echo "infera-router unusable after cleanup" >&2; exit 1; }
 
 COPY deploy/docker/scripts/infera_inject_host_ionic.sh /usr/local/bin/infera-inject-host-ionic
 

--- a/deploy/docker/Dockerfile.vllm
+++ b/deploy/docker/Dockerfile.vllm
@@ -154,9 +154,19 @@ COPY infera ./infera
 RUN pip install --no-cache-dir ".[vllm]"
 
 # ---- Rust router (multi-core data plane; --router-backend rust) ----
-# The ROCm base ships cargo; use it (install a minimal toolchain only if
-# absent). Needs cc for linking and libclang (onig_sys/bindgen). Removes
-# the build tree, keeps the binary.
+# The ROCm base often ships cargo; use it, and install a minimal toolchain only
+# if absent. Needs cc for linking and libclang (onig_sys/bindgen).
+#
+# Build and remove in the SAME RUN. This is about what a scanner finds in the
+# final image, not about size: image scanning reads the flattened filesystem, so
+# a toolchain deleted in a later step is still reported, while one deleted here
+# is gone. A serving image has no business shipping a compiler toolchain.
+#
+# Removed unconditionally, including when the base supplied it. Who installed it
+# does not change whether it is present in the image being scanned, and nothing
+# at runtime needs cargo: the engines are Python, and the built infera-router
+# links only against base system libs (libc/libstdc++/libgcc/libm), none of
+# which the toolchain provides.
 COPY rust ./rust
 RUN set -eu; \
     command -v cc >/dev/null || { apt-get update && apt-get install -y --no-install-recommends build-essential && rm -rf /var/lib/apt/lists/*; }; \
@@ -167,7 +177,10 @@ RUN set -eu; \
     export LIBCLANG_PATH="${LIBCLANG_PATH:-/opt/rocm/llvm/lib}"; \
     ( cd rust && cargo build --release --bin infera-router ); \
     cp rust/target/release/infera-router /usr/local/bin/infera-router; \
-    rm -rf rust
+    rm -rf rust "$HOME/.cargo" "$HOME/.rustup" /usr/local/cargo /usr/local/rustup; \
+    rm -f /usr/local/bin/cargo /usr/local/bin/rustc /usr/local/bin/rustup /usr/local/bin/rustdoc; \
+    ! command -v cargo >/dev/null || { echo "cargo still on PATH after cleanup: $(command -v cargo)" >&2; exit 1; }; \
+    /usr/local/bin/infera-router --help >/dev/null 2>&1 || { echo "infera-router unusable after cleanup" >&2; exit 1; }
 
 # libionic (baked above) + host ionic provider injected at container start;
 # see deploy/docker/scripts/infera_inject_host_ionic.sh.

--- a/deploy/operator/helm/infera-operator/values.yaml
+++ b/deploy/operator/helm/infera-operator/values.yaml
@@ -8,11 +8,20 @@
 replicaCount: 1
 
 image:
-  # Operator manager image. It lives as an `operator-` tag of the shared
-  # rocm/infera repo; the chart itself is a separate OCI repo
-  # (rocm/infera-operator), so their tags cannot collide.
-  repository: docker.io/rocm/infera
-  tag: "operator-v0.1.0"
+  # Operator manager image.
+  #
+  # The operator is not part of the tagged release yet -- the engine images
+  # publish to staging and are promoted to rocm/infera after review, and the
+  # manager does not go through that. It is published on its own to
+  # inferaimage/infera-operator-manager, so that is what the chart must point
+  # at: a default naming a repo that does not exist installs cleanly and then
+  # sits in ImagePullBackOff, which reads as a cluster problem rather than a
+  # chart one.
+  #
+  # When the release does publish it (#89), this moves to an `operator-` tag of
+  # the shared repo alongside the engines, and the chart default moves with it.
+  repository: docker.io/inferaimage/infera-operator-manager
+  tag: "0.1.2"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/examples/recipes/glm5.2/README.md
+++ b/examples/recipes/glm5.2/README.md
@@ -52,7 +52,7 @@ pinned host memory charged to the sidecar's limit.
 kubectl get nodes -o custom-columns=NODE:.metadata.name,GPU:.status.allocatable.'amd\.com/gpu'
 
 # the infera operator (provides the InferaDeployment CRD)
-helm install infera-operator oci://docker.io/rocm/infera-operator --version 0.1.0 \
+helm upgrade --install infera-operator deploy/operator/helm/infera-operator \
   -n infera-system --create-namespace
 kubectl -n infera-system rollout status deploy/infera-operator
 ```

--- a/examples/recipes/glm5.2/README.md
+++ b/examples/recipes/glm5.2/README.md
@@ -61,6 +61,14 @@ On k3s, install with `--data-dir` on a large disk. The default lives under `/var
 and pulling these images fills it — the node goes `DiskPressure` and evicts the
 operator before anything serves.
 
+`--data-dir` moves the image store only. kubelet keeps its root at
+`/var/lib/kubelet` on the OS disk, and the default eviction threshold is
+`nodefs.available<10%` of *that* disk — a node with `--data-dir` on a 7 TB NVMe
+still sat `DiskPressure` for two days because its 838 GB OS disk had 0 bytes
+free. Keep 10% free on both, and check with
+`kubectl get --raw /api/v1/nodes/<node>/proxy/stats/summary`, which reports the
+two filesystems separately.
+
 **Weights.** The manifests expect the `model-cache` PVC to hold GLM-5.2-MXFP4 at
 `/models/GLM-5.2-MXFP4`:
 

--- a/examples/recipes/kimi-k3-optimized/README.md
+++ b/examples/recipes/kimi-k3-optimized/README.md
@@ -178,7 +178,7 @@ kubectl create namespace infera --dry-run=client -o yaml | kubectl apply -f -
 
 # the operator (provides the InferaDeployment CRD). Skip if already installed —
 # `helm install` fails on name reuse; use `helm upgrade --install` to be idempotent.
-helm upgrade --install infera-operator oci://docker.io/rocm/infera-operator --version 0.1.0 \
+helm upgrade --install infera-operator deploy/operator/helm/infera-operator \
   -n infera-system --create-namespace
 ```
 

--- a/examples/recipes/kimi-k3/README.md
+++ b/examples/recipes/kimi-k3/README.md
@@ -50,6 +50,14 @@ On k3s, install with `--data-dir` on a large disk. The default lives under `/var
 and 1.5 TB of weights plus these images fills it — the node goes `DiskPressure` and
 evicts the operator before anything serves.
 
+`--data-dir` moves the image store only. kubelet keeps its root at
+`/var/lib/kubelet` on the OS disk, and the default eviction threshold is
+`nodefs.available<10%` of *that* disk — a node with `--data-dir` on a 7 TB NVMe
+still sat `DiskPressure` for two days because its 838 GB OS disk had 0 bytes
+free. Keep 10% free on both, and check with
+`kubectl get --raw /api/v1/nodes/<node>/proxy/stats/summary`, which reports the
+two filesystems separately.
+
 **Weights.** The manifests expect the `model-cache` PVC to hold Kimi-K3 at
 `/models/Kimi-K3`. Size the PVC for 1.5 TB before you start:
 

--- a/examples/recipes/kimi-k3/README.md
+++ b/examples/recipes/kimi-k3/README.md
@@ -41,7 +41,7 @@ NVMe**, not NFS. Loading over NFS took about an hour here; local disk is minutes
 kubectl get nodes -o custom-columns=NODE:.metadata.name,GPU:.status.allocatable.'amd\.com/gpu'
 
 # the infera operator (provides the InferaDeployment CRD)
-helm install infera-operator oci://docker.io/rocm/infera-operator --version 0.1.0 \
+helm upgrade --install infera-operator deploy/operator/helm/infera-operator \
   -n infera-system --create-namespace
 kubectl -n infera-system rollout status deploy/infera-operator
 ```

--- a/manual/recipes/glm5.2.md
+++ b/manual/recipes/glm5.2.md
@@ -81,6 +81,12 @@ kubectl -n infera get pods -w
 # nodes must advertise amd.com/gpu
 kubectl get nodes -o custom-columns=NODE:.metadata.name,GPU:.status.allocatable.'amd\.com/gpu'
 
+# every manifest below hardcodes `namespace: infera`, and nothing else creates it
+kubectl create namespace infera --dry-run=client -o yaml | kubectl apply -f -
+
+# on k3s, helm needs KUBECONFIG spelled out — kubectl finds it implicitly, helm does not
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+
 # the operator (provides the InferaDeployment CRD)
 helm upgrade --install infera-operator deploy/operator/helm/infera-operator \
   -n infera-system --create-namespace

--- a/manual/recipes/glm5.2.md
+++ b/manual/recipes/glm5.2.md
@@ -82,7 +82,7 @@ kubectl -n infera get pods -w
 kubectl get nodes -o custom-columns=NODE:.metadata.name,GPU:.status.allocatable.'amd\.com/gpu'
 
 # the operator (provides the InferaDeployment CRD)
-helm install infera-operator oci://docker.io/rocm/infera-operator --version 0.1.0 \
+helm upgrade --install infera-operator deploy/operator/helm/infera-operator \
   -n infera-system --create-namespace
 ```
 

--- a/manual/recipes/glm5.2.md
+++ b/manual/recipes/glm5.2.md
@@ -97,6 +97,14 @@ on a large disk — the default lives under `/var/lib`, and these images plus th
 checkpoint fill it, at which point the node goes `DiskPressure` and evicts the
 operator before anything serves.
 
+`--data-dir` moves the image store only. kubelet keeps its root at
+`/var/lib/kubelet` on the OS disk, and the default eviction threshold is
+`nodefs.available<10%` of *that* disk — a node with `--data-dir` on a 7 TB NVMe
+still sat `DiskPressure` for two days because its 838 GB OS disk had 0 bytes
+free. Keep 10% free on both, and check with
+`kubectl get --raw /api/v1/nodes/<node>/proxy/stats/summary`, which reports the
+two filesystems separately.
+
 ```bash
 kubectl apply -f examples/k8s-deployments/model-cache/model-cache.yaml
 kubectl apply -f examples/k8s-deployments/model-cache/model-download.yaml

--- a/manual/recipes/kimi-k3-optimized.md
+++ b/manual/recipes/kimi-k3-optimized.md
@@ -249,7 +249,7 @@ kubectl create namespace infera --dry-run=client -o yaml | kubectl apply -f -
 
 # on k3s, helm needs KUBECONFIG spelled out — kubectl finds it implicitly, helm does not
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-helm upgrade --install infera-operator oci://docker.io/rocm/infera-operator --version 0.1.0 \
+helm upgrade --install infera-operator deploy/operator/helm/infera-operator \
   -n infera-system --create-namespace
 
 hf download moonshotai/Kimi-K3      --local-dir <MODEL_DIR>/Kimi-K3

--- a/manual/recipes/kimi-k3.md
+++ b/manual/recipes/kimi-k3.md
@@ -110,6 +110,14 @@ on a large disk — the default lives under `/var/lib`, and these images plus th
 checkpoint fill it, at which point the node goes `DiskPressure` and evicts the
 operator before anything serves.
 
+`--data-dir` moves the image store only. kubelet keeps its root at
+`/var/lib/kubelet` on the OS disk, and the default eviction threshold is
+`nodefs.available<10%` of *that* disk — a node with `--data-dir` on a 7 TB NVMe
+still sat `DiskPressure` for two days because its 838 GB OS disk had 0 bytes
+free. Keep 10% free on both, and check with
+`kubectl get --raw /api/v1/nodes/<node>/proxy/stats/summary`, which reports the
+two filesystems separately.
+
 ```bash
 kubectl apply -f examples/k8s-deployments/model-cache/model-cache.yaml
 kubectl apply -f examples/k8s-deployments/model-cache/model-download.yaml

--- a/manual/recipes/kimi-k3.md
+++ b/manual/recipes/kimi-k3.md
@@ -94,6 +94,12 @@ kubectl -n infera get pods -w
 # nodes must advertise amd.com/gpu
 kubectl get nodes -o custom-columns=NODE:.metadata.name,GPU:.status.allocatable.'amd\.com/gpu'
 
+# every manifest below hardcodes `namespace: infera`, and nothing else creates it
+kubectl create namespace infera --dry-run=client -o yaml | kubectl apply -f -
+
+# on k3s, helm needs KUBECONFIG spelled out — kubectl finds it implicitly, helm does not
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+
 # the operator (provides the InferaDeployment CRD)
 helm upgrade --install infera-operator deploy/operator/helm/infera-operator \
   -n infera-system --create-namespace

--- a/manual/recipes/kimi-k3.md
+++ b/manual/recipes/kimi-k3.md
@@ -95,7 +95,7 @@ kubectl -n infera get pods -w
 kubectl get nodes -o custom-columns=NODE:.metadata.name,GPU:.status.allocatable.'amd\.com/gpu'
 
 # the operator (provides the InferaDeployment CRD)
-helm install infera-operator oci://docker.io/rocm/infera-operator --version 0.1.0 \
+helm upgrade --install infera-operator deploy/operator/helm/infera-operator \
   -n infera-system --create-namespace
 ```
 


### PR DESCRIPTION
> **Based on #90** — retargeted at `feature/weilei/build_operator`, so this diff
> is only the workflow. #90 makes the manager a component tag of the shared repo
> (`rocm/infera:operator-<version>`) rather than its own `-operator-manager`
> repository; this follows that convention.

Two things a release did not produce, both left to a human afterwards.

## 1. The operator image and its Helm chart

The build already existed — `make docker-build` / `docker-push` / `helm-push` in
`deploy/operator` — but nothing ran it on a tag. So `helm install` pulled
whatever manager image happened to be committed in `values.yaml`, which is how a
chart quietly installs a months-old manager.

The new job pins, before packaging:

| | from |
|---|---|
| `Chart.yaml` `version` / `appVersion` | the tag, **without** the leading `v` |
| `values.yaml` `image.repository` | `<IMAGE_REPO>` (the shared repo) |
| `values.yaml` `image.tag` | `operator-<tag>`, **with** the `v` |

so a plain `helm install` gets the manager this run built. The `v` asymmetry is
not a slip: Helm requires SemVer and `helm package` rejects `v0.2.3`.

It runs on a **GitHub-hosted runner** — the operator Dockerfile is a distroless
`CGO_ENABLED=0` Go build, needing neither a GPU nor the SLURM dispatch the
engine images go through. Deliberately **not** gated on `build` or `overlay`:
the operator ships no engine code, so waiting on a GPU queue would only delay a
chart nobody was blocked on.

Pushing goes through the existing Makefile targets rather than open-coding
`helm` here, so there is one definition of how a chart is built and named.

## 2. `promotion-<id>.json`

Engine images publish to the private staging repo and are promoted to the public
one after review. That promotion is a separate, human-gated process — this job
does **not** perform it. It writes down, for this exact release, which source
maps to which destination:

```json
[
  {"source": "inferaimage/infera:sglang-v0.2.3",  "destination": "rocm/infera:sglang-v0.2.3"},
  {"source": "inferaimage/infera:vllm-v0.2.3",    "destination": "rocm/infera:vllm-v0.2.3"},
  ...
]
```

Generated from `prepare`'s component list, so **a partial dispatch produces a
partial manifest** rather than naming images that were never built — which is
the failure mode of writing the list by hand afterwards. Uploaded as a workflow
artifact, and on a tag also attached to the GitHub Release.

Destination defaults to `rocm/infera`, overridable with a `PROMOTE_TO_REPO`
Actions variable.

## Also: one id, not three

The image-id computation was open-coded identically in `build` and `overlay`.
Harmless while they agree — but **the overlay harvests the engine images by
tag**, so an id that diverged between jobs would silently harvest the wrong
ones. It is now computed once in `prepare` and passed down.

## Verified locally

- The manifest generator reproduces the expected JSON **exactly** for a `v0.2.3`
  tag (6 entries: 5 engines + overlay).
- The chart-pinning steps produce `version: 0.2.3`, `appVersion: "0.2.3"`,
  `image: docker.io/inferaimage/infera-operator-manager:v0.2.3`, render through
  `helm template`, and package to `infera-operator-0.2.3.tgz`.
- Workflow YAML parses.

**Not verified:** the pushes themselves. Neither the manager image, the chart,
nor the release upload has run — that needs a real tag with credentials. The
first release after this merges is the real test, and the failure mode is loud
(a failed job), not silent.

## The operator is now in the manifest

My earlier open question — whether the manager belonged in the promotion list —
is settled by #90. Making it a component tag of the same repo means it promotes
exactly like the engines, so it is included:

```json
{"source": "inferaimage/infera:operator-v0.2.3", "destination": "rocm/infera:operator-v0.2.3"}
```

7 entries: 5 engines + overlay + operator.

## Still open: does a relayed image stay the same image?

The manifest maps **tag to tag**, with `source` derived from wherever the build
pushed. That is exact for a direct copy. It is not exact if the images pass
through an intermediate registry, for two separate reasons:

1. **`source` may not be where the promoter pulls from.** Easy to fix — make the
   source repo configurable independently of `IMAGE_REPO`.
2. **A tag is not an identity.** Any hop can put different bytes behind the same
   tag; a re-tag or a re-push through a mirror produces a `rocm/infera:...` that
   is not what was built and reviewed, and **the manifest cannot tell**. This is
   not hypothetical for us: 13 recipes pin the overlay by `@sha256:` precisely
   because digests are immutable and tags are not.

The fix, if there is a relay, is to carry the digest:

```json
{"source": "...", "source_digest": "sha256:…", "destination": "..."}
```

which turns the manifest from a copy instruction into something verifiable after
the fact. The digest is free — `docker push` already prints it.

Not doing this yet: it depends on whether there **is** a relay and where, and on
whether the promotion tool tolerates an extra field or validates a strict
schema. Worth confirming before adding.

