### PR TITLE
build(docker): remove the Rust toolchain from the engine images

### DIFF
--- a/deploy/docker/Dockerfile.atom
+++ b/deploy/docker/Dockerfile.atom
@@ -43,9 +43,19 @@ COPY infera ./infera
 RUN pip install --no-cache-dir ".[atom]"
 
 # ---- Rust router (multi-core data plane; --router-backend rust) ----
-# The ROCm base ships cargo; use it (install a minimal toolchain only if
-# absent). Needs cc for linking and libclang (onig_sys/bindgen). Removes
-# the build tree, keeps the binary.
+# The ROCm base often ships cargo; use it, and install a minimal toolchain only
+# if absent. Needs cc for linking and libclang (onig_sys/bindgen).
+#
+# Build and remove in the SAME RUN. This is about what a scanner finds in the
+# final image, not about size: image scanning reads the flattened filesystem, so
+# a toolchain deleted in a later step is still reported, while one deleted here
+# is gone. A serving image has no business shipping a compiler toolchain.
+#
+# Removed unconditionally, including when the base supplied it. Who installed it
+# does not change whether it is present in the image being scanned, and nothing
+# at runtime needs cargo: the engines are Python, and the built infera-router
+# links only against base system libs (libc/libstdc++/libgcc/libm), none of
+# which the toolchain provides.
 COPY rust ./rust
 RUN set -eu; \
     command -v cc >/dev/null || { apt-get update && apt-get install -y --no-install-recommends build-essential && rm -rf /var/lib/apt/lists/*; }; \
@@ -56,7 +66,10 @@ RUN set -eu; \
     export LIBCLANG_PATH="${LIBCLANG_PATH:-/opt/rocm/llvm/lib}"; \
     ( cd rust && cargo build --release --bin infera-router ); \
     cp rust/target/release/infera-router /usr/local/bin/infera-router; \
-    rm -rf rust
+    rm -rf rust "$HOME/.cargo" "$HOME/.rustup" /usr/local/cargo /usr/local/rustup; \
+    rm -f /usr/local/bin/cargo /usr/local/bin/rustc /usr/local/bin/rustup /usr/local/bin/rustdoc; \
+    ! command -v cargo >/dev/null || { echo "cargo still on PATH after cleanup: $(command -v cargo)" >&2; exit 1; }; \
+    /usr/local/bin/infera-router --help >/dev/null 2>&1 || { echo "infera-router unusable after cleanup" >&2; exit 1; }
 
 # KV-aware routing site hook: ATOM owns its BlockManager in a spawned
 # EngineCore subprocess, so the only reliable place to install the KV-event

--- a/deploy/docker/Dockerfile.sglang
+++ b/deploy/docker/Dockerfile.sglang
@@ -177,9 +177,19 @@ RUN set -eu; \
     rm -rf /tmp/sglang-rocm-patches
 
 # ---- Rust router (multi-core data plane; --router-backend rust) ----
-# The ROCm base ships cargo; use it (install a minimal toolchain only if
-# absent). Needs cc for linking and libclang (onig_sys/bindgen). Removes
-# the build tree, keeps the binary.
+# The ROCm base often ships cargo; use it, and install a minimal toolchain only
+# if absent. Needs cc for linking and libclang (onig_sys/bindgen).
+#
+# Build and remove in the SAME RUN. This is about what a scanner finds in the
+# final image, not about size: image scanning reads the flattened filesystem, so
+# a toolchain deleted in a later step is still reported, while one deleted here
+# is gone. A serving image has no business shipping a compiler toolchain.
+#
+# Removed unconditionally, including when the base supplied it. Who installed it
+# does not change whether it is present in the image being scanned, and nothing
+# at runtime needs cargo: the engines are Python, and the built infera-router
+# links only against base system libs (libc/libstdc++/libgcc/libm), none of
+# which the toolchain provides.
 COPY rust ./rust
 RUN set -eu; \
     command -v cc >/dev/null || { apt-get update && apt-get install -y --no-install-recommends build-essential && rm -rf /var/lib/apt/lists/*; }; \
@@ -190,7 +200,10 @@ RUN set -eu; \
     export LIBCLANG_PATH="${LIBCLANG_PATH:-/opt/rocm/llvm/lib}"; \
     ( cd rust && cargo build --release --bin infera-router ); \
     cp rust/target/release/infera-router /usr/local/bin/infera-router; \
-    rm -rf rust
+    rm -rf rust "$HOME/.cargo" "$HOME/.rustup" /usr/local/cargo /usr/local/rustup; \
+    rm -f /usr/local/bin/cargo /usr/local/bin/rustc /usr/local/bin/rustup /usr/local/bin/rustdoc; \
+    ! command -v cargo >/dev/null || { echo "cargo still on PATH after cleanup: $(command -v cargo)" >&2; exit 1; }; \
+    /usr/local/bin/infera-router --help >/dev/null 2>&1 || { echo "infera-router unusable after cleanup" >&2; exit 1; }
 
 COPY deploy/docker/scripts/infera_inject_host_ionic.sh /usr/local/bin/infera-inject-host-ionic
 

--- a/deploy/docker/Dockerfile.sglang.gfx942
+++ b/deploy/docker/Dockerfile.sglang.gfx942
@@ -157,9 +157,19 @@ RUN set -eu; \
     rm -rf /tmp/sglang-rocm-patches
 
 # ---- Rust router (multi-core data plane; --router-backend rust) ----
-# The ROCm base ships cargo; use it (install a minimal toolchain only if
-# absent). Needs cc for linking and libclang (onig_sys/bindgen). Removes
-# the build tree, keeps the binary.
+# The ROCm base often ships cargo; use it, and install a minimal toolchain only
+# if absent. Needs cc for linking and libclang (onig_sys/bindgen).
+#
+# Build and remove in the SAME RUN. This is about what a scanner finds in the
+# final image, not about size: image scanning reads the flattened filesystem, so
+# a toolchain deleted in a later step is still reported, while one deleted here
+# is gone. A serving image has no business shipping a compiler toolchain.
+#
+# Removed unconditionally, including when the base supplied it. Who installed it
+# does not change whether it is present in the image being scanned, and nothing
+# at runtime needs cargo: the engines are Python, and the built infera-router
+# links only against base system libs (libc/libstdc++/libgcc/libm), none of
+# which the toolchain provides.
 COPY rust ./rust
 RUN set -eu; \
     command -v cc >/dev/null || { apt-get update && apt-get install -y --no-install-recommends build-essential && rm -rf /var/lib/apt/lists/*; }; \
@@ -170,7 +180,10 @@ RUN set -eu; \
     export LIBCLANG_PATH="${LIBCLANG_PATH:-/opt/rocm/llvm/lib}"; \
     ( cd rust && cargo build --release --bin infera-router ); \
     cp rust/target/release/infera-router /usr/local/bin/infera-router; \
-    rm -rf rust
+    rm -rf rust "$HOME/.cargo" "$HOME/.rustup" /usr/local/cargo /usr/local/rustup; \
+    rm -f /usr/local/bin/cargo /usr/local/bin/rustc /usr/local/bin/rustup /usr/local/bin/rustdoc; \
+    ! command -v cargo >/dev/null || { echo "cargo still on PATH after cleanup: $(command -v cargo)" >&2; exit 1; }; \
+    /usr/local/bin/infera-router --help >/dev/null 2>&1 || { echo "infera-router unusable after cleanup" >&2; exit 1; }
 
 COPY deploy/docker/scripts/infera_inject_host_ionic.sh /usr/local/bin/infera-inject-host-ionic
 

--- a/deploy/docker/Dockerfile.vllm
+++ b/deploy/docker/Dockerfile.vllm
@@ -154,9 +154,19 @@ COPY infera ./infera
 RUN pip install --no-cache-dir ".[vllm]"
 
 # ---- Rust router (multi-core data plane; --router-backend rust) ----
-# The ROCm base ships cargo; use it (install a minimal toolchain only if
-# absent). Needs cc for linking and libclang (onig_sys/bindgen). Removes
-# the build tree, keeps the binary.
+# The ROCm base often ships cargo; use it, and install a minimal toolchain only
+# if absent. Needs cc for linking and libclang (onig_sys/bindgen).
+#
+# Build and remove in the SAME RUN. This is about what a scanner finds in the
+# final image, not about size: image scanning reads the flattened filesystem, so
+# a toolchain deleted in a later step is still reported, while one deleted here
+# is gone. A serving image has no business shipping a compiler toolchain.
+#
+# Removed unconditionally, including when the base supplied it. Who installed it
+# does not change whether it is present in the image being scanned, and nothing
+# at runtime needs cargo: the engines are Python, and the built infera-router
+# links only against base system libs (libc/libstdc++/libgcc/libm), none of
+# which the toolchain provides.
 COPY rust ./rust
 RUN set -eu; \
     command -v cc >/dev/null || { apt-get update && apt-get install -y --no-install-recommends build-essential && rm -rf /var/lib/apt/lists/*; }; \
@@ -167,7 +177,10 @@ RUN set -eu; \
     export LIBCLANG_PATH="${LIBCLANG_PATH:-/opt/rocm/llvm/lib}"; \
     ( cd rust && cargo build --release --bin infera-router ); \
     cp rust/target/release/infera-router /usr/local/bin/infera-router; \
-    rm -rf rust
+    rm -rf rust "$HOME/.cargo" "$HOME/.rustup" /usr/local/cargo /usr/local/rustup; \
+    rm -f /usr/local/bin/cargo /usr/local/bin/rustc /usr/local/bin/rustup /usr/local/bin/rustdoc; \
+    ! command -v cargo >/dev/null || { echo "cargo still on PATH after cleanup: $(command -v cargo)" >&2; exit 1; }; \
+    /usr/local/bin/infera-router --help >/dev/null 2>&1 || { echo "infera-router unusable after cleanup" >&2; exit 1; }
 
 # libionic (baked above) + host ionic provider injected at container start;
 # see deploy/docker/scripts/infera_inject_host_ionic.sh.


### PR DESCRIPTION
Scanning the **published v0.2.7** images (not the source tree) shows #101 and
#102 landed, but the Rust toolchain removal never did — it was only ever on the
#89 branch, which was **closed** without merging. So `514529c7` is not on
`main` and not in any shipped image. This cherry-picks it, unchanged.

## What the v0.2.7 scan shows

`inferaimage/infera:vllm-v0.2.7`, Trivy 0.72.0, `--ignore-unfixed` (matching the
original reports' methodology):

| type | count | status |
|---|---|---|
| `gobinary` | **0** | fixed by #101 — `/usr/local/go` confirmed absent |
| `cargo` | **59** | ← this PR |
| `python-pkg` | 22 | vendor-pinned, see below |
| `ubuntu` | 1076 | inherited from the vendor base |

All 59 cargo findings are in the Rust **source registry**, not in shipped code:

```
 18  /root/.cargo/registry/.../reqwest-0.12.28/Cargo.lock
 16  /root/.cargo/registry/.../tokenizers-0.20.4/Cargo.lock
 11  /root/.cargo/registry/.../tokio-rustls-0.26.4/Cargo.lock
  3  /root/.cargo/registry/.../http-body-util-0.1.3/Cargo.lock
  2  /root/.cargo/registry/.../tokio-util-0.7.18/Cargo.lock
```

The cleanup does `rm -rf "$HOME/.cargo"`, which is exactly where these live.

Independently confirmed on the running image:

```
$ docker run --rm --entrypoint sh inferaimage/infera:vllm-v0.2.7 \
    -c 'ls -d /usr/local/go 2>/dev/null && echo PRESENT || echo GONE'
GONE                 # <- #101 worked

$ ... -c 'ls -d /root/.cargo'
/root/.cargo         # <- still there, hence this PR
```

Also verified `kvd-v0.2.7` and `server-v0.2.7` both scan to **TOTAL: 0** — #102
worked as intended in the shipped artifact.

## The change

Unmodified cherry-pick of `514529c7`. Builds `infera-router`, then deletes the
toolchain **in the same RUN**, unconditionally — including on bases that ship
cargo themselves (sglang, atom). A delete in a later layer leaves the files in
the one below.

Nothing at runtime needs cargo: the engines are Python, and `infera-router`
links only against base system libs. Two in-RUN assertions keep it honest —
cargo must be off `PATH`, and `infera-router` must still answer `--help`.

The original commit was verified by building against all three base families
and scanning from outside the build:

| base | result |
|---|---|
| vllm (no cargo in base, rustup path) | cargo/rustc/rustup gone, 0 residue |
| sglang (cargo 1.97 in base) | gone; sglang import + launch_server OK |
| atom (cargo 1.94 in base) | gone; infera-router OK |

## Not addressed here

The 22 `python-pkg` findings sit at vendor-pinned versions (aiohttp,
cryptography, nltk) and the 1076 `ubuntu` ones are inherited from the vendor
base. Neither is ours to fix in this Dockerfile; they need a base bump or a
vendor pin change, which is a separate decision.