### PR TITLE
fix(router): publish policy_active_blocks where the refcounts change

### DIFF
--- a/infera/router/policy/kv_event_aware.py
+++ b/infera/router/policy/kv_event_aware.py
@@ -198,7 +198,10 @@ class KvEventAwarePolicy(Policy):
             cache_hits=cache_hits,
             request_blocks=len(picked_blocks),
         )
-        metrics.policy_active_blocks.labels(worker_id=picked.route_key).set(active(picked))
+        # policy_active_blocks is NOT published here: at this point the pick's
+        # own blocks have not been refcounted yet (on_request_started does that,
+        # after pick returns), so writing it here reports a one-request-stale
+        # count. It is published from _publish_active on every refcount change.
         metrics.cache_control_seen_total.labels(retention=hints.retention.value).inc()
 
         # Structured log: ops can grep `policy=kv-aware role=...` and correlate
@@ -232,8 +235,27 @@ class KvEventAwarePolicy(Policy):
         prefix = f"{worker_id}#dp"
         for key in [k for k in self._active_block_refs if k == worker_id or k.startswith(prefix)]:
             self._active_block_refs.pop(key, None)
+            # Drop the series too: a removed worker that keeps exporting its
+            # last in-flight count reads as a permanently loaded worker.
+            try:
+                metrics.policy_active_blocks.remove(key)
+            except KeyError:
+                pass
         for key in [k for k in self._mm_affinity if k == worker_id or k.startswith(prefix)]:
             self._mm_affinity.pop(key, None)
+
+    def _publish_active(self, route_key: str) -> None:
+        """Mirror ``route_key``'s in-flight block count into the gauge.
+
+        Must be called after every mutation of ``_active_block_refs``. Setting
+        it only where the refcounts change is the point: publishing from
+        ``pick()`` reports the count from *before* this request's blocks are
+        added, so the gauge trails by one request and reads a flat 0 whenever
+        requests finish before the next one is picked.
+        """
+        metrics.policy_active_blocks.labels(worker_id=route_key).set(
+            len(self._active_block_refs.get(route_key, {}))
+        )
 
     def on_request_started(self, route_key: str, blocks: list[int] | None = None) -> None:
         if not blocks:
@@ -241,6 +263,7 @@ class KvEventAwarePolicy(Policy):
         refs = self._active_block_refs.setdefault(route_key, {})
         for h in blocks:
             refs[h] = refs.get(h, 0) + 1
+        self._publish_active(route_key)
 
     def on_request_finished(self, route_key: str, blocks: list[int] | None = None) -> None:
         if not blocks:
@@ -254,6 +277,7 @@ class KvEventAwarePolicy(Policy):
                 refs.pop(h, None)
             else:
                 refs[h] = rc
+        self._publish_active(route_key)
 
     async def aclose(self) -> None:
         await self._kv.aclose()

--- a/tests/unit/router/test_kv_event_aware_policy.py
+++ b/tests/unit/router/test_kv_event_aware_policy.py
@@ -28,6 +28,7 @@ from infera.common.worker_pool import (
 )
 from infera.router.cache_control import extract_image_keys
 from infera.router.policy.kv_event_aware import KvEventAwarePolicy
+from infera.server import metrics
 
 # ----------------------------------------------------------------------
 # Stubs
@@ -212,6 +213,61 @@ def test_finished_removes_one_refcount_per_block_not_the_whole_set():
 
     policy.on_request_finished("w1", [10, 20])
     assert policy._active_block_refs["w1"] == {}
+
+
+# ----------------------------------------------------------------------
+# the policy_active_blocks gauge tracks the refcounts
+# ----------------------------------------------------------------------
+
+
+def _gauge(route_key: str) -> float:
+    return metrics.policy_active_blocks.labels(worker_id=route_key)._value.get()
+
+
+def test_gauge_follows_refcounts_through_start_and_finish():
+    """Regression: the gauge used to be published only from pick(), before
+    on_request_started refcounted the pick's own blocks. It therefore lagged by
+    one request and — with requests that finish before the next pick — sat at 0
+    forever, so `infera_policy_active_blocks` looked like it was never
+    populated even while routing worked."""
+    client = _StubKvClient({})
+    policy = KvEventAwarePolicy(client, _StubHasher([]))  # type: ignore[arg-type]
+
+    policy.on_request_started("w-gauge-1", [10, 20, 30])
+    assert _gauge("w-gauge-1") == 3
+
+    policy.on_request_finished("w-gauge-1", [10, 20, 30])
+    assert _gauge("w-gauge-1") == 0
+
+
+def test_gauge_is_live_during_serial_traffic():
+    """Serial traffic (finish before the next pick) is exactly the shape that
+    made the old gauge read a flat zero."""
+    client = _StubKvClient({})
+    hashes = [1, 2, 3]
+    policy = KvEventAwarePolicy(client, _StubHasher(hashes))  # type: ignore[arg-type]
+
+    for _ in range(3):
+        picked, blocks = policy.pick([_worker("w-gauge-2")], {"model": "m"})
+        policy.on_request_started(picked.route_key, blocks)
+        # Non-zero WHILE in flight — the old code reported 0 here.
+        assert _gauge(picked.route_key) == 3
+        policy.on_request_finished(picked.route_key, blocks)
+        assert _gauge(picked.route_key) == 0
+
+
+def test_removed_worker_stops_exporting_a_stale_active_count():
+    """A worker that goes away must not keep exporting its last in-flight
+    count, which would read as a permanently loaded worker."""
+    client = _StubKvClient({})
+    policy = KvEventAwarePolicy(client, _StubHasher([]))  # type: ignore[arg-type]
+
+    policy.on_request_started("w-gauge-3", [10, 20, 30])
+    assert _gauge("w-gauge-3") == 3
+
+    policy.on_worker_removed("w-gauge-3")
+    # Series dropped: re-reading the label creates a fresh child at 0.
+    assert _gauge("w-gauge-3") == 0
 
 
 def test_finished_with_unknown_blocks_is_safe():


### PR DESCRIPTION
## The bug

`infera_policy_active_blocks` reads a flat `0` on a live router — the load term
of the kv-aware cost function looks like it is never populated. Reported from a
2-node k3s deploy (Python router backend).

## Root cause

The gauge was written in exactly one place: inside `pick()`. But `pick()` runs
*before* `on_request_started()` refcounts the request's blocks, so the value
published is always the count from *before* the current request.

Under serial traffic — each request finishing before the next is picked, i.e.
any router that is not saturated — that pre-increment count is `0` every time,
so the gauge never moves off zero. Under concurrency it is simply one request
behind.

The refcounting in `_active_block_refs` was correct all along, so **routing
decisions were never affected**. Only the exported metric lied.

## The fix

- Publish from a new `_publish_active()` at every mutation of
  `_active_block_refs` (`on_request_started` / `on_request_finished`), and drop
  the stale write in `pick()`.
- Drop the gauge series in `on_worker_removed()`. A removed worker that keeps
  exporting its last in-flight count reads as a permanently loaded worker —
  what a pod restart would leave behind. Deleting the series is right rather
  than zeroing it: a stale `0` and a genuinely idle `0` are indistinguishable
  to a query.

## Verification

The same scenario was run against the unfixed and fixed policy, reading the
gauge by scraping the **exported Prometheus text** rather than internals — so
this is what a Grafana panel would show.

200 serial requests, sampled every 10th with one request in flight (true value 3):

| | old | new |
|---|---|---|
| scrapes reading > 0 | **0 / 20** | 20 / 20 |
| distinct values seen | `[0.0]` | `[3.0]` |

Scenario matrix (serial / concurrent / worker-removal): **7 of 11 sample points
wrong on old, 0 of 11 on new**. The concurrent rows show the mechanism directly
— old scraped `0, 3, 6` where truth was `3, 6, 9`.

Three regression tests added; they fail on the old code and pass on the new.
Full `tests/unit/router` + `tests/unit/gaie`: 247 passed. `ruff check` clean.

## Note on the Rust router

`rust/router/src/policy.rs:321` logs the same one-request-behind `active_blocks`
value in its `pick` tracing line, but exports no Prometheus gauge, so there is
nothing to fix there for metrics. Worth knowing if that path ever gains one.