### PR TITLE
fix(rust): defects introduced by #113's own review fixes

### DIFF
--- a/rust/router/src/disagg.rs
+++ b/rust/router/src/disagg.rs
@@ -541,7 +541,7 @@ async fn open_decode(
                         "decode {} error {}: {}",
                         d.worker.worker_id,
                         st.as_u16(),
-                        &txt[..txt.len().min(300)]
+                        truncate_chars(&txt, 300)
                     ));
                 }
                 state.breaker.record_success(&d.worker.worker_id);

--- a/rust/router/src/discovery_k8s.rs
+++ b/rust/router/src/discovery_k8s.rs
@@ -348,7 +348,7 @@ fn handle_pod(pod: &Value, deleted: bool, tracked: &mut HashMap<String, Tracked>
     let existed = tracked.contains_key(&name);
     let unchanged = tracked
         .get(&name)
-        .is_some_and(|t| !t.announced && same_worker(&t.worker, &worker));
+        .is_some_and(|t| !t.announced && *t.worker == worker);
     if unchanged {
         // Pods generate MODIFIED events for things the router does not care
         // about -- status conditions, resourceVersion bumps on every heartbeat
@@ -371,28 +371,6 @@ fn handle_pod(pod: &Value, deleted: bool, tracked: &mut HashMap<String, Tracked>
         },
     );
     true
-}
-
-/// Whether a re-registration carries anything the router acts on.
-///
-/// `disagg_meta` counts: it carries the prefill worker's bootstrap address, so
-/// an engine that restarted on a new port inside an otherwise unchanged Pod
-/// would keep the old one here and every PD handoff would go to an address
-/// nobody is listening on. `engine` counts for the same reason -- it selects
-/// the PD protocol.
-fn same_worker(a: &Worker, b: &Worker) -> bool {
-    a.worker_id == b.worker_id
-        && a.url == b.url
-        && a.model_name == b.model_name
-        && a.engine == b.engine
-        && a.status == b.status
-        && a.disagg_mode == b.disagg_mode
-        && a.disagg_meta == b.disagg_meta
-        && a.kv_events_endpoint == b.kv_events_endpoint
-        && a.kv_block_size == b.kv_block_size
-        && a.dp_rank == b.dp_rank
-        && a.dp_size == b.dp_size
-        && a.request_transport == b.request_transport
 }
 
 fn publish(

--- a/rust/router/src/k8s.rs
+++ b/rust/router/src/k8s.rs
@@ -53,7 +53,16 @@ pub fn make_client(timeout: Option<Duration>) -> Result<reqwest::Client> {
     // rotation the file holds both, and taking only the first would reject
     // whichever one the API server is currently presenting.
     if let Ok(pem) = std::fs::read(format!("{SA_DIR}/ca.crt")) {
-        for cert in reqwest::Certificate::from_pem_bundle(&pem).context("parsing the cluster CA")? {
+        let certs =
+            reqwest::Certificate::from_pem_bundle(&pem).context("parsing the cluster CA")?;
+        // A bundle with nothing in it parses fine -- unrecognised sections are
+        // skipped -- and would leave the client with no cluster CA at all.
+        // Failing here names the cause; carrying on turns it into every API
+        // call failing later on an unknown issuer.
+        if certs.is_empty() {
+            anyhow::bail!("{SA_DIR}/ca.crt contains no certificates");
+        }
+        for cert in certs {
             builder = builder.add_root_certificate(cert);
         }
     }

--- a/rust/router/src/kv_event_nats.rs
+++ b/rust/router/src/kv_event_nats.rs
@@ -36,6 +36,10 @@ pub const KV_EVENTS_SUBJECT_PREFIX: &str = "infera.kv.events";
 pub const KV_EVENTS_STREAM: &str = "INFERA_KV_EVENTS";
 pub const KV_VIEW_BUCKET: &str = "infera_kv_view";
 
+/// How long a connection has to last before it counts as healthy, resetting
+/// the reconnect backoff.
+const HEALTHY_CONNECTION: Duration = Duration::from_secs(60);
+
 /// `infera.kv.events.<token>.<rank>` -> (worker_id, rank).
 pub fn parse_kv_subject(subject: &str) -> Option<(String, i64)> {
     let rest = subject
@@ -72,6 +76,7 @@ pub async fn run(client: Arc<KvEventClient>, url: Option<&str>) -> Result<()> {
     let shown = crate::nats_request::redact(&url);
     let mut backoff = Duration::from_secs(1);
     loop {
+        let started = tokio::time::Instant::now();
         match feed_once(client.clone(), &url, &shown).await {
             Ok(()) => tracing::warn!(
                 "kv events (nats): the event stream ended; reconnecting in {}s",
@@ -81,6 +86,14 @@ pub async fn run(client: Arc<KvEventClient>, url: Option<&str>) -> Result<()> {
                 "kv events (nats): {e:#}; reconnecting in {}s",
                 backoff.as_secs()
             ),
+        }
+        // A connection that lasted is evidence the broker is healthy, so the
+        // next interruption should not inherit the backoff a start-up flap
+        // built up. Without this a few early retries pin it at 30s for the
+        // life of the process, and every later reconnect blinds kv-aware for
+        // that long.
+        if started.elapsed() >= HEALTHY_CONNECTION {
+            backoff = Duration::from_secs(1);
         }
         tokio::time::sleep(backoff).await;
         backoff = (backoff * 2).min(Duration::from_secs(30));
@@ -102,22 +115,33 @@ async fn feed_once(client: Arc<KvEventClient>, url: &str, shown: &str) -> Result
         tracing::warn!("kv events (nats): could not create the event stream: {e:#}");
     }
 
+    tracing::info!("kv events (nats): subscribed {KV_EVENTS_SUBJECT_PREFIX}.> at {shown}");
     // The bucket bootstrap runs alongside the replay rather than before it:
     // waiting would delay live deltas, and the seeding rule (only where there
     // is no incremental view) makes the order harmless.
+    //
+    // It retries on its own rather than ending the connection, because the two
+    // are not equally important: the event stream is the authoritative,
+    // ordered source, and the bucket only shortcuts a cold start. Tying them
+    // together would let a transient bucket error throw away a healthy event
+    // subscription and force a full replay.
     let bucket = tokio::spawn({
         let client = client.clone();
         let js = js.clone();
         async move {
-            if let Err(e) = watch_bucket(client, js).await {
-                tracing::warn!("kv events (nats): bucket bootstrap ended: {e:#}");
+            let mut backoff = Duration::from_secs(1);
+            loop {
+                if let Err(e) = watch_bucket(client.clone(), js.clone()).await {
+                    tracing::warn!("kv events (nats): bucket watch: {e:#}");
+                }
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(Duration::from_secs(30));
             }
         }
     });
 
-    tracing::info!("kv events (nats): subscribed {KV_EVENTS_SUBJECT_PREFIX}.> at {shown}");
     let outcome = consume_events(client, js).await;
-    // The next attempt starts its own; leaving this one would double-apply
+    // The next connection starts its own; leaving this one would double-apply
     // every bucket update.
     bucket.abort();
     outcome

--- a/rust/router/src/nats_request.rs
+++ b/rust/router/src/nats_request.rs
@@ -312,6 +312,7 @@ impl NatsRequestClient {
                 Some(tokio::time::Instant::now() + self.max_duration)
             },
             max_duration: self.max_duration,
+            idle_since: tokio::time::Instant::now(),
             finished: false,
             terminal_frame_seen: false,
         })
@@ -325,20 +326,24 @@ enum Skip {
     NotAReply,
 }
 
-/// Whether a payload is JetStream's `{"stream":..,"seq":..}` storage ack.
+/// Whether a payload is a JetStream publish acknowledgement rather than a
+/// worker's reply.
 ///
-/// Deliberately narrow: only a body with both fields and nothing a worker would
-/// send. A worker reply is either the engine's bytes or an error string, and an
-/// engine answering with exactly this shape and no `rs-type` header is not a
-/// case worth trading correctness for.
+/// Both forms count. A success is `{"stream":..,"seq":..}`; a refusal carries
+/// an `error` object and no sequence at all, which is the case where treating
+/// it as data would hand the client a JetStream error document as the start of
+/// its response.
+///
+/// No length ceiling: an ack with a long `domain` would slip past one, and the
+/// `rs-type` check above already keeps this off the path for every real reply.
 fn is_jetstream_ack(payload: &[u8]) -> bool {
-    if payload.len() > 256 {
-        return false;
-    }
-    match serde_json::from_slice::<serde_json::Value>(payload) {
-        Ok(v) => v.get("stream").is_some_and(|s| s.is_string()) && v.get("seq").is_some(),
-        Err(_) => false,
-    }
+    let v: serde_json::Value = match serde_json::from_slice(payload) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let success = v.get("stream").is_some_and(|s| s.is_string()) && v.get("seq").is_some();
+    let refusal = v.get("error").is_some_and(|e| e.is_object());
+    success || refusal
 }
 
 /// The reply side of one request. Dropping it before the stream finished tells
@@ -349,6 +354,10 @@ pub struct ReplyStream {
     worker_id: String,
     nc: async_nats::Client,
     idle_timeout: Duration,
+    /// When the idle window started: the last time a frame reached the caller.
+    /// Held here rather than restarted per read so that skipping a message
+    /// cannot extend it.
+    idle_since: tokio::time::Instant,
     deadline: Option<tokio::time::Instant>,
     max_duration: Duration,
     /// Nothing more can be read. Set by every terminal path, including the
@@ -365,12 +374,18 @@ impl ReplyStream {
     /// Next frame, or a synthesised error frame when a deadline expires.
     /// Returns `None` only if the subscription ends without a terminal frame.
     pub async fn next(&mut self) -> Option<Frame> {
-        // Loops only to skip messages that are not worker replies at all; every
-        // other path returns. The deadlines are recomputed each time round, so
-        // a skipped message cannot extend them.
+        // Loops only to skip messages that were never worker replies; every
+        // other path returns. Both deadlines are measured from `idle_since`
+        // and the total's absolute instant, neither of which a skipped message
+        // resets -- so a peer that keeps publishing them cannot hold the
+        // request open, which is what a per-iteration timeout would have let
+        // it do.
         loop {
             match self.next_inner().await {
-                Skip::Frame(f) => return f,
+                Skip::Frame(f) => {
+                    self.idle_since = tokio::time::Instant::now();
+                    return f;
+                }
                 Skip::NotAReply => continue,
             }
         }
@@ -381,8 +396,12 @@ impl ReplyStream {
             return Skip::Frame(None);
         }
         // Budget is the smaller of the idle gap and whatever is left of the
-        // total, so whichever deadline is nearer fires first.
-        let idle = (!self.idle_timeout.is_zero()).then_some(self.idle_timeout);
+        // total, so whichever deadline is nearer fires first. The idle part is
+        // what remains of the window since the last frame reached the caller,
+        // not a fresh window per read -- otherwise skipping a message would
+        // silently extend it.
+        let idle = (!self.idle_timeout.is_zero())
+            .then(|| self.idle_timeout.saturating_sub(self.idle_since.elapsed()));
         let total_left = self
             .deadline
             .map(|d| d.saturating_duration_since(tokio::time::Instant::now()));
@@ -561,6 +580,14 @@ mod tests {
         assert!(is_jetstream_ack(
             br#"{"stream":"X","seq":1,"domain":"hub"}"#
         ));
+        // A refusal carries no sequence at all. Read as data it would hand the
+        // client a JetStream error document as the start of its response.
+        assert!(is_jetstream_ack(
+            br#"{"type":"io.nats.jetstream.api.v1.pub_ack_response","error":{"code":400}}"#
+        ));
+        // Long enough to have slipped past the old 256-byte ceiling.
+        let padded = format!(r#"{{"stream":"S","seq":1,"domain":"{}"}}"#, "d".repeat(300));
+        assert!(is_jetstream_ack(padded.as_bytes()));
 
         // Real replies must never be swallowed.
         assert!(!is_jetstream_ack(br#"{"id":"x","choices":[]}"#));

--- a/rust/router/src/pool.rs
+++ b/rust/router/src/pool.rs
@@ -36,7 +36,11 @@ fn default_transport() -> String {
 
 /// Mirror of `infera.common.worker_pool.WorkerInfo` as registered in etcd.
 /// Extra fields in the payload (e.g. `kv`) are ignored.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// `PartialEq` so discovery can tell a real re-registration from a heartbeat
+/// that changed nothing. Derived rather than hand-written: a field added later
+/// and forgotten there is a change the router silently ignores, which is
+/// exactly how the prefill bootstrap address once went stale.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Worker {
     pub worker_id: String,
     pub url: String,

--- a/rust/router/src/proxy.rs
+++ b/rust/router/src/proxy.rs
@@ -80,13 +80,16 @@ async fn attempt_nats(
     // Without this the throttle changed the publish path to JetStream without
     // ever refusing anything outside PD.
     if !nats.admit(&wid).await {
+        // Built through serde rather than formatted: a worker id comes from a
+        // Pod annotation and a quote in it would produce malformed JSON.
+        let body =
+            serde_json::json!({ "error": format!("worker {wid} request backlog over limit") })
+                .to_string();
         return Err(Response::builder()
             .status(StatusCode::TOO_MANY_REQUESTS)
             .header(header::CONTENT_TYPE, "application/json")
             .header("Retry-After", "1")
-            .body(Body::from(format!(
-                r#"{{"error":"worker {wid} request backlog over limit"}}"#
-            )))
+            .body(Body::from(body))
             .expect("429 response is valid"));
     }
 

--- a/rust/router/tests/kv_event_nats.rs
+++ b/rust/router/tests/kv_event_nats.rs
@@ -27,10 +27,18 @@ use infera_router::kv_event_nats::{self, KV_EVENTS_SUBJECT_PREFIX, KV_VIEW_BUCKE
 use infera_router::pool::Worker;
 use rmpv::Value as Mv;
 
-fn broker_url() -> Option<String> {
+/// These need a live broker, so they are `#[ignore]`d: a test that silently
+/// returns would be reported as passing, and these are what guard the fixes
+/// nothing else can reach -- the subject encoding, the replay policy, that a
+/// timeout cancels its worker, that admission fails open. `cargo test` prints
+/// them as ignored, which is a truthful "not run".
+///
+///     INFERA_TEST_NATS=nats://127.0.0.1:4222 cargo test -- --ignored
+fn broker_url() -> String {
     std::env::var("INFERA_TEST_NATS")
         .ok()
         .filter(|s| !s.is_empty())
+        .expect("set INFERA_TEST_NATS to a reachable broker to run the ignored tests")
 }
 
 fn worker(id: &str, block_size: i64) -> Worker {
@@ -62,14 +70,9 @@ fn batch(events: Vec<Mv>) -> Vec<u8> {
 }
 
 #[tokio::test]
+#[ignore = "needs a broker: INFERA_TEST_NATS"]
 async fn a_published_batch_reaches_the_cache_view() {
-    let url = match broker_url() {
-        Some(u) => u,
-        None => {
-            eprintln!("skipping: set INFERA_TEST_NATS to a reachable broker");
-            return;
-        }
-    };
+    let url = broker_url();
     let wid = format!("10.0.0.1:{}", 9000 + (std::process::id() % 500));
     let token = URL_SAFE_NO_PAD.encode(wid.as_bytes());
 
@@ -139,14 +142,9 @@ async fn a_published_batch_reaches_the_cache_view() {
 /// gates the mixed path too, getting it wrong would refuse every request in the
 /// fleet.
 #[tokio::test]
+#[ignore = "needs a broker: INFERA_TEST_NATS"]
 async fn admission_admits_when_the_backlog_cannot_be_measured() {
-    let url = match broker_url() {
-        Some(u) => u,
-        None => {
-            eprintln!("skipping: set INFERA_TEST_NATS to a reachable broker");
-            return;
-        }
-    };
+    let url = broker_url();
     let wid = "10.0.3.1:9000";
 
     // Throttle off: no JetStream, nothing to measure, everything admitted.
@@ -175,14 +173,9 @@ async fn admission_admits_when_the_backlog_cannot_be_measured() {
 /// is already discarded. That is the entire reason the deadlines exist, so the
 /// cancel has to go out on the timeout path, not only when a client hangs up.
 #[tokio::test]
+#[ignore = "needs a broker: INFERA_TEST_NATS"]
 async fn a_timed_out_request_cancels_the_worker() {
-    let url = match broker_url() {
-        Some(u) => u,
-        None => {
-            eprintln!("skipping: set INFERA_TEST_NATS to a reachable broker");
-            return;
-        }
-    };
+    let url = broker_url();
     let wid = format!("10.0.2.1:{}", 9000 + (std::process::id() % 500));
 
     // Watch for the cancel the router should publish.
@@ -229,14 +222,9 @@ async fn a_timed_out_request_cancels_the_worker() {
 }
 
 #[tokio::test]
+#[ignore = "needs a broker: INFERA_TEST_NATS"]
 async fn the_bucket_bootstraps_a_cold_start_without_clobbering_a_live_view() {
-    let url = match broker_url() {
-        Some(u) => u,
-        None => {
-            eprintln!("skipping: set INFERA_TEST_NATS to a reachable broker");
-            return;
-        }
-    };
+    let url = broker_url();
     let wid = format!("10.0.1.1:{}", 9000 + (std::process::id() % 500));
     let token = URL_SAFE_NO_PAD.encode(wid.as_bytes());
 

--- a/rust/router/tests/kv_event_nats.rs
+++ b/rust/router/tests/kv_event_nats.rs
@@ -62,6 +62,25 @@ fn block_stored(hashes: &[u64], parent: Option<u64>, token_ids: &[u32], bs: i64)
 
 /// `KVEventBatch = [ts, events, attn_dp_rank?]` -- msgspec `array_like`, the
 /// same shape the ZMQ test builds.
+/// The event stream, with the configuration the router and the relay both
+/// create it with. Idempotent, so it does not matter who gets there first.
+async fn ensure_event_stream(js: &async_nats::jetstream::Context) {
+    use async_nats::jetstream::stream::{Config, DiscardPolicy, RetentionPolicy, StorageType};
+    let cfg = Config {
+        name: "INFERA_KV_EVENTS".to_string(),
+        subjects: vec![format!("{KV_EVENTS_SUBJECT_PREFIX}.>")],
+        retention: RetentionPolicy::Limits,
+        storage: StorageType::File,
+        discard: DiscardPolicy::Old,
+        max_bytes: 256 * 1024 * 1024,
+        max_messages: 1_000_000,
+        ..Default::default()
+    };
+    if js.create_stream(cfg.clone()).await.is_err() {
+        js.update_stream(&cfg).await.expect("event stream");
+    }
+}
+
 fn batch(events: Vec<Mv>) -> Vec<u8> {
     let v = Mv::Array(vec![Mv::from(0.0_f64), Mv::Array(events)]);
     let mut buf = Vec::new();
@@ -82,6 +101,11 @@ async fn a_published_batch_reaches_the_cache_view() {
     // messages would build an empty view for a worker that had already cached.
     let nc = async_nats::connect(&url).await.expect("connect");
     let js = async_nats::jetstream::new(nc.clone());
+    // A worker's relay creates this in production, and the router creates it
+    // too -- but neither has run yet here, and publishing to a subject no
+    // stream captures is rejected. Without this the test only passed on a
+    // broker where an earlier run had left the stream behind.
+    ensure_event_stream(&js).await;
     let subject = format!("{KV_EVENTS_SUBJECT_PREFIX}.{token}.0");
     js.publish(
         subject.clone(),


### PR DESCRIPTION
## What this is

Follow-up to [#113](https://github.com/AMD-AGI/Infera/pull/113), which merged
before these landed. Reviewing that PR's fixes found five problems **in the
fixes themselves** — one of them the same class of bug the round was meant to
eliminate.

## The findings

**A sixth byte-slice was left behind.** The search that found the others
matched two literal widths and missed `min(300)` in `open_decode`, which
truncates the same kind of text — a decode worker's error body. Reproduced as a
panic on the request task, which drops the connection instead of returning the
502 it was building.

**Skipping a message restarted the idle window.** The loop added to skip
JetStream acks recomputed the idle timeout per read, so a peer publishing them
could hold a request open indefinitely, and with the total cap off by default
nothing else bounded it. Worse, the comment claimed the opposite — that a
skipped message could not extend a deadline — which is the kind of statement
that stops the next reader from checking. The window is now measured from the
last frame delivered to the caller.

**An empty `ca.crt` became a silent no-CA client.** `from_pem_bundle` skips
unrecognised sections, so an empty or corrupt file returns `Ok(vec![])` where
the single-certificate call had failed outright. Startup then succeeded and
every API call failed on an unknown issuer, far from the cause.

**The kv reconnect backoff only ever grew.** A few flaps during broker startup
pinned it at 30 s for the life of the process, so every later reconnect blinded
kv-aware for that long — the degradation the reconnect loop exists to prevent.

**Tying the bucket watch to the event stream** made a transient bucket error
throw away a healthy subscription and force a full replay. The two are not
equally important: the stream is authoritative and ordered, the bucket only
shortcuts a cold start. Caught by an integration test that failed only under
parallel execution.

## Tests that were passing without running

The broker-dependent tests returned early when `INFERA_TEST_NATS` was unset,
and a test that returns is reported as **passing**. They are the only cover the
timeout-cancel and fail-open fixes have, so in CI they were green assertions
about nothing. They are `#[ignore]`d now — `cargo test` says `4 ignored`, which
is a truthful "not run".

One of them also depended on a stream an earlier run had left on the broker: on
a fresh one it failed every time. It creates its own precondition now.

## Smaller items

- A negative PubAck is recognised as an ack too — it carries an `error` object
  and no sequence, so it was still being handed to the client as the start of a
  body.
- The 429 body is built through serde: a worker id comes from a Pod annotation,
  and a quote in it produced malformed JSON.
- `Worker` derives `PartialEq` instead of a hand-written twelve-field
  comparison. Forgetting a field there is exactly how the prefill bootstrap
  address went stale in the first place.

## Test plan

- [x] `cargo test` — 154 tests, all green on a **fresh** broker (no inherited state)
- [x] `cargo clippy --all-targets` and `cargo fmt --check` clean
- [x] `pytest tests/unit` — 1338 passing
- [x] Each fix verified to fail when reverted
- [ ] CI

Made with [Cursor](https://cursor.com)