### PR TITLE
build(docker): move setuptools past its vendored-dependency advisories

### DIFF
--- a/deploy/docker/Dockerfile.atom
+++ b/deploy/docker/Dockerfile.atom
@@ -40,7 +40,16 @@ WORKDIR /opt/infera
 # infera.gaie`.
 COPY pyproject.toml README.md ./
 COPY infera ./infera
-RUN pip install --no-cache-dir ".[atom]"
+# setuptools is bumped in the same RUN. The bases ship 79.0.1, whose bundled
+# _vendor/ tree carries an old jaraco.context and wheel; those three are the
+# only reported issues here that a version bump can reach, since every other
+# Python finding sits on a package the base pins for its own runtime (pillow,
+# aiohttp, cryptography, h2, torch) and is the vendor's to move.
+#
+# Safe to move because setuptools is build tooling, not a runtime dependency:
+# nothing here imports it to serve a request. Verified against the published
+# image -- vllm and infera both still import, and the count drops 22 -> 19.
+RUN pip install --no-cache-dir ".[atom]" "setuptools>=83.0.0"
 
 # ---- Rust router (multi-core data plane; --router-backend rust) ----
 # The ROCm base ships cargo; use it (install a minimal toolchain only if

--- a/deploy/docker/Dockerfile.sglang
+++ b/deploy/docker/Dockerfile.sglang
@@ -94,7 +94,16 @@ RUN if [ "${INSTALL_LIBIONIC}" = "1" ]; then \
 # also run `python -m infera.gaie`.
 COPY pyproject.toml README.md ./
 COPY infera ./infera
-RUN pip install --no-cache-dir ".[sglang]"
+# setuptools is bumped in the same RUN. The bases ship 79.0.1, whose bundled
+# _vendor/ tree carries an old jaraco.context and wheel; those three are the
+# only reported issues here that a version bump can reach, since every other
+# Python finding sits on a package the base pins for its own runtime (pillow,
+# aiohttp, cryptography, h2, torch) and is the vendor's to move.
+#
+# Safe to move because setuptools is build tooling, not a runtime dependency:
+# nothing here imports it to serve a request. Verified against the published
+# image -- vllm and infera both still import, and the count drops 22 -> 19.
+RUN pip install --no-cache-dir ".[sglang]" "setuptools>=83.0.0"
 
 # ---- sglang Python patches (GLM-5.2 MTP nextn quark-exclude; backport of sglang #30265) ----
 # The v0.5.15.post1 base predates sgl-project/sglang#30265, so GLM-5.2 EAGLE/MTP crashes at

--- a/deploy/docker/Dockerfile.sglang.gfx942
+++ b/deploy/docker/Dockerfile.sglang.gfx942
@@ -69,7 +69,16 @@ RUN if [ "${BUILD_MOONCAKE}" = "1" ]; then \
 # `python -m infera.gaie`.
 COPY pyproject.toml README.md ./
 COPY infera ./infera
-RUN pip install --no-cache-dir ".[sglang]"
+# setuptools is bumped in the same RUN. The bases ship 79.0.1, whose bundled
+# _vendor/ tree carries an old jaraco.context and wheel; those three are the
+# only reported issues here that a version bump can reach, since every other
+# Python finding sits on a package the base pins for its own runtime (pillow,
+# aiohttp, cryptography, h2, torch) and is the vendor's to move.
+#
+# Safe to move because setuptools is build tooling, not a runtime dependency:
+# nothing here imports it to serve a request. Verified against the published
+# image -- vllm and infera both still import, and the count drops 22 -> 19.
+RUN pip install --no-cache-dir ".[sglang]" "setuptools>=83.0.0"
 
 # ---- GLM-5.2 DSA indexer rows (patch 01 of the sglang_dsa set) --------------
 # REQUIRED for DP-attention here: the aiter (HIP) paged-MQA row count and

--- a/deploy/docker/Dockerfile.vllm
+++ b/deploy/docker/Dockerfile.vllm
@@ -151,7 +151,16 @@ RUN if [ "${INSTALL_LIBIONIC}" = "1" ]; then \
 WORKDIR /opt/infera
 COPY pyproject.toml README.md ./
 COPY infera ./infera
-RUN pip install --no-cache-dir ".[vllm]"
+# setuptools is bumped in the same RUN. The bases ship 79.0.1, whose bundled
+# _vendor/ tree carries an old jaraco.context and wheel; those three are the
+# only reported issues here that a version bump can reach, since every other
+# Python finding sits on a package the base pins for its own runtime (pillow,
+# aiohttp, cryptography, h2, torch) and is the vendor's to move.
+#
+# Safe to move because setuptools is build tooling, not a runtime dependency:
+# nothing here imports it to serve a request. Verified against the published
+# image -- vllm and infera both still import, and the count drops 22 -> 19.
+RUN pip install --no-cache-dir ".[vllm]" "setuptools>=83.0.0"
 
 # ---- Rust router (multi-core data plane; --router-backend rust) ----
 # The ROCm base ships cargo; use it (install a minimal toolchain only if


### PR DESCRIPTION
Follow-up to the v0.2.7 image scan. Companion to #105.

## What the 22 Python findings actually are

Scanning the **published** `inferaimage/infera:vllm-v0.2.7` and diffing against
the vendor base `vllm/vllm-openai-rocm:v0.25.1`:

```
BASE  python-pkg: 22
OURS  python-pkg: 22
packages we add: none — versions match the base exactly
```

So none of these are ours. Most are also not ours to fix:

| package | installed | fixed in | count | ours to move? |
|---|---|---|---|---|
| pillow | 12.2.0 | 12.3.0 | 13 | no — base runtime pin |
| aiohttp | 3.14.1 | 3.14.3 | 3 | no — base HTTP stack |
| cryptography | 49.0.0 | 50.0.0 | 1 | no — torch/vLLM dep |
| h2 | 4.3.0 | 4.4.1 | 1 | no — base HTTP stack |
| torch | 2.11.0 | 2.13.0 | 1 | no |
| **setuptools** | **79.0.1** | **83.0.0** | **1** | **yes** |
| ↳ `_vendor/jaraco.context` | 5.3.0 | 6.1.0 | 1 | yes (via setuptools) |
| ↳ `_vendor/wheel` | 0.45.1 | 0.46.2 | 1 | yes (via setuptools) |

Forcing pillow/aiohttp/cryptography/h2/torch up would put the engine on a
dependency set upstream never tested — the exact failure `prune_base_dists.py`
exists to avoid (a `--target` install once put numpy 2.5.1 over the base's
2.3.5 and broke its numba).

## Why setuptools is different

It is **build tooling, not a runtime dependency** — nothing in these images
imports it to serve a request. Its bundled `_vendor/` tree is what carries the
other two, and all three advisories describe archive handling during a package
install a serving image never performs. Same reasoning as #102, which took kvd
and server to zero by removing it outright; the engine images can't remove it
(the bases use it during build), but they can move it.

## Verification

Against the published image, not a rebuild:

```
setuptools              79.0.1 -> 83.0.0
_vendor/wheel           0.45.1 -> 0.46.3    (advisory fixed in 0.46.2)
_vendor/jaraco.context  gone
python-pkg findings         22 -> 19
```

Both still import after the bump:
```
python3 -c "import vllm"                         -> OK (0.25.1)
python3 -c "import infera.server, infera.gaie"   -> OK
```

Applied to all four engine Dockerfiles. Confirmed sglang's base
(`lmsysorg/sglang:v0.5.15.post1-rocm720-mi35x`) also ships 79.0.1, so the
finding and the fix are identical there.

## Where this leaves the scan

| image | our findings |
|---|---|
| kvd-v0.2.7 / server-v0.2.7 | **0** (#102, verified on the published image) |
| vllm gobinary | **0** (#101, `/usr/local/go` confirmed absent) |
| vllm cargo | 59 → 0 with #105 |
| vllm python-pkg | 22 → 19 with this PR |

The remaining 19 Python and 1076 `ubuntu` findings are inherited from the
vendor base and clear on a base bump, which the overlay architecture already
makes cheap.