### PR TITLE
fix(router): decode ATOM KV events with map schema

### DIFF
--- a/infera/router/kv_event/events.py
+++ b/infera/router/kv_event/events.py
@@ -132,11 +132,11 @@ ALL_CLEARED_TYPES = (AllBlocksCleared, SglangAllBlocksCleared)
 def batch_type_for_engine(engine) -> type:
     """KVEventBatch schema matching a worker's engine wire format.
 
-    vLLM emits tagged-MAP events; SGLang (and anything else, the historical
-    default) emits tagged-ARRAY events.
+    vLLM and Infera's ATOM event hook emit tagged-MAP events; SGLang (the
+    historical default) emits tagged-ARRAY events.
     """
     from infera.common.worker_pool import EngineType
 
-    if engine == EngineType.VLLM:
+    if engine in (EngineType.VLLM, EngineType.ATOM):
         return KVEventBatch
     return SglangKVEventBatch

--- a/tests/unit/router/test_kv_event_client.py
+++ b/tests/unit/router/test_kv_event_client.py
@@ -42,8 +42,10 @@ from infera.router.kv_event.events import (
     AllBlocksCleared,
     BlockRemoved,
     BlockStored,
+    KVEventBatch,
     SglangBlockStored,
     SglangKVEventBatch,
+    batch_type_for_engine,
 )
 from infera.router.kv_event.hasher import ROUTER_SEED, hash_chunk
 
@@ -333,6 +335,32 @@ def test_on_worker_removed_unknown_id_is_noop():
 # ----------------------------------------------------------------------
 # Wire-format / transport layer
 # ----------------------------------------------------------------------
+
+
+def test_atom_decoder_matches_infera_atom_hook_wire_format():
+    """ATOM's Infera hook publishes the same tagged-map schema as vLLM.
+
+    Selecting SGLang's tagged-array decoder for an ATOM worker rejects every
+    event and leaves KV-aware routing with an empty cache view.
+    """
+    payload = msgspec.msgpack.encode(
+        KVEventBatch(
+            ts=1.0,
+            events=[
+                _make_stored(
+                    block_hashes=[111],
+                    parent_block_hash=None,
+                    token_ids=[1, 2, 3, 4],
+                )
+            ],
+        )
+    )
+
+    decoded = msgspec.msgpack.decode(payload, type=batch_type_for_engine(EngineType.ATOM))
+
+    assert isinstance(decoded, KVEventBatch)
+    assert isinstance(decoded.events[0], BlockStored)
+    assert decoded.events[0].block_hashes == [111]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- select Infera's tagged-map `KVEventBatch` decoder for ATOM workers
- preserve SGLang's tagged-array decoder and vLLM's existing tagged-map behavior
- add a regression test that encodes the exact schema emitted by Infera's ATOM hook and decodes it through the engine dispatch path

## Root cause

Infera's ATOM `BlockManager` hook constructs `BlockStored` events and wraps them in `KVEventBatch`. That is the tagged-map schema shared with vLLM. `batch_type_for_engine`, however, selected the tagged-map decoder only for `EngineType.VLLM`; ATOM fell through to `SglangKVEventBatch`, whose events are tagged arrays.

On a live MI300X aggregate deployment, both ATOM workers published events and cached repeated prefixes, but the router rejected each payload with:

```
kv decode failed ... Expected 'array', got 'object' - at '$[1][0]'
```

The router cache view therefore stayed empty even though the engine cache was working.

## Validation

- `pytest -q tests/unit/router/test_kv_event_client.py`: 16 passed.
- Ruff lint and format checks passed for both changed files.
- `git diff --check` passed.
- Broader macOS suite: 1,304 tests passed; remaining failures/errors are platform-dependent shared-memory, Unix-socket-path, and engine tests unrelated to this two-file change.

Current hardware proof uses exact Infera head `8ed8f1728c745d4e91ba9eaa09ed81159aa57e41`:

- [MI300X run 31524554022](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/31524554022), [aggregate job 93889668083](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/31524554022/job/93889668083): both ATOM workers subscribed to KV events; zero wire-decode errors; KV-aware routing decisions progressed from 0 to 6 to 14 cached blocks across repeated-prefix requests; c1/c4 benchmarks and artifacts succeeded; Slurm 11836 `COMPLETED 0:0`.
- The same run's [1P/1D job 93889668107](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/31524554022/job/93889668107) completed cleanly with 25/25 KV transfers and no router or transfer failure.

Original live reproduction: [InferenceX run 31510136132](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/31510136132), job 93841739828.

Companion integration: https://github.com/SemiAnalysisAI/srt-slurm/pull/3.
