### PR TITLE
fix(kvd): classify an L3 mount through sysfs when lsblk cannot name its device

### DIFF
--- a/infera/kvd/storage_classify.py
+++ b/infera/kvd/storage_classify.py
@@ -46,16 +46,24 @@ A CPU-count guardrail caps the final pick at
 ``max(2, cpu_count() // n_shards)`` so 8-shard configs on small boxes
 never spin up more threads than the box can productively schedule.
 
-The probe is a chain of cheap subprocess calls — ``findmnt`` and
-``lsblk`` — both shipped by util-linux on every modern distro. If
-either binary is missing (containers, exotic systems) we fall back to
-the conservative "buffered" + workers=4 default and log a WARN.
+The probe starts from ``findmnt`` to name the mount, then resolves that
+mount to its physical devices two ways. ``lsblk -no NAME,TRAN,ROTA`` is
+tried first, since the transport table above was calibrated against its
+TRAN column. It answers by device *name*, though, which fails on an LVM
+mount (the name findmnt hands back is a udev symlink) and inside a
+container (``/dev`` holds only what ``--device`` put there). So whenever
+lsblk comes back empty, or with devices it could not name a transport
+for, we walk sysfs instead: ``major:minor`` from ``stat()`` into
+``/sys/dev/block``, then down ``slaves/`` to the physical disks. sysfs
+needs no device node, no udev and no subprocess, and the block layer is
+not namespaced, so an unprivileged container sees the whole topology.
 
-The chain handles md-raid, LVM, dm-crypt, and bind mounts transparently
-by walking ``lsblk -no NAME,TRAN,ROTA`` recursively. For mixed-device
-arrays (e.g. NVMe + SATA in the same md0) the worst-case device wins
-— a single SATA member in an mdraid pulls the whole array into the
-"buffered" bucket.
+Between them the two cover md-raid, LVM, dm-crypt, partitions and bind
+mounts. If both come up empty we fall back to the conservative
+"buffered" + workers=4 default and log a WARN. For mixed-device arrays
+(e.g. NVMe + SATA in the same md0) the worst-case device wins — a single
+SATA member in an mdraid pulls the whole array into the "buffered"
+bucket.
 
 Public API:
 
@@ -323,6 +331,151 @@ def _lsblk_inverse_parent(devpath: str) -> tuple[str, bool | None]:
     return "", None
 
 
+# ----------------------------------------------------------------------
+# sysfs device walk — the fallback for everything lsblk cannot answer
+# ----------------------------------------------------------------------
+#
+# lsblk resolves a device by *name*, which is where it loses two cases we
+# actually run in:
+#
+#   - **LVM.** ``findmnt`` reports ``/dev/mapper/<vg>-<lv>``, a symlink udev
+#     creates; the kernel's own node is ``/dev/dm-N``. The forward walk then
+#     reports the leaf as ``<vg>-<lv>``, and ``/dev/<vg>-<lv>`` is not a path
+#     that exists, so the ``--inverse`` walk that would have supplied the
+#     transport dead-ends. md is unaffected — ``md0`` and ``/dev/md0`` agree —
+#     which is why this went unnoticed.
+#   - **Containers.** ``/dev`` is a private, near-empty devtmpfs; Docker only
+#     populates what ``--device`` names. lsblk cannot open the node at all.
+#     ``privileged: true`` does not rescue LVM either: the host devtmpfs it
+#     exposes carries ``/dev/dm-N`` but not the ``/dev/mapper/`` symlinks,
+#     because those are udev's work and containers do not run udev.
+#
+# sysfs sidesteps both. It is indexed by ``major:minor`` rather than by name,
+# and those numbers come straight from ``stat()`` — no node, no udev, no
+# subprocess. It is also global: the block layer is not namespaced, so a
+# container sees the full topology even unprivileged.
+
+# Every sysfs lookup below hangs off this one root so the tests can aim the
+# whole walk at a fixture tree instead of the machine they happen to run on.
+_SYSFS_ROOT = "/sys"
+
+
+def _sysfs_read(path: str) -> str:
+    """Read a sysfs attribute; "" if it is missing or unreadable."""
+    try:
+        with open(path) as f:
+            return f.read().strip()
+    except OSError:
+        return ""
+
+
+def _sysfs_whole_disk(name: str) -> str:
+    """Resolve a partition to the disk that carries it.
+
+    Partitions have neither ``queue/`` nor ``device/`` of their own — both
+    live on the whole-disk node one level up (``.../block/sda/sda1`` → ``sda``).
+    Non-partitions are returned unchanged.
+    """
+    real = os.path.realpath(os.path.join(f"{_SYSFS_ROOT}/class/block", name))
+    if os.path.exists(os.path.join(real, "partition")):
+        return os.path.basename(os.path.dirname(real))
+    return name
+
+
+def _sysfs_transport(name: str) -> str:
+    """Best-effort transport for a leaf device, mirroring lsblk's TRAN.
+
+    Returns "" when the bus cannot be identified, which the callers already
+    treat as "unknown → buffered". Since this whole path only runs after
+    lsblk has failed to answer, an unrecognised bus is no worse than the
+    status quo — every transport we *do* resolve is a strict improvement.
+    """
+    disk = _sysfs_whole_disk(name)
+    devlink = os.path.join(f"{_SYSFS_ROOT}/class/block", disk, "device")
+    if not os.path.exists(devlink):
+        # No backing device: dm/md nodes with no slaves, loop, zram, ramdisk.
+        return ""
+    devpath = os.path.realpath(devlink)
+    subsystem = os.path.basename(os.path.realpath(os.path.join(devlink, "subsystem")))
+    if subsystem in ("nvme", "virtio", "mmc"):
+        return subsystem
+    if subsystem != "scsi":
+        return ""
+    # SCSI multiplexes every serial bus, so the subsystem alone says nothing.
+    # util-linux keys off the host's proc_name; we follow it, then fall back
+    # to the shape of the device path for the buses that do not set one.
+    m = re.search(r"/host(\d+)/", devpath + "/")
+    proc = _sysfs_read(f"{_SYSFS_ROOT}/class/scsi_host/host{m.group(1)}/proc_name") if m else ""
+    if proc.startswith("iscsi"):
+        return "iscsi"
+    if os.path.exists(os.path.join(devpath, "sas_address")):
+        return "sas"
+    if "/usb" in devpath:
+        return "usb"
+    if proc in ("ahci", "ata_piix") or proc.startswith(("sata_", "pata_")) or "/ata" in devpath:
+        return "sata"
+    fc_host = f"{_SYSFS_ROOT}/class/fc_host"
+    if os.path.isdir(fc_host) and os.listdir(fc_host):
+        return "fc"
+    return ""
+
+
+def _sysfs_leaves(name: str, seen: set[str] | None = None) -> list[str]:
+    """Descend ``slaves/`` until devices that have none — the physical disks.
+
+    ``slaves/`` is how the block layer records "this virtual device is built
+    on those"; dm stacks (LVM, dm-crypt) and md arrays both populate it, and
+    nesting them just deepens the recursion. ``seen`` guards against a device
+    appearing under two parents (an LVM RAID mirrors each leg through its own
+    rimage) rather than against a real cycle, which the kernel forbids.
+    """
+    seen = seen if seen is not None else set()
+    if name in seen:
+        return []
+    seen.add(name)
+    slaves = os.path.join(f"{_SYSFS_ROOT}/class/block", name, "slaves")
+    try:
+        children = sorted(os.listdir(slaves)) if os.path.isdir(slaves) else []
+    except OSError:
+        children = []
+    if not children:
+        return [name]
+    out: list[str] = []
+    for child in children:
+        out += _sysfs_leaves(child, seen)
+    return out
+
+
+def _sysfs_rotational(name: str) -> bool:
+    """``queue/rotational`` for a leaf, read off its whole disk."""
+    disk = _sysfs_whole_disk(name)
+    return _sysfs_read(f"{_SYSFS_ROOT}/class/block/{disk}/queue/rotational") == "1"
+
+
+def _sysfs_for_path(path: Path) -> list[DeviceInfo]:
+    """Resolve ``path`` to its physical devices through sysfs alone.
+
+    Returns [] when sysfs cannot answer — no /sys mounted, or a filesystem
+    with no block device behind it (NFS and friends report a synthetic
+    ``st_dev`` that has no ``/sys/dev/block`` entry). Never raises.
+    """
+    try:
+        st = os.stat(path)
+        devno = f"{os.major(st.st_dev)}:{os.minor(st.st_dev)}"
+        link = f"{_SYSFS_ROOT}/dev/block/{devno}"
+        if not os.path.exists(link):
+            return []
+        top = os.path.basename(os.path.realpath(link))
+        # dict.fromkeys dedupes while keeping the walk order stable.
+        return [
+            DeviceInfo(dev=d, transport=_sysfs_transport(d), rotational=_sysfs_rotational(d))
+            for d in dict.fromkeys(_sysfs_leaves(top))
+        ]
+    except OSError as exc:
+        logger.debug("storage_classify: sysfs walk of %s failed: %s", path, exc)
+        return []
+
+
 def _nfs_mount_opts(source: str, path: Path) -> str:
     """Return the raw mount-options string for the NFS mount covering
     ``path``. Empty string if /proc/mounts isn't readable or no NFS
@@ -429,9 +582,24 @@ def classify_storage(path: Path) -> StorageInfo:
     if fstype in _NO_DIRECT_FSTYPES:
         return info
     devices = _lsblk_for_source(source)
+    # lsblk is kept as the fast path because it is what the transport table
+    # above was calibrated against, but it answers by name and so cannot see
+    # through an LVM mount or into a container's empty /dev. Take the sysfs
+    # answer whenever lsblk returned nothing, or returned devices it could not
+    # put a transport on — both of those end at "conservative buffered", and
+    # on NVMe that is a ~4x throughput cut taken for a naming detail.
+    if not devices or any(not d.transport for d in devices):
+        from_sysfs = _sysfs_for_path(path)
+        if from_sysfs and any(d.transport for d in from_sysfs):
+            logger.debug(
+                "storage_classify: lsblk could not classify source=%r; sysfs resolved %d device(s)",
+                source,
+                len(from_sysfs),
+            )
+            devices = from_sysfs
     if not devices:
         info.warnings.append(
-            f"lsblk returned no devices for source={source!r}; defaulting to buffered"
+            f"neither lsblk nor sysfs found devices for source={source!r}; defaulting to buffered"
         )
     info.devices = devices
     return info

--- a/infera/kvd/storage_classify.py
+++ b/infera/kvd/storage_classify.py
@@ -389,6 +389,10 @@ def _sysfs_transport(name: str) -> str:
     treat as "unknown → buffered". Since this whole path only runs after
     lsblk has failed to answer, an unrecognised bus is no worse than the
     status quo — every transport we *do* resolve is a strict improvement.
+
+    Every check below is a per-device one, and answers the same way lsblk
+    would. There is deliberately no guessing beyond that: a bus we cannot
+    name from this device's own sysfs entries stays "", and "" is buffered.
     """
     disk = _sysfs_whole_disk(name)
     devlink = os.path.join(f"{_SYSFS_ROOT}/class/block", disk, "device")
@@ -402,10 +406,15 @@ def _sysfs_transport(name: str) -> str:
     if subsystem != "scsi":
         return ""
     # SCSI multiplexes every serial bus, so the subsystem alone says nothing.
-    # util-linux keys off the host's proc_name; we follow it, then fall back
-    # to the shape of the device path for the buses that do not set one.
-    m = re.search(r"/host(\d+)/", devpath + "/")
-    proc = _sysfs_read(f"{_SYSFS_ROOT}/class/scsi_host/host{m.group(1)}/proc_name") if m else ""
+    # util-linux keys off the SCSI host this device hangs from; we follow it,
+    # then fall back to the shape of the device's own path for the buses that
+    # set no proc_name. Every one of these is scoped to this device — the
+    # host number comes out of its path, and the path is its own.
+    host = re.search(r"/host(\d+)/", devpath + "/")
+    hostn = host.group(1) if host else ""
+    proc = _sysfs_read(f"{_SYSFS_ROOT}/class/scsi_host/host{hostn}/proc_name") if hostn else ""
+    if hostn and os.path.isdir(f"{_SYSFS_ROOT}/class/fc_host/host{hostn}"):
+        return "fc"
     if proc.startswith("iscsi"):
         return "iscsi"
     if os.path.exists(os.path.join(devpath, "sas_address")):
@@ -414,9 +423,6 @@ def _sysfs_transport(name: str) -> str:
         return "usb"
     if proc in ("ahci", "ata_piix") or proc.startswith(("sata_", "pata_")) or "/ata" in devpath:
         return "sata"
-    fc_host = f"{_SYSFS_ROOT}/class/fc_host"
-    if os.path.isdir(fc_host) and os.listdir(fc_host):
-        return "fc"
     return ""
 
 

--- a/tests/unit/kvd/test_storage_classify.py
+++ b/tests/unit/kvd/test_storage_classify.py
@@ -932,6 +932,46 @@ def test_sysfs_reads_sas_from_the_device_attribute(fake_sysfs):
     assert storage_classify._sysfs_for_path(probe)[0].transport == "sas"
 
 
+def test_sysfs_does_not_name_a_bus_from_machine_wide_state(fake_sysfs, tmp_path):
+    """A RAID card presenting a logical volume supplies no per-device signal,
+    so it has to stay unknown. Answering from something machine-wide instead —
+    "this box has an fc_host, so call it fc" — labels a local disk a SAN.
+    """
+    probe = fake_sysfs(
+        {
+            "sdf": {
+                "subsystem": "scsi",
+                "devpath": "pci0000:00/host2/target2:2:0/2:2:0:0",
+                "rotational": "0",
+            }
+        },
+        target="sdf",
+        scsi_hosts={"host2": "megaraid_sas"},
+    )
+    # An FC HBA elsewhere in the box, on a host this disk has nothing to do with.
+    (tmp_path / "sys" / "class" / "fc_host" / "host9").mkdir(parents=True)
+    assert storage_classify._sysfs_for_path(probe)[0].transport == ""
+
+
+def test_sysfs_names_fc_when_the_hba_is_this_disk_s_own_host(fake_sysfs, tmp_path):
+    """The other half of the pair: a real SAN is worth naming, because
+    'SAN fc → buffered' reads a great deal better in the startup log than an
+    unknown transport, which also logs a WARN."""
+    probe = fake_sysfs(
+        {
+            "sdg": {
+                "subsystem": "scsi",
+                "devpath": "pci0000:00/host4/rport-4:0-0/target4:0:0/4:0:0:0",
+                "rotational": "0",
+            }
+        },
+        target="sdg",
+        scsi_hosts={"host4": "lpfc"},
+    )
+    (tmp_path / "sys" / "class" / "fc_host" / "host4").mkdir(parents=True)
+    assert storage_classify._sysfs_for_path(probe)[0].transport == "fc"
+
+
 def test_sysfs_returns_nothing_when_the_devno_is_not_registered(fake_sysfs, tmp_path):
     """A filesystem with no block device behind it — NFS reports a synthetic
     st_dev that has no /sys/dev/block entry."""

--- a/tests/unit/kvd/test_storage_classify.py
+++ b/tests/unit/kvd/test_storage_classify.py
@@ -17,6 +17,7 @@ asserts on the ``pick_io_mode`` decision + the ``StorageInfo`` payload.
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -750,3 +751,279 @@ def test_format_workers_decision_nfs_includes_nconnect(fake_run, fake_proc_mount
     out = format_workers_decision(info, workers, rationale)
     assert "nconnect" in out
     assert "8" in out
+
+
+# ----------------------------------------------------------------------
+# sysfs device walk — the path that covers what lsblk cannot resolve.
+#
+# Every case here builds a real directory tree shaped like sysfs and points
+# the module at it, so the walk is exercised end to end (symlinks, slaves/
+# recursion, partition→disk resolution) without depending on whatever disks
+# the test machine happens to have.
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_sysfs(monkeypatch, tmp_path):
+    """Build a sysfs fixture tree and aim the module's walk at it.
+
+    ``devices`` maps each block device name to its shape:
+
+        rotational   "0" / "1"     ``queue/rotational``; whole disks only,
+                                   since that is where the kernel puts it
+        slaves       [names]       the devices this one is built on
+        subsystem    "nvme"/...    the bus its backing device sits on
+        devpath      "a/b/c"       where under ``/sys/devices`` that lands —
+                                   this is what carries ``/hostN/`` and ``/usb``
+        sas_address  True          the attribute that marks a SAS disk
+        parent_disk  "sda"         makes this device a partition of that disk
+
+    ``scsi_hosts`` maps a host name to its ``proc_name``, the attribute
+    util-linux reads to tell iSCSI and SATA apart.
+
+    Returns the path to probe: ``tmp_path`` itself, registered in the fake
+    ``/sys/dev/block`` under its own real ``st_dev`` so ``stat()`` lands on
+    the fixture topology on any machine.
+    """
+
+    def build(devices: dict, target: str, scsi_hosts: dict | None = None) -> Path:
+        root = tmp_path / "sys"
+        blk = root / "class" / "block"
+        blk.mkdir(parents=True)
+        (root / "dev" / "block").mkdir(parents=True)
+        devices_dir = root / "devices"
+
+        def node_dir(name: str, spec: dict) -> Path:
+            parent = spec.get("parent_disk")
+            if not parent:
+                d = blk / name
+                d.mkdir(parents=True, exist_ok=True)
+                return d
+            # A partition lives inside its disk's directory, and /sys/class
+            # only links to it — which is exactly what the walk relies on to
+            # find the disk that carries the queue/ and device/ attributes.
+            d = devices_dir / "block" / parent / name
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "partition").write_text("1\n")
+            if not (blk / name).exists():
+                (blk / name).symlink_to(d)
+            return d
+
+        # Whole disks first: a partition's entry has to be able to point into
+        # its parent's directory.
+        ordered = sorted(devices.items(), key=lambda kv: bool(kv[1].get("parent_disk")))
+        for name, spec in ordered:
+            d = node_dir(name, spec)
+            if "rotational" in spec:
+                (d / "queue").mkdir(exist_ok=True)
+                (d / "queue" / "rotational").write_text(spec["rotational"] + "\n")
+            for child in spec.get("slaves", []):
+                (d / "slaves").mkdir(exist_ok=True)
+                (d / "slaves" / child).mkdir(exist_ok=True)
+            subsystem = spec.get("subsystem")
+            if subsystem:
+                phys = devices_dir / spec.get("devpath", f"pci0000:00/{name}")
+                phys.mkdir(parents=True, exist_ok=True)
+                bus = root / "bus" / subsystem
+                bus.mkdir(parents=True, exist_ok=True)
+                if not (phys / "subsystem").exists():
+                    (phys / "subsystem").symlink_to(bus)
+                if spec.get("sas_address"):
+                    (phys / "sas_address").write_text("0x5000c500a1b2c3d4\n")
+                if not (d / "device").exists():
+                    (d / "device").symlink_to(phys)
+
+        for host, proc_name in (scsi_hosts or {}).items():
+            hd = root / "class" / "scsi_host" / host
+            hd.mkdir(parents=True, exist_ok=True)
+            (hd / "proc_name").write_text(proc_name + "\n")
+
+        probe = tmp_path / "probe"
+        probe.mkdir(exist_ok=True)
+        st = probe.stat()
+        devno = f"{os.major(st.st_dev)}:{os.minor(st.st_dev)}"
+        (root / "dev" / "block" / devno).symlink_to(blk / target)
+
+        monkeypatch.setattr(storage_classify, "_SYSFS_ROOT", str(root))
+        return probe
+
+    return build
+
+
+def test_sysfs_walks_lvm_stack_down_to_nvme_members(fake_sysfs):
+    """The case lsblk cannot do: the logical volume's name is not a path,
+    so only a major:minor lookup reaches the members."""
+    probe = fake_sysfs(
+        {
+            "dm-8": {"slaves": ["dm-0", "dm-1"], "rotational": "0"},
+            "dm-0": {"slaves": ["nvme0n1"], "rotational": "0"},
+            "dm-1": {"slaves": ["nvme1n1"], "rotational": "0"},
+            "nvme0n1": {"subsystem": "nvme", "rotational": "0"},
+            "nvme1n1": {"subsystem": "nvme", "rotational": "0"},
+        },
+        target="dm-8",
+    )
+    devices = storage_classify._sysfs_for_path(probe)
+    assert [d.dev for d in devices] == ["nvme0n1", "nvme1n1"]
+    assert all(d.transport == "nvme" and not d.rotational for d in devices)
+
+
+def test_sysfs_walks_md_stack(fake_sysfs):
+    probe = fake_sysfs(
+        {
+            "md0": {"slaves": ["sda", "sdb"], "rotational": "0"},
+            "sda": {"subsystem": "scsi", "devpath": "pci0000:00/ata1/host1/sda", "rotational": "0"},
+            "sdb": {"subsystem": "scsi", "devpath": "pci0000:00/ata2/host2/sdb", "rotational": "0"},
+        },
+        target="md0",
+        scsi_hosts={"host1": "ahci", "host2": "ahci"},
+    )
+    devices = storage_classify._sysfs_for_path(probe)
+    assert [d.dev for d in devices] == ["sda", "sdb"]
+    assert all(d.transport == "sata" for d in devices)
+
+
+def test_sysfs_dedupes_a_leaf_reached_through_two_parents(fake_sysfs):
+    """An LVM RAID mirrors each leg through its own rimage, so the same
+    physical disk can be reachable more than once."""
+    probe = fake_sysfs(
+        {
+            "dm-9": {"slaves": ["dm-2", "dm-3"], "rotational": "0"},
+            "dm-2": {"slaves": ["nvme0n1"], "rotational": "0"},
+            "dm-3": {"slaves": ["nvme0n1"], "rotational": "0"},
+            "nvme0n1": {"subsystem": "nvme", "rotational": "0"},
+        },
+        target="dm-9",
+    )
+    assert [d.dev for d in storage_classify._sysfs_for_path(probe)] == ["nvme0n1"]
+
+
+def test_sysfs_resolves_a_partition_to_its_parent_disk(fake_sysfs):
+    """Partitions carry neither queue/ nor device/ — both belong to the disk."""
+    probe = fake_sysfs(
+        {
+            "sda": {
+                "subsystem": "scsi",
+                "devpath": "platform/host0/session1/target0:0:0/0:0:0:1",
+                "rotational": "1",
+            },
+            "sda1": {"parent_disk": "sda"},
+        },
+        target="sda1",
+        scsi_hosts={"host0": "iscsi_tcp"},
+    )
+    devices = storage_classify._sysfs_for_path(probe)
+    assert [(d.dev, d.transport, d.rotational) for d in devices] == [("sda1", "iscsi", True)]
+
+
+def test_sysfs_reads_sas_from_the_device_attribute(fake_sysfs):
+    probe = fake_sysfs(
+        {
+            "sdc": {
+                "subsystem": "scsi",
+                "devpath": "pci0000:00/host3/sdc",
+                "sas_address": True,
+                "rotational": "0",
+            }
+        },
+        target="sdc",
+        scsi_hosts={"host3": "mpt3sas"},
+    )
+    assert storage_classify._sysfs_for_path(probe)[0].transport == "sas"
+
+
+def test_sysfs_returns_nothing_when_the_devno_is_not_registered(fake_sysfs, tmp_path):
+    """A filesystem with no block device behind it — NFS reports a synthetic
+    st_dev that has no /sys/dev/block entry."""
+    fake_sysfs({"nvme0n1": {"subsystem": "nvme", "rotational": "0"}}, target="nvme0n1")
+    monkey_root = Path(str(tmp_path / "sys" / "dev" / "block"))
+    for entry in monkey_root.iterdir():
+        entry.unlink()
+    assert storage_classify._sysfs_for_path(tmp_path / "probe") == []
+
+
+def test_sysfs_leaves_transport_blank_for_an_unrecognised_bus(fake_sysfs):
+    """Unknown is still a useful answer — it keeps the conservative default
+    rather than guessing O_DIRECT onto something that would hate it."""
+    probe = fake_sysfs(
+        {"xvda": {"subsystem": "xen", "rotational": "0"}},
+        target="xvda",
+    )
+    devices = storage_classify._sysfs_for_path(probe)
+    assert [(d.dev, d.transport) for d in devices] == [("xvda", "")]
+
+
+# --- and the same thing end to end, through pick_io_mode ---------------
+
+
+def _lvm_on_nvme(fake_sysfs):
+    return fake_sysfs(
+        {
+            "dm-8": {"slaves": ["nvme0n1"], "rotational": "0"},
+            "nvme0n1": {"subsystem": "nvme", "rotational": "0"},
+        },
+        target="dm-8",
+    )
+
+
+def test_lsblk_failing_outright_is_recovered_by_sysfs(fake_run, fake_sysfs):
+    """Inside a container /dev holds only what --device put there, so lsblk
+    cannot open the node at all. Before the sysfs fallback this mount was
+    classified 'unknown device' and ran buffered on NVMe."""
+    probe = _lvm_on_nvme(fake_sysfs)
+    fake_run(
+        {
+            "findmnt": "/dev/mapper/nvme_vg-nvme_lv xfs\n",
+            "lsblk": ("lsblk: not a block device\n", 32),
+        }
+    )
+    o_direct, rationale = pick_io_mode(probe)
+    assert o_direct is True
+    assert "nvme" in rationale
+
+
+def test_lsblk_answering_without_a_transport_is_recovered_by_sysfs(fake_run, fake_sysfs):
+    """On the host lsblk does resolve the LV, but the --inverse walk that
+    would supply the transport is handed /dev/<vg>-<lv>, which is not a
+    path that exists. The row comes back bare."""
+    probe = _lvm_on_nvme(fake_sysfs)
+    fake_run(
+        {
+            "findmnt": "/dev/mapper/nvme_vg-nvme_lv xfs\n",
+            "lsblk": "nvme_vg-nvme_lv  0\n",  # blank TRAN, and no inverse answer
+        }
+    )
+    info = classify_storage(probe)
+    assert [d.dev for d in info.devices] == ["nvme0n1"]
+    assert pick_io_mode(probe)[0] is True
+
+
+def test_a_complete_lsblk_answer_is_not_second_guessed(fake_run, fake_sysfs):
+    """sysfs is a fallback, not an override: when lsblk names a transport it
+    wins, even where the fixture topology would say something else."""
+    probe = _lvm_on_nvme(fake_sysfs)  # sysfs here would say nvme → O_DIRECT
+    fake_run(
+        {
+            "findmnt": "/dev/sdb1 ext4\n",
+            "lsblk": "sdb sata 0\n",
+        }
+    )
+    o_direct, rationale = pick_io_mode(probe)
+    assert o_direct is False
+    assert "sata" in rationale
+
+
+def test_both_probes_failing_still_lands_on_conservative_buffered(fake_run, monkeypatch, tmp_path):
+    """No lsblk answer and no sysfs either — the posture that protects an
+    HDD or a SAN from having O_DIRECT guessed onto it."""
+    fake_run(
+        {
+            "findmnt": "/dev/mapper/vg-lv xfs\n",
+            "lsblk": ("", 32),
+        }
+    )
+    monkeypatch.setattr(storage_classify, "_SYSFS_ROOT", str(tmp_path / "no-sysfs-here"))
+    info = classify_storage(tmp_path)
+    assert info.devices == []
+    assert any("sysfs" in w for w in info.warnings)
+    assert pick_io_mode(tmp_path) == (False, "unknown device, conservative buffered")


### PR DESCRIPTION
## The problem

`storage_classify` resolves a mount to its physical devices with `lsblk`,
which answers by device *name*. Two shapes we run in have no name it can open,
and both end at "unknown device → conservative buffered".

**LVM.** `findmnt` reports `/dev/mapper/<vg>-<lv>`, a symlink udev creates; the
kernel's own node is `/dev/dm-N`. The forward walk reports the leaf as
`<vg>-<lv>`, and the `--inverse` walk that would have supplied the transport is
handed `/dev/<vg>-<lv>`, which is not a path that exists.

**Containers.** `/dev` is a private, near-empty devtmpfs holding only what
`--device` named, so `lsblk` cannot open the node at all. `privileged: true`
does not rescue LVM either — the host devtmpfs it exposes carries `/dev/dm-N`
but not the `/dev/mapper/` symlinks, those being udev's work and containers not
running udev. Measured on this host, an unprivileged container and a privileged
one both fail; only the failure mode differs.

This went unnoticed because md is unaffected: `md0` and `/dev/md0` agree, and md
is what the walk was written against — `_lsblk_for_source`'s docstring says so
(`e.g. /dev/md0`). Every kvd deployment validated so far has been md-backed.

From the gfx942 bench, kvd running as an unprivileged sidecar with L3 on xfs
over an 8-NVMe LVM:

    WARNING storage_classify: lsblk returned no devices for
            source='/dev/mapper/nvme_vg-nvme_lv'; defaulting to buffered

On that mount buffered measures 3.70 GB/s against 14.56 GB/s with O_DIRECT — a
4x cut taken for a naming detail, and one that until now had to be worked around
with an explicit `--io-mode direct`.

## The fix

Walk sysfs when lsblk returns nothing, or returns devices it could not put a
transport on. sysfs is indexed by the `major:minor` that `stat()` already gives
us rather than by name, so it needs no device node, no udev and no subprocess;
and the block layer is not namespaced, so an unprivileged container sees the
full topology. From `/sys/dev/block/<maj>:<min>` the walk descends `slaves/` to
the physical disks, then reads `queue/rotational` and identifies the bus the way
util-linux does, off the device's own SCSI host.

`lsblk` stays the fast path — the transport table in this module was calibrated
against its TRAN column — and a complete answer from it is never second-guessed.
Both probes coming up empty still lands on conservative buffered, which is what
protects an HDD or a SAN from having O_DIRECT guessed onto it.

## Verification

Same LVM mount, `--io-mode auto`:

| | before | after |
|---|---|---|
| host | `unknown transport ''` → buffered | `nvme-ssd (nvme0n1)` → **DIRECT** |
| unprivileged container | `not a block device` → buffered | `nvme-ssd (nvme0n1)` → **DIRECT** |

From inside the container, with no `--device` of any kind:

    L3 io_mode: DIRECT (auto)
      mount    = /dev/mapper/nvme_vg-nvme_lv (xfs)
      devices  = [nvme0n1 (nvme, ssd), ... nvme7n1 (nvme, ssd)]
      rationale: nvme-ssd (nvme0n1)

No regression on what already worked: this host's iSCSI-backed root still
resolves `sda1 → iscsi` and its NVMe still resolves `nvme → DIRECT`, both
matching `lsblk`'s own answer. NFS, tmpfs and the worker-count picks are
unchanged.

13 new tests build a fixture tree shaped like sysfs and point the walk at it, so
the LVM stack, md stack, partition→disk resolution, SAS, per-device FC, leaf
dedup and unknown-bus cases are all exercised without depending on the disks the
test machine happens to have. `tests/unit/kvd/`: 546 passed, 1 skipped.

## Commits

1. the sysfs walk and its wiring
2. a review catch — the FC check read machine-wide state, so any `fc_host` in
   the box labelled every unclassified SCSI disk a SAN. Now scoped to the
   device's own host, as util-linux does.

## Follow-up (not in this PR)

The `--io-mode direct` override in the gfx942 recipe can come out once this has
run through a real kvd startup on `auto`. Worth leaving in place until then.
