### PR TITLE
build(docker): drop the Go toolchain Mooncake's dependencies.sh installs

### DIFF
--- a/deploy/docker/scripts/build_mooncake_rocm.sh
+++ b/deploy/docker/scripts/build_mooncake_rocm.sh
@@ -130,21 +130,12 @@ if [ -n "${ASIO_SO:-}" ]; then
 fi
 
 # ---- drop the Go toolchain dependencies.sh installed ------------------------
-# Upstream's dependencies.sh installs Go unconditionally, for the etcd metadata
-# client and the Rust/Go store. We build with USE_ETCD=OFF and WITH_STORE=OFF,
-# so nothing we ship links against it and nothing at runtime invokes it -- the
-# engine is a Python extension module over HIP/RDMA.
-#
-# Removed HERE, in the same RUN as the build, for the same reason cargo is in
-# Dockerfile.vllm: a scanner reads the flattened final filesystem, so a
-# toolchain deleted in a later layer is still reported. Left in place it put a
-# full Go distribution in the vLLM image and 72 stdlib CVE hits on the scan,
-# none of which describe code this image can execute.
-#
-# Only /usr/local/go is touched. On bases that ship their own Go under
-# $HOME/go (sglang, atom), that copy is the base's to manage, and it is
-# reported against the base image too -- removing it here would not change what
-# the diff-vs-baseline shows.
+# dependencies.sh installs Go unconditionally, for the etcd metadata client and
+# the Rust/Go store. We build with USE_ETCD=OFF and WITH_STORE=OFF, so nothing
+# we ship links against it -- the engine is a Python extension over HIP/RDMA.
+# Removed here, in the same RUN as the build, because a delete in a later layer
+# leaves the files in the one below. Only /usr/local/go: bases that ship their
+# own Go under $HOME/go own that copy.
 if [ -d /usr/local/go ]; then
     rm -rf /usr/local/go
     echo "removed /usr/local/go (installed by dependencies.sh; USE_ETCD=OFF, WITH_STORE=OFF)"
@@ -182,9 +173,7 @@ for _v in MC_ENABLE_HIP_TRANSPORT MC_DISABLE_HIP_TRANSPORT; do
 done
 echo "MC_HIP_GATE_VERIFY OK (HIP transport OFF by default)"
 # Assert the Go toolchain really is gone, so a future dependencies.sh that puts
-# it somewhere else fails the build instead of quietly reappearing in a scan.
-# Checked after the import test below would be too late -- keep it adjacent to
-# the other invariants this script guarantees about its own output.
+# it somewhere else fails the build instead of silently shipping it again.
 if [ -d /usr/local/go ]; then
     echo "ERROR: /usr/local/go still present after cleanup." >&2
     echo "       dependencies.sh moved the Go toolchain; update the rm above." >&2

--- a/deploy/docker/scripts/build_mooncake_rocm.sh
+++ b/deploy/docker/scripts/build_mooncake_rocm.sh
@@ -129,6 +129,27 @@ if [ -n "${ASIO_SO:-}" ]; then
     echo "installed libasio.so"
 fi
 
+# ---- drop the Go toolchain dependencies.sh installed ------------------------
+# Upstream's dependencies.sh installs Go unconditionally, for the etcd metadata
+# client and the Rust/Go store. We build with USE_ETCD=OFF and WITH_STORE=OFF,
+# so nothing we ship links against it and nothing at runtime invokes it -- the
+# engine is a Python extension module over HIP/RDMA.
+#
+# Removed HERE, in the same RUN as the build, for the same reason cargo is in
+# Dockerfile.vllm: a scanner reads the flattened final filesystem, so a
+# toolchain deleted in a later layer is still reported. Left in place it put a
+# full Go distribution in the vLLM image and 72 stdlib CVE hits on the scan,
+# none of which describe code this image can execute.
+#
+# Only /usr/local/go is touched. On bases that ship their own Go under
+# $HOME/go (sglang, atom), that copy is the base's to manage, and it is
+# reported against the base image too -- removing it here would not change what
+# the diff-vs-baseline shows.
+if [ -d /usr/local/go ]; then
+    rm -rf /usr/local/go
+    echo "removed /usr/local/go (installed by dependencies.sh; USE_ETCD=OFF, WITH_STORE=OFF)"
+fi
+
 # ---- verify ----------------------------------------------------------------
 SO="$(python3 -c 'import mooncake.engine as e; print(e.__file__)')"
 echo "installed: $SO"
@@ -160,5 +181,15 @@ for _v in MC_ENABLE_HIP_TRANSPORT MC_DISABLE_HIP_TRANSPORT; do
     fi
 done
 echo "MC_HIP_GATE_VERIFY OK (HIP transport OFF by default)"
+# Assert the Go toolchain really is gone, so a future dependencies.sh that puts
+# it somewhere else fails the build instead of quietly reappearing in a scan.
+# Checked after the import test below would be too late -- keep it adjacent to
+# the other invariants this script guarantees about its own output.
+if [ -d /usr/local/go ]; then
+    echo "ERROR: /usr/local/go still present after cleanup." >&2
+    echo "       dependencies.sh moved the Go toolchain; update the rm above." >&2
+    exit 1
+fi
+echo "MC_NO_GO_VERIFY OK (/usr/local/go absent)"
 python3 -c "from mooncake.engine import TransferEngine; print('MOONCAKE IMPORT OK')"
 echo "MC_BUILD_DONE"


### PR DESCRIPTION
## Where the Go came from

`build_mooncake_rocm.sh` runs Mooncake's `dependencies.sh`, which installs Go
unconditionally — it is needed for the etcd metadata client and the Rust/Go
store. We configure with `USE_ETCD=OFF` and `WITH_STORE=OFF`, so nothing we
ship links against it and nothing at runtime invokes it; the engine is a Python
extension module over HIP/RDMA. Confirmed: no reference to `/usr/local/go`,
`GOROOT`, or `GOPATH` anywhere in `infera/`, the overlay, or the docker scripts.

Left in place, it puts a full Go distribution at `/usr/local/go` in the vLLM
image, and its stdlib is the single largest thing we add on top of that base.
Only vLLM is affected: the sglang and atom bases already ship a Go toolchain of
their own under `$HOME/go`, and the Go paths in our sglang and atom images are
byte-for-byte the same set as in their bases.

## The fix

Remove `/usr/local/go` in the **same RUN** as the build, for the reason
514529c7 gives for cargo: a delete in a later layer leaves the files in the one
below. An assertion beside the existing HIP-gate check fails the build if a
future `dependencies.sh` relocates Go, rather than letting it silently reappear.

Only `/usr/local/go` is touched. The base-provided `$HOME/go` on sglang/atom is
the base's to manage.

## Checks

- `bash -n` passes
- logic exercised against a fake root, all three paths:

| case | result |
|---|---|
| Go present | removed, assertion passes, exit 0 |
| Go absent (idempotent re-run) | no-op, exit 0 |
| removal skipped, Go still present | **exit 1** with the diagnostic |

## Related

Companion to #102, which removes pip/setuptools/wheel from the kvd and server
images.
