### PR TITLE
fix(router): charge for picks the hasher produced no blocks for

### DIFF
--- a/infera/router/policy/kv_event_aware.py
+++ b/infera/router/policy/kv_event_aware.py
@@ -76,6 +76,16 @@ _MM_IMAGE_BLOCK_WEIGHT = 48.0
 # pinned while anything from 0.95 up balanced it.
 _RECENT_DECAY = 0.97
 
+# Load charged for a pick we have no block information about: the hasher
+# returned nothing, because the prompt is shorter than the index block size
+# (768 tokens by default) or tokenisation failed. Such a request still costs
+# the worker something, and charging 0 would hold the load term at 0 for every
+# candidate -- restoring the permanent tie, and with it the 100/0 split, on any
+# workload whose prompts are short. One block is the smallest honest estimate:
+# enough to break the tie and rotate workers, small enough that a real
+# multi-block request still outweighs it.
+_UNKNOWN_COST_BLOCKS = 1.0
+
 
 class KvEventAwarePolicy(Policy):
     """Pick the worker minimising
@@ -242,7 +252,7 @@ class KvEventAwarePolicy(Policy):
         # rather than in on_request_started because the hooks run on the
         # dispatch path, which skips them on the failure routes -- and a pick
         # that goes uncharged is invisible to the next one.
-        self._record_dispatch(picked.route_key, len(picked_blocks) - cache_hits)
+        self._record_dispatch(picked.route_key, len(picked_blocks) - cache_hits, len(picked_blocks))
 
         # Telemetry: record the pick decision per role + target, plus
         # the retention bucket we observed on this request.
@@ -303,16 +313,27 @@ class KvEventAwarePolicy(Policy):
         for key in [k for k in self._recent_blocks if k == worker_id or k.startswith(prefix)]:
             self._recent_blocks.pop(key, None)
 
-    def _record_dispatch(self, route_key: str, missed_blocks: int) -> None:
-        """Decay every worker's recent total, then charge the pick's misses.
+    def _record_dispatch(self, route_key: str, missed_blocks: int, request_blocks: int) -> None:
+        """Decay every worker's recent total, then charge for the pick.
 
         Decaying on each pick rather than on a wall-clock timer keeps routing a
         pure function of the request sequence: same requests in, same decisions
         out, which is what makes the behaviour testable. Totals that decay to
         nothing are dropped so an idle worker returns to a clean 0.
 
-        A fully-cached pick charges 0 -- the worker has no prefill to do, so it
-        takes on no load and stays the right answer for that prompt.
+        Two different situations both arrive here with zero misses, and they
+        must not be charged the same way:
+
+        - ``request_blocks > 0`` and every one of them hit. The worker has no
+          prefill to do, so it takes on no load and stays the right answer for
+          that prompt. Charge nothing.
+        - ``request_blocks == 0``. The hasher produced no blocks at all -- the
+          prompt is shorter than the index block size, or tokenisation failed.
+          We know nothing about this request's cost, but the worker still has
+          to serve it. Charging nothing here leaves the load term at 0 for
+          every candidate forever, which is the exact tie that sends every
+          request to whichever worker sorts first: the 100/0 split this term
+          exists to prevent, reappearing on short prompts. Charge the floor.
         """
         for key in list(self._recent_blocks):
             decayed = self._recent_blocks[key] * _RECENT_DECAY
@@ -320,9 +341,12 @@ class KvEventAwarePolicy(Policy):
                 del self._recent_blocks[key]
             else:
                 self._recent_blocks[key] = decayed
-        if missed_blocks <= 0:
+        charge = float(missed_blocks)
+        if request_blocks <= 0:
+            charge = _UNKNOWN_COST_BLOCKS
+        if charge <= 0:
             return
-        self._recent_blocks[route_key] = self._recent_blocks.get(route_key, 0.0) + missed_blocks
+        self._recent_blocks[route_key] = self._recent_blocks.get(route_key, 0.0) + charge
 
     def _publish_active(self, route_key: str) -> None:
         """Mirror ``route_key``'s in-flight block count into the gauge.

--- a/rust/router/src/policy.rs
+++ b/rust/router/src/policy.rs
@@ -165,6 +165,13 @@ const MM_IMAGE_BLOCK_WEIGHT: f64 = 48.0;
 /// routers are independent implementations of the same policy and must agree.
 const RECENT_DECAY: f64 = 0.97;
 
+/// Load charged for a pick we have no block information about -- the hasher
+/// returned nothing, because the prompt is shorter than the index block size or
+/// tokenisation failed. Charging 0 would hold the load term at 0 for every
+/// candidate and restore the permanent tie. Mirrors `_UNKNOWN_COST_BLOCKS` in
+/// infera/router/policy/kv_event_aware.py.
+const UNKNOWN_COST_BLOCKS: f64 = 1.0;
+
 /// Pick the worker minimising
 ///   `cost(w) = w_overlap * (request_blocks - hits(w)) + load(w)`
 ///   `load(w) = active_blocks(w) + recent_blocks(w)`
@@ -255,16 +262,29 @@ impl KvEventAwarePolicy {
     /// out. Totals that decay to nothing are dropped so an idle worker returns
     /// to a clean 0. A fully-cached pick charges nothing -- the worker has no
     /// prefill to do, so it takes on no load and stays the right answer.
-    fn record_dispatch(&self, route_key: &str, missed_blocks: usize) {
+    fn record_dispatch(&self, route_key: &str, missed_blocks: usize, request_blocks: usize) {
         let mut recent = self.recent.lock().expect("recent mutex poisoned");
         recent.retain(|_, v| {
             *v *= RECENT_DECAY;
             *v >= 1e-3
         });
-        if missed_blocks == 0 {
+        // Zero misses arrives here two different ways, and they must not be
+        // charged alike. request_blocks > 0 with no misses means a fully cached
+        // prompt: no prefill to do, so no load, and the holder keeps winning it.
+        // request_blocks == 0 means the hasher produced nothing -- a prompt
+        // under the index block size, or failed tokenisation. That request
+        // still costs the worker something, and charging 0 would hold the load
+        // term at 0 on every candidate, restoring the permanent tie and the
+        // 100/0 split on short-prompt workloads.
+        let charge = if request_blocks == 0 {
+            UNKNOWN_COST_BLOCKS
+        } else {
+            missed_blocks as f64
+        };
+        if charge <= 0.0 {
             return;
         }
-        *recent.entry(route_key.to_string()).or_insert(0.0) += missed_blocks as f64;
+        *recent.entry(route_key.to_string()).or_insert(0.0) += charge;
     }
 
     /// How many of `keys` this worker is recorded as holding (its warm images).
@@ -378,7 +398,7 @@ impl Policy for KvEventAwarePolicy {
         // rather than in on_request_started because the hooks run on the
         // dispatch path, which skips them on the failure routes -- and a pick
         // that goes uncharged is invisible to the next one.
-        self.record_dispatch(&picked_key, blocks.len().saturating_sub(hits));
+        self.record_dispatch(&picked_key, blocks.len().saturating_sub(hits), blocks.len());
         // Mark the chosen worker as now holding this request's images, so the
         // next request for the same image is drawn back to its warm cache.
         let mm_matched = self.mm_hits(&picked_key, &mm_keys);
@@ -521,7 +541,7 @@ mod tests {
         assert_eq!(pol.active_len("a"), 0);
         assert_eq!(pol.load_of("a"), 0.0);
 
-        pol.record_dispatch("a", 10);
+        pol.record_dispatch("a", 10, 10);
         assert_eq!(pol.active_len("a"), 0, "nothing in flight");
         assert!(
             pol.load_of("a") > 0.0,
@@ -531,13 +551,24 @@ mod tests {
     }
 
     #[test]
+    fn a_pick_with_no_block_information_is_still_charged() {
+        // A prompt under the index block size hashes to nothing. Charging 0 for
+        // it would hold the load term at 0 on every candidate, restoring the
+        // tie that sends every request to whichever worker sorts first.
+        let kv = Arc::new(KvEventClient::new());
+        let pol = KvEventAwarePolicy::new(kv, BlockHasher::disabled(), 1.0, None, None);
+        pol.record_dispatch("a", 0, 0);
+        assert!(pol.load_of("a") > 0.0, "unhashable pick accrued no load");
+    }
+
+    #[test]
     fn a_fully_cached_pick_is_charged_nothing() {
         // The charge is the blocks the winner had to COMPUTE. A worker serving
         // a prompt it already holds takes on no prefill work, so it accrues no
         // load and stays the right answer for that prompt.
         let kv = Arc::new(KvEventClient::new());
         let pol = KvEventAwarePolicy::new(kv, BlockHasher::disabled(), 1.0, None, None);
-        pol.record_dispatch("a", 0);
+        pol.record_dispatch("a", 0, 10);
         assert_eq!(pol.load_of("a"), 0.0);
     }
 
@@ -548,10 +579,10 @@ mod tests {
         // mode for another.
         let kv = Arc::new(KvEventClient::new());
         let pol = KvEventAwarePolicy::new(kv, BlockHasher::disabled(), 1.0, None, None);
-        pol.record_dispatch("bursty", 10);
+        pol.record_dispatch("bursty", 10, 10);
         assert!(pol.load_of("bursty") > 0.0);
         for _ in 0..500 {
-            pol.record_dispatch("other", 1);
+            pol.record_dispatch("other", 1, 1);
         }
         assert_eq!(
             pol.load_of("bursty"),
@@ -566,8 +597,8 @@ mod tests {
         // with nothing in flight, which is the state this term represents.
         let kv = Arc::new(KvEventClient::new());
         let pol = KvEventAwarePolicy::new(kv, BlockHasher::disabled(), 1.0, None, None);
-        pol.record_dispatch("gone#dp0", 5);
-        pol.record_dispatch("stay", 5);
+        pol.record_dispatch("gone#dp0", 5, 5);
+        pol.record_dispatch("stay", 5, 5);
         pol.sync_workers(&[worker("stay", 16, None)]);
         assert_eq!(pol.load_of("gone#dp0"), 0.0);
         assert!(pol.load_of("stay") > 0.0);

--- a/tests/unit/router/test_kv_aware_routing_extremes.py
+++ b/tests/unit/router/test_kv_aware_routing_extremes.py
@@ -334,3 +334,44 @@ async def test_recent_load_decays_so_an_idle_worker_returns_to_contention(rig):
         policy.on_request_finished(target.route_key, blocks)
 
     assert "a:1" not in policy._recent_blocks, "an idle worker never returned to 0"
+
+
+async def test_prompts_too_short_to_hash_still_spread(rig):
+    """A prompt under the index block size hashes to nothing. The load charge
+    must not be zero for those, or the term stays 0 on every candidate and the
+    tie sends the whole run to whichever worker sorts first -- the 100/0 split
+    reappearing on short prompts, which is what a user hit after the load-term
+    fix landed.
+
+    token_ids shorter than BS produce no blocks at all, which is the same state
+    the real hasher reaches on a sub-768-token prompt.
+    """
+    policy, _client, a, b = rig
+    counts = {"a:1": 0, "b:1": 0}
+    for i in range(30):
+        # Two tokens: fewer than BS, so hash_request returns [].
+        target, blocks = policy.pick([a, b], {"model": "m", "token_ids": [i, i + 1]})
+        assert blocks == [], "precondition: this prompt must hash to zero blocks"
+        counts[target.worker.worker_id] += 1
+        policy.on_request_started(target.route_key, blocks)
+        policy.on_request_finished(target.route_key, blocks)
+
+    assert min(counts.values()) > 0, f"unhashable prompts pinned one worker: {counts}"
+    assert abs(counts["a:1"] - counts["b:1"]) <= 2, f"did not spread: {counts}"
+
+
+async def test_a_fully_cached_pick_is_still_charged_nothing(rig):
+    """The zero-block floor must not leak into the fully-cached case: a worker
+    serving a prompt it already holds does no prefill, so it accrues no load and
+    keeps winning that prompt. Distinguishing the two is the whole point of
+    passing request_blocks alongside the miss count."""
+    policy, client, a, b = rig
+    prompt = list(range(40))
+    _store(client, "a:1", prompt)
+
+    for _ in range(15):
+        target, blocks = policy.pick([a, b], {"model": "m", "token_ids": prompt})
+        assert target.worker.worker_id == "a:1"
+        policy.on_request_started(target.route_key, blocks)
+        policy.on_request_finished(target.route_key, blocks)
+    assert policy._recent_blocks.get("a:1", 0.0) == 0.0, "fully-cached picks accrued load"


### PR DESCRIPTION
A user retesting kv-aware reported `--kv-overlap-weight` **1.0 and 0.01 giving
identical placement**, with no cache-aware routing visible.

Their instinct that this was suspicious was right, and it goes further than I
first thought. My initial read was "short prompts make the weight cancel, so
both weights agree" — true, but incomplete. **The load term collapses too, and
that is a real defect in #103.**

## Reproduced

Live two-worker Kimi-K3 fleet, v0.2.7, `--kv-overlap-weight 20.0`:

```
picked=chi2774 cache_hits=0 request_blocks=0 active_blocks=0 w_overlap=20.00
picked=chi2774 cache_hits=0 request_blocks=0 active_blocks=0 w_overlap=20.00
...
12 short-prompt requests -> 12 to the same worker
```

Same fleet, same weight, only the prompt lengthened:

```
picked=chi2774 cache_hits=4 request_blocks=4 active_blocks=0 w_overlap=20.00
```

## Why it happens

The router's index block size is **768 tokens**. A shorter prompt hashes to
zero blocks — the state a smoke test naturally lands in.

**Expected:** `cost = overlap_weight * (request_blocks - hits) + load`, so with
`request_blocks = 0` the weighted term is 0 for every candidate and every weight
agrees. Fine on its own — the load term should then decide.

**Not expected:** the load term collapses as well. `_record_dispatch` charges
the blocks the winner *missed*, so a pick with no blocks charges **nothing**.
`recent_blocks` stays 0 everywhere, `active_blocks` is already 0 under paced
traffic, and the cost is a perfect tie — `min()` returns the first candidate,
forever. **The 100/0 split #103 fixed comes straight back on short prompts.**

## The bug

The zero-miss test conflated two situations:

| case | meaning | correct charge |
|---|---|---|
| `request_blocks > 0`, all hit | fully cached — no prefill to do | **0** (or affinity breaks) |
| `request_blocks == 0` | no block info at all | **not 0** — it still costs something |

Passing `request_blocks` alongside the miss count separates them. The second
gets a one-block floor: the smallest honest estimate, enough to break the tie
and rotate workers, small enough that a real multi-block request outweighs it.

## Measured

200 requests, two symmetric workers, serial pacing:

| workload | before | after |
|---|---|---|
| prompts hashing to zero blocks | **200 / 0** | **100 / 100** |
| normal prompts | 106 / 94 | 106 / 94 (unchanged) |

## Tests

- `test_prompts_too_short_to_hash_still_spread` — **fails against the previous
  code**, passes now
- `test_a_fully_cached_pick_is_still_charged_nothing` — guards the distinction
  from being collapsed again
- 249 Python router tests, 71 Rust tests, clippy clean

Ported to the Rust router, which had the identical defect.

## Note for the reporter

This does not make short prompts *route by cache* — they carry no cache
information, so there is nothing to route on. It makes them **spread** instead
of piling onto one worker. To see `--kv-overlap-weight` actually change
placement, prompts must exceed the index block size. `bench/_kv_aware_diagnose.py`
reports which situation a given deployment is in.