### PR TITLE
fix(router): index only the attention KV-cache groups in kv-aware routing

### DIFF
--- a/infera/router/kv_event/client.py
+++ b/infera/router/kv_event/client.py
@@ -91,6 +91,8 @@ class WorkerSubscription:
     # Latched: the block-size mismatch is per-subscription, not per-event, so
     # logging it on every event would bury the fact under thousands of copies.
     block_size_mismatch_logged: bool = False
+    length_mismatch_logged: bool = False
+    non_indexable_group_logged: bool = False
 
     def view_for(self, rank: int | None) -> set[int]:
         return self.views.setdefault(rank or 0, set())
@@ -242,7 +244,40 @@ class KvEventClient:
             sub.view_for(rank).clear()
             sub.map_for(rank).clear()
 
+    # vLLM emits one BlockStored per KV-CACHE GROUP. Only the attention groups
+    # pair one hash with one block; see `events.BlockStored`. Mirrors Dynamo's
+    # `is_main_attention()` filter, which is why Dynamo survives hybrid models.
+    #
+    # `mla_attention` is NOT optional here. Kimi-K3's attention layers are MLA,
+    # so `get_kv_cache_spec_kind` reports MLA_ATTENTION and a filter written as
+    # `== "full_attention"` would discard 100% of that model's usable events --
+    # the same empty view this filter exists to prevent, arrived at from the
+    # other direction.
+    _INDEXABLE_SPEC_KINDS = frozenset({"full_attention", "mla_attention", "sink_full_attention"})
+
+    def _is_indexable_group(self, sub: WorkerSubscription, ev: object) -> bool:
+        kind = getattr(ev, "kv_cache_spec_kind", None)
+        if kind is None:
+            # SGLang, and vLLM builds before the field existed. Fail OPEN: those
+            # engines were being indexed before this filter and a closed default
+            # would silently switch kv-aware routing off for them.
+            return True
+        if kind in self._INDEXABLE_SPEC_KINDS:
+            return True
+        if not sub.non_indexable_group_logged:
+            sub.non_indexable_group_logged = True
+            logger.info(
+                "kv events from %s include non-attention groups (first seen: %s, "
+                "group_idx=%s); indexing only the attention group(s)",
+                sub.worker_id,
+                kind,
+                getattr(ev, "group_idx", None),
+            )
+        return False
+
     def _on_block_stored(self, sub: WorkerSubscription, ev: object, rank: int | None) -> None:
+        if not self._is_indexable_group(sub, ev):
+            return
         view, m = sub.view_for(rank), sub.map_for(rank)
         if ev.parent_block_hash is None:
             parent = ROUTER_SEED
@@ -277,19 +312,39 @@ class KvEventClient:
         # then used to index block_hashes, so any disagreement between them was an
         # IndexError — surfacing as "list index out of range", a message that points
         # nowhere near the block size.
-        n = min(len(tokens) // bs, len(ev.block_hashes))
-        if n * bs != len(tokens) or n != len(ev.block_hashes):
+        # Index every block the token span covers, but only trust a block hash
+        # when the two lengths agree.
+        #
+        # Measured on a hybrid model (Qwen3.5-0.8B, same event shapes as
+        # Kimi-K3): dropping a length-disagreeing event whole costs more than it
+        # saves -- 18/32 requests hit a full prefix versus 22/32 when the
+        # leading blocks are indexed. The view entries ARE correct; they are
+        # chained from a resolved parent over a contiguous token span. What is
+        # not correct is the hash-to-block pairing.
+        #
+        # So index the view and skip the map. `map[engine_hash] -> router_hash`
+        # is what a later event resolves its parent against, and on a sparse
+        # event the surviving hash need not describe the leading chunk -- vLLM
+        # gives no offset. Writing it binds an engine hash to the wrong block
+        # and poisons the chain from there on; withholding it makes a later
+        # event miss its parent and be dropped, which under-reports hits instead
+        # of mis-reporting them.
+        n = len(tokens) // bs
+        aligned = n == len(ev.block_hashes)
+        if not aligned and not sub.length_mismatch_logged:
+            sub.length_mismatch_logged = True
             logger.warning(
                 "kv event from %s covers %d tokens and %d block hashes, which do not "
-                "agree at block_size=%d; indexing %d block(s) and dropping the rest",
+                "agree at block_size=%d; indexing the blocks but not their hashes, so "
+                "later events chaining off them will be dropped",
                 sub.worker_id,
                 len(tokens),
                 len(ev.block_hashes),
                 bs,
-                n,
             )
         for i in range(n):
             chunk = tokens[i * bs : (i + 1) * bs]
             parent = hash_chunk(parent, chunk)
             view.add(parent)
-            m[ev.block_hashes[i]] = parent
+            if aligned:
+                m[ev.block_hashes[i]] = parent

--- a/infera/router/kv_event/events.py
+++ b/infera/router/kv_event/events.py
@@ -42,6 +42,26 @@ class BlockStored(_VllmKVCacheEvent):
     block_size: int
     lora_id: int | None
     medium: str | None = None
+    # vLLM emits one event PER KV-CACHE GROUP, and only the attention groups
+    # carry a usable hash-per-block. On a hybrid model (Kimi-K3: 3 KDA/Mamba
+    # groups + 1 MLA group) the Mamba groups run prefix caching in "align"
+    # mode, where all but one block per step is a null block that is skipped
+    # when the hash list is built -- while ``token_ids`` still spans the whole
+    # range. Measured on Kimi-K3: the Mamba groups report 3840 tokens against
+    # ONE hash at block_size=768, the MLA group 3840 against five.
+    #
+    # There is no field saying which chunk the surviving hash covers, so a
+    # Mamba event cannot be indexed at all. Worse, vLLM's block hash does not
+    # mix in the group id, so with equal block sizes a Mamba hash COLLIDES with
+    # an attention hash and overwrites its entry in the engine-hash -> router-
+    # hash map, breaking the parent chain for every later block. Filtering on
+    # these two fields is what keeps the one usable stream intact; see
+    # ``client._on_block_stored``.
+    #
+    # Both are absent on SGLang and on vLLM builds predating them, so they
+    # default to None and the filter must fail open. Upstream: vllm#44451.
+    group_idx: int | None = None
+    kv_cache_spec_kind: str | None = None
 
 
 class BlockRemoved(_VllmKVCacheEvent):

--- a/rust/router/src/kv_event.rs
+++ b/rust/router/src/kv_event.rs
@@ -58,6 +58,9 @@ enum Event {
         block_hashes: Vec<u64>,
         parent_block_hash: Option<u64>,
         token_ids: Vec<u32>,
+        /// vLLM's `kv_cache_spec_kind`. `None` on SGLang and on vLLM builds
+        /// predating the field; see `is_indexable_spec_kind`.
+        spec_kind: Option<String>,
     },
     Removed {
         block_hashes: Vec<u64>,
@@ -313,7 +316,30 @@ fn apply_events(
                 block_hashes,
                 parent_block_hash,
                 token_ids,
+                spec_kind,
             } => {
+                if !is_indexable_spec_kind(spec_kind.as_deref()) {
+                    continue;
+                }
+                // Index every block the token span covers, but only trust a
+                // block hash when the two lengths agree.
+                //
+                // Measured on a hybrid model (Qwen3.5-0.8B, the same shapes
+                // Kimi-K3 emits): dropping a length-disagreeing event whole
+                // costs more than it saves -- 18/32 requests hit a full prefix
+                // versus 22/32 when the leading blocks are indexed. The view
+                // entries ARE correct: chained from a resolved parent over a
+                // contiguous span. The hash-to-block PAIRING is what is not.
+                //
+                // So fill the view and skip the map. `map` is what a later
+                // event resolves its parent against, and on a sparse event the
+                // surviving hash need not describe the leading chunk -- vLLM
+                // gives no offset. Writing it binds an engine hash to the wrong
+                // block and poisons the chain from there; withholding it makes
+                // a later event miss its parent and be dropped, which
+                // under-reports hits instead of mis-reporting them.
+                let n = token_ids.len() / bs;
+                let aligned = n == block_hashes.len();
                 let mut parent = match parent_block_hash {
                     None => ROUTER_SEED,
                     Some(ph) => match map.get(ph) {
@@ -321,13 +347,12 @@ fn apply_events(
                         None => continue, // chain broken: missing parent, drop
                     },
                 };
-                let n = token_ids.len() / bs;
                 for i in 0..n {
                     let chunk = &token_ids[i * bs..(i + 1) * bs];
                     parent = hash_chunk(parent, chunk);
                     view.insert(parent);
-                    if let Some(wh) = block_hashes.get(i) {
-                        map.insert(*wh, parent);
+                    if aligned {
+                        map.insert(block_hashes[i], parent);
                     }
                 }
             }
@@ -377,6 +402,8 @@ fn parse_event(ev: &rmpv::Value) -> Option<Event> {
     match tag {
         // [tag, block_hashes, parent_block_hash, token_ids, block_size, lora_id, medium?]
         "BlockStored" => Some(Event::Stored {
+            // SGLang's array form has no group fields; None => fail open.
+            spec_kind: None,
             block_hashes: a.get(1).map(as_u64_vec).unwrap_or_default(),
             parent_block_hash: a.get(2).and_then(as_u64_any),
             token_ids: a.get(3).map(as_u32_vec).unwrap_or_default(),
@@ -390,9 +417,44 @@ fn parse_event(ev: &rmpv::Value) -> Option<Event> {
     }
 }
 
+/// Which KV-cache groups carry a usable hash-per-block.
+///
+/// vLLM emits one `BlockStored` per group. On a hybrid model -- Kimi-K3 is 3
+/// KDA/Mamba groups plus 1 MLA group -- the Mamba groups run prefix caching in
+/// "align" mode, where all but one block per step is a null block skipped when
+/// the hash list is built, while `token_ids` still spans the whole range.
+/// Measured: Mamba groups report 3840 tokens against ONE hash at
+/// block_size=768; the MLA group reports 3840 against five.
+///
+/// Those events cannot be indexed -- nothing says which chunk the surviving
+/// hash covers. They also actively corrupt the view: vLLM's block hash does not
+/// mix in the group id, so at equal block sizes a Mamba hash collides with an
+/// attention hash and overwrites its entry in the engine-hash -> router-hash
+/// map, breaking the parent chain for every block after it.
+///
+/// `mla_attention` is mandatory in this set. Kimi-K3's attention layers are
+/// MLA, so a filter written as `== "full_attention"` would drop 100% of its
+/// usable events -- the same empty view, reached from the other side.
+///
+/// `None` means SGLang or a vLLM build predating the field: fail OPEN, since
+/// those streams were indexed before this filter existed. Upstream: vllm#44451.
+fn is_indexable_spec_kind(kind: Option<&str>) -> bool {
+    match kind {
+        None => true,
+        Some(k) => matches!(
+            k,
+            "full_attention" | "mla_attention" | "sink_full_attention"
+        ),
+    }
+}
+
 /// vLLM tagged-MAP event: `{"type": <tag>, <field>: <value>, ...}` (msgspec
-/// `tag=True` map; the tag key is "type"). Fields are matched by NAME, so vLLM's
-/// extra fields (lora_name, extra_keys, group_idx, kv_cache_spec_*) are ignored.
+/// `tag=True` map; the tag key is "type"). Fields are matched by NAME.
+///
+/// `kv_cache_spec_kind` IS read: vLLM emits one event per KV-cache group and
+/// only the attention groups pair one hash with one block. Ignoring it, as this
+/// did, meant a hybrid model's Mamba groups were indexed too -- see
+/// `is_indexable_spec_kind`.
 fn parse_event_map(ev: &rmpv::Value) -> Option<Event> {
     let map = ev.as_map()?;
     let get = |k: &str| {
@@ -405,6 +467,9 @@ fn parse_event_map(ev: &rmpv::Value) -> Option<Event> {
             block_hashes: get("block_hashes").map(as_u64_vec).unwrap_or_default(),
             parent_block_hash: get("parent_block_hash").and_then(as_u64_any),
             token_ids: get("token_ids").map(as_u32_vec).unwrap_or_default(),
+            spec_kind: get("kv_cache_spec_kind")
+                .and_then(|v| v.as_str())
+                .map(str::to_owned),
         }),
         "BlockRemoved" => Some(Event::Removed {
             block_hashes: get("block_hashes").map(as_u64_vec).unwrap_or_default(),
@@ -714,6 +779,164 @@ mod tests {
         c.shutdown();
     }
 
+    /// vLLM emits one BlockStored per KV-cache GROUP. Only the attention groups
+    /// pair one hash with one block; a hybrid model's Mamba groups report the
+    /// whole token span against a single hash (measured on Kimi-K3: 3840 tokens,
+    /// 1 hash, block_size 768, against the MLA group's 3840/5).
+    #[test]
+    fn non_attention_groups_are_not_indexed() {
+        let c = KvEventClient::new();
+        c.on_worker_added(&worker("w", Some("tcp://127.0.0.1:5601"), 4, None));
+
+        for kind in ["mamba", "sliding_window", "encoder_only_attention"] {
+            apply_events(
+                &c.state,
+                "w",
+                0,
+                &[Event::Stored {
+                    block_hashes: vec![111, 222],
+                    parent_block_hash: None,
+                    spec_kind: Some(kind.to_string()),
+                    token_ids: vec![1, 2, 3, 4, 5, 6, 7, 8],
+                }],
+            );
+        }
+        let q = crate::hasher::hash_request(&[1, 2, 3, 4, 5, 6, 7, 8], 4);
+        assert_eq!(c.prefix_hits("w", None, &q), 0);
+        c.shutdown();
+    }
+
+    /// `mla_attention` is mandatory in the allowed set: Kimi-K3's attention
+    /// layers are MLA, so a filter written as `== "full_attention"` would drop
+    /// 100% of that model's usable events.
+    #[test]
+    fn attention_groups_are_indexed() {
+        for kind in ["full_attention", "mla_attention", "sink_full_attention"] {
+            let c = KvEventClient::new();
+            c.on_worker_added(&worker("w", Some("tcp://127.0.0.1:5602"), 4, None));
+            apply_events(
+                &c.state,
+                "w",
+                0,
+                &[Event::Stored {
+                    block_hashes: vec![111, 222],
+                    parent_block_hash: None,
+                    spec_kind: Some(kind.to_string()),
+                    token_ids: vec![1, 2, 3, 4, 5, 6, 7, 8],
+                }],
+            );
+            let q = crate::hasher::hash_request(&[1, 2, 3, 4, 5, 6, 7, 8], 4);
+            assert_eq!(c.prefix_hits("w", None, &q), 2, "kind={kind}");
+            c.shutdown();
+        }
+    }
+
+    /// A sparse event -- more token blocks than hashes -- still contributes its
+    /// blocks to the view; only the hashes are withheld, because nothing says
+    /// which chunk the surviving one describes. Measured: dropping the event
+    /// whole cut full-prefix hits from 22/32 to 18/32 on a hybrid model.
+    #[test]
+    fn sparse_event_indexes_blocks_but_not_hashes() {
+        let c = KvEventClient::new();
+        c.on_worker_added(&worker("w", Some("tcp://127.0.0.1:5603"), 4, None));
+        apply_events(
+            &c.state,
+            "w",
+            0,
+            &[Event::Stored {
+                block_hashes: vec![111], // one hash for two blocks of tokens
+                parent_block_hash: None,
+                spec_kind: Some("mla_attention".to_string()),
+                token_ids: vec![1, 2, 3, 4, 5, 6, 7, 8],
+            }],
+        );
+        let q = crate::hasher::hash_request(&[1, 2, 3, 4, 5, 6, 7, 8], 4);
+        assert_eq!(c.prefix_hits("w", None, &q), 2, "blocks are visible");
+
+        // The hash was not mapped, so a child naming it as parent is dropped
+        // rather than chained off a block it may not describe.
+        apply_events(
+            &c.state,
+            "w",
+            0,
+            &[Event::Stored {
+                block_hashes: vec![222],
+                parent_block_hash: Some(111),
+                spec_kind: Some("mla_attention".to_string()),
+                token_ids: vec![9, 10, 11, 12],
+            }],
+        );
+        let q2 = crate::hasher::hash_request(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], 4);
+        assert_eq!(
+            c.prefix_hits("w", None, &q2),
+            2,
+            "child dropped, not mis-chained"
+        );
+        c.shutdown();
+    }
+
+    /// The property the filter exists for. Both groups get the SAME block hash
+    /// (vLLM mixes no group id in), so a Mamba event arriving AFTER the
+    /// attention event overwrites `map[hash] -> router_hash` with a hash over
+    /// its own tokens; the next chunk then chains off the wrong node and the
+    /// view holds a block no query can reproduce.
+    #[test]
+    fn a_later_mamba_event_cannot_poison_the_attention_chain() {
+        let c = KvEventClient::new();
+        c.on_worker_added(&worker("w", Some("tcp://127.0.0.1:5604"), 4, None));
+
+        let stored = |hashes: Vec<u64>, parent, kind: &str, toks: Vec<u32>| Event::Stored {
+            block_hashes: hashes,
+            parent_block_hash: parent,
+            spec_kind: Some(kind.to_string()),
+            token_ids: toks,
+        };
+        apply_events(
+            &c.state,
+            "w",
+            0,
+            &[stored(
+                vec![111, 222],
+                None,
+                "mla_attention",
+                vec![1, 2, 3, 4, 5, 6, 7, 8],
+            )],
+        );
+        // same hashes, different tokens, arriving second
+        apply_events(
+            &c.state,
+            "w",
+            0,
+            &[stored(
+                vec![111, 222],
+                None,
+                "mamba",
+                vec![90, 91, 92, 93, 94, 95, 96, 97],
+            )],
+        );
+        // follow-on chunk, parented on the attention group's second block
+        apply_events(
+            &c.state,
+            "w",
+            0,
+            &[stored(
+                vec![333],
+                Some(222),
+                "mla_attention",
+                vec![9, 10, 11, 12],
+            )],
+        );
+
+        let q = crate::hasher::hash_request(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], 4);
+        assert_eq!(q.len(), 3);
+        assert_eq!(
+            c.prefix_hits("w", None, &q),
+            3,
+            "a later non-attention event overwrote the attention group's hash map"
+        );
+        c.shutdown();
+    }
+
     // Drive the view-maintenance chain directly (no sockets) — this is the core
     // correctness property: a BlockStored feeds token_ids through the SAME chain
     // as the query side, so prefix_hits matches hash_request.
@@ -730,6 +953,7 @@ mod tests {
             &[Event::Stored {
                 block_hashes: vec![111, 222],
                 parent_block_hash: None,
+                spec_kind: None,
                 token_ids: vec![1, 2, 3, 4, 5, 6, 7, 8],
             }],
         );
@@ -756,6 +980,7 @@ mod tests {
             &[Event::Stored {
                 block_hashes: vec![111, 222],
                 parent_block_hash: None,
+                spec_kind: None,
                 token_ids: vec![1, 2, 3, 4, 5, 6, 7, 8],
             }],
         );
@@ -787,6 +1012,7 @@ mod tests {
             &[Event::Stored {
                 block_hashes: vec![1],
                 parent_block_hash: None,
+                spec_kind: None,
                 token_ids: vec![1, 2, 3, 4],
             }],
         );

--- a/tests/unit/router/test_kv_aware_routing_extremes.py
+++ b/tests/unit/router/test_kv_aware_routing_extremes.py
@@ -1,0 +1,224 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""Routing outcomes that are decidable by hand, so a wrong one is obviously wrong.
+
+The pipeline tests answer "does a hit happen". These answer "does the RIGHT
+worker get it", on inputs where the correct answer is not a matter of degree:
+everything to one worker, an exact half-and-half split, a strict subset losing
+to a superset. A policy that quietly degenerates to a fixed tiebreak passes a
+hit-rate test on one worker and fails these.
+
+That degeneration is not hypothetical. In production kv-aware routing sent
+32 of 32 requests to a single worker while the second node sat idle, and every
+decision logged ``cache_hits=0``. Nothing in the suite would have caught it,
+because no test asked where requests went when there was a choice.
+
+Cost, from ``KvEventAwarePolicy.pick``:
+
+    cost(t) = w_overlap * (blocks_in_request - blocks_t_already_has)
+              + w_mm * images_t_lacks
+              + in_flight_blocks_on_t
+
+with ties broken by the lower in-flight count. At the default weight of 1.0,
+one uncached block and one in-flight request are worth the same, which is what
+makes the load-versus-locality cases below decidable rather than a judgement.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from infera.common.worker_pool import (
+    DisaggMode,
+    EngineType,
+    WorkerInfo,
+    WorkerStatus,
+)
+from infera.router.kv_event.client import KvEventClient
+from infera.router.kv_event.events import BlockStored
+from infera.router.policy.kv_event_aware import KvEventAwarePolicy
+
+BS = 4
+
+
+def _worker(wid: str) -> WorkerInfo:
+    return WorkerInfo(
+        worker_id=wid,
+        url=f"http://{wid}",
+        model_name="m",
+        engine=EngineType.VLLM,
+        status=WorkerStatus.ACTIVE,
+        disagg_mode=DisaggMode.MIXED,
+        kv_events_endpoint=f"tcp://{wid}:5555",
+        kv_block_size=BS,
+    )
+
+
+class _IdentityHasher:
+    def hash_for(self, body: dict, *, block_size: int, engine=None) -> list[int]:
+        from infera.router.kv_event.hasher import hash_request
+
+        return hash_request(body.get("token_ids", []), block_size)
+
+
+@pytest.fixture
+async def rig():
+    """Two workers behind one policy, with their event subscriptions stubbed out
+    so blocks can be placed directly and the outcome is not a race."""
+    client = KvEventClient()
+    policy = KvEventAwarePolicy(client, _IdentityHasher())
+    a, b = _worker("a:1"), _worker("b:1")
+    for w in (a, b):
+        policy.on_worker_added(w)
+        for t in client._subs[w.worker_id].tasks:
+            t.cancel()
+    return policy, client, a, b
+
+
+def _store(client, wid: str, tokens: list[int], first_hash: int = 0) -> None:
+    """Give a worker the blocks for `tokens`, as one aligned event."""
+    n = len(tokens) // BS
+    client._handle_event(
+        client._subs[wid],
+        BlockStored(
+            block_hashes=[bytes([first_hash + i]) for i in range(n)],
+            parent_block_hash=None,
+            token_ids=list(tokens),
+            block_size=BS,
+            lora_id=None,
+            group_idx=0,
+            kv_cache_spec_kind="full_attention",
+        ),
+        rank=None,
+    )
+
+
+def _pick(policy, workers, tokens):
+    target, _ = policy.pick(list(workers), {"model": "m", "token_ids": list(tokens)})
+    return target.worker.worker_id
+
+
+# --- everything to one worker ------------------------------------------------
+
+
+async def test_every_request_goes_to_the_only_worker_that_has_the_prefix(rig):
+    """One worker holds the whole prompt, the other holds nothing. There is no
+    tradeoff to weigh: 20/20 to the holder."""
+    policy, client, a, b = rig
+    prompt = list(range(40))  # 10 blocks
+    _store(client, "a:1", prompt)
+
+    picks = [_pick(policy, (a, b), prompt) for _ in range(20)]
+    assert picks.count("a:1") == 20, f"{picks.count('b:1')}/20 went to the cold worker"
+
+
+async def test_the_holder_still_wins_when_it_is_the_second_candidate(rig):
+    """Candidate order must not decide this. A degenerate tiebreak looks correct
+    whenever the holder happens to be listed first."""
+    policy, client, a, b = rig
+    prompt = list(range(40))
+    _store(client, "b:1", prompt)
+
+    assert _pick(policy, (a, b), prompt) == "b:1"
+    assert _pick(policy, (b, a), prompt) == "b:1"
+
+
+# --- an exact half-and-half split -------------------------------------------
+
+
+async def test_two_disjoint_prefixes_split_exactly_down_the_middle(rig):
+    """Each worker owns one prefix. Requests must sort themselves 10/10 by
+    content, not alternate: a round-robin router also produces 10/10 overall,
+    but sends half of each prefix to the wrong worker."""
+    policy, client, a, b = rig
+    p1 = list(range(40))
+    p2 = list(range(1000, 1040))
+    _store(client, "a:1", p1, first_hash=0)
+    _store(client, "b:1", p2, first_hash=100)
+
+    by_prefix = {"p1": [], "p2": []}
+    for _ in range(10):
+        by_prefix["p1"].append(_pick(policy, (a, b), p1))
+        by_prefix["p2"].append(_pick(policy, (a, b), p2))
+
+    assert by_prefix["p1"] == ["a:1"] * 10, "prefix 1 must always follow its holder"
+    assert by_prefix["p2"] == ["b:1"] * 10, "prefix 2 must always follow its holder"
+
+
+# --- more of the prefix wins ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "a_blocks,b_blocks,winner",
+    [
+        (2, 8, "b:1"),  # strict subset loses to the longer match
+        (8, 2, "a:1"),  # and the same the other way round
+        (0, 1, "b:1"),  # even one block beats nothing
+        (9, 10, "b:1"),  # a single block of difference still decides
+    ],
+)
+async def test_the_longer_cached_prefix_wins(rig, a_blocks, b_blocks, winner):
+    policy, client, a, b = rig
+    prompt = list(range(40))  # 10 blocks
+    if a_blocks:
+        _store(client, "a:1", prompt[: a_blocks * BS], first_hash=0)
+    if b_blocks:
+        _store(client, "b:1", prompt[: b_blocks * BS], first_hash=100)
+
+    assert _pick(policy, (a, b), prompt) == winner
+
+
+# --- cold start must spread, not pile up ------------------------------------
+
+
+async def test_a_cold_fleet_spreads_instead_of_piling_onto_one_worker(rig):
+    """Neither worker has anything, so every candidate costs the same and the
+    in-flight count is the only signal left. This is the exact shape of the
+    production failure -- 32/32 to one worker -- and it is what the tiebreak
+    exists to prevent."""
+    policy, _client, a, b = rig
+    counts = {"a:1": 0, "b:1": 0}
+    for i in range(20):
+        prompt = list(range(i * 100, i * 100 + 40))  # a fresh prefix each time
+        target, blocks = policy.pick([a, b], {"model": "m", "token_ids": prompt})
+        wid = target.worker.worker_id
+        counts[wid] += 1
+        policy.on_request_started(target.route_key, blocks)  # stays in flight
+
+    assert counts == {"a:1": 10, "b:1": 10}, f"cold fleet did not spread: {counts}"
+
+
+async def test_load_outweighs_a_one_block_cache_edge(rig):
+    """One cached block and one in-flight request are both worth 1 at the
+    default weight, so a worker holding one extra block but carrying two more
+    in-flight requests must lose. Stated as a test because it is the tradeoff
+    someone will change the weight to alter."""
+    policy, client, a, b = rig
+    prompt = list(range(40))
+    _store(client, "a:1", prompt[: 1 * BS], first_hash=0)  # A: 1 block, 9 misses
+
+    # Put 2 blocks' worth of in-flight work on A. Cost(A) = 9 + 2 = 11 > Cost(B) = 10.
+    ta, blocks = policy.pick([a], {"model": "m", "token_ids": prompt})
+    policy.on_request_started(ta.route_key, blocks[:2])
+
+    assert _pick(policy, (a, b), prompt) == "b:1"
+
+
+async def test_finishing_a_request_returns_the_worker_to_contention(rig):
+    """In-flight cost must be released, or a worker that served a burst is
+    written off long after it went idle."""
+    policy, client, a, b = rig
+    prompt = list(range(40))
+    _store(client, "a:1", prompt[: 1 * BS], first_hash=0)
+
+    ta, blocks = policy.pick([a], {"model": "m", "token_ids": prompt})
+    policy.on_request_started(ta.route_key, blocks[:2])
+    assert _pick(policy, (a, b), prompt) == "b:1"
+
+    policy.on_request_finished(ta.route_key, blocks[:2])
+    assert _pick(policy, (a, b), prompt) == "a:1", (
+        "A holds a block and is idle again; it must win once its load is released"
+    )

--- a/tests/unit/router/test_kv_block_size_mismatch.py
+++ b/tests/unit/router/test_kv_block_size_mismatch.py
@@ -82,18 +82,30 @@ def test_worker_without_block_size_is_not_subscribed(caplog):
     assert client._subs == {}
 
 
-async def test_mismatched_event_does_not_raise_and_indexes_what_it_can():
+async def test_mismatched_event_indexes_blocks_but_not_hashes():
     """The real shape of the bug: 768 tokens, 1 block hash, subscriber at 1.
 
-    Before the fix this raised IndexError on i=1 and killed the subscriber.
+    The first fix stopped this raising IndexError. The second dropped the event
+    whole, on the reasoning that a partial index binds an engine hash to a block
+    it may not describe. That reasoning is right about the HASH and wrong about
+    the BLOCK, and measuring it showed the cost: on a hybrid model emitting
+    these shapes, dropping cut full-prefix hits from 22/32 to 18/32.
+
+    The view entries are correct -- each is chained from a resolved parent over
+    a contiguous token span, which is exactly what a query reproduces. Only the
+    hash-to-block pairing is unknown, and only `map` uses it.
+
+    So: index the blocks, withhold the hashes. A later event naming one of those
+    hashes as its parent then misses and is dropped, which under-reports hits
+    rather than chaining off the wrong node.
     """
     client = KvEventClient()
     sub = await _subscribed(client, 1)
 
     client._handle_event(sub, _stored(tokens=768, hashes=1, block_size=768), rank=0)
 
-    assert len(sub.map_for(0)) == 1, "only the hashes actually supplied may be indexed"
-    assert len(sub.view_for(0)) == 1
+    assert len(sub.view_for(0)) == 768, "the blocks the span covers are indexable"
+    assert len(sub.map_for(0)) == 0, "their hashes are not"
 
 
 async def test_block_size_disagreement_is_reported_once(caplog):
@@ -123,16 +135,23 @@ async def test_agreeing_event_is_unaffected():
 
 
 @pytest.mark.parametrize(
-    "tokens,hashes,expect",
+    "tokens,hashes,view,mapped",
     [
-        (8, 1, 1),  # more tokens than hashes cover — the observed failure
-        (4, 3, 1),  # fewer tokens than hashes — the mirror case
-        (0, 0, 0),  # empty event
+        (8, 2, 2, 2),  # agreeing: 2 hashes x block_size 4 == 8 tokens
+        (8, 1, 2, 0),  # more tokens than hashes cover — the observed failure
+        (4, 3, 1, 0),  # fewer tokens than hashes — the mirror case
+        (0, 0, 0, 0),  # empty event
     ],
 )
-async def test_bound_is_the_minimum_of_both(tokens, hashes, expect):
+async def test_view_follows_the_tokens_and_the_map_follows_agreement(tokens, hashes, view, mapped):
+    """The view is bounded by the token span, the map by the lengths agreeing.
+
+    Both disagreement directions withhold the hashes: the direction of the error
+    does not tell you which block the surviving hash belongs to.
+    """
     client = KvEventClient()
     sub = await _subscribed(client, 4)
 
     client._handle_event(sub, _stored(tokens=tokens, hashes=hashes, block_size=4), rank=0)
-    assert len(sub.map_for(0)) == expect
+    assert len(sub.view_for(0)) == view
+    assert len(sub.map_for(0)) == mapped

--- a/tests/unit/router/test_kv_event_e2e_hybrid.py
+++ b/tests/unit/router/test_kv_event_e2e_hybrid.py
@@ -1,0 +1,252 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""Two workers, real ZMQ, a hybrid model's event stream — does routing follow the cache?
+
+``test_kv_event_e2e.py`` covers the same pipeline for SGLang. This is the vLLM
+hybrid case, which fails differently and was found in production rather than by
+a test: kv-aware routing reported ``cache_hits=0`` on every decision and pinned
+all traffic to one worker, leaving the other node's GPUs idle. That is not a
+degraded hit rate, it is half the fleet.
+
+The shapes below are what a live Kimi-K3 worker publishes, captured off the
+wire (block_size 768, ``--max-num-batched-tokens 4096`` so chunked prefill
+splits at ``4096 // 768 * 768 = 3840``):
+
+    kv_cache_spec_kind   group_idx   token_ids   block_hashes
+    mamba                        0        3840              1
+    mamba                        1        3840              1
+    mamba                        2        3840              1
+    mla_attention                3        3840              5
+
+Three of the four groups are unusable: prefix caching runs in "align" mode on
+the KDA layers, so all but one block per step is a null block skipped when the
+hash list is built, while ``token_ids`` still spans everything. Nothing says
+which chunk the surviving hash covers.
+
+They are also actively destructive. vLLM mixes no group id into the block hash,
+so at equal block sizes a Mamba hash COLLIDES with an attention hash and
+overwrites its entry in the engine-hash -> router-hash map; the next chunk then
+resolves its parent to the wrong node. Three streams silently destroyed the
+fourth, which is why the fix is a filter and not a lenient decoder.
+
+Uses real ZMQ rather than calling ``_handle_event`` directly, so the msgspec
+schema is exercised: the two fields the filter depends on, ``group_idx`` and
+``kv_cache_spec_kind``, were on the wire all along and were being discarded
+because the struct did not declare them. A test that constructs events in
+Python cannot catch that.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from typing import Any
+
+import msgspec
+import pytest
+import zmq
+
+from infera.common.worker_pool import (
+    DisaggMode,
+    EngineType,
+    WorkerInfo,
+    WorkerStatus,
+)
+from infera.router.kv_event.client import KvEventClient
+from infera.router.policy.kv_event_aware import KvEventAwarePolicy
+from infera.router.policy.target import RouteTarget
+
+_TOPIC = b"kv-events"
+BS = 768
+CHUNK_BLOCKS = 5
+CHUNK = BS * CHUNK_BLOCKS
+
+
+def _free_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _worker(worker_id: str, endpoint: str) -> WorkerInfo:
+    return WorkerInfo(
+        worker_id=worker_id,
+        url=f"http://{worker_id}",
+        model_name="test/m",
+        engine=EngineType.VLLM,
+        status=WorkerStatus.ACTIVE,
+        disagg_mode=DisaggMode.MIXED,
+        kv_events_endpoint=endpoint,
+        kv_block_size=BS,
+    )
+
+
+class _IdentityHasher:
+    """Treat ``body["token_ids"]`` as already tokenized, so request/worker
+    alignment is controlled by the test rather than by a tokenizer."""
+
+    def hash_for(self, body: dict, *, block_size: int, engine=None) -> list[int]:
+        from infera.router.kv_event.hasher import hash_request
+
+        return hash_request(body.get("token_ids", []), block_size)
+
+
+def _chunk_payload(
+    tokens: list[int], first_block: int, parent: bytes | None, *, mamba_last: bool = False
+) -> bytes:
+    """One prefill chunk, encoded exactly as vLLM puts it on the wire.
+
+    Built as plain dicts, not our own structs, so the test does not inherit the
+    schema it is meant to be checking.
+
+    ``mamba_last`` exists because ORDER DECIDED CORRECTNESS before the fix, and
+    an earlier draft of this test missed the bug entirely by picking the lucky
+    order. With the attention event last, its five correct hashes overwrite
+    whatever the Mamba events wrote and the view comes out right by accident.
+    Put the Mamba events last and they clobber the attention group's map, so
+    the next chunk resolves its parent to the wrong node.
+
+    vLLM does not promise either order. A router whose cache view depends on it
+    is broken whichever way the engine happens to emit today.
+    """
+    hashes = [bytes([first_block + i]) for i in range(len(tokens) // BS)]
+    base = {
+        "type": "BlockStored",
+        "parent_block_hash": parent,
+        "token_ids": tokens,
+        "block_size": BS,
+        "lora_id": None,
+    }
+    mamba = [
+        {**base, "block_hashes": [hashes[-1]], "group_idx": g, "kv_cache_spec_kind": "mamba"}
+        for g in (0, 1, 2)
+    ]
+    attn = {**base, "block_hashes": hashes, "group_idx": 3, "kv_cache_spec_kind": "mla_attention"}
+    events = [attn, *mamba] if mamba_last else [*mamba, attn]
+    return msgspec.msgpack.encode([0.0, events, None])
+
+
+async def _publish_until(
+    pub: Any, payloads: list[bytes], predicate, *, deadline_s: float = 5.0
+) -> bool:
+    """PUB/SUB drops messages sent before the subscriber attaches, so resend
+    until the effect is visible or the deadline passes."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + deadline_s
+    while loop.time() < deadline:
+        for p in payloads:
+            pub.send_multipart([_TOPIC, p])
+        await asyncio.sleep(0.05)
+        if predicate():
+            return True
+    return False
+
+
+@pytest.mark.parametrize("mamba_last", [False, True], ids=["attn-last", "mamba-last"])
+@pytest.mark.asyncio
+async def test_routing_follows_the_cache_across_two_workers(mamba_last):
+    """The production scenario, end to end, under BOTH intra-batch orders.
+
+    Worker A serves a prompt; its events go out. A request for the SAME prompt
+    must then pick A over an idle B.
+
+    Both orders are run because only one of them fails without the fix. With
+    the attention event last its correct hashes overwrite the Mamba groups'
+    and everything works by luck; with the Mamba events last they overwrite the
+    attention group's map and the second chunk chains off the wrong parent. The
+    fix makes the outcome independent of an order vLLM never promised.
+    """
+    ctx = zmq.Context.instance()
+    port_a, port_b = _free_port(), _free_port()
+    pub_a = ctx.socket(zmq.PUB)
+    pub_a.bind(f"tcp://127.0.0.1:{port_a}")
+    pub_b = ctx.socket(zmq.PUB)
+    pub_b.bind(f"tcp://127.0.0.1:{port_b}")
+
+    client = KvEventClient()
+    policy = KvEventAwarePolicy(client, _IdentityHasher())
+    wa = _worker("a:30000", f"tcp://127.0.0.1:{port_a}")
+    wb = _worker("b:30000", f"tcp://127.0.0.1:{port_b}")
+    policy.on_worker_added(wa)
+    policy.on_worker_added(wb)
+
+    prompt = list(range(2 * CHUNK))
+    payloads = [
+        _chunk_payload(prompt[:CHUNK], 0, None, mamba_last=mamba_last),
+        _chunk_payload(
+            prompt[CHUNK:], CHUNK_BLOCKS, bytes([CHUNK_BLOCKS - 1]), mamba_last=mamba_last
+        ),
+    ]
+    try:
+        ok = await _publish_until(
+            pub_a,
+            payloads,
+            lambda: len(client._subs["a:30000"].view_for(None)) >= 2 * CHUNK_BLOCKS,
+        )
+        assert ok, (
+            "worker A's view never filled: the attention group's events are not "
+            "being indexed at all"
+        )
+        assert len(client._subs["b:30000"].view_for(None)) == 0, "B was never fed"
+
+        # The assertion that matters. View SIZE is not it: a poisoned chain
+        # still produces ten entries, five of them hashed from the wrong parent,
+        # and A still beats an empty B -- so "the right worker won" passes while
+        # half the prompt is invisible. Count what actually matches.
+        from infera.router.kv_event.hasher import hash_request
+
+        want = hash_request(prompt, BS)
+        view = client._subs["a:30000"].view_for(None)
+        matched = sum(1 for h in want if h in view)
+        assert matched == 2 * CHUNK_BLOCKS, (
+            f"{matched}/{2 * CHUNK_BLOCKS} blocks of the prompt are visible on the "
+            "worker that just served it; the chain continued from a clobbered parent"
+        )
+
+        target, blocks = policy.pick([wa, wb], {"model": "test/m", "token_ids": prompt})
+        assert isinstance(target, RouteTarget)
+        assert target.worker.worker_id == "a:30000"
+        assert len(blocks) == 2 * CHUNK_BLOCKS
+    finally:
+        await client.aclose()
+        pub_a.close(linger=0)
+        pub_b.close(linger=0)
+
+
+@pytest.mark.asyncio
+async def test_the_view_is_one_groups_worth_not_four():
+    """Four events arrive per chunk and three are unusable. If they were all
+    indexed the view would be inflated with blocks hashed from a Mamba group's
+    span -- which is how the collision corrupts the map."""
+    ctx = zmq.Context.instance()
+    port = _free_port()
+    pub = ctx.socket(zmq.PUB)
+    pub.bind(f"tcp://127.0.0.1:{port}")
+
+    client = KvEventClient()
+    policy = KvEventAwarePolicy(client, _IdentityHasher())
+    policy.on_worker_added(_worker("a:30000", f"tcp://127.0.0.1:{port}"))
+    try:
+        payload = _chunk_payload(list(range(CHUNK)), 0, None)
+        ok = await _publish_until(
+            pub,
+            [payload],
+            lambda: len(client._subs["a:30000"].view_for(None)) >= CHUNK_BLOCKS,
+        )
+        assert ok, "the attention group's chunk never landed"
+        # Give the other three groups every chance to be indexed too.
+        for _ in range(5):
+            pub.send_multipart([_TOPIC, payload])
+            await asyncio.sleep(0.05)
+
+        sub = client._subs["a:30000"]
+        assert len(sub.view_for(None)) == CHUNK_BLOCKS
+        assert len(sub.map_for(None)) == CHUNK_BLOCKS
+    finally:
+        await client.aclose()
+        pub.close(linger=0)

--- a/tests/unit/router/test_kv_event_group_filter.py
+++ b/tests/unit/router/test_kv_event_group_filter.py
@@ -1,0 +1,184 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""vLLM emits one BlockStored per KV-cache group; only attention groups are indexable.
+
+Measured on Kimi-K3 (3 KDA/Mamba groups + 1 MLA group, block_size 768, one
+prefill chunk):
+
+    kv_cache_spec_kind   group_idx   token_ids   block_hashes
+    mamba                        0        3840              1
+    mamba                        1        3840              1
+    mamba                        2        3840              1
+    mla_attention                3        3840              5
+
+The Mamba groups run prefix caching in "align" mode, where all but one block per
+step is a null block that is skipped when the hash list is built, while
+``token_ids`` still spans the whole range. There is no field saying which chunk
+the surviving hash covers, so the event cannot be indexed.
+
+Indexing it anyway is not merely useless. vLLM's block hash does not mix in the
+group id, so at equal block sizes a Mamba hash COLLIDES with an attention hash
+and overwrites its entry in the engine-hash -> router-hash map; every later
+attention event naming that hash as its parent then chains off the wrong node.
+That is how 3 of 4 event streams silently destroyed the one usable stream, and
+the symptom was ``cache_hits=0`` on every routing decision with all traffic
+pinned to a single worker.
+
+Upstream: vllm#44451 (open). NVIDIA Dynamo survives hybrid models only because
+its `is_main_attention()` filter drops these groups before decoding.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from infera.common.worker_pool import EngineType, WorkerInfo
+from infera.router.kv_event.client import KvEventClient
+from infera.router.kv_event.events import BlockStored
+from infera.router.kv_event.hasher import hash_request
+
+BS = 4
+
+
+def _worker():
+    return WorkerInfo(
+        worker_id="w1:30000",
+        url="http://w1:30000",
+        model_name="m",
+        engine=EngineType.VLLM,
+        kv_events_endpoint="tcp://w1:5555",
+        kv_block_size=BS,
+    )
+
+
+def _stored(*, blocks, spec_kind, group_idx=0, parent=None, first_hash=0, first_token=0):
+    """An event whose lengths AGREE, so only the group filter can reject it.
+
+    ``first_token`` matters: a follow-on chunk carries the NEXT tokens, not the
+    same ones again, and hashing the wrong span makes the chain diverge from
+    what a query reproduces.
+    """
+    return BlockStored(
+        block_hashes=[bytes([first_hash + i]) for i in range(blocks)],
+        parent_block_hash=parent,
+        token_ids=list(range(first_token, first_token + blocks * BS)),
+        block_size=BS,
+        lora_id=None,
+        group_idx=group_idx,
+        kv_cache_spec_kind=spec_kind,
+    )
+
+
+async def _subscribed(client):
+    client.on_worker_added(_worker())
+    sub = client._subs["w1:30000"]
+    for t in sub.tasks:
+        t.cancel()
+    return sub
+
+
+@pytest.mark.parametrize("kind", ["full_attention", "mla_attention", "sink_full_attention"])
+async def test_attention_groups_are_indexed(kind):
+    """``mla_attention`` is not optional: Kimi-K3's attention layers are MLA, so
+    a filter written as ``== "full_attention"`` drops 100% of its usable events
+    — the same empty view the filter exists to prevent, reached from the other
+    side."""
+    client = KvEventClient()
+    sub = await _subscribed(client)
+
+    client._handle_event(sub, _stored(blocks=2, spec_kind=kind), rank=0)
+
+    assert len(sub.map_for(0)) == 2
+    assert len(sub.view_for(0)) == 2
+
+
+@pytest.mark.parametrize("kind", ["mamba", "sliding_window", "encoder_only_attention"])
+async def test_non_attention_groups_are_dropped(kind):
+    client = KvEventClient()
+    sub = await _subscribed(client)
+
+    client._handle_event(sub, _stored(blocks=2, spec_kind=kind), rank=0)
+
+    assert len(sub.map_for(0)) == 0
+    assert len(sub.view_for(0)) == 0
+
+
+async def test_absent_spec_kind_fails_open():
+    """SGLang, and vLLM builds predating the field, send no kind at all. Those
+    streams were indexed before this filter existed, so a closed default would
+    silently switch kv-aware routing off for them — the same class of regression
+    this filter is fixing."""
+    client = KvEventClient()
+    sub = await _subscribed(client)
+
+    client._handle_event(sub, _stored(blocks=2, spec_kind=None), rank=0)
+
+    assert len(sub.map_for(0)) == 2
+
+
+async def test_a_later_mamba_event_cannot_poison_the_attention_chain():
+    """The property the filter exists for, asserted through the query path.
+
+    vLLM mixes no group id into the block hash, so at equal block sizes the
+    Mamba and attention groups hand out the SAME hash for the same position.
+    Order decides the damage: when the Mamba event arrives AFTER the attention
+    event, it overwrites ``map[hash] -> router_hash`` with a hash computed over
+    its own token span, and the next chunk -- which names that hash as its
+    parent -- chains off the wrong node. The view then holds a block hash that
+    no query can ever reproduce.
+
+    Asserted the way routing actually asks: hash the full prompt and count how
+    many of its blocks are in the view. Checking ``len(map)`` would not catch
+    this, because the clobber replaces an entry rather than adding one.
+    """
+    client = KvEventClient()
+    sub = await _subscribed(client)
+
+    # attention group: blocks 0-1 of the prompt, tokens 0..7
+    client._handle_event(sub, _stored(blocks=2, spec_kind="mla_attention", group_idx=3), rank=0)
+    # mamba group: same hashes, DIFFERENT tokens, arriving second
+    mamba = _stored(blocks=2, spec_kind="mamba", group_idx=0, first_token=100)
+    client._handle_event(sub, mamba, rank=0)
+
+    # the next chunk: block 2, tokens 8..11, parented on block 1
+    client._handle_event(
+        sub,
+        _stored(
+            blocks=1,
+            spec_kind="mla_attention",
+            group_idx=3,
+            parent=bytes([1]),
+            first_hash=2,
+            first_token=2 * BS,
+        ),
+        rank=0,
+    )
+
+    # A query over the whole 3-block prompt must find all three.
+    want = hash_request(list(range(3 * BS)), BS)
+    assert len(want) == 3
+    hits = sum(1 for h in want if h in sub.view_for(0))
+    assert hits == 3, (
+        f"{hits}/3 blocks visible: a later non-attention event overwrote the "
+        "attention group's hash map and the chain continued from the wrong node"
+    )
+
+
+async def test_dropping_is_reported_once(caplog):
+    """Silence here is how the original defect survived: a router that quietly
+    indexes nothing looks exactly like one with a cold cache."""
+    client = KvEventClient()
+    sub = await _subscribed(client)
+
+    with caplog.at_level(logging.INFO):
+        for _ in range(3):
+            client._handle_event(sub, _stored(blocks=2, spec_kind="mamba"), rank=0)
+
+    hits = [r for r in caplog.records if "non-attention groups" in r.getMessage()]
+    assert len(hits) == 1, "latched: three events must not produce three copies"
+    assert "mamba" in hits[0].getMessage()

--- a/tests/unit/router/test_kv_event_kimi_k3_shapes.py
+++ b/tests/unit/router/test_kv_event_kimi_k3_shapes.py
@@ -1,0 +1,140 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""End-to-end replay of the event shapes a real Kimi-K3 worker emits.
+
+The per-field unit tests in ``test_kv_event_group_filter`` prove the filter
+rejects what it should. They do not prove a request can HIT afterwards, which is
+the property that actually matters and the one that stayed broken in production
+after the filter went in: ``cache_hits=0`` on every routing decision.
+
+Captured from a live worker (block_size 768, ``--max-num-batched-tokens 4096``,
+so chunked prefill splits at ``4096 // 768 * 768 = 3840``):
+
+    kv_cache_spec_kind   group_idx   token_ids   block_hashes
+    mamba                        0        3840              1
+    mamba                        1        3840              1
+    mamba                        2        3840              1
+    mla_attention                3        3840              5
+
+Four groups per chunk, all at the same block size, and vLLM mixes no group id
+into the hash -- so the Mamba groups' hashes collide with the attention group's.
+"""
+
+from __future__ import annotations
+
+from infera.common.worker_pool import EngineType, WorkerInfo
+from infera.router.kv_event.client import KvEventClient
+from infera.router.kv_event.events import BlockStored
+from infera.router.kv_event.hasher import hash_request
+
+BS = 768
+CHUNK_BLOCKS = 5  # 3840 tokens / 768
+CHUNK = BS * CHUNK_BLOCKS
+
+
+def _worker():
+    return WorkerInfo(
+        worker_id="w1:30000",
+        url="http://w1:30000",
+        model_name="m",
+        engine=EngineType.VLLM,
+        kv_events_endpoint="tcp://w1:5555",
+        kv_block_size=BS,
+    )
+
+
+async def _subscribed(client):
+    client.on_worker_added(_worker())
+    sub = client._subs["w1:30000"]
+    for t in sub.tasks:
+        t.cancel()
+    return sub
+
+
+def _chunk_events(tokens, first_block, parent):
+    """One prefill chunk as four events, in the order vLLM emits them.
+
+    The Mamba groups repeat the attention group's hashes because the engine
+    derives them from the same token span with no group id mixed in. Each
+    reports the whole span against a single hash -- align mode keeps exactly one
+    real block per step and nulls the rest.
+    """
+    hashes = [bytes([first_block + i]) for i in range(len(tokens) // BS)]
+    common = dict(
+        parent_block_hash=parent,
+        token_ids=list(tokens),
+        block_size=BS,
+        lora_id=None,
+    )
+    return [
+        BlockStored(block_hashes=[hashes[-1]], group_idx=g, kv_cache_spec_kind="mamba", **common)
+        for g in (0, 1, 2)
+    ] + [
+        BlockStored(block_hashes=hashes, group_idx=3, kv_cache_spec_kind="mla_attention", **common)
+    ]
+
+
+async def test_a_two_chunk_prefill_is_fully_hittable():
+    """The property production needs: replay a prompt's events, then ask for the
+    same prompt and get every block back.
+
+    Two chunks, because a single one never exercises the parent map: chunk two
+    names chunk one's last block as its parent, and that lookup is exactly what
+    a colliding Mamba hash used to break.
+    """
+    client = KvEventClient()
+    sub = await _subscribed(client)
+
+    prompt = list(range(2 * CHUNK))
+    for ev in _chunk_events(prompt[:CHUNK], first_block=0, parent=None):
+        client._handle_event(sub, ev, rank=0)
+    for ev in _chunk_events(
+        prompt[CHUNK:], first_block=CHUNK_BLOCKS, parent=bytes([CHUNK_BLOCKS - 1])
+    ):
+        client._handle_event(sub, ev, rank=0)
+
+    want = hash_request(prompt, BS)
+    assert len(want) == 2 * CHUNK_BLOCKS
+    hits = sum(1 for h in want if h in sub.view_for(0))
+    assert hits == len(want), (
+        f"{hits}/{len(want)} blocks visible after replaying a two-chunk prefill; "
+        "a request for this prompt would route as if the cache were cold"
+    )
+
+
+async def test_a_partial_prefix_hits_its_prefix_only():
+    """A shorter prompt sharing the first chunk must hit exactly that chunk --
+    not more (which would be a false hit onto another prefix) and not less."""
+    client = KvEventClient()
+    sub = await _subscribed(client)
+
+    prompt = list(range(2 * CHUNK))
+    for ev in _chunk_events(prompt[:CHUNK], first_block=0, parent=None):
+        client._handle_event(sub, ev, rank=0)
+    for ev in _chunk_events(
+        prompt[CHUNK:], first_block=CHUNK_BLOCKS, parent=bytes([CHUNK_BLOCKS - 1])
+    ):
+        client._handle_event(sub, ev, rank=0)
+
+    shared = hash_request(prompt[:CHUNK], BS)
+    assert sum(1 for h in shared if h in sub.view_for(0)) == CHUNK_BLOCKS
+
+    divergent = hash_request(list(range(CHUNK)) + list(range(9_000, 9_000 + CHUNK)), BS)
+    hits = sum(1 for h in divergent if h in sub.view_for(0))
+    assert hits == CHUNK_BLOCKS, f"{hits} hits: a divergent tail must not match"
+
+
+async def test_the_view_holds_only_the_attention_group():
+    """Four groups arrive per chunk; only one is indexable, so the view must be
+    one chunk's worth of blocks, not four."""
+    client = KvEventClient()
+    sub = await _subscribed(client)
+
+    for ev in _chunk_events(list(range(CHUNK)), first_block=0, parent=None):
+        client._handle_event(sub, ev, rank=0)
+
+    assert len(sub.view_for(0)) == CHUNK_BLOCKS
+    assert len(sub.map_for(0)) == CHUNK_BLOCKS


### PR DESCRIPTION
## The failure

kv-aware routing against **Kimi-K3 on two mixed workers** logged `cache_hits=0`
on every decision and pinned all traffic to one worker. The second node's GPUs
sat idle. Not a degraded hit rate — half the fleet.

## Cause

vLLM emits one `BlockStored` **per KV-cache group**, and only the attention
group pairs one hash with one block. Kimi-K3 is hybrid (24 MLA + 69 KDA); the
KDA groups run prefix caching in `align` mode, which nulls all but one block
per step, so those events carry `token_ids` spanning the whole chunk and a
single surviving hash — with nothing on the wire saying which block it covers.
Captured off a live worker (`block_size 768`, `--max-num-batched-tokens 4096`,
so chunked prefill splits at 3840):

| `kv_cache_spec_kind` | `group_idx` | `token_ids` | `block_hashes` |
|---|---|---|---|
| mamba | 0 | 3840 | 1 |
| mamba | 1 | 3840 | 1 |
| mamba | 2 | 3840 | 1 |
| mla_attention | 3 | 3840 | 5 |

Indexing all four is worse than indexing none. vLLM mixes **no group id into
the block hash**, so at equal block sizes a Mamba hash collides with an
attention hash and overwrites its entry in `map[engine_hash] -> router_hash`.
The next chunk then resolves its parent to the wrong node and everything after
it hashes off a poisoned chain. Which group won depended on intra-batch
emission order, which vLLM does not promise.

Upstream: [vllm#44451](https://github.com/vllm-project/vllm/issues/44451) is
open and untriaged, [vllm#44488](https://github.com/vllm-project/vllm/pull/44488)
(block offsets) has no reviews. NVIDIA Dynamo survives hybrid models because it
filters with `is_main_attention()` — which is what this PR does.

## The fix

Filter by `kv_cache_spec_kind`. The two fields the filter needs (`group_idx`,
`kv_cache_spec_kind`) were on the wire all along — our msgspec struct just did
not declare them, so they were discarded before anything could look. Same
change in the Rust decoder.

Two decisions worth reviewing specifically:

- **`mla_attention` is mandatory in the whitelist.** Kimi-K3's attention layers
  are MLA, so a filter written as `== "full_attention"` discards 100% of that
  model's usable events — the same empty view, reached from the other side.
- **The filter fails OPEN when the field is absent** (SGLang, older vLLM). Those
  engines were indexed before this change; a closed default would switch
  kv-aware routing off for them silently.

**A length disagreement no longer drops the event whole.** An earlier revision
of this branch did, and it measurably costs hits: on Qwen3.5-0.8B (same event
shapes) 18/32 requests hit a full prefix with the whole-event drop, versus
22/32 with no filter at all. The view entries *are* correct — chained from a
resolved parent over a contiguous token span. What is not correct is the
hash-to-block pairing, so **the view is indexed and the map is not**. A later
event then misses its parent and is dropped, which under-reports hits instead
of mis-reporting them.

## Tests

`tests/unit/router` **239 passed**; Rust `cargo test` **80 passed**, `cargo fmt --check` clean.

| File | What it covers |
|---|---|
| `test_kv_event_group_filter.py` | the filter per field, asserted through the query path |
| `test_kv_event_kimi_k3_shapes.py` | replays the captured shapes above, two chunks |
| `test_kv_event_e2e_hybrid.py` | **real ZMQ + msgpack dicts** (not our structs), parametrized over both emission orders; asserts matched block count, not view size |
| `test_kv_aware_routing_extremes.py` | routing outcomes decidable by hand — all-to-the-holder, an exact 10/10 split by content, subset-loses-to-superset, cold-fleet spread, load-vs-locality |

Two of these exist because earlier drafts were vacuous. The e2e test builds
events as **plain dicts** because a test that constructs our own structs starts
from the fixed state and cannot catch a field the schema never declared; and it
runs **both** emission orders because with the attention event last, its correct
hashes overwrite the Mamba groups' and the bug disappears by luck.

The extremes file exists because nothing in the suite ever gave the policy a
*choice* — which is precisely why "32/32 to one worker" was green. Verified
non-vacuous against two degenerate policies: replacing the pick with
`targets[0]` fails 8/10, dropping the cache term so only load counts fails 5/10.

## Not claimed

A local A/B on Qwen3.5-0.8B gives **19/32** full hits with this fix versus
**22/32** on stock v0.2.3. I have not explained that 3-hit gap and am not going
to invent a reason for it. Note the local rig is a *dense-path* comparison —
the production zero-hit case is not reproduced by it, and its most likely cause
was a concurrency flaw in the affinity test I was measuring with (rounds fired
concurrently, so repeats raced KV-event propagation). The hybrid-group bug here
is real and independently demonstrated by the replay tests, but it is not
established that it alone explains the production symptom.
