### PR TITLE
build(docker): drop pip/setuptools/wheel from the kvd and server images

### DIFF
--- a/deploy/docker/Dockerfile.kvd
+++ b/deploy/docker/Dockerfile.kvd
@@ -24,7 +24,21 @@ COPY pyproject.toml README.md ./
 COPY infera ./infera
 # Include the [gaie] extra for parity with the other infera images so the
 # ext_proc EndpointPicker (infera.gaie) can run from here too.
-RUN pip install --no-cache-dir ".[gaie]"
+#
+# pip/setuptools/wheel are build tooling, removed in the same RUN that uses
+# them: nothing here imports setuptools or pkg_resources, and the daemon starts
+# as `python -m infera.kvd`. Same RUN because a delete in a later layer leaves
+# the files in the one below. By path, since pip cannot uninstall itself.
+RUN set -eu; \
+    pip install --no-cache-dir ".[gaie]"; \
+    sp="$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"; \
+    rm -rf "$sp/pip" "$sp/setuptools" "$sp/wheel" "$sp/pkg_resources" \
+           "$sp"/pip-*.dist-info "$sp"/setuptools-*.dist-info \
+           "$sp"/wheel-*.dist-info "$sp"/_distutils_hack; \
+    rm -f "$sp/distutils-precedence.pth"; \
+    python -c "import infera.kvd, infera.gaie"; \
+    ! python -c "import setuptools" 2>/dev/null \
+      || { echo "setuptools still importable after cleanup" >&2; exit 1; }
 
 # Default socket path matches the adapter's default and the kvd CLI default.
 # Operators usually override via --socket /run/infera-kvd/... on the

--- a/deploy/docker/Dockerfile.server
+++ b/deploy/docker/Dockerfile.server
@@ -11,7 +11,21 @@ COPY pyproject.toml README.md ./
 COPY infera ./infera
 # Include the [gaie] extra so the ext_proc EndpointPicker (infera.gaie) can
 # also run from this image (grpcio/protobuf/grpcio-health-checking/cryptography).
-RUN pip install --no-cache-dir ".[gaie]"
+#
+# pip/setuptools/wheel are build tooling, removed in the same RUN that uses
+# them: nothing here imports setuptools or pkg_resources, and the server starts
+# as `python -m infera.server`. Same RUN because a delete in a later layer
+# leaves the files in the one below. By path, since pip cannot uninstall itself.
+RUN set -eu; \
+    pip install --no-cache-dir ".[gaie]"; \
+    sp="$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"; \
+    rm -rf "$sp/pip" "$sp/setuptools" "$sp/wheel" "$sp/pkg_resources" \
+           "$sp"/pip-*.dist-info "$sp"/setuptools-*.dist-info \
+           "$sp"/wheel-*.dist-info "$sp"/_distutils_hack; \
+    rm -f "$sp/distutils-precedence.pth"; \
+    python -c "import infera.server, infera.gaie"; \
+    ! python -c "import setuptools" 2>/dev/null \
+      || { echo "setuptools still importable after cleanup" >&2; exit 1; }
 
 EXPOSE 8000
 ENTRYPOINT ["python", "-m", "infera.server"]


### PR DESCRIPTION
Both `Dockerfile.kvd` and `Dockerfile.server` install with pip and then keep it,
along with setuptools and wheel, in the final layer. Nothing in either image
needs them at runtime: the daemon starts as `python -m infera.kvd`, the server
as `python -m infera.server`, and neither infera nor the `[gaie]` extra imports
setuptools or pkg_resources.

setuptools' bundled `_vendor/` tree is the only reported issue in either image
— archive handling during a package install these images never perform.
Removing the build tooling takes both to zero.

## How

Removed in the same `RUN` as the install, since a delete in a later layer leaves
the files in the one below, and by path rather than `pip uninstall`, since pip
cannot reliably uninstall itself. The `RUN` then imports the entrypoint modules
and asserts setuptools is gone, so an over-broad `rm` fails the build rather
than shipping.

## Verification

Rebuilt both images:

| | imports | `--help` |
|---|---|---|
| kvd | `import infera.kvd, infera.gaie` OK | prints usage |
| server | `import infera.server, infera.gaie` OK | prints usage |

## Related

Companion to #101, which removes the Go toolchain from the engine images.