### PR TITLE
fix(router): keep a load signal between requests in kv-aware routing

### DIFF
--- a/bench/_kv_aware_split_loadtest.py
+++ b/bench/_kv_aware_split_loadtest.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""Reproduce the reported 448/0 kv-aware split against the real policy.
+
+Drives KvEventAwarePolicy with the traffic shape from the field report:
+two symmetric aggregated workers, multi-turn agent sessions, per-session
+causal pacing (a turn finishes before the next turn of that session is
+issued). Counts picks per worker, the way engine-side
+prefix_cache_queries_total deltas would.
+
+Only the KvEventClient and the tokenizer are stubbed: the client is
+replaced by a model of what the engines' caches would actually hold
+(blocks land on the worker that served the request), and the hasher
+returns token ids directly so no model download is needed. The cost
+function, the refcount bookkeeping and the lifecycle hooks are the real
+ones.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import sys
+from collections import Counter
+
+from infera.common.worker_pool import DisaggMode, EngineType, WorkerInfo, WorkerStatus
+from infera.router.kv_event.hasher import hash_request
+from infera.router.policy.kv_event_aware import KvEventAwarePolicy
+
+BLOCK_SIZE = 16
+
+
+class SimulatedFleet:
+    """Stands in for KvEventClient: each worker's view holds the blocks of
+    the requests that worker actually served (unbounded, i.e. best case for
+    locality -- a real engine evicts, which can only spread load further)."""
+
+    def __init__(self, worker_ids: list[str]) -> None:
+        self._views: dict[str, set[int]] = {w: set() for w in worker_ids}
+
+    def cache_view(self, worker_id: str, dp_rank: int | None = None) -> set[int]:
+        return self._views[worker_id]
+
+    def store(self, worker_id: str, blocks: list[int]) -> None:
+        self._views[worker_id].update(blocks)
+
+    def on_worker_added(self, w: WorkerInfo) -> None:
+        pass
+
+    def on_worker_removed(self, worker_id: str) -> None:
+        pass
+
+    async def aclose(self) -> None:
+        pass
+
+
+class TokenHasher:
+    """Hashes the pre-tokenized ids the trace generator produces, using the
+    router's own chaining -- skips the tokenizer, keeps the hash chain."""
+
+    def hash_for(self, body: dict, *, block_size: int, engine=None) -> list[int]:
+        return hash_request(body["_tokens"], block_size)
+
+
+def _worker(worker_id: str) -> WorkerInfo:
+    return WorkerInfo(
+        worker_id=worker_id,
+        url=f"http://{worker_id}",
+        model_name="moonshotai/Kimi-K3",
+        engine=EngineType.VLLM,
+        status=WorkerStatus.ACTIVE,
+        disagg_mode=DisaggMode.MIXED,
+        kv_events_endpoint=f"tcp://{worker_id}:5557",
+        kv_block_size=BLOCK_SIZE,
+    )
+
+
+def make_trace(n_requests: int, seed: int = 0) -> list[dict]:
+    """Multi-turn agent sessions: each turn re-sends the conversation so far
+    plus new content, so turn N shares a long prefix with turn N-1.
+
+    Shaped after the Mooncake toolagent trace: a shared system prompt, then
+    per-session divergence, then per-turn growth.
+    """
+    rng = random.Random(seed)
+    system = [rng.randrange(1000, 2000) for _ in range(3 * BLOCK_SIZE)]
+
+    reqs: list[dict] = []
+    session = 0
+    while len(reqs) < n_requests:
+        session += 1
+        tokens = list(system) + [rng.randrange(10_000, 90_000) for _ in range(4 * BLOCK_SIZE)]
+        for turn in range(rng.randint(3, 8)):
+            tokens = tokens + [rng.randrange(10_000, 90_000) for _ in range(3 * BLOCK_SIZE)]
+            reqs.append(
+                {
+                    "model": "moonshotai/Kimi-K3",
+                    "_tokens": list(tokens),
+                    "_session": session,
+                    "_turn": turn,
+                }
+            )
+            if len(reqs) >= n_requests:
+                break
+    return reqs[:n_requests]
+
+
+def run(policy: KvEventAwarePolicy, fleet: SimulatedFleet, workers, trace) -> Counter:
+    """Serial pacing: each request is picked, started and finished before the
+    next -- the low-concurrency case the report describes."""
+    picks: Counter = Counter()
+    for req in trace:
+        target, blocks = policy.pick(workers, req)
+        picks[target.route_key] += 1
+        policy.on_request_started(target.route_key, blocks)
+        # The engine serves it and caches the blocks.
+        fleet.store(target.worker.worker_id, blocks)
+        policy.on_request_finished(target.route_key, blocks)
+    return picks
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--requests", type=int, default=448)
+    ap.add_argument(
+        "--kv-overlap-weight",
+        type=float,
+        nargs="+",
+        default=[0.01, 0.1, 1.0, 20.0],
+    )
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    workers = [_worker("worker-A"), _worker("worker-B")]
+    trace = make_trace(args.requests, seed=args.seed)
+
+    print(f"trace: {len(trace)} requests, {len({r['_session'] for r in trace})} sessions")
+    print(f"       block_size={BLOCK_SIZE}, serial pacing, 2 symmetric workers\n")
+    print(f"{'overlap_weight':>15} | {'worker-A':>9} | {'worker-B':>9} | split")
+    print(f"{'-' * 15}-+-{'-' * 9}-+-{'-' * 9}-+------")
+
+    worst = 0.0
+    for w in args.kv_overlap_weight:
+        fleet = SimulatedFleet([x.worker_id for x in workers])
+        policy = KvEventAwarePolicy(fleet, TokenHasher(), overlap_weight=w)
+        picks = run(policy, fleet, workers, trace)
+        a, b = picks.get("worker-A", 0), picks.get("worker-B", 0)
+        share = max(a, b) / max(1, a + b)
+        worst = max(worst, share)
+        print(f"{w:>15g} | {a:>9} | {b:>9} | {share:>5.1%}")
+
+    print()
+    if worst > 0.99:
+        print("REPRODUCED: at least one weight pins ~all traffic on one worker.")
+        return 1
+    print("not reproduced at these weights.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infera/router/policy/kv_event_aware.py
+++ b/infera/router/policy/kv_event_aware.py
@@ -43,15 +43,56 @@ _NONE_RETENTION_DAMPENER = 0.1
 _MM_AFFINITY_CAP = 256
 _MM_IMAGE_BLOCK_WEIGHT = 48.0
 
+# Per-pick decay on each worker's recent-dispatch total (half-life ~23 picks).
+#
+# The load half of the cost function counts blocks that are *in flight*, which
+# is 0 for every worker whenever a request finishes before the next one is
+# picked. Session-paced agent traffic has exactly that shape, so on that
+# workload the cost function loses its load term entirely: a cold fleet ties,
+# the tie goes to whichever candidate is enumerated first, and the cache that
+# winner picks up re-elects it on every later request. The result is a
+# permanent 100/0 split across symmetric workers at any overlap weight.
+#
+# `recent` keeps the load signal alive across requests that never overlap in
+# time. A pick is charged the blocks the winner MISSED, not the blocks the
+# request contains: prefill work is proportional to what the worker has to
+# compute, and a block already in its cache costs it nothing. Charging misses
+# rather than totals is what lets the term coexist with cache affinity --
+# a worker serving a fully-cached prompt accrues no load, so it keeps winning
+# that prompt, while a worker handed a cold prompt accrues the whole thing and
+# the next cold prompt goes elsewhere.
+#
+# Misses are in blocks, the same unit as in-flight load, so the two sum without
+# a conversion factor and the term scales with request size. Charging one point
+# per request instead would cap the term at 1/(1 - decay) no matter how large
+# the requests were, which a single block of cache edge outvotes outright at
+# any overlap weight above that cap -- leaving the split unfixed on exactly the
+# prefill-weighted pools (typical production weight: 20.0) that most need
+# spreading.
+#
+# The decay sets how long a worker carries what it was handed. Too fast and the
+# term cannot accumulate enough to displace an incumbent between one session
+# and the next; measured against the field trace, 0.9 still left w=20 fully
+# pinned while anything from 0.95 up balanced it.
+_RECENT_DECAY = 0.97
+
 
 class KvEventAwarePolicy(Policy):
     """Pick the worker minimising
 
-        cost(w) = overlap_weight * (request_blocks - hits(w)) + active_blocks(w)
+        cost(w) = overlap_weight * (request_blocks - hits(w)) + load(w)
+        load(w) = active_blocks(w) + recent_blocks(w)
 
     where ``active_blocks(w)`` is a refcounted set of distinct in-flight
     block hashes (deduped across requests sharing prefixes), not a sum of
-    prompt lengths.
+    prompt lengths, and ``recent_blocks(w)`` is a decayed sum of the block
+    counts recently dispatched to ``w``.
+
+    Both halves are load-bearing. ``active_blocks`` alone is 0 for every
+    worker under traffic paced so that a request finishes before the next is
+    picked -- the normal shape of multi-turn agent sessions -- which drops the
+    load term out of the comparison and pins the whole fleet's traffic onto
+    one worker. See ``_RECENT_DECAY``.
 
     For PD-disaggregated routing, the disagg-bootstrap router passes
     ``role_hint="prefill"`` or ``role_hint="decode"`` to ``pick``. The
@@ -87,8 +128,11 @@ class KvEventAwarePolicy(Policy):
         self._w_decode = (
             decode_overlap_weight if decode_overlap_weight is not None else overlap_weight
         )
-        # worker_id -> {block_hash -> refcount}; len() is the load term.
+        # worker_id -> {block_hash -> refcount}; len() is the in-flight load.
         self._active_block_refs: dict[str, dict[int, int]] = {}
+        # route_key -> decayed sum of recently dispatched block counts. Carries
+        # the load signal across requests that never overlap in time.
+        self._recent_blocks: dict[str, float] = {}
         # route_key -> ordered set of recent image keys (MRU last, bounded LRU).
         # Multimodal affinity: a request whose image a worker already holds
         # costs less there, co-locating repeat images onto the warm vision
@@ -170,17 +214,21 @@ class KvEventAwarePolicy(Policy):
         def active(t: RouteTarget) -> int:
             return len(self._active_block_refs.get(t.route_key, {}))
 
+        def load(t: RouteTarget) -> float:
+            """Blocks in flight now, plus blocks dispatched recently."""
+            return active(t) + self._recent_blocks.get(t.route_key, 0.0)
+
         def cost(t: RouteTarget) -> float:
             total = len(hashes_for.get((t.worker.engine, t.worker.kv_block_size), []))
             hits = self._cache_hits(t, hashes_for)
             # Image miss term: images this worker does NOT already hold cost
             # w_mm each; the worker with the warm vision cache pays 0 → wins.
             mm_miss = len(mm_keys) - self._mm_hits(t.route_key, mm_keys)
-            return w_overlap * (total - hits) + w_mm * mm_miss + active(t)
+            return w_overlap * (total - hits) + w_mm * mm_miss + load(t)
 
-        # Tie-break by lower active so equal-cost candidates fall back to
+        # Tie-break by lower load so equal-cost candidates fall back to
         # least-loaded.
-        picked = min(targets, key=lambda t: (cost(t), active(t)))
+        picked = min(targets, key=lambda t: (cost(t), load(t)))
         picked_blocks = list(
             hashes_for.get((picked.worker.engine, picked.worker.kv_block_size), [])
         )
@@ -189,9 +237,15 @@ class KvEventAwarePolicy(Policy):
         mm_affinity_hits = self._mm_hits(picked.route_key, mm_keys)
         self._record_mm(picked.route_key, mm_keys)
 
+        cache_hits = self._cache_hits(picked, hashes_for)
+        # Charge the winner for the blocks it will have to compute. Done here
+        # rather than in on_request_started because the hooks run on the
+        # dispatch path, which skips them on the failure routes -- and a pick
+        # that goes uncharged is invisible to the next one.
+        self._record_dispatch(picked.route_key, len(picked_blocks) - cache_hits)
+
         # Telemetry: record the pick decision per role + target, plus
         # the retention bucket we observed on this request.
-        cache_hits = self._cache_hits(picked, hashes_for)
         metrics.record_pick(
             role=role_hint or "mixed",
             worker_id=picked.route_key,
@@ -243,6 +297,32 @@ class KvEventAwarePolicy(Policy):
                 pass
         for key in [k for k in self._mm_affinity if k == worker_id or k.startswith(prefix)]:
             self._mm_affinity.pop(key, None)
+        # Iterated separately from _active_block_refs: a worker can carry a
+        # recent total with nothing in flight, which is the state this term
+        # exists to represent.
+        for key in [k for k in self._recent_blocks if k == worker_id or k.startswith(prefix)]:
+            self._recent_blocks.pop(key, None)
+
+    def _record_dispatch(self, route_key: str, missed_blocks: int) -> None:
+        """Decay every worker's recent total, then charge the pick's misses.
+
+        Decaying on each pick rather than on a wall-clock timer keeps routing a
+        pure function of the request sequence: same requests in, same decisions
+        out, which is what makes the behaviour testable. Totals that decay to
+        nothing are dropped so an idle worker returns to a clean 0.
+
+        A fully-cached pick charges 0 -- the worker has no prefill to do, so it
+        takes on no load and stays the right answer for that prompt.
+        """
+        for key in list(self._recent_blocks):
+            decayed = self._recent_blocks[key] * _RECENT_DECAY
+            if decayed < 1e-3:
+                del self._recent_blocks[key]
+            else:
+                self._recent_blocks[key] = decayed
+        if missed_blocks <= 0:
+            return
+        self._recent_blocks[route_key] = self._recent_blocks.get(route_key, 0.0) + missed_blocks
 
     def _publish_active(self, route_key: str) -> None:
         """Mirror ``route_key``'s in-flight block count into the gauge.

--- a/infera/server/args.py
+++ b/infera/server/args.py
@@ -148,8 +148,9 @@ def parse_server_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=float,
         default=1.0,
         help="kv-aware only: weight on the cache-locality term in "
-        "cost = w * (request_blocks - hits) + active_blocks. Larger values "
-        "favour cache reuse over load balance (default: 1.0). Used for "
+        "cost = w * (request_blocks - hits) + load, where load counts blocks "
+        "in flight plus a decayed total of blocks recently dispatched. Larger "
+        "values favour cache reuse over load balance (default: 1.0). Used for "
         "mixed-pool routing and as the fallback when the prefill/decode "
         "weights below are unset.",
     )

--- a/rust/router/src/policy.rs
+++ b/rust/router/src/policy.rs
@@ -137,18 +137,52 @@ const MM_AFFINITY_CAP: usize = 256;
 /// load differences without a separate weight knob.
 const MM_IMAGE_BLOCK_WEIGHT: f64 = 48.0;
 
+/// Per-pick decay on each worker's recent-dispatch total (half-life ~23 picks).
+///
+/// The load half of the cost function counts blocks that are *in flight*, which
+/// is 0 for every worker whenever a request finishes before the next one is
+/// picked. Session-paced agent traffic has exactly that shape, so on that
+/// workload the cost function loses its load term entirely: a cold fleet ties,
+/// the tie goes to whichever candidate is enumerated first, and the cache that
+/// winner picks up re-elects it on every later request. The result is a
+/// permanent 100/0 split across symmetric workers at any overlap weight.
+///
+/// `recent` keeps the load signal alive across requests that never overlap in
+/// time. A pick is charged the blocks the winner MISSED, not the blocks the
+/// request contains: prefill work is proportional to what the worker has to
+/// compute, and a block already in its cache costs it nothing. That is what
+/// lets the term coexist with cache affinity -- a worker serving a fully-cached
+/// prompt accrues no load and keeps winning it, while a worker handed a cold
+/// prompt accrues the whole thing and the next cold prompt goes elsewhere.
+///
+/// Misses are in blocks, the same unit as in-flight load, so the two sum
+/// without a conversion factor and the term scales with request size. Charging
+/// one point per request instead would cap the term at `1/(1 - decay)` no
+/// matter how large the requests were, which a single block of cache edge
+/// outvotes outright at any overlap weight above that cap.
+///
+/// Mirrors `_RECENT_DECAY` in infera/router/policy/kv_event_aware.py; the two
+/// routers are independent implementations of the same policy and must agree.
+const RECENT_DECAY: f64 = 0.97;
+
 /// Pick the worker minimising
-///   `cost(w) = w_overlap * (request_blocks - hits(w)) + active_blocks(w)`
-/// where `hits(w)` is the longest cached prefix on that worker's DP rank and
-/// `active_blocks(w)` is the refcounted set of distinct in-flight block hashes.
+///   `cost(w) = w_overlap * (request_blocks - hits(w)) + load(w)`
+///   `load(w) = active_blocks(w) + recent_blocks(w)`
+/// where `hits(w)` is the longest cached prefix on that worker's DP rank,
+/// `active_blocks(w)` is the refcounted set of distinct in-flight block hashes,
+/// and `recent_blocks(w)` is a decayed sum of the blocks recently dispatched to
+/// it. Both halves of the load term are needed -- see [`RECENT_DECAY`].
 pub struct KvEventAwarePolicy {
     kv: Arc<KvEventClient>,
     hasher: BlockHasher,
     w: f64,
     w_prefill: f64,
     w_decode: f64,
-    // route_key -> {block_hash -> refcount}; len() is the load term.
+    // route_key -> {block_hash -> refcount}; len() is the in-flight load.
     active: Mutex<HashMap<String, HashMap<u64, i64>>>,
+    // route_key -> decayed sum of recently dispatched block counts. Carries the
+    // load signal across requests that never overlap in time.
+    recent: Mutex<HashMap<String, f64>>,
     // route_key -> recent image keys (MRU front, bounded LRU). Multimodal
     // affinity: a request whose image a worker already holds costs less there,
     // co-locating repeat images onto the worker with the warm vision cache.
@@ -170,6 +204,7 @@ impl KvEventAwarePolicy {
             w_prefill: prefill_overlap_weight.unwrap_or(overlap_weight),
             w_decode: decode_overlap_weight.unwrap_or(overlap_weight),
             active: Mutex::new(HashMap::new()),
+            recent: Mutex::new(HashMap::new()),
             mm_affinity: Mutex::new(HashMap::new()),
         }
     }
@@ -199,6 +234,37 @@ impl KvEventAwarePolicy {
             .get(route_key)
             .map(|m| m.len())
             .unwrap_or(0)
+    }
+
+    /// Blocks in flight now, plus blocks dispatched recently.
+    fn load_of(&self, route_key: &str) -> f64 {
+        let recent = self
+            .recent
+            .lock()
+            .expect("recent mutex poisoned")
+            .get(route_key)
+            .copied()
+            .unwrap_or(0.0);
+        self.active_len(route_key) as f64 + recent
+    }
+
+    /// Decay every worker's recent total, then charge the pick's misses.
+    ///
+    /// Decaying on each pick rather than on a wall-clock timer keeps routing a
+    /// pure function of the request sequence: same requests in, same decisions
+    /// out. Totals that decay to nothing are dropped so an idle worker returns
+    /// to a clean 0. A fully-cached pick charges nothing -- the worker has no
+    /// prefill to do, so it takes on no load and stays the right answer.
+    fn record_dispatch(&self, route_key: &str, missed_blocks: usize) {
+        let mut recent = self.recent.lock().expect("recent mutex poisoned");
+        recent.retain(|_, v| {
+            *v *= RECENT_DECAY;
+            *v >= 1e-3
+        });
+        if missed_blocks == 0 {
+            return;
+        }
+        *recent.entry(route_key.to_string()).or_insert(0.0) += missed_blocks as f64;
     }
 
     /// How many of `keys` this worker is recorded as holding (its warm images).
@@ -286,10 +352,10 @@ impl Policy for KvEventAwarePolicy {
                 .saturating_sub(self.mm_hits(&route_key, &mm_keys));
             w_overlap * (total.saturating_sub(hits) as f64)
                 + w_mm * (mm_miss as f64)
-                + self.active_len(&route_key) as f64
+                + self.load_of(&route_key)
         };
 
-        // min by (cost, active) — tie-break to least-loaded.
+        // min by (cost, load) — tie-break to least-loaded.
         let picked = targets
             .iter()
             .min_by(|a, b| {
@@ -297,8 +363,9 @@ impl Policy for KvEventAwarePolicy {
                 ca.partial_cmp(&cb)
                     .unwrap_or(std::cmp::Ordering::Equal)
                     .then_with(|| {
-                        self.active_len(&a.route_key())
-                            .cmp(&self.active_len(&b.route_key()))
+                        self.load_of(&a.route_key())
+                            .partial_cmp(&self.load_of(&b.route_key()))
+                            .unwrap_or(std::cmp::Ordering::Equal)
                     })
             })
             .expect("candidates non-empty")
@@ -307,6 +374,11 @@ impl Policy for KvEventAwarePolicy {
         let blocks = blocks_of(&picked).clone();
         let hits = hits_of(&picked);
         let picked_key = picked.route_key();
+        // Charge the winner for the blocks it will have to compute. Done here
+        // rather than in on_request_started because the hooks run on the
+        // dispatch path, which skips them on the failure routes -- and a pick
+        // that goes uncharged is invisible to the next one.
+        self.record_dispatch(&picked_key, blocks.len().saturating_sub(hits));
         // Mark the chosen worker as now holding this request's images, so the
         // next request for the same image is drawn back to its warm cache.
         let mm_matched = self.mm_hits(&picked_key, &mm_keys);
@@ -381,6 +453,10 @@ impl Policy for KvEventAwarePolicy {
             .lock()
             .expect("active mutex poisoned")
             .retain(|rk, _| alive(rk));
+        self.recent
+            .lock()
+            .expect("recent mutex poisoned")
+            .retain(|rk, _| alive(rk));
         self.mm_affinity
             .lock()
             .expect("mm_affinity mutex poisoned")
@@ -432,6 +508,69 @@ mod tests {
             pick.target.worker.worker_id, "b",
             "least-loaded when no cache info"
         );
+    }
+
+    #[test]
+    fn recent_dispatch_keeps_a_load_signal_between_requests() {
+        // The bug this guards: with in-flight blocks as the only load term,
+        // traffic paced so each request finishes before the next is picked
+        // leaves every worker reading 0, and the first pick then wins every
+        // subsequent one on candidate order. Nothing is in flight here.
+        let kv = Arc::new(KvEventClient::new());
+        let pol = KvEventAwarePolicy::new(kv, BlockHasher::disabled(), 1.0, None, None);
+        assert_eq!(pol.active_len("a"), 0);
+        assert_eq!(pol.load_of("a"), 0.0);
+
+        pol.record_dispatch("a", 10);
+        assert_eq!(pol.active_len("a"), 0, "nothing in flight");
+        assert!(
+            pol.load_of("a") > 0.0,
+            "load signal must outlive the request"
+        );
+        assert!(pol.load_of("a") > pol.load_of("b"));
+    }
+
+    #[test]
+    fn a_fully_cached_pick_is_charged_nothing() {
+        // The charge is the blocks the winner had to COMPUTE. A worker serving
+        // a prompt it already holds takes on no prefill work, so it accrues no
+        // load and stays the right answer for that prompt.
+        let kv = Arc::new(KvEventClient::new());
+        let pol = KvEventAwarePolicy::new(kv, BlockHasher::disabled(), 1.0, None, None);
+        pol.record_dispatch("a", 0);
+        assert_eq!(pol.load_of("a"), 0.0);
+    }
+
+    #[test]
+    fn recent_load_decays_back_to_zero_when_a_worker_goes_idle() {
+        // Transient by construction: a worker that took a burst and then went
+        // quiet must return to contention, or the fix trades one starvation
+        // mode for another.
+        let kv = Arc::new(KvEventClient::new());
+        let pol = KvEventAwarePolicy::new(kv, BlockHasher::disabled(), 1.0, None, None);
+        pol.record_dispatch("bursty", 10);
+        assert!(pol.load_of("bursty") > 0.0);
+        for _ in 0..500 {
+            pol.record_dispatch("other", 1);
+        }
+        assert_eq!(
+            pol.load_of("bursty"),
+            0.0,
+            "idle worker never returned to 0"
+        );
+    }
+
+    #[test]
+    fn sync_prunes_removed_worker_recent_load() {
+        // Pruned separately from `active`: a worker can carry a recent total
+        // with nothing in flight, which is the state this term represents.
+        let kv = Arc::new(KvEventClient::new());
+        let pol = KvEventAwarePolicy::new(kv, BlockHasher::disabled(), 1.0, None, None);
+        pol.record_dispatch("gone#dp0", 5);
+        pol.record_dispatch("stay", 5);
+        pol.sync_workers(&[worker("stay", 16, None)]);
+        assert_eq!(pol.load_of("gone#dp0"), 0.0);
+        assert!(pol.load_of("stay") > 0.0);
     }
 
     #[test]

--- a/tests/unit/router/test_kv_aware_routing_extremes.py
+++ b/tests/unit/router/test_kv_aware_routing_extremes.py
@@ -222,3 +222,115 @@ async def test_finishing_a_request_returns_the_worker_to_contention(rig):
     assert _pick(policy, (a, b), prompt) == "a:1", (
         "A holds a block and is idle again; it must win once its load is released"
     )
+
+
+# --- load must survive between requests, not just during them ----------------
+
+
+async def test_serial_traffic_does_not_pin_every_request_to_one_worker(rig):
+    """The reported production failure, reduced to its smallest form.
+
+    Each request finishes before the next is picked, so nothing is ever in
+    flight when a decision is made. If in-flight blocks are the only load
+    signal, every worker reads 0, the first cold pick wins on candidate order,
+    and the cache it gains re-elects it for the rest of the run -- 100/0 on a
+    symmetric pair, at any overlap weight.
+
+    Distinct prefixes per request, so there is no locality reason to prefer
+    either worker.
+    """
+    policy, _client, a, b = rig
+    counts = {"a:1": 0, "b:1": 0}
+    for i in range(40):
+        prompt = list(range(i * 100, i * 100 + 40))
+        target, blocks = policy.pick([a, b], {"model": "m", "token_ids": prompt})
+        counts[target.worker.worker_id] += 1
+        # Started AND finished before the next pick: the paced-traffic shape.
+        policy.on_request_started(target.route_key, blocks)
+        policy.on_request_finished(target.route_key, blocks)
+
+    assert min(counts.values()) > 0, f"one worker got everything: {counts}"
+    assert abs(counts["a:1"] - counts["b:1"]) <= 4, f"serial traffic did not spread: {counts}"
+
+
+async def test_serial_traffic_spreads_even_at_a_high_overlap_weight(rig):
+    """A high --kv-prefill-overlap-weight must not reintroduce the pin.
+
+    The load term is unweighted, so a fix that keeps it bounded independently
+    of request size loses to one block of cache edge once the weight exceeds
+    that bound. 20.0 is the documented production prefill weight.
+    """
+    _policy, client, a, b = rig
+    policy = KvEventAwarePolicy(client, _IdentityHasher(), overlap_weight=20.0)
+    counts = {"a:1": 0, "b:1": 0}
+    for i in range(40):
+        prompt = list(range(i * 100, i * 100 + 40))
+        target, blocks = policy.pick([a, b], {"model": "m", "token_ids": prompt})
+        counts[target.worker.worker_id] += 1
+        policy.on_request_started(target.route_key, blocks)
+        policy.on_request_finished(target.route_key, blocks)
+
+    assert min(counts.values()) > 0, f"high weight pinned the fleet: {counts}"
+
+
+async def test_a_fully_cached_prompt_stays_on_its_holder_under_serial_traffic(rig):
+    """Balance must not cost affinity.
+
+    The recent-dispatch charge is the blocks the winner had to COMPUTE, so a
+    worker serving a prompt it already holds accrues nothing and keeps winning
+    it. Were the charge the request's total size instead, repeat requests would
+    ping-pong and every one after the first would miss.
+    """
+    policy, client, a, b = rig
+    prompt = list(range(40))
+    _store(client, "a:1", prompt)
+
+    for _ in range(20):
+        target, blocks = policy.pick([a, b], {"model": "m", "token_ids": prompt})
+        assert target.worker.worker_id == "a:1"
+        policy.on_request_started(target.route_key, blocks)
+        policy.on_request_finished(target.route_key, blocks)
+
+
+async def test_a_saturated_incumbent_yields_new_work_to_an_idle_worker(rig):
+    """Recent load has to be able to outweigh a shared-prefix edge.
+
+    A worker that has served a long run of traffic carries a large recent
+    total; a cold worker carries none. A new prompt sharing only a short prefix
+    with the incumbent must go to the idle worker.
+    """
+    policy, client, a, b = rig
+    shared = list(range(8))  # 2 blocks both would hit on
+    for i in range(20):
+        prompt = shared + list(range(1000 + i * 100, 1000 + i * 100 + 32))
+        target, blocks = policy.pick([a], {"model": "m", "token_ids": prompt})
+        policy.on_request_started(target.route_key, blocks)
+        # first_hash stays a single byte: _store packs it with bytes([...]).
+        _store(client, "a:1", prompt, first_hash=i * 10)
+        policy.on_request_finished(target.route_key, blocks)
+
+    fresh = shared + list(range(9000, 9032))
+    assert _pick(policy, (a, b), fresh) == "b:1", (
+        "a saturated worker kept new work on the strength of a 2-block prefix"
+    )
+
+
+async def test_recent_load_decays_so_an_idle_worker_returns_to_contention(rig):
+    """The charge is transient. A worker that took a burst and then went quiet
+    must not be written off permanently -- otherwise the fix trades one
+    starvation mode for another."""
+    policy, _client, a, b = rig
+    for i in range(20):
+        prompt = list(range(i * 100, i * 100 + 40))
+        target, blocks = policy.pick([a], {"model": "m", "token_ids": prompt})
+        policy.on_request_started(target.route_key, blocks)
+        policy.on_request_finished(target.route_key, blocks)
+
+    assert policy._recent_blocks.get("a:1", 0.0) > 0.0
+    for i in range(400):
+        prompt = list(range(50_000 + i * 100, 50_000 + i * 100 + 40))
+        target, blocks = policy.pick([b], {"model": "m", "token_ids": prompt})
+        policy.on_request_started(target.route_key, blocks)
+        policy.on_request_finished(target.route_key, blocks)
+
+    assert "a:1" not in policy._recent_blocks, "an idle worker never returned to 0"


### PR DESCRIPTION
Reported from the field: kv-aware sends every request to one worker while the
other sits idle, on symmetric workers, at every overlap weight. Present on
v0.2.2, v0.2.4 and v0.2.5. Two aggregated Kimi-K3 TP8 workers on MI355X
replaying a multi-turn agent trace, measured from each engine's own
`prefix_cache_queries_total` rather than router metrics:

| policy | worker A / worker B |
|---|---|
| `round-robin` | 224 / 224 |
| `kv-aware` | **448 / 0** |

## This is not what #99 fixed

#99 corrected the `infera_policy_active_blocks` gauge, which was published in
`pick()` before the refcount and read one request behind. The refcounts were
correct and routing used them directly, so only the exported metric was wrong.
The reporter measured engine-side counters, not the gauge. Separate defect, in
the pick decision itself.

## Root cause

The load term is `active_blocks` — blocks in flight. It is credited in
`on_request_started` and released in `on_request_finished`, both on the
dispatch path around the request (`infera/router/mixed.py:121,145`). Under
traffic paced so a request finishes before the next is picked — per-session
causal pacing, the normal shape of agent sessions — nothing is in flight at a
decision. Instrumented over 448 requests: **max `active_blocks` at any pick =
0**. The load term drops out of the comparison entirely.

What remains is a tie on a cold fleet. `min()` returns the first minimum, so
`candidates[0]` wins, gains the prefix, wins the next on cache hits, and grows
its cache. Nothing pulls back. Reversing candidate order flips which worker is
pinned.

Both halves matter — separated by substituting the tie-break:

| weight | tie=first | tie=random |
|---|---|---|
| 0 | 448/0 | 227/221 |
| 0.01 | 448/0 | 448/0 |
| 1.0 | 448/0 | 448/0 |

At `w=0` (no locality at all) it is still 448/0 on tie-break alone.
Randomising the tie fixes only that row — above 0, the first pick's cache
advantage takes over regardless. So neither a tie-break change nor a weight
change is sufficient.

Concurrency-gated, which is why CI never saw it: C=1 gives 448/0, C≥2 splits
evenly. The existing tests set active blocks explicitly and never exercise the
serial path.

## Fix

Carry a decayed per-worker total of recently dispatched blocks alongside the
in-flight count; use the sum as the load term.

**Charged on misses, not totals.** Prefill work is proportional to what the
worker must compute, so a block already cached costs it nothing. A worker
serving a prompt it holds accrues no load and keeps winning it; a worker
handed a cold prompt accrues the whole thing and the next cold prompt goes
elsewhere. This is what lets the term coexist with affinity — charging totals
makes repeat requests ping-pong, which the existing
`test_every_request_goes_to_the_only_worker_that_has_the_prefix` catches.

**Denominated in blocks, not requests.** Same unit as in-flight load, so the
two sum without a conversion factor and the term scales with request size. A
per-request charge caps at `1/(1-decay)` regardless of size, which one block
of cache edge outvotes at any weight above that cap — leaving the split
unfixed at the documented production prefill weight of 20.0.

## Results

448 requests, 83 sessions, 2 workers, serial pacing:

| weight | before | after | block hit rate | sessions kept whole |
|---|---|---|---|---|
| 0.01 | 448/0 | 208/240 | 60.7% | 0/83 |
| 0.1 | 448/0 | 222/226 | 61.1% | 1/83 |
| 1.0 | 448/0 | 225/223 | 78.4% | 82/83 |
| 2.0 | 448/0 | 220/228 | 78.6% | 83/83 |
| 20.0 | 448/0 | 230/218 | 78.6% | 83/83 |

Before, every row was 448/0 — the weight had no effect on placement. After, it
does what it documents: low values balance, high values keep sessions whole.
**At 20.0 the fix keeps the full 78.6% hit rate and all 83 sessions intact
while splitting evenly** — balance recovered without giving up locality.

Worst-worker share across 4 seeds (ideal in parens):

| workers | w=0.01 | w=1.0 | w=2.0 |
|---|---|---|---|
| 2 | 53.6% | 51.3% | 51.6% | (50.0%) |
| 4 | 27.0% | 26.6% | 26.3% | (25.0%) |
| 8 | 14.1% | 14.3% | 14.5% | (12.5%) |

Balanced at C=1…64.

The decay constant was chosen by sweep, not guess — 0.9 still left w=20 pinned;
0.95 and above balance it. 0.97 for headroom.

## Rust router

`rust/router/src/policy.rs` is an independent implementation of the same cost
function and had the identical defect. Ported, with its own tests. This also
answers the reporter's question: switching data planes would not have helped.

## Tests

- 247 Python router tests pass (5 new)
- 84 Rust tests pass (4 new), clippy clean
- 1227 total Python unit tests pass; the 6 failures in `test_sglang_wiring` /
  `test_preflight_kv` are pre-existing and fail identically without this change

Four of the five new Python tests fail against the old policy. The fifth
(`a_fully_cached_prompt_stays_on_its_holder`) passes both — it guards against
the fix over-correcting.

`bench/_kv_aware_split_loadtest.py` is the driver used to find and verify
this; it drives the real policy, stubbing only the event client and tokenizer.

## Not addressed here

Snapshot 404s on vLLM, also mentioned in the report: `/v1/kv-snapshot` is
mounted only by the SGLang wiring (`infera/engine/sglang/kv_wiring.py:164`),
but the vLLM launcher advertises its own API port as `snapshot_endpoint`
(`infera/engine/vllm/__main__.py:102`), so the router GETs a route vLLM never
serves. Harmless — the ZMQ event stream is what populates the cache view — but
we should either mount it or stop advertising it. Separate issue.