### PR TITLE
fix(kvd,sglang): return sglang's StorageMetrics from the adapter's ge…

### DIFF
--- a/infera/engine/sglang/kvd_adapter.py
+++ b/infera/engine/sglang/kvd_adapter.py
@@ -356,6 +356,12 @@ class InferaKvdBackend(HiCacheStorage):  # type: ignore[misc]
         # One sample per batch io, drained by get_stats(). Bounded rather than
         # gated on a flag: SGLang only polls get_stats() when metrics are on,
         # and unbounded lists would grow for the entire run when they are off.
+        #
+        # The lock is load-bearing, not defensive: SGLang records from its
+        # prefetch and backup worker threads and drains from the scheduler
+        # thread, and the drain is a read-then-clear that would otherwise lose
+        # whatever lands between its two halves.
+        self._metrics_lock = threading.Lock()
         self._prefetch_pgs: deque[int] = deque(maxlen=_METRICS_SAMPLE_CAP)
         self._backup_pgs: deque[int] = deque(maxlen=_METRICS_SAMPLE_CAP)
         self._prefetch_bandwidth: deque[float] = deque(maxlen=_METRICS_SAMPLE_CAP)
@@ -625,6 +631,7 @@ class InferaKvdBackend(HiCacheStorage):  # type: ignore[misc]
         started = time.perf_counter()
         pages_done = 0
         bytes_done = 0
+        unsized_pages = False
         for transfer in transfers:
             name = transfer.name
             keys = list(transfer.keys or [])
@@ -666,16 +673,25 @@ class InferaKvdBackend(HiCacheStorage):  # type: ignore[misc]
                 else:
                     per_key.append(self._v2_read_page(name, key, host_pool, page_offset))
             results[name] = per_key
+            pages = sum(per_key)
             info = self._get_pool_buffer_info(host_pool)
-            page_bytes = info[2] if info else 0
-            pages_done += sum(per_key)
-            bytes_done += sum(per_key) * page_bytes
-        self._record_io(
-            pages=pages_done,
-            nbytes=bytes_done,
-            elapsed=time.perf_counter() - started,
-            write=write,
-        )
+            if info is None:
+                # Pool shape we don't recognize, so we have no page stride and
+                # no way to size the transfer. `elapsed` covers every pool in
+                # the batch, so counting this one's pages with zero bytes — or
+                # dropping only its bytes — understates the rate. Drop the
+                # whole sample; registration already logged the unknown shape.
+                unsized_pages = unsized_pages or pages > 0
+                continue
+            pages_done += pages
+            bytes_done += pages * info[2]
+        if not unsized_pages:
+            self._record_io(
+                pages=pages_done,
+                nbytes=bytes_done,
+                elapsed=time.perf_counter() - started,
+                write=write,
+            )
         return results
 
     def _pool_storage_key(self, pool_name: Any, key: str) -> str:
@@ -1038,16 +1054,19 @@ class InferaKvdBackend(HiCacheStorage):  # type: ignore[misc]
 
     def _record_io(self, *, pages: int, nbytes: int, elapsed: float, write: bool) -> None:
         """Append one batch-io sample. Bandwidth is GB/s over the whole
-        batch, matching what SGLang's built-in backends report."""
-        if pages <= 0 or elapsed <= 0:
+        batch, matching what SGLang's built-in backends report. A batch we
+        cannot size is dropped rather than published as 0 GB/s — an absent
+        sample reads as "no data", a zero reads as "the transfer stalled"."""
+        if pages <= 0 or nbytes <= 0 or elapsed <= 0:
             return
         gb_per_s = (nbytes / elapsed) / 1e9
-        if write:
-            self._backup_pgs.append(pages)
-            self._backup_bandwidth.append(gb_per_s)
-        else:
-            self._prefetch_pgs.append(pages)
-            self._prefetch_bandwidth.append(gb_per_s)
+        with self._metrics_lock:
+            if write:
+                self._backup_pgs.append(pages)
+                self._backup_bandwidth.append(gb_per_s)
+            else:
+                self._prefetch_pgs.append(pages)
+                self._prefetch_bandwidth.append(gb_per_s)
 
     def get_stats(self) -> StorageMetrics | None:
         """Drain the batch-io samples for SGLang's hicache observability.
@@ -1063,14 +1082,15 @@ class InferaKvdBackend(HiCacheStorage):  # type: ignore[misc]
         if _STORAGE_METRICS_MISPLACED:  # pragma: no cover — needs a future sglang
             return None
         metrics = StorageMetrics()
-        metrics.prefetch_pgs.extend(self._prefetch_pgs)
-        metrics.backup_pgs.extend(self._backup_pgs)
-        metrics.prefetch_bandwidth.extend(self._prefetch_bandwidth)
-        metrics.backup_bandwidth.extend(self._backup_bandwidth)
-        self._prefetch_pgs.clear()
-        self._backup_pgs.clear()
-        self._prefetch_bandwidth.clear()
-        self._backup_bandwidth.clear()
+        with self._metrics_lock:
+            metrics.prefetch_pgs.extend(self._prefetch_pgs)
+            metrics.backup_pgs.extend(self._backup_pgs)
+            metrics.prefetch_bandwidth.extend(self._prefetch_bandwidth)
+            metrics.backup_bandwidth.extend(self._backup_bandwidth)
+            self._prefetch_pgs.clear()
+            self._backup_pgs.clear()
+            self._prefetch_bandwidth.clear()
+            self._backup_bandwidth.clear()
         return metrics
 
     def daemon_counters(self) -> dict | None:

--- a/infera/engine/sglang/kvd_adapter.py
+++ b/infera/engine/sglang/kvd_adapter.py
@@ -52,6 +52,9 @@ import contextvars
 import logging
 import os
 import threading
+import time
+from collections import deque
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -98,6 +101,33 @@ except ImportError:  # pragma: no cover — exercised only without sglang instal
 
     _SGLANG_AVAILABLE = False
 
+# `get_stats()` is polled every scheduler step by SGLang's hicache
+# observability and its return value goes straight into
+# `StorageMetricsCollector.log_storage_metrics`, which asserts the exact type.
+# Returning anything else (we used to return a dict of daemon counters) kills
+# the scheduler with a bare AssertionError. Absent sglang, the local stand-in
+# keeps this module importable for unit tests.
+try:
+    from sglang.srt.observability.metrics_collector import StorageMetrics
+
+    _STORAGE_METRICS_FROM_SGLANG = True
+except ImportError:  # pragma: no cover — exercised only without sglang installed
+    _STORAGE_METRICS_FROM_SGLANG = False
+
+    @dataclass
+    class StorageMetrics:  # type: ignore[no-redef]
+        prefetch_pgs: list[int] = field(default_factory=list)
+        backup_pgs: list[int] = field(default_factory=list)
+        prefetch_bandwidth: list[float] = field(default_factory=list)
+        backup_bandwidth: list[float] = field(default_factory=list)
+
+
+# sglang is here but its StorageMetrics is not where we look for it — a future
+# release moved or renamed it. The stand-in above satisfies nothing in that
+# case: the assert is against sglang's own class, so handing one back is the
+# original crash again. Report no metrics instead.
+_STORAGE_METRICS_MISPLACED = _SGLANG_AVAILABLE and not _STORAGE_METRICS_FROM_SGLANG
+
 
 def _torch():
     """Lazy torch handle. Raises a clean error if called when torch
@@ -109,6 +139,20 @@ def _torch():
 
 
 logger = logging.getLogger(__name__)
+
+if _STORAGE_METRICS_MISPLACED:  # pragma: no cover — needs a future sglang
+    logger.critical(
+        "infera: sglang is installed but "
+        "sglang.srt.observability.metrics_collector.StorageMetrics is not "
+        "importable. hicache storage metrics (prefetch/backup pages and "
+        "bandwidth) will be empty until the import in kvd_adapter.py is "
+        "pointed at the new location."
+    )
+
+# Per-series cap on undrained hicache metric samples. At one sample per batch
+# io this is a few seconds of traffic; the deques only fill up when SGLang is
+# not polling get_stats(), i.e. when metrics are off and nobody reads them.
+_METRICS_SAMPLE_CAP = 4096
 
 
 _DEFAULT_SOCKET_PATH = "/var/run/infera-kvd.sock"
@@ -308,6 +352,15 @@ class InferaKvdBackend(HiCacheStorage):  # type: ignore[misc]
         self._hipfile_read_warned: set[Any] = set()
         self._hipfile_write_warned: set[Any] = set()
 
+        # ----- hicache storage metrics -----
+        # One sample per batch io, drained by get_stats(). Bounded rather than
+        # gated on a flag: SGLang only polls get_stats() when metrics are on,
+        # and unbounded lists would grow for the entire run when they are off.
+        self._prefetch_pgs: deque[int] = deque(maxlen=_METRICS_SAMPLE_CAP)
+        self._backup_pgs: deque[int] = deque(maxlen=_METRICS_SAMPLE_CAP)
+        self._prefetch_bandwidth: deque[float] = deque(maxlen=_METRICS_SAMPLE_CAP)
+        self._backup_bandwidth: deque[float] = deque(maxlen=_METRICS_SAMPLE_CAP)
+
         self._start_background_loop()
         self._connect_or_raise()
 
@@ -355,7 +408,16 @@ class InferaKvdBackend(HiCacheStorage):  # type: ignore[misc]
         connection IS the throughput path; we'll add it when measured."""
         if target_locations is None or len(target_locations) != len(keys):
             raise ValueError("InferaKvdBackend.batch_get requires aligned target_locations")
-        return [self.get(k, t) for k, t in zip(keys, target_locations, strict=True)]
+        started = time.perf_counter()
+        out = [self.get(k, t) for k, t in zip(keys, target_locations, strict=True)]
+        hits = [t for t in out if t is not None]
+        self._record_io(
+            pages=len(hits),
+            nbytes=sum(int(t.numel()) * int(t.element_size()) for t in hits),
+            elapsed=time.perf_counter() - started,
+            write=False,
+        )
+        return out
 
     def set(
         self,
@@ -406,10 +468,22 @@ class InferaKvdBackend(HiCacheStorage):  # type: ignore[misc]
         PoolTransfer can pipeline."""
         if values is None or len(values) != len(keys):
             raise ValueError("InferaKvdBackend.batch_set requires aligned values")
+        started = time.perf_counter()
         success = True
+        written = 0
+        nbytes = 0
         for k, v in zip(keys, values, strict=True):
-            if not self.set(k, v):
+            if self.set(k, v):
+                written += 1
+                nbytes += int(v.numel()) * int(v.element_size())
+            else:
                 success = False
+        self._record_io(
+            pages=written,
+            nbytes=nbytes,
+            elapsed=time.perf_counter() - started,
+            write=True,
+        )
         return success
 
     # ------------------------------------------------------------------
@@ -548,6 +622,9 @@ class InferaKvdBackend(HiCacheStorage):  # type: ignore[misc]
             if write
             else self._retention_default
         )
+        started = time.perf_counter()
+        pages_done = 0
+        bytes_done = 0
         for transfer in transfers:
             name = transfer.name
             keys = list(transfer.keys or [])
@@ -589,6 +666,16 @@ class InferaKvdBackend(HiCacheStorage):  # type: ignore[misc]
                 else:
                     per_key.append(self._v2_read_page(name, key, host_pool, page_offset))
             results[name] = per_key
+            info = self._get_pool_buffer_info(host_pool)
+            page_bytes = info[2] if info else 0
+            pages_done += sum(per_key)
+            bytes_done += sum(per_key) * page_bytes
+        self._record_io(
+            pages=pages_done,
+            nbytes=bytes_done,
+            elapsed=time.perf_counter() - started,
+            write=write,
+        )
         return results
 
     def _pool_storage_key(self, pool_name: Any, key: str) -> str:
@@ -949,10 +1036,47 @@ class InferaKvdBackend(HiCacheStorage):  # type: ignore[misc]
         on the same kvd are untouched."""
         self._run_async(self._client.clear(model=self._model, compat_key=self._compat_key))
 
-    def get_stats(self) -> dict | None:
-        """Daemon-side counters. SGLang's hicache observability picks
-        this up; we surface the same numbers to Prometheus on the server
-        via `/v1/kv-stats`."""
+    def _record_io(self, *, pages: int, nbytes: int, elapsed: float, write: bool) -> None:
+        """Append one batch-io sample. Bandwidth is GB/s over the whole
+        batch, matching what SGLang's built-in backends report."""
+        if pages <= 0 or elapsed <= 0:
+            return
+        gb_per_s = (nbytes / elapsed) / 1e9
+        if write:
+            self._backup_pgs.append(pages)
+            self._backup_bandwidth.append(gb_per_s)
+        else:
+            self._prefetch_pgs.append(pages)
+            self._prefetch_bandwidth.append(gb_per_s)
+
+    def get_stats(self) -> StorageMetrics | None:
+        """Drain the batch-io samples for SGLang's hicache observability.
+
+        Polled every scheduler step. The return type is load-bearing:
+        `StorageMetricsCollector.log_storage_metrics` asserts on it, so a
+        wrong type takes the scheduler down rather than degrading metrics.
+        `None` is the one other value it accepts, and the only safe answer
+        when we cannot construct sglang's own class. Daemon-side counters
+        live in `daemon_counters()` — they are a different thing and SGLang
+        has nowhere to put them.
+        """
+        if _STORAGE_METRICS_MISPLACED:  # pragma: no cover — needs a future sglang
+            return None
+        metrics = StorageMetrics()
+        metrics.prefetch_pgs.extend(self._prefetch_pgs)
+        metrics.backup_pgs.extend(self._backup_pgs)
+        metrics.prefetch_bandwidth.extend(self._prefetch_bandwidth)
+        metrics.backup_bandwidth.extend(self._backup_bandwidth)
+        self._prefetch_pgs.clear()
+        self._backup_pgs.clear()
+        self._prefetch_bandwidth.clear()
+        self._backup_bandwidth.clear()
+        return metrics
+
+    def daemon_counters(self) -> dict | None:
+        """Daemon-side totals (entries, bytes, hits/misses/evictions).
+        Used to confirm kvd is actually being read and written, which the
+        per-step `get_stats()` histograms cannot show on their own."""
         try:
             stats = self._run_async(self._client.stats())
         except (KvdConnectionError, KvdProtocolError):

--- a/tests/engine/sglang/test_sglang_kvd_adapter.py
+++ b/tests/engine/sglang/test_sglang_kvd_adapter.py
@@ -438,6 +438,24 @@ async def test_get_stats_returns_none_when_sglang_moved_the_type(
 
 
 @pytest.mark.asyncio
+async def test_record_io_drops_a_batch_it_cannot_size(kvd_daemon, patched_adapter_codecs):
+    """A transfer whose byte count we could not derive must not surface as
+    a 0 GB/s sample: absent reads as "no data", zero reads as "stalled"."""
+    backend = await asyncio.to_thread(InferaKvdBackend, _make_config(), socket_path=kvd_daemon)
+    try:
+        backend._record_io(pages=4, nbytes=0, elapsed=0.001, write=False)
+        backend._record_io(pages=4, nbytes=0, elapsed=0.001, write=True)
+
+        metrics = await asyncio.to_thread(backend.get_stats)
+        assert metrics.prefetch_pgs == []
+        assert metrics.backup_pgs == []
+        assert metrics.prefetch_bandwidth == []
+        assert metrics.backup_bandwidth == []
+    finally:
+        await asyncio.to_thread(backend.close)
+
+
+@pytest.mark.asyncio
 async def test_get_stats_samples_are_bounded(kvd_daemon, patched_adapter_codecs):
     """With metrics off nobody drains, so the accumulators must not grow
     without bound for the length of a run."""
@@ -787,6 +805,23 @@ class _FakeHostPool:
         self._storage[i : i + self.page_size] = bytes(data_page.payload)
 
 
+class _SizedFakeHostPool(_FakeHostPool):
+    """A pool the adapter *can* size, i.e. one that carries the MLA-shaped
+    `kv_buffer` that `_get_pool_buffer_info` duck-types on. Plain
+    `_FakeHostPool` has no buffer attribute at all, so the two together
+    cover both arms of the metric sampling."""
+
+    def __init__(self, n_slots: int, page_size: int = 2) -> None:
+        super().__init__(n_slots, page_size)
+        self.kv_buffer = SimpleNamespace(
+            data_ptr=lambda: 4096,
+            numel=lambda: n_slots,
+            element_size=lambda: 1,
+        )
+        self.kv_cache_dim = 1
+        self.dtype = SimpleNamespace(itemsize=1)
+
+
 class _FakeIndices:
     """Stand-in for a torch.LongTensor of host indices. Supports
     `numel()` and integer indexing returning an obj with `.item()`."""
@@ -930,6 +965,78 @@ async def test_batch_set_v2_roundtrip_kv_and_indexer(
         # kvd hit counter should advance by 4 (we read 2×2 pages).
         stats_after = await asyncio.to_thread(backend.daemon_counters)
         assert stats_after["hits_total"] >= 4
+    finally:
+        await asyncio.to_thread(backend.close)
+
+
+@pytest.mark.asyncio
+async def test_batch_io_v2_records_no_sample_for_a_pool_it_cannot_size(
+    kvd_daemon, patched_adapter_codecs, fake_sglang_v2_types
+):
+    """`_FakeHostPool` carries neither buffer attribute, so the adapter has
+    no page stride for it. The transfer still has to work, and it has to
+    leave no bandwidth sample rather than one reading 0 GB/s."""
+    PoolName = fake_sglang_v2_types.PoolName
+    PoolHitPolicy = fake_sglang_v2_types.PoolHitPolicy
+
+    backend = await asyncio.to_thread(
+        kvd_adapter.InferaKvdBackend,
+        _make_config(),
+        socket_path=kvd_daemon,
+        client_id="v2-unsized-metrics",
+    )
+    try:
+        kv_pool = _FakeHostPool(n_slots=8, page_size=2)
+        assert backend._get_pool_buffer_info(kv_pool) is None, "pool must be unrecognized"
+        backend.registered_pools = {PoolName.KV: kv_pool}
+
+        keys = ["unsized_alpha", "unsized_beta"]
+        kv_t = _make_transfer(PoolName, PoolHitPolicy, PoolName.KV, keys, [0, 1, 2, 3])
+        assert await asyncio.to_thread(backend.batch_set_v2, [kv_t]) == {PoolName.KV: [True, True]}
+
+        metrics = await asyncio.to_thread(backend.get_stats)
+        assert metrics.backup_pgs == []
+        assert metrics.backup_bandwidth == []
+    finally:
+        await asyncio.to_thread(backend.close)
+
+
+@pytest.mark.asyncio
+async def test_batch_io_v2_drops_the_sample_when_one_pool_is_unsized(
+    kvd_daemon, patched_adapter_codecs, fake_sglang_v2_types
+):
+    """A batch spans several pools but is timed as a whole. If one pool's
+    bytes are unknowable, keeping the others' would divide real bytes by
+    the whole batch's time and understate the rate, so the sample goes."""
+    PoolName = fake_sglang_v2_types.PoolName
+    PoolHitPolicy = fake_sglang_v2_types.PoolHitPolicy
+
+    backend = await asyncio.to_thread(
+        kvd_adapter.InferaKvdBackend,
+        _make_config(),
+        socket_path=kvd_daemon,
+        client_id="v2-mixed-metrics",
+    )
+    try:
+        sized = _SizedFakeHostPool(n_slots=8, page_size=2)
+        unsized = _FakeHostPool(n_slots=8, page_size=2)
+        assert backend._get_pool_buffer_info(sized) is not None
+        assert backend._get_pool_buffer_info(unsized) is None
+        backend.registered_pools = {PoolName.KV: sized, PoolName.INDEXER: unsized}
+
+        # Sized pool alone: one sample, and it is not a zero.
+        kv_t = _make_transfer(PoolName, PoolHitPolicy, PoolName.KV, ["mixed_a"], [0, 1])
+        await asyncio.to_thread(backend.batch_set_v2, [kv_t])
+        metrics = await asyncio.to_thread(backend.get_stats)
+        assert metrics.backup_pgs == [1]
+        assert metrics.backup_bandwidth and metrics.backup_bandwidth[0] > 0
+
+        # Same batch plus the unsized pool: nothing recorded at all.
+        idx_t = _make_transfer(PoolName, PoolHitPolicy, PoolName.INDEXER, ["mixed_b"], [0, 1])
+        await asyncio.to_thread(backend.batch_set_v2, [kv_t, idx_t])
+        after = await asyncio.to_thread(backend.get_stats)
+        assert after.backup_pgs == []
+        assert after.backup_bandwidth == []
     finally:
         await asyncio.to_thread(backend.close)
 

--- a/tests/engine/sglang/test_sglang_kvd_adapter.py
+++ b/tests/engine/sglang/test_sglang_kvd_adapter.py
@@ -217,7 +217,7 @@ async def test_adapter_init_connects(kvd_daemon, patched_adapter_codecs):
     )
     try:
         # Round-trip a stats call as a liveness probe.
-        stats = await asyncio.to_thread(backend.get_stats)
+        stats = await asyncio.to_thread(backend.daemon_counters)
         assert stats is not None
         assert stats["entries"] == 0
     finally:
@@ -349,7 +349,7 @@ async def test_adapter_get_size_mismatch_returns_none(kvd_daemon, patched_adapte
 
 
 @pytest.mark.asyncio
-async def test_adapter_get_stats_after_traffic(kvd_daemon, patched_adapter_codecs):
+async def test_adapter_daemon_counters_after_traffic(kvd_daemon, patched_adapter_codecs):
     socket = kvd_daemon
     backend = await asyncio.to_thread(InferaKvdBackend, _make_config(), socket_path=socket)
     try:
@@ -358,13 +358,95 @@ async def test_adapter_get_stats_after_traffic(kvd_daemon, patched_adapter_codec
         await asyncio.to_thread(backend.get, "a", target)  # hit
         await asyncio.to_thread(backend.get, "absent", _FakeTensor(b"\x00"))  # miss
 
-        stats = await asyncio.to_thread(backend.get_stats)
+        stats = await asyncio.to_thread(backend.daemon_counters)
         assert stats is not None
         # Counts include the auxiliary stats call's own GETs etc; just
         # sanity-check ranges.
         assert stats["entries"] == 1
         assert stats["hits_total"] >= 1
         assert stats["misses_total"] >= 1
+    finally:
+        await asyncio.to_thread(backend.close)
+
+
+# ----------------------------------------------------------------------
+# hicache storage metrics
+#
+# SGLang polls get_stats() every scheduler step and feeds the result
+# straight into StorageMetricsCollector.log_storage_metrics, which does
+# `assert isinstance(storage_metrics, StorageMetrics)`. Returning the
+# daemon-counter dict here used to take the prefill scheduler down with a
+# bare AssertionError the moment KVD and --enable-metrics were both on.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_stats_returns_storage_metrics_type(kvd_daemon, patched_adapter_codecs):
+    """The type is the contract: anything else crashes the scheduler."""
+    backend = await asyncio.to_thread(InferaKvdBackend, _make_config(), socket_path=kvd_daemon)
+    try:
+        metrics = await asyncio.to_thread(backend.get_stats)
+        assert isinstance(metrics, kvd_adapter.StorageMetrics)
+        # Every field the collector iterates must exist and be iterable.
+        assert metrics.prefetch_pgs == []
+        assert metrics.backup_pgs == []
+        assert metrics.prefetch_bandwidth == []
+        assert metrics.backup_bandwidth == []
+    finally:
+        await asyncio.to_thread(backend.close)
+
+
+@pytest.mark.asyncio
+async def test_get_stats_records_then_drains_batch_io(kvd_daemon, patched_adapter_codecs):
+    """Batch ops leave one sample per call; get_stats drains them so the
+    histograms observe each sample exactly once."""
+    backend = await asyncio.to_thread(InferaKvdBackend, _make_config(), socket_path=kvd_daemon)
+    try:
+        keys = ["m1", "m2"]
+        values = [_FakeTensor(b"aaaa"), _FakeTensor(b"bbbb")]
+        await asyncio.to_thread(backend.batch_set, keys, values)
+        await asyncio.to_thread(backend.batch_get, keys, [_FakeTensor(b"\x00" * 4) for _ in keys])
+
+        metrics = await asyncio.to_thread(backend.get_stats)
+        assert metrics.backup_pgs == [2], "one sample per batch_set, 2 pages written"
+        assert metrics.prefetch_pgs == [2], "one sample per batch_get, 2 pages read"
+        assert len(metrics.backup_bandwidth) == 1
+        assert len(metrics.prefetch_bandwidth) == 1
+        assert all(b > 0 for b in metrics.backup_bandwidth + metrics.prefetch_bandwidth)
+
+        # Drained: a second poll with no traffic in between is empty.
+        again = await asyncio.to_thread(backend.get_stats)
+        assert again.prefetch_pgs == []
+        assert again.backup_pgs == []
+    finally:
+        await asyncio.to_thread(backend.close)
+
+
+@pytest.mark.asyncio
+async def test_get_stats_returns_none_when_sglang_moved_the_type(
+    kvd_daemon, patched_adapter_codecs, monkeypatch
+):
+    """If a future sglang moves StorageMetrics, our local stand-in would
+    fail the same isinstance assert. None is the only other value
+    log_storage_metrics accepts, so metrics go empty instead of fatal."""
+    monkeypatch.setattr(kvd_adapter, "_STORAGE_METRICS_MISPLACED", True)
+    backend = await asyncio.to_thread(InferaKvdBackend, _make_config(), socket_path=kvd_daemon)
+    try:
+        assert await asyncio.to_thread(backend.get_stats) is None
+    finally:
+        await asyncio.to_thread(backend.close)
+
+
+@pytest.mark.asyncio
+async def test_get_stats_samples_are_bounded(kvd_daemon, patched_adapter_codecs):
+    """With metrics off nobody drains, so the accumulators must not grow
+    without bound for the length of a run."""
+    backend = await asyncio.to_thread(InferaKvdBackend, _make_config(), socket_path=kvd_daemon)
+    try:
+        cap = kvd_adapter._METRICS_SAMPLE_CAP
+        for _ in range(cap + 10):
+            backend._record_io(pages=1, nbytes=1024, elapsed=0.001, write=False)
+        assert len(backend._prefetch_pgs) == cap
     finally:
         await asyncio.to_thread(backend.close)
 
@@ -831,7 +913,7 @@ async def test_batch_set_v2_roundtrip_kv_and_indexer(
         assert set_res[PoolName.INDEXER] == [True, True]
 
         # Daemon should report 4 stored entries (2 pages × 2 pools).
-        stats = await asyncio.to_thread(backend.get_stats)
+        stats = await asyncio.to_thread(backend.daemon_counters)
         assert stats["entries"] == 4
 
         # Wipe and read back through v2 → byte-perfect restore.
@@ -846,7 +928,7 @@ async def test_batch_set_v2_roundtrip_kv_and_indexer(
             assert idx_pool._storage[s] == 0xA0 + s, f"idx slot {s} mismatch"
 
         # kvd hit counter should advance by 4 (we read 2×2 pages).
-        stats_after = await asyncio.to_thread(backend.get_stats)
+        stats_after = await asyncio.to_thread(backend.daemon_counters)
         assert stats_after["hits_total"] >= 4
     finally:
         await asyncio.to_thread(backend.close)


### PR DESCRIPTION
# Description

`InferaKvdBackend.get_stats()` returned a dict of kvd daemon counters, but SGLang
treats that method as a typed contract: hicache observability polls
`storage_backend.get_stats()` once per scheduler step and passes the result straight
into `StorageMetricsCollector.log_storage_metrics()`, which does
`assert isinstance(storage_metrics, StorageMetrics)`. With a kvd backend the prefill
scheduler therefore died on a bare `AssertionError` (exit -3, then SIGQUIT) about two
minutes after startup, before ever reporting ready:

```
scheduler.py              _get_new_batch_prefill_raw
  unified_radix_cache.py    check_hicache_events
    metrics_collector.py      assert isinstance(..., StorageMetrics)
```

Triggering it takes two switches at once: a dynamic hicache storage backend **and**
`--enable-metrics`, which is what sets `enable_storage_metrics`. Earlier kvd runs
passed no metrics flag, so the collector was never built, `get_stats()` was never
called, and the wrong return type stayed harmless.

**This is not a version regression, and it is not gfx942-specific.** The assert and
the per-step poll are identical in v0.5.14 (line 1816), v0.5.15 and v0.5.15.post1
(1817) and v0.5.16 (1833), and the call sites in `hiradix_cache.py`,
`unified_radix_cache.py` and `hi_mamba_radix_cache.py` are present in all four —
upstream sgl-project/sglang#9965 introduced them, before any base we ship on. Both
engine images carry the trap: `Dockerfile.sglang.gfx942` (MI300X/MI325X, v0.5.16) and
`Dockerfile.sglang` (MI355X, v0.5.15.post1). `StorageMetrics`, the `HiCacheStorage`
ABC (including `get_stats()` defaulting to `None`) and `HiCacheStorageConfig` are
identical across those two bases, so the fix applies unchanged to both.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- `get_stats()` returns `StorageMetrics` and drains on read, matching the built-in
  backends, so each sample is observed by the histograms exactly once.
- One sample per batch io, recorded in the v2 funnel (`_batch_io_v2`) and on the v1
  `batch_get` / `batch_set` paths: pages and GB/s, with per-page bytes reusing the
  existing `_get_pool_buffer_info()`.
- Accumulators are `deque(maxlen=4096)` rather than lists. With metrics off nobody
  drains them, and a list would grow for the whole run.
- Daemon counters are not lost — they move to a new `daemon_counters()`. They are the
  only way to confirm kvd is really being read and written (`smoke.sh` uses them) and
  SGLang has nowhere to put them. SGLang is the sole `get_stats()` consumer in the
  tree; the same-named function in `infera/kv/api.py` is a FastAPI route handler.
- Import hardening: `except ImportError` used to install a local look-alike dataclass
  unconditionally. That is right when sglang is absent (unit tests) and wrong when
  sglang is present but has moved the class, since the assert is against sglang's own
  type — a look-alike would be the original crash again. The two cases are now
  distinguished: the second logs `critical` at import and makes `get_stats()` return
  `None`, the one other value `log_storage_metrics` accepts.
- Tests: four cases pin the contract (return type, drain-on-read, bounded
  accumulators, `None` when the type cannot be imported); four existing assertions
  that read daemon counters now go through `daemon_counters()`.

Validated on 2 × MI300X (gfx942, ROCm 7.2.0), GLM-5.2-FP8 1P1D with DP-attention and
MTP, kvd and `--enable-metrics` both on: 225/225 requests completed, no scheduler
death. Not exercised on the MI355X image — the v0.5.15.post1 claim above is a
source-level comparison, and no shipped mi35x recipe passes `--enable-metrics` today.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — n/a, no user-facing
      doc change; the bench recipe write-up lives on a separate branch
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
  (`pytest tests/engine/sglang/test_sglang_kvd_adapter.py`: 35 passed, 1 skipped —
  the skip needs torch; `pre-commit run --files` on both files is green)
