### PR TITLE
ci(release): stop the pypi job racing the Release into existence

### DIFF
--- a/.github/scripts/build_test_push.sh
+++ b/.github/scripts/build_test_push.sh
@@ -72,8 +72,13 @@ cd "$(dirname "$0")/../.."
 # inside the STOCK vendor bases so they can be pruned down to what those bases
 # lack. So it needs four refs, and getting any of them wrong is silent:
 #
-#   NATIVE_IMAGE / SGLANG_NATIVE_IMAGE  <- the engine images from THIS run, so a
-#       release never ships an overlay carrying a previous release's native code.
+#   NATIVE_IMAGE            <- the vLLM engine image from THIS run, so a release
+#       never ships an overlay carrying a previous release's native code. Only
+#       the vLLM (CPython 3.12) tree is harvested: the SGLang (3.10) family's
+#       Mooncake is COMPILED in Dockerfile.payload's `mooncake310` stage, so
+#       that the HIP-transport gate is guaranteed present rather than inherited
+#       from whatever the engine image happened to ship. There is deliberately
+#       no SGLANG_NATIVE_IMAGE here.
 #   VLLM_BASE_IMAGE / SGLANG_BASE_IMAGE <- read out of the engine Dockerfiles
 #       rather than repeated here. The prune keeps exactly what the base lacks,
 #       so a base ref that drifts from the one the engine image was built on
@@ -95,15 +100,14 @@ if [ "$engine" = overlay ]; then
   else                        esuf="local"
   fi
   native_vllm="${NATIVE_IMAGE:-${IMAGE}:vllm-${esuf}}"
-  native_sglang="${SGLANG_NATIVE_IMAGE:-${IMAGE}:sglang-${esuf}}"
 
   build_args=(
     --build-arg "VLLM_BASE_IMAGE=${vllm_base}"
     --build-arg "SGLANG_BASE_IMAGE=${sglang_base}"
     --build-arg "NATIVE_IMAGE=${native_vllm}"
-    --build-arg "SGLANG_NATIVE_IMAGE=${native_sglang}"
   )
-  echo "overlay: harvest  vllm=${native_vllm}  sglang=${native_sglang}"
+  echo "overlay: harvest  vllm=${native_vllm}"
+  echo "overlay: compile  sglang mooncake in-image (mooncake310 stage)"
   echo "overlay: deps on  vllm=${vllm_base}"
   echo "overlay: deps on  sglang=${sglang_base}"
 fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,7 +284,28 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${GITHUB_REF_NAME}" dist/* --clobber
+        # Create-if-absent, exactly as `manual` does. This job deliberately has
+        # no `needs:` -- a wheel depends on neither the engine images nor the
+        # overlay -- but that means it can reach this step before `manual` (the
+        # only other job that creates the Release) has run, and `gh release
+        # upload` against a nonexistent release fails with "release not found".
+        # That is not hypothetical: it is how the pypi job died on the v0.2.4
+        # tag push (run 31217988270) while every step before it passed.
+        # Gating on `manual` instead would make the wheel wait on the GPU
+        # builds for no reason, so make whichever job gets there first create it.
+        run: |
+          set -euo pipefail
+          if ! gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            # `manual` may be creating it at this same moment, so losing the
+            # race is fine -- but only if a release really does exist after.
+            # Re-checking rather than swallowing the error keeps a genuine
+            # failure (bad permissions, wrong tag) from surfacing later as a
+            # confusing "release not found" on the upload.
+            gh release create "${GITHUB_REF_NAME}" \
+              --title "${GITHUB_REF_NAME}" --notes "Automated release build." \
+              || gh release view "${GITHUB_REF_NAME}" >/dev/null
+          fi
+          gh release upload "${GITHUB_REF_NAME}" dist/* --clobber
       - name: Publish to PyPI
         # Skipped unless PYPI_API_TOKEN is set. amd-infera has never been
         # published, so claiming the name is a deliberate act, not something a
@@ -331,7 +352,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
           tar -czf "infera-manual-${TAG}.tar.gz" -C manual/_build/html .
-          gh release view "$TAG" >/dev/null 2>&1 || \
-            gh release create "$TAG" --title "$TAG" --notes "Automated release build."
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            # `pypi` creates the Release too and neither job waits on the other,
+            # so losing the race is fine -- but re-check rather than swallow, so
+            # a genuine create failure does not resurface as "release not found".
+            gh release create "$TAG" --title "$TAG" --notes "Automated release build." \
+              || gh release view "$TAG" >/dev/null
+          fi
           gh release upload "$TAG" "infera-manual-${TAG}.tar.gz" --clobber

--- a/deploy/overlay/Dockerfile.payload
+++ b/deploy/overlay/Dockerfile.payload
@@ -28,8 +28,10 @@
 # rebuilding those here would mean carrying a full ROCm toolchain):
 #   docker build -f deploy/overlay/Dockerfile.payload -t infera-overlay:latest .
 ARG NATIVE_IMAGE=rocm/infera:vllm-v0.1.1
-# The SGLang ABI family needs its own harvest: same Mooncake, different CPython.
-ARG SGLANG_NATIVE_IMAGE=rocm/infera:sglang-v0.1.2
+# No SGLANG_NATIVE_IMAGE: the SGLang (CPython 3.10) family's Mooncake is compiled
+# in the `mooncake310` stage below rather than harvested, so that the
+# HIP-transport gate is guaranteed present -- see the comment on that stage. An
+# ARG here that no FROM consumes reads as "the sglang tree is harvested too".
 
 # The Python trees are built INSIDE the vendor bases they will be overlaid onto,
 # not on a plain python:X-slim. `pip install --target` ignores the environment and

--- a/examples/recipes/README.md
+++ b/examples/recipes/README.md
@@ -67,10 +67,12 @@ Build the overlay before deploying:
 docker build -f deploy/overlay/Dockerfile.payload -t inferaimage/infera-overlay:v0.2.2 .
 ```
 
-The build harvests **one native tree per ABI family** — `NATIVE_IMAGE` supplies
-the vLLM one (CPython 3.12) and `SGLANG_NATIVE_IMAGE` the SGLang one (3.10).
-Mooncake and hipFile bind both the ROCm major and the CPython minor, so neither
-tree can stand in for the other.
+The build produces **one native tree per ABI family**, by two different routes:
+`NATIVE_IMAGE` supplies the vLLM one (CPython 3.12) by harvesting it, while the
+SGLang one (3.10) is compiled during the build itself, so that its Mooncake is
+known to carry the HIP-transport gate instead of inheriting whatever the engine
+image shipped. Mooncake and hipFile bind both the ROCm major and the CPython
+minor, so neither tree can stand in for the other.
 
 The families do not carry the same capabilities, and that is by design:
 


### PR DESCRIPTION
Two independent bugs found while working out why the v0.2.4 release published
only some of its artefacts.

## 1. `pypi` and `manual` race each other to create the GitHub Release

Both jobs do `gh release create ... || true` before uploading their assets, and
neither is gated on the other — so on a tag push they run concurrently and one
of them always loses the create. `|| true` hides that, which is fine, but it
also hides *every other* failure of `gh release create`: bad permissions, a
malformed tag, a transient API error. The job then falls through to
`gh release upload` and dies there with a confusing "release not found" that
points nowhere near the actual cause.

Both steps now:

```yaml
if ! gh release view "$TAG" >/dev/null 2>&1; then
  gh release create "$TAG" ... || gh release view "$TAG" >/dev/null
fi
gh release upload "$TAG" ... --clobber
```

Losing the race is still fine — the re-check confirms a release really does
exist. A genuine failure now exits non-zero at the step that caused it.

Exercised against a stub `gh` covering all four paths:

| case | outcome |
|---|---|
| release absent, create succeeds | exit 0 |
| release already exists | exit 0 (no create attempted) |
| create loses the race, release exists after | exit 0 |
| create fails for a real reason, no release | **exit 1** |

## 2. `SGLANG_NATIVE_IMAGE` is a phantom

`build_test_push.sh` passed `--build-arg SGLANG_NATIVE_IMAGE=...` and logged
`overlay: harvest sglang=<ref>`, but `Dockerfile.payload` declares that ARG
without any `FROM` consuming it. The SGLang (CPython 3.10) family's Mooncake is
**compiled** in the `mooncake310` stage — deliberately, so the HIP-transport
gate is guaranteed present rather than inherited — and has been since that
stage was added.

So the build log claimed a harvest that never happened, naming an image the
build never pulled. Anyone debugging an SGLang native-payload problem would
start from the wrong artefact. `examples/recipes/README.md` repeated the same
claim to users.

Removed the build-arg and the ARG, and the log now says what the build does:

```
overlay: harvest  vllm=<ref>
overlay: compile  sglang mooncake in-image (mooncake310 stage)
```

No behaviour change to the image — the arg was never read.

## Checks

- `release.yml` parses; job list and `needs:` graph unchanged
- `bash -n build_test_push.sh`
- every remaining ARG in `Dockerfile.payload` is consumed by a `FROM`