### PR TITLE
fix(overlay): repair the overlay build and cover it in CI

### DIFF
--- a/.github/scripts/build_test_push.sh
+++ b/.github/scripts/build_test_push.sh
@@ -114,9 +114,21 @@ fi
 
 case "$cmd" in
   build)
+    # BUILD_TARGET stops at one stage instead of building the whole file. CI uses
+    # it to verify the overlay compiles on a PR: the final image harvests from
+    # ${IMAGE}:vllm-<id>, which only exists after a release run has pushed it, but
+    # every stage up to native310 needs nothing but the public vendor bases.
+    # Tagging a partial build would publish a half image under a real name, so a
+    # targeted build is left untagged.
+    tag_args=()
+    if [ -n "${BUILD_TARGET:-}" ]; then
+      echo "build: --target ${BUILD_TARGET} (verify only, not tagged)"
+      tag_args=(--target "$BUILD_TARGET")
+    else
+      for r in "${refs[@]}"; do tag_args+=(-t "$r"); done
+    fi
     # --network=host: RUN steps need DNS, and these nodes resolve via 127.0.0.1
     # which a default bridge build netns can't reach.
-    tag_args=(); for r in "${refs[@]}"; do tag_args+=(-t "$r"); done
     docker build --network=host ${build_args[@]+"${build_args[@]}"} \
                  "${tag_args[@]}" -f "$dockerfile" .
     ;;

--- a/.github/scripts/dispatch_build.sh
+++ b/.github/scripts/dispatch_build.sh
@@ -1,22 +1,34 @@
 #!/usr/bin/env bash
 # Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
-# Build+push an engine image on a SLURM node (the runner has no docker). Spur's
-# srun propagates the caller's env, so the token is set inline on the srun call.
-#   .github/scripts/dispatch_build.sh <sglang|vllm|atom|kvd|server>
+# Build (and by default push) an engine image on a SLURM node (the runner has no
+# docker). Spur's srun propagates the caller's env, so the token is set inline on
+# the srun call.
+#   .github/scripts/dispatch_build.sh <sglang|vllm|atom|kvd|server|overlay> [cmd]
+#
+# cmd defaults to `ship` (login+build+push), which is what release.yml wants. CI
+# passes `build` to verify an image compiles without publishing it — that needs no
+# registry credentials, so the token is only required for the pushing commands.
 set -uo pipefail
 
-engine="${1:?usage: dispatch_build.sh <engine>}"
+engine="${1:?usage: dispatch_build.sh <engine> [build|push|ship]}"
+cmd="${2:-ship}"
 BTP="$(dirname "$(readlink -f "$0")")/build_test_push.sh"
 
 # Keep the token out of this script's env; _run_srun re-exports it for srun only.
 token="${INFERAIMAGE_DOCKERHUB_TOKEN:-}"
 unset INFERAIMAGE_DOCKERHUB_TOKEN
-[ -n "$token" ] || { echo "INFERAIMAGE_DOCKERHUB_TOKEN is empty" >&2; exit 1; }
+case "$cmd" in
+  ship | push)
+    [ -n "$token" ] || { echo "INFERAIMAGE_DOCKERHUB_TOKEN is empty" >&2; exit 1; } ;;
+esac
 
 part="${INFERA_E2E_SLURM_PARTITION:-amd-spur}"
 resv=(); [ -n "${INFERA_E2E_RESERVATION:-}" ] && resv=(--reservation="$INFERA_E2E_RESERVATION")
 jobname="infera-build-${INFERA_E2E_JOB_TAG:-$engine}"
+# Forwarded to build_test_push.sh so a verify-only run can stop at a stage that
+# needs no engine image from this run (see BUILD_TARGET there).
+target="${BUILD_TARGET:-}"
 
 # $out holds srun client banners; remote build output goes to $logf on shared
 # NFS so tail -F can stream it live to GHA (buffered srun stdout would not show).
@@ -30,13 +42,14 @@ if [ -n "${GITHUB_ACTIONS:-}" ] || [ "${CI:-}" = "true" ] || [ -n "${INFERA_DISP
   tailf="$logf"
 fi
 
-remote=(bash "$BTP" ship "$engine")
+remote=(bash "$BTP" "$cmd" "$engine")
 [ "$shared" -eq 1 ] && \
-  remote=(bash -c 'lf="$1"; shift; exec >"$lf" 2>&1; exec bash "$@"' _ "$logf" "$BTP" ship "$engine")
+  remote=(bash -c 'lf="$1"; shift; exec >"$lf" 2>&1; exec bash "$@"' _ "$logf" "$BTP" "$cmd" "$engine")
 
 _run_srun() {
   (
     export INFERAIMAGE_DOCKERHUB_TOKEN="$token"
+    export BUILD_TARGET="$target"
     srun -N1 -p "$part" -t 02:00:00 \
       -J "$jobname" "${resv[@]}" \
       "${remote[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,42 @@ jobs:
         if: always() && (cancelled() || failure())
         run: .github/scripts/reclaim_slurm_jobs.sh infera-ci- "-${{ github.run_id }}-engine"
 
+  # Overlay payload: verify it still COMPILES. Until now the overlay was built
+  # only by release.yml, i.e. first built on a tag push -- so a change that broke
+  # it sat on main until release day. It did: a3037b7b made the sglang Mooncake
+  # builder patch-free, and Dockerfile.payload kept asserting a string only the
+  # dropped patch produced, breaking every overlay build with nothing to catch it.
+  #
+  # Build-only, no push, and stopped at native310 via BUILD_TARGET: the stages
+  # past it harvest from ${IMAGE}:vllm-<id>, which does not exist for a PR. What
+  # is left is exactly the part that broke -- the Mooncake compile and its
+  # capability assertions -- and it needs only the public vendor bases and no GPU.
+  overlay:
+    needs: [lint, changes, e2e_gate]
+    if: >-
+      !cancelled() &&
+      needs.changes.outputs.code == 'true' &&
+      needs.lint.result != 'failure' && needs.lint.result != 'cancelled' &&
+      (needs.e2e_gate.outputs.run == 'true' || github.event_name == 'workflow_dispatch')
+    runs-on: [self-hosted, crusoe]
+    timeout-minutes: 60
+    env:
+      INFERA_E2E_SLURM_PARTITION: amd-spur
+      INFERA_E2E_RESERVATION: infera-cicd-reserved
+      INFERA_E2E_JOB_TAG: ${{ github.run_id }}-overlay
+      BUILD_TARGET: native310
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      # exec, so dispatch_build.sh IS the step's entry process and a CI cancel
+      # reaches it directly -- see the engine job.
+      - name: overlay build (verify only, no push)
+        run: exec bash .github/scripts/dispatch_build.sh overlay build
+      - name: reclaim this job's SLURM jobs (on cancel/failure)
+        if: always() && (cancelled() || failure())
+        run: .github/scripts/reclaim_slurm_jobs.sh infera-build- "-${{ github.run_id }}-overlay"
+
   # Full PD-mixed e2e (per engine, parallel). When it runs is e2e_gate's call.
   e2e-mixed:
     # Skipped for docs-only changes, and held back if lint failed. Checking

--- a/deploy/overlay/Dockerfile.payload
+++ b/deploy/overlay/Dockerfile.payload
@@ -82,26 +82,31 @@ FROM ${NATIVE_IMAGE} AS native312
 COPY deploy/overlay/harvest_native.sh /tmp/harvest_native.sh
 RUN sh /tmp/harvest_native.sh
 
-# Mooncake for the SGLang family is BUILT HERE, not harvested. The published
-# engine images ship the base's own Mooncake: in rocm/infera:sglang-v0.1.1 and
-# v0.1.2 the engine.so has mtime 2026-07-15 04:57:53 — byte-identical to the base
-# — and `strings` finds no MC_ENABLE_HIP_TRANSPORT, so the B.2 HIP-transport gate
-# never reached them even though it landed on 2026-07-21, before both builds.
+# Mooncake for the SGLang family is BUILT HERE, not harvested. Harvesting it from
+# an engine image inherits whatever that image happened to have — in
+# rocm/infera:sglang-v0.1.1 and v0.1.2 the engine.so was byte-identical to the
+# base's — so building it means the overlay carries a payload we can state
+# properties about.
 #
-# Without the gate, Mooncake registers the HIP (hipIpc) transport unconditionally
-# and prefers it for GPU-to-GPU, and cross-node PD then dies in
-# hipIpcOpenMemHandle — an IPC handle is host-local, so a peer node can never open
-# it. Harvesting Mooncake from an engine image inherits whatever that image
-# happened to have; building it here means the overlay carries a payload we can
-# state properties about.
+# The problem being solved: Mooncake used to register the HIP (hipIpc) transport
+# unconditionally and prefer it for GPU-to-GPU, so cross-node PD died in
+# hipIpcOpenMemHandle — an IPC handle is host-local, so a peer NODE can never open
+# it. Infera carried a private B.2 patch gating installTransport("hip") behind
+# MC_ENABLE_HIP_TRANSPORT. That gate is obsolete at the pinned ref: upstream now
+# routes per target with isHipReachableTarget(), skipping "hip" buffers for a
+# cross-host peer and falling back to rdma/tcp on its own.
+#
+# So this stage mirrors Dockerfile.sglang exactly — same builder, pure upstream,
+# no private patch dir. Asserting MC_ENABLE_HIP_TRANSPORT here would assert a
+# string only the dropped patch produced, which is what broke this build when
+# a3037b7b made the builder patch-free. Assert the mechanism that replaced it.
 FROM ${SGLANG_BASE_IMAGE} AS mooncake310
-COPY deploy/docker/patches/mooncake_cpp/ /tmp/mooncake_cpp/
 COPY deploy/docker/scripts/build_mooncake_sglang.sh /tmp/build_mooncake_sglang.sh
-RUN MC_CPP_PATCH_DIR=/tmp/mooncake_cpp bash /tmp/build_mooncake_sglang.sh \
+RUN bash /tmp/build_mooncake_sglang.sh \
     && python3 -c "import mooncake.engine as e; print(e.__file__)" \
     && strings "$(python3 -c 'import mooncake.engine as e; print(e.__file__)')" \
-         | grep -q MC_ENABLE_HIP_TRANSPORT \
-    && echo "mooncake310: HIP-transport gate verified present"
+         | grep -q isHipReachableTarget \
+    && echo "mooncake310: cross-host HIP locality routing verified present"
 
 FROM mooncake310 AS native310
 COPY deploy/overlay/harvest_native.sh /tmp/harvest_native.sh


### PR DESCRIPTION
## What

Two commits: fix the overlay image build, then add the CI job that would have caught it.

## Why it is broken

`a3037b7b` ("build(mooncake): pin every image to one upstream ref and drop two landed patches") made `build_mooncake_sglang.sh` patch-free — *"Keep no private source patches here."* `deploy/overlay/Dockerfile.payload` was not updated with it and still:

- passes `MC_CPP_PATCH_DIR=/tmp/mooncake_cpp` (now ignored by the builder),
- `COPY`s the `mooncake_cpp` patch dir (now unused),
- asserts `strings engine.so | grep -q MC_ENABLE_HIP_TRANSPORT`.

That string is produced **only** by `transfer_engine_impl.diff`, the private B.2 patch the builder no longer applies. So the Mooncake compile succeeds and reports `dma-buf=present cross-host-routing=present`, and then the grep exits 1 — every overlay build fails.

A Mooncake version bump does not help. `MC_ENABLE_HIP_TRANSPORT` appears at **no** upstream ref:

| ref | `MC_ENABLE_HIP_TRANSPORT` | `isHipReachableTarget` | `chunk_limit` |
|---|---|---|---|
| pinned `faae8dd4` | absent | present | present |
| latest tag `v0.3.12.post1` | absent | present | **absent** |
| upstream `main` | absent | present | present |

(`v0.3.12.post1` would also fail the builder's own `#2644` assertion.)

## The fix

The gate is obsolete, not missing. It existed to stop `installTransport("hip")` registering GPU buffers as intra-node hipIpc segments a peer node cannot open (`hipIpcOpenMemHandle` → 201). Upstream now decides per target: `isHipReachableTarget()` skips `hip` buffers for a cross-host peer and falls back to rdma/tcp, *"without requiring the operator to set MC_DISABLE_HIP"*.

So `mooncake310` now mirrors `Dockerfile.sglang`, which calls the same builder with no patch dir and no gate assertion — and whose shipped `engine.so` has `MC_ENABLE_HIP_TRANSPORT`×0, `isHipReachableTarget`×2. We assert the mechanism that replaced the gate.

## CI

The overlay was built only by `release.yml`, i.e. first built on a tag push — so a break sat on `main` until release day, and this one did.

New `overlay` job on the same gate as `engine` (non-draft PRs into main, merges to main). Build only, never pushes. Stops at `native310` via a new `BUILD_TARGET`: the stages past it harvest from `${IMAGE}:vllm-<id>`, which does not exist for a PR, while everything up to `native310` needs only the public vendor bases and no GPU — and that is exactly the part that broke. Targeted builds are left untagged so a partial image cannot be published under a real name.

`dispatch_build.sh` now takes the command as an optional 2nd arg (default `ship`, so `release.yml` is unchanged) and only requires `INFERAIMAGE_DOCKERHUB_TOKEN` for commands that actually push.

## Verification

Built locally on this branch against `main`:

- `BUILD_TARGET=native310 build_test_push.sh build overlay` → OK, logs `mooncake310: cross-host HIP locality routing verified present`
- full `build_test_push.sh build overlay` → OK, 629 MB, both refs tagged
- `pre-commit run --files ...` → all green; `bash -n` clean on both scripts; workflow parses with `yaml.safe_load`