### PR TITLE
fix(ci): keep the GPU tiers running when the cluster stops cooperating

### DIFF
--- a/deploy/docker/Dockerfile.atom
+++ b/deploy/docker/Dockerfile.atom
@@ -12,22 +12,25 @@ COPY deploy/docker/patches/atom/ /tmp/atom-patches/
 RUN for f in /tmp/atom-patches/patch_*.py; do echo "[atom-patch] $f"; python3 "$f" || echo "[atom-patch] skipped $f"; done \
     && rm -rf /tmp/atom-patches
 
-# ---- Mooncake (main + B-group C++ patches) --------------------------------
-# The base ships a Mooncake whose GPU MR path is bare ibv_reg_mr, which needs
-# the legacy ib_peer_mem module. Rebuild from the ref vLLM uses ONLY when
-# MOONCAKE_HIP_DMABUF=1; at the default 0 the base's Mooncake is left untouched.
+# ---- Mooncake (pinned upstream + the B.2 hip-transport gate) ---------------
+# WHY: the base ships a single-protocol Mooncake without B.2, so a cross-node PD
+# target is handed to HIP IPC and KV transfer dies on hipIpcOpenMemHandle 201.
+# Same ref and args as Dockerfile.vllm, which documents what MOONCAKE_HIP_DMABUF
+# selects; it must not also gate the rebuild, or the default image carries the
+# base's Mooncake and cannot do cross-node PD at all.
+# HOW: shared build_mooncake_rocm.sh mode 1 (MOONCAKE_DMABUF=1).
 ARG BUILD_MOONCAKE=1
-ARG MOONCAKE_GIT_REF=747003c058015c4077a266e7ccd7549bbc9baede
-ARG MOONCAKE_HIP_DMABUF=0
+ARG MOONCAKE_GIT_REF=faae8dd4a6309c3ecd47e0721a83b0250d686fa2
+ARG MOONCAKE_HIP_DMABUF=1
 COPY deploy/docker/scripts/build_mooncake_rocm.sh /tmp/build_mooncake_rocm.sh
 COPY deploy/docker/patches/mooncake_cpp/ /tmp/mooncake_cpp/
-RUN if [ "${BUILD_MOONCAKE}" = "1" ] && [ "${MOONCAKE_HIP_DMABUF}" = "1" ]; then \
-        MOONCAKE_DMABUF=1 MOONCAKE_HIP_DMABUF=1 \
+RUN if [ "${BUILD_MOONCAKE}" = "1" ]; then \
+        MOONCAKE_DMABUF=1 MOONCAKE_HIP_DMABUF="${MOONCAKE_HIP_DMABUF}" \
         MOONCAKE_GIT_REF="${MOONCAKE_GIT_REF}" \
         MC_CPP_PATCH_DIR=/tmp/mooncake_cpp \
         bash /tmp/build_mooncake_rocm.sh; \
     else \
-        echo "MOONCAKE_HIP_DMABUF=0 — using the base image's Mooncake"; \
+        echo "BUILD_MOONCAKE=0 — skipping Mooncake build"; \
     fi \
     && rm -rf /tmp/build_mooncake_rocm.sh /tmp/mooncake_cpp
 
@@ -65,6 +68,9 @@ RUN pip install --no-cache-dir ".[atom]" "setuptools>=83.0.0"
 # at runtime needs cargo: the engines are Python, and the built infera-router
 # links only against base system libs (libc/libstdc++/libgcc/libm), none of
 # which the toolchain provides.
+#
+# The rc files go with it: rustup appends an unguarded `. "$HOME/.cargo/env"`,
+# which then errors on every login shell the image runs.
 COPY rust ./rust
 RUN set -eu; \
     command -v cc >/dev/null || { apt-get update && apt-get install -y --no-install-recommends build-essential && rm -rf /var/lib/apt/lists/*; }; \
@@ -77,7 +83,9 @@ RUN set -eu; \
     cp rust/target/release/infera-router /usr/local/bin/infera-router; \
     rm -rf rust "$HOME/.cargo" "$HOME/.rustup" /usr/local/cargo /usr/local/rustup; \
     rm -f /usr/local/bin/cargo /usr/local/bin/rustc /usr/local/bin/rustup /usr/local/bin/rustdoc; \
+    sed -i '/\.cargo\/env/d' "$HOME/.profile" "$HOME/.bashrc" 2>/dev/null || true; \
     ! command -v cargo >/dev/null || { echo "cargo still on PATH after cleanup: $(command -v cargo)" >&2; exit 1; }; \
+    ! bash -lc true 2>&1 | grep -q cargo || { echo "a login shell still references cargo" >&2; exit 1; }; \
     /usr/local/bin/infera-router --help >/dev/null 2>&1 || { echo "infera-router unusable after cleanup" >&2; exit 1; }
 
 # KV-aware routing site hook: ATOM owns its BlockManager in a spawned

--- a/deploy/docker/patch.upstream.status.md
+++ b/deploy/docker/patch.upstream.status.md
@@ -140,11 +140,13 @@ so expect upstream to close this differently than we did.
 ## Mooncake C++ — `patches/mooncake_cpp/`
 
 SGLang now builds Mooncake `faae8dd4` directly and carries no private Mooncake
-source patch. The one file below is still applied by the vLLM build, and must be
-removed there once it enables upstream multi-protocol routing. `Dockerfile.atom`
-copies the patch dir too, but only rebuilds Mooncake under
-`MOONCAKE_HIP_DMABUF=1` — not its default, and nothing in this repo passes it. That
-path is still pinned to `747003c` and would need a validated ref bump before use.
+source patch. The one file below is still applied by the vLLM and ATOM builds, and
+must be removed there once they enable upstream multi-protocol routing.
+
+`Dockerfile.atom` stayed on `747003c` through the retirement of B.1 and B.3 below,
+on the premise that nothing passed the `MOONCAKE_HIP_DMABUF=1` its rebuild was
+gated on; `ci.yml`'s `INFERA_E2E_BUILD_ARGS` reaches every engine's build, and at
+that ref B.1's wiring is absent, so the image failed its own dma-buf assertion.
 
 | patch | fixes | upstream issue | upstream PR | ours? | PR state |
 |---|---|---|---|---|---|

--- a/infera/engine/atom/__main__.py
+++ b/infera/engine/atom/__main__.py
@@ -91,6 +91,20 @@ async def main() -> None:
         kv_events_endpoint = f"tcp://{advertise_host}:{port}"
         kv_block_size = args.kv_block_size
 
+    # Ionic RoCE-v2 RDMA env defaults for the Mooncake transfer engine
+    # (set-if-unset; an operator/launcher still overrides via env). Must run
+    # BEFORE engine.start() spawns the ATOM subprocess so it's inherited.
+    # Without these the transfer engine silently falls back to TCP.
+    from infera.engine.rocm_rdma_env import (
+        apply_kv_host_ip_default,
+        apply_rocm_rdma_env_defaults,
+    )
+
+    apply_rocm_rdma_env_defaults()
+    # Pin ATOM_HOST_IP to the RDMA rail (else ATOM's get_ip() picks the public NIC
+    # and KV transfer targets the wrong interface). Must follow the GID default.
+    apply_kv_host_ip_default()
+
     # MI325X (gfx942) + DeepSeek-V4: enforce the support matrix (raise on an
     # unsupported quant/engine combo) and apply the fp8 env defaults (Flash also
     # gets MTP CLI). No-op on other arches / non-dsv4 models. Must run before the

--- a/rust/router/tests/kv_event_nats.rs
+++ b/rust/router/tests/kv_event_nats.rs
@@ -65,6 +65,7 @@ fn block_stored(hashes: &[u64], parent: Option<u64>, token_ids: &[u32], bs: i64)
 /// The event stream, with the configuration the router and the relay both
 /// create it with. Idempotent, so it does not matter who gets there first.
 async fn ensure_event_stream(js: &async_nats::jetstream::Context) {
+    use async_nats::jetstream::stream::{Config, DiscardPolicy, RetentionPolicy, StorageType};
     let cfg = Config {
         name: kv_event_nats::KV_EVENTS_STREAM.to_string(),
         subjects: vec![format!("{KV_EVENTS_SUBJECT_PREFIX}.>")],

--- a/tests/e2e/pd_disag/sglang/matrix.py
+++ b/tests/e2e/pd_disag/sglang/matrix.py
@@ -27,7 +27,12 @@ CASES = [
         {
             "env": {"SGLANG_USE_AITER": "1"},
             "server_ready_timeout": 1800,
-            "args": ["--mem-fraction-static", "0.9"],
+            # triton, not the default aiter backend: the CK batch_prefill instance
+            # this case needs (page_size < kN0 over a >2GB KV cache, gfx950) is
+            # absent from the aiter in the v0.5.17 base, so both TP ranks raise
+            # "no matching kernel found" and the prefill leg dies. Drop this once a
+            # base image carries the instance; aiter stays on for MoE either way.
+            "args": ["--mem-fraction-static", "0.9", "--attention-backend", "triton"],
         },
     ],
 ]

--- a/tests/e2e/pd_mixed/sglang/matrix.py
+++ b/tests/e2e/pd_mixed/sglang/matrix.py
@@ -15,14 +15,22 @@ from ...harness.matrix import DEEPSEEK_V4_PRO, GLM_5_1_FP8, GPT_OSS, KIMI_K26_MX
 # [enable, model, tp, ep, dp_attn] (+ optional opts dict). A tuple/list on an axis
 # enumerates it (e.g. (True, False) runs both). MoE models can exercise ep.
 CASES = [
-    # gpt-oss-120b: tp2, ep on/off.
+    # gpt-oss-120b: tp2, ep on/off. On triton, not the default aiter backend: the
+    # CK batch_prefill instance this case needs (page_size < kN0 over a >2GB KV
+    # cache, gfx950) is absent from the aiter in the v0.5.17 base, so both TP ranks
+    # raise "no matching kernel found" and the engine dies before serving. Drop this
+    # once a base image carries the instance; aiter stays on for MoE either way.
     [
         True,
         GPT_OSS,
         2,
         True,
         False,
-        {"env": {"SGLANG_USE_AITER": "1"}, "server_ready_timeout": 1800},
+        {
+            "env": {"SGLANG_USE_AITER": "1"},
+            "server_ready_timeout": 1800,
+            "args": ["--attention-backend", "triton"],
+        },
     ],
     [
         True,

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -202,6 +202,10 @@ SLURM_TIME="${INFERA_E2E_SLURM_TIME:-02:00:00}"
 # Burst QoS is a fallback, never used up front: a dispatch queued this long on
 # the group node limit is resubmitted with it (see _watch_job / _dispatch_slurm).
 QOS_FALLBACK="${INFERA_E2E_SLURM_QOS_FALLBACK:-amd-burst-qos}"
+# Remembered across _hold_pair calls: the group node limit belongs to the run,
+# not to the pair being tried, so a per-call array spends HOLD_WAIT rediscovering
+# the same answer on every round of the outer retry loop.
+_HOLD_QOS=()
 QOS_WAIT="${INFERA_E2E_QOS_WAIT:-30}"
 # _hold_pair's own window: its -N2 --gres=gpu:8 batch job needs longer to start
 # than a single-node srun, and giving up early only churns the pair-hold race.
@@ -315,14 +319,14 @@ _rival_holder() {
 # The caller reports 1 and 2 differently: they used to read alike, so a refused
 # sbatch was announced as a lost race and pointed triage away from the scheduler.
 _hold_pair() {
-  local pair="$1" script="$SCRATCH/hold.sh" jid st rs waited qos=() i other
+  local pair="$1" script="$SCRATCH/hold.sh" jid st rs waited i other
   # A real script file, not --wrap: on Spur --wrap always NODE_FAILs at -N2.
   printf '#!/bin/bash\nsleep %s\n' "${INFERA_E2E_HOLD_SLEEP:-10800}" > "$script"
   for i in 1 2 3; do
     jid=$(sbatch --parsable -N2 -n2 -w "$pair" --gres=gpu:8 -p "$SLURM_PART" \
       -t "$SLURM_TIME" -J "infera-ci-hold-${INFERA_E2E_JOB_TAG:-local}" \
       ${INFERA_E2E_RESERVATION:+--reservation="$INFERA_E2E_RESERVATION"} \
-      "${qos[@]}" "$script" 2>/dev/null) || continue
+      "${_HOLD_QOS[@]}" "$script" 2>/dev/null) || continue
     waited=0
     while [ "$waited" -lt "$HOLD_WAIT" ]; do
       st=$(scontrol show job "$jid" 2>/dev/null | grep -oE 'JobState=[A-Z_]+' | cut -d= -f2)
@@ -342,7 +346,7 @@ _hold_pair() {
     done
     # Read the reason BEFORE cancelling; the burst QoS is the way past a group
     # node limit, and a launch failure is Spur being flaky — both just retry.
-    [ "${#qos[@]}" -eq 0 ] && [ "${rs#QOSGrp}" != "$rs" ] && qos=(-q "$QOS_FALLBACK")
+    [ "${#_HOLD_QOS[@]}" -eq 0 ] && [ "${rs#QOSGrp}" != "$rs" ] && _HOLD_QOS=(-q "$QOS_FALLBACK")
     scancel "$jid" >/dev/null 2>&1
     echo "[e2e disagg] hold attempt $i on $pair not started (${st:-?}/${rs:-?}) — retrying" >&2
   done
@@ -726,13 +730,16 @@ run_e2e_disagg() {
         echo "[e2e disagg] WARNING: no 2 free nodes in '$SLURM_PART' within ${INFERA_E2E_WAIT_NODES_TIMEOUT:-6400}s — skipping $e" >&2
         break
       fi
-      # Losing the race is not a node fault, so the pair must NOT join $exclude:
-      # with a small pool the engine would exclude every node and then starve on
-      # an idle cluster. Bounded so a pathological loser fails loudly instead.
+      # Losing the race (1) is not a node fault, so that pair must NOT join
+      # $exclude: with a small pool the engine would exclude every node and then
+      # starve on an idle cluster. SLURM never placing the hold (2) is the
+      # opposite -- a node reading State=IDLE, CPUAlloc=0 and unreserved can still
+      # answer Priority, so re-picking an order-stable list returns the same pair.
       # Not `if ! _hold_pair`: inside that, $? is the negation's, not the call's.
       _hold_pair "$n1,$n2"; hold_rc=$?
       if [ "$hold_rc" -ne 0 ]; then
         races=$((races + 1))
+        [ "$hold_rc" -eq 2 ] && exclude="${exclude:+$exclude,}$n1,$n2"
         if [ "$races" -ge "$max_races" ]; then
           if [ "$hold_rc" -eq 2 ]; then
             echo "[e2e disagg] SLURM never placed a node hold in $races attempts — giving up on $e" >&2

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -227,16 +227,18 @@ _skip_or_fail() {
 
 _have_slurm() { command -v srun >/dev/null 2>&1; }
 # The nodes reservation $1 covers, one per line. Non-zero means the QUERY failed;
-# exit 0 with no output means the reservation genuinely is not there. Spur keeps
-# the two separable: it ignores the NAME arg and dumps every reservation, so a
-# missing name still exits 0 and the awk below simply matches nothing.
+# exit 0 with no output means the reservation genuinely is not there. Callers act
+# on that distinction, and naming the reservation destroys it: `scontrol show
+# reservation NAME` exits 1 for a name that is not there, the same status an
+# unreachable controller gives. Asking for all of them exits 0 whenever the
+# controller answered, and the awk below already filters by name.
 # Capture before parsing: under pipefail a later stage's status would otherwise
-# masquerade as a failed query, and callers now act on that distinction.
+# masquerade as a failed query.
 _reservation_nodes() {
   local out
   # Forward scontrol's own words: callers can only say "cannot reach the
   # scheduler", which is not enough to act on.
-  out=$(scontrol show reservation "$1" 2>&1) || { printf '%s\n' "$out" >&2; return 1; }
+  out=$(scontrol show reservation 2>&1) || { printf '%s\n' "$out" >&2; return 1; }
   printf '%s\n' "$out" | awk -v r="ReservationName=$1" '
     BEGIN{RS="";FS="\n"}
     $1==r { for(i=1;i<=NF;i++) if($i ~ /Nodes=/){ n=$i; sub(/.*Nodes=/,"",n); sub(/[[:space:]].*/,"",n); print n; exit } }' \

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -401,9 +401,14 @@ _watch_job() {
     state=$(squeue -h -j "$jid" -o '%T' 2>/dev/null)
     reason=$(squeue -h -j "$jid" -o '%r' 2>/dev/null)
     [ "$state" = "PENDING" ] || continue
-    if [ "$reason" = "JobHoldMaxRequeue" ]; then
-      : > "$hold"; scancel "$jid" >/dev/null 2>&1; return
-    fi
+    # Neither clears on its own, and JobLaunchFailure names no node -- squeue and
+    # scontrol both leave the node list empty -- so cancelling and letting the
+    # scheduler choose again is the only move. Trailing * because %r appends the
+    # detail: "JobLaunchFailure (dispatch confirmation failed: 0 of 1 confirmed)".
+    case "$reason" in
+      JobHoldMaxRequeue* | JobLaunchFailure*)
+        printf '%s\n' "${reason%% (*}" > "$hold"; scancel "$jid" >/dev/null 2>&1; return ;;
+    esac
     if [ "$reason" = "QOSGrpNodeLimit" ] && [ "$waited" -ge "$QOS_WAIT" ]; then
       : > "$qos"; scancel "$jid" >/dev/null 2>&1; return
     fi
@@ -500,15 +505,16 @@ _dispatch_slurm() {
     # Let tail catch the final (NFS-propagated) lines before stopping it.
     sleep 3; kill "$tailpid" 2>/dev/null; wait "$tailpid" 2>/dev/null
     [ "$prc" -eq 0 ] && break
-    # Held job: the watchdog already cancelled it — resubmit without burning a
-    # real attempt, and fail the tier once the hold retries are exhausted.
+    # The watchdog already cancelled it — resubmit without burning a real
+    # attempt, and fail the tier once these retries are exhausted.
     if [ -f "$holdflag" ]; then
       held=$((held + 1)); prc=1
+      local why; why=$(cat "$holdflag" 2>/dev/null)
       if [ "$held" -ge "$max_held" ]; then
-        echo "[$label] job stuck in JobHoldMaxRequeue after $held retries — giving up" >&2
+        echo "[$label] job stuck in ${why:-a scheduler hold} after $held retries — giving up" >&2
         break
       fi
-      echo "[$label] job held (JobHoldMaxRequeue) — cancelled, retry $held/$max_held in 5s" >&2
+      echo "[$label] job ${why:-held} — cancelled, retry $held/$max_held in 5s" >&2
       attempt=$((attempt - 1)); sleep 5; continue
     fi
     # Queued on the group node limit past $QOS_WAIT: the watchdog cancelled it —

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -199,14 +199,17 @@ _default_partition() {
 SLURM_PART="${INFERA_E2E_SLURM_PARTITION:-$(_default_partition)}"
 SLURM_PART="${SLURM_PART:-amd-spur}"
 SLURM_TIME="${INFERA_E2E_SLURM_TIME:-02:00:00}"
-# Burst QoS is a fallback, never used up front: a dispatch queued this long on
-# the group node limit is resubmitted with it (see _watch_job / _dispatch_slurm).
+# Burst QoS is a fallback, never used up front: a dispatch still queued after
+# QOS_WAIT is cancelled and resubmitted with it, once (see _dispatch_slurm).
 QOS_FALLBACK="${INFERA_E2E_SLURM_QOS_FALLBACK:-amd-burst-qos}"
 # Remembered across _hold_pair calls: the group node limit belongs to the run,
 # not to the pair being tried, so a per-call array spends HOLD_WAIT rediscovering
 # the same answer on every round of the outer retry loop.
 _HOLD_QOS=()
-QOS_WAIT="${INFERA_E2E_QOS_WAIT:-30}"
+# How long a dispatch may sit queued before it is retried on QOS_FALLBACK. Timed
+# rather than matched on a reason: one group node limit reads QOSGrpNodeLimit when
+# the job names its nodes and plain None when it does not.
+QOS_WAIT="${INFERA_E2E_QOS_WAIT:-120}"
 # _hold_pair's own window: its -N2 --gres=gpu:8 batch job needs longer to start
 # than a single-node srun, and giving up early only churns the pair-hold race.
 HOLD_WAIT="${INFERA_E2E_HOLD_WAIT:-60}"
@@ -409,7 +412,9 @@ _watch_job() {
       JobHoldMaxRequeue* | JobLaunchFailure*)
         printf '%s\n' "${reason%% (*}" > "$hold"; scancel "$jid" >/dev/null 2>&1; return ;;
     esac
-    if [ "$reason" = "QOSGrpNodeLimit" ] && [ "$waited" -ge "$QOS_WAIT" ]; then
+    # Timed, and armed only while the caller has somewhere to escape to: see
+    # QOS_WAIT, and $qwatch in _dispatch_slurm.
+    if [ -n "$qos" ] && [ "$waited" -ge "$QOS_WAIT" ]; then
       : > "$qos"; scancel "$jid" >/dev/null 2>&1; return
     fi
     if [ "$waited" -ge "$next" ]; then
@@ -498,7 +503,10 @@ _dispatch_slurm() {
         -J "$jobname" "${xflag[@]}" "${resv[@]}" "${qos[@]}" \
         "${remote[@]}" > "$out" 2>&1 &
     local srunpid=$!
-    _watch_job "$out" "$holdflag" "$qosflag" "$label" &
+    # Empty once switched: burst is where the escape leads, so queueing there is
+    # just queueing and the job timeout is the backstop.
+    local qwatch="$qosflag"; [ "${#qos[@]}" -gt 0 ] && qwatch=""
+    _watch_job "$out" "$holdflag" "$qwatch" "$label" &
     local holdpid=$!
     wait "$srunpid"; prc=$?
     kill "$holdpid" 2>/dev/null; wait "$holdpid" 2>/dev/null
@@ -517,16 +525,12 @@ _dispatch_slurm() {
       echo "[$label] job ${why:-held} — cancelled, retry $held/$max_held in 5s" >&2
       attempt=$((attempt - 1)); sleep 5; continue
     fi
-    # Queued on the group node limit past $QOS_WAIT: the watchdog cancelled it —
-    # resubmit once on the burst QoS (not a real attempt); refused again = fail.
+    # Still queued after $QOS_WAIT: the watchdog cancelled it — resubmit on the
+    # burst QoS, not spending a real attempt.
     if [ -f "$qosflag" ]; then
       prc=1
-      if [ "${#qos[@]}" -gt 0 ]; then
-        echo "[$label] still QOSGrpNodeLimit on --qos=$QOS_FALLBACK — giving up" >&2
-        break
-      fi
       qos=(--qos="$QOS_FALLBACK")
-      echo "[$label] QOSGrpNodeLimit for ${QOS_WAIT}s — resubmitting with --qos=$QOS_FALLBACK" >&2
+      echo "[$label] queued ${QOS_WAIT}s on the default QoS — resubmitting with --qos=$QOS_FALLBACK" >&2
       attempt=$((attempt - 1)); continue
     fi
     # Docker errors land in $logf (shared) or $out (local); "running on <node>"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -247,14 +247,20 @@ _reservation_nodes() {
 # Ask the NODE, not squeue: a multi-node job's %N is a compacted hostlist
 # (crsuse2-m2m-[090,183]) holding neither full name, and Spur has no `scontrol
 # show hostnames`. Unreadable => busy, never hand out what we cannot verify.
+# Allocation is only half of "free": Spur leaves a node inside another team's
+# reservation reading State=IDLE with CPUAlloc=0, and puts the membership in
+# ActiveReservation instead. sbatch then refuses it with ReqNodeNotAvail.
 _node_free() {
-  local alloc
-  alloc=$(scontrol show node "$1" 2>/dev/null | grep -oE 'CPUAlloc=[0-9]+' | head -1 | cut -d= -f2)
-  [ -n "$alloc" ] && [ "$alloc" -eq 0 ] 2>/dev/null
+  local out alloc resv
+  out=$(scontrol show node "$1" 2>/dev/null) || return 1
+  alloc=$(printf '%s\n' "$out" | grep -oE 'CPUAlloc=[0-9]+' | head -1 | cut -d= -f2)
+  [ -n "$alloc" ] && [ "$alloc" -eq 0 ] 2>/dev/null || return 1
+  resv=$(printf '%s\n' "$out" | grep -oE 'ActiveReservation=[^[:space:]]+' | head -1 | cut -d= -f2)
+  [ -z "$resv" ] || [ "$resv" = "${INFERA_E2E_RESERVATION:-}" ]
 }
-# Free nodes for the PD-disagg pair, one per line: the reservation's own (a
-# reserved node reads 'resv', never 'idle', so sinfo would miss it), else the
-# partition's idle ones.
+# Free nodes for the PD-disagg pair, one per line: the reservation's own, else
+# the partition's idle ones. Both go through _node_free, which is what keeps
+# another team's reserved nodes out of the second list.
 _candidate_nodes() {
   local n nodes=""
   if [ -n "${INFERA_E2E_RESERVATION:-}" ]; then
@@ -262,10 +268,8 @@ _candidate_nodes() {
     # through would hand the PD pair unreserved nodes off the open partition.
     nodes=$(_reservation_nodes "$INFERA_E2E_RESERVATION") || return 0
   fi
-  if [ -z "$nodes" ]; then
-    sinfo -h -N -p "$SLURM_PART" -t idle -o '%n' 2>/dev/null | awk 'NF && !seen[$0]++'
-    return
-  fi
+  [ -n "$nodes" ] ||
+    nodes=$(sinfo -h -N -p "$SLURM_PART" -t idle -o '%n' 2>/dev/null | awk 'NF && !seen[$0]++')
   for n in $nodes; do
     _node_free "$n" && echo "$n"
   done

--- a/tests/unit/engine/test_launcher_rdma_wiring.py
+++ b/tests/unit/engine/test_launcher_rdma_wiring.py
@@ -1,0 +1,45 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""Every engine launcher must apply the ROCm RDMA env defaults itself.
+
+The helpers in ``rocm_rdma_env`` are set-if-unset, so a launcher that never calls
+them raises nothing and starts normally — the cost lands at run time as a silent
+TCP fallback, or KV sent to the public NIC. The ATOM launcher shipped that way:
+``apply_kv_host_ip_default`` names ``ATOM_HOST_IP`` and ATOM's ``get_ip()`` in its
+own docstring, yet only the sglang and vLLM launchers ever called it, so on ATOM
+the whole set only arrived if a launch script happened to pass every var by hand.
+
+Read as source rather than imported: these modules pull in their engine at import
+time, which is not installed in the unit environment.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+_REQUIRED = {"apply_rocm_rdma_env_defaults", "apply_kv_host_ip_default"}
+
+
+def _called_names(engine: str) -> set[str]:
+    src = (_REPO / "infera" / "engine" / engine / "__main__.py").read_text()
+    return {
+        node.func.id
+        for node in ast.walk(ast.parse(src))
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+
+
+@pytest.mark.parametrize("engine", ["atom", "sglang", "vllm"])
+def test_launcher_applies_rdma_env_defaults(engine):
+    missing = _REQUIRED - _called_names(engine)
+    assert not missing, (
+        f"infera.engine.{engine}.__main__ never calls {sorted(missing)}; "
+        "its PD KV transfer would fall back to TCP or bind the wrong interface"
+    )


### PR DESCRIPTION
# Description

`infera-cicd-reserved` was deleted on 2026-08-12. Every GPU tier then failed, and
each failure exposed a different place where the harness reads one signal from the
scheduler and acts as if it were another. Two build defects surfaced with them,
having been masked for days by a warm Docker layer cache on the four reservation
nodes that no longer exist.

## Type of change

* Bug fix (non-breaking change which fixes an issue)
* Infra/Build change

## Changes

**The scheduler says the same thing in more than one way**

* A deleted reservation and an unreachable controller both make
  `scontrol show reservation NAME` exit 1. Ask for all of them instead — that
  exits 0 whenever the controller answered — and the callers can tell the two
  apart again. Until then every tier reported the scheduler as unreachable and
  kept submitting against a pool that no longer existed.
* A node inside another team's reservation reads `State=IDLE`, `CPUAlloc=0`, and
  is refused on submission; the membership is in `ActiveReservation`, which
  `_node_free` did not read. On 2026-08-12 that was 26 of the 28 nodes `sinfo`
  offered.
* One group node limit reads `QOSGrpNodeLimit` to a job that names its nodes and
  plain `None` to one that does not, so matching the word left the mixed tier
  queued on the default QoS for 44 minutes while the same submission on the burst
  QoS started in seconds. The escape is now armed by time queued, not by the
  reason, and fires once per dispatch.
* `JobLaunchFailure` — the scheduler allocated nodes and could not launch on them
  — was treated as ordinary queueing. It does not clear on its own: watched for
  90 seconds, unchanged. It now cancels and resubmits, as `JobHoldMaxRequeue`
  already did.

**Retrying has to change something**

* Both disagg engines spent all ten of their rounds on one unusable pair, because
  a pair that SLURM refuses to hold was not excluded before re-picking off an
  order-stable list. Only a refusal is excluded; losing the pair to another
  engine still is not, so a small pool cannot be drained.
* The burst QoS, once discovered, is remembered across `_hold_pair` calls. It was
  a local, so each round paid `HOLD_WAIT` to rediscover it.

**Two build defects the node cache had been hiding**

* `Dockerfile.atom` stayed on Mooncake `747003c` when #112 moved the other images
  to `faae8dd4` and deleted the patch that wired `USE_HIP_DMABUF` into
  `rdma_transport` — which `747003c` still needed. Every green `e2e-disag (atom)`
  since had reused a cached image layer built before that; the first build on a
  fresh node failed the build script's own symbol check. Verified by building on
  a live node: `ibv_reg_dmabuf_mr` and `hsa_amd_portable_export_dmabuf` present.
* Both sglang gpt-oss cases have failed since #112 took the image to the v0.5.17
  base. `-9 before reporting ready` is sglang killing its own tree; two frames in
  is `no matching kernel found ... page_size=1`. gpt-oss is sliding-window, so
  aiter hands CK a token-indexed buffer whatever `--page-size` says, and CK's
  gfx950 `batch_prefill` instance for `page_size < kN0` over a >2GB KV cache did
  not survive its move to a codegen dispatcher. Pinned to the triton backend;
  `SGLANG_USE_AITER` stays, since it also selects the MXFP4 MoE path.

**Also**

* `rust` has not compiled on main since the kv-event test began naming four
  JetStream types without importing them. Not from this branch; every branch cut
  from main is red until it lands.
* The ROCm RDMA env defaults are applied in the atom launcher, with unit coverage.

## Verification

Each scheduler change was exercised against the live cluster or against stubbed
`squeue`/`sbatch`, and the atom image was built end to end on a compute node. The
disagg retry loop was watched through a real run: it took two rounds to find a
usable pair where the previous run had taken ten and found none.

> Note for reviewers: this does not give CI its GPUs back. `infera-cicd-reserved`
> is still gone and the default QoS is at its group node limit — 15 nodes held by
> long-running placeholder jobs across seven users — so the tiers reach the burst
> QoS on every run. What changed is that they now fail for the reason that is
> true, and recover from the ones that are recoverable.

# Checklist:

* [x] The functionality is complete
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes