### PR TITLE
feat(agent_sys): add env_mgr layered environment manager

### DIFF
--- a/agent_sys/env_mgr/README.md
+++ b/agent_sys/env_mgr/README.md
@@ -1,0 +1,55 @@
+# env_mgr
+
+Layered environment manager for the agent work system. Driven by one
+self-contained YAML recipe, it can **check / dry-run / install / bootstrap**
+an environment (Python, apt, binaries, Claude plugins/MCP) and report per-item
+status plus delivered artifacts (path/version/deps).
+
+Design spec: `../docs/superpowers/specs/2026-08-17-env-mgr-design.md`.
+
+## Installers and the mature tool each wraps (ai.env.md rule 4)
+
+| installer | wraps | why |
+|---|---|---|
+| `uv`      | [uv](https://docs.astral.sh/uv/) | de-facto Python toolchain; ref form runs `uv pip install -e` against the project's own manifest, tool form runs `uv tool install` for standalone tools (serena). |
+| `apt`     | dpkg/apt-get | standard Debian package DB; v1 only **detects + prints** the apt-get line (never sudo). |
+| `bin`     | any check_cmd + install one-liner | for standalone binaries with no project manifest (uv-via-pip, pyright-via-npm). |
+| `oneline` | a single shell line | declarative one-line actions; exactly one line so each is inspectable in dry-run. |
+| `embed`   | a multi-line shell body | only when control flow is needed (serena per-project index). |
+| `claude`  | `claude plugin` | Claude Code manages plugin state itself; we just add/list. |
+
+Nothing is installed by env_mgr directly — each installer shells out to the
+tool above and can be swapped without touching the CLI or the recipe.
+
+## Usage
+
+```bash
+# The shipped recipe uses placeholder paths; point it at a real repo/workspace
+# with --path (and --workspace) rather than editing the file.
+uv run env-mgr check    env_mgr/recipes/sglang.repo.yaml --path /path/to/repo
+uv run env-mgr dry-run  env_mgr/recipes/sglang.repo.yaml --path /path/to/repo
+uv run env-mgr install  env_mgr/recipes/sglang.repo.yaml --path /path/to/repo --tag lsp
+uv run env-mgr bootstrap env_mgr/recipes/sglang.repo.yaml --path /path/to/repo
+```
+
+Exit code: 2 on any FAIL, else 0.
+
+## v1 limitations
+
+- **Cross-layer skip-with-warning is not implemented** (design §4.1). env_mgr
+  does not yet walk the parent chain to detect that an item is already
+  satisfied by an upper layer and skip it with a warning. Each installer's own
+  idempotent `check` covers the practical single-host case. Consequently
+  `--on-conflict weak` is a **v1 no-op**: it skips cross-layer conflict
+  detection entirely and proceeds with install (exit 0), whereas `fail`
+  records the conflict and halts before install (exit 2). Only cross-layer
+  *version-conflict detection* under `fail` is active.
+- **workspace layer is stubbed** — the default `$HOME/workspace.infera.aiopt`
+  path, its warning, and user-bin symlinking are not wired up yet.
+- **system apt is detect-and-print only** — the `apt` installer never runs
+  sudo; it prints the `apt-get install` line for you to run.
+
+## Relationship to the former `../helper/` demo
+
+`../helper/*.sh` was the original shell demo. It has been removed; its logic
+now lives entirely in this recipe and the installers above.

--- a/agent_sys/env_mgr/__init__.py
+++ b/agent_sys/env_mgr/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""env_mgr — layered environment manager for the agent work system."""
+
+__version__ = "0.1.0"

--- a/agent_sys/env_mgr/__main__.py
+++ b/agent_sys/env_mgr/__main__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_sys/env_mgr/cli.py
+++ b/agent_sys/env_mgr/cli.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""env-mgr CLI: parse stage/filters, run, report, exit code."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from .outcome import Outcome
+from .recipe import RecipeError, load_recipe
+from .report import render_human, render_json
+from .runner import STAGES, Filters, run
+
+
+def _parse(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="env-mgr")
+    p.add_argument("stage", choices=STAGES)
+    p.add_argument("recipe", help="path to the recipe yaml")
+    p.add_argument("--tag", action="append", default=[], dest="tags")
+    p.add_argument("--installer", default=None)
+    p.add_argument("--importance", default=None)
+    p.add_argument("--item", default=None)
+    p.add_argument("--path", default=None, help="override target.path")
+    p.add_argument("--workspace", default=None, help="override target.parent.workspace")
+    p.add_argument(
+        "--on-conflict",
+        choices=("fail", "weak"),
+        default="fail",
+        help="cross-layer version-conflict policy. 'fail' (default) records the "
+        "conflict and halts before install (exit 2); 'weak' is a v1 no-op that "
+        "skips conflict detection and proceeds (exit 0).",
+    )
+    p.add_argument("--json", action="store_true")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse(sys.argv[1:] if argv is None else argv)
+    try:
+        target, items = load_recipe(args.recipe)
+        if args.path:
+            target.path = args.path
+        if args.workspace:
+            target.parent["workspace"] = args.workspace
+        filters = Filters(
+            tags=args.tags,
+            installer=args.installer,
+            importance=args.importance,
+            item=args.item,
+        )
+        outcomes, status = run(target, items, args.stage, filters, on_conflict=args.on_conflict)
+    except (RecipeError, KeyError, ValueError) as e:
+        outcomes = [Outcome("fail", f"{type(e).__name__}: {e}")]
+        status = "FAIL"
+    text = render_json(outcomes, status) if args.json else render_human(outcomes, status)
+    print(text)
+    return 2 if status == "FAIL" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent_sys/env_mgr/installers/__init__.py
+++ b/agent_sys/env_mgr/installers/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Installer implementations and the registry builder."""

--- a/agent_sys/env_mgr/installers/apt.py
+++ b/agent_sys/env_mgr/installers/apt.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""apt installer: detect packages, PRINT the apt-get line. Never sudo."""
+
+from __future__ import annotations
+
+from ..outcome import Outcome
+from ..recipe import Item, Target
+from .base import _run_bootstrap, level_for_missing, run_cmd
+
+
+class AptInstaller:
+    name = "apt"
+
+    def _missing(self, item: Item) -> list[str]:
+        provides = item.spec.get("provides", {})
+        missing = []
+        for pkg in item.spec.get("packages", []):
+            cmd = provides.get(pkg) if isinstance(provides, dict) else None
+            if cmd:
+                rc, _ = run_cmd(f"command -v {cmd}")
+            else:
+                rc, _ = run_cmd(f"dpkg -s {pkg}")
+            if rc != 0:
+                missing.append(pkg)
+        return missing
+
+    def check(self, item: Item, target: Target) -> list[Outcome]:
+        missing = self._missing(item)
+        if not missing:
+            return [Outcome("ok", "all apt packages present")]
+        return [
+            Outcome(
+                level_for_missing(item.importance),
+                f"missing apt packages: {', '.join(missing)}",
+                {"missing": missing, "apt_get": f"sudo apt-get install -y {' '.join(missing)}"},
+            )
+        ]
+
+    def plan(self, item: Item, target: Target) -> list[Outcome]:
+        missing = self._missing(item)
+        if not missing:
+            return [Outcome("ok", "all apt packages present")]
+        line = f"sudo apt-get install -y {' '.join(missing)}"
+        return [Outcome("info", f"apt-get install needed: {line}", {"apt_get": line})]
+
+    def install(self, item: Item, target: Target) -> list[Outcome]:
+        # v1: never sudo. Same behavior as plan — print, don't run.
+        return self.plan(item, target)
+
+    def bootstrap(self, item: Item, target: Target) -> list[Outcome]:
+        return _run_bootstrap(item, target)

--- a/agent_sys/env_mgr/installers/base.py
+++ b/agent_sys/env_mgr/installers/base.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Installer protocol + shared command/version helpers."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from typing import Protocol, runtime_checkable
+
+from ..outcome import Outcome
+from ..recipe import (
+    Item,
+    Target,  # noqa: F401  (re-export for installer type hints)
+)
+
+_VERSION_RE = re.compile(r"\d+\.\d+(?:\.\d+)?")
+
+_MISSING_LEVEL = {
+    "required": "fail",
+    "strongly-suggested": "warn",
+    "suggested": "info",
+}
+
+
+def run_cmd(cmd: str, cwd: str | None = None) -> tuple[int, str]:
+    """Run a shell string; return (returncode, combined stdout+stderr stripped).
+
+    Never raises on non-zero exit.
+    """
+    proc = subprocess.run(cmd, shell=True, cwd=cwd, capture_output=True, text=True)
+    return proc.returncode, (proc.stdout + proc.stderr).strip()
+
+
+def probe_version(check_cmd: str, cwd: str | None = None) -> str | None:
+    rc, out = run_cmd(check_cmd, cwd=cwd)
+    if rc != 0:
+        return None
+    m = _VERSION_RE.search(out)
+    return m.group(0) if m else None
+
+
+def level_for_missing(importance: str) -> str:
+    return _MISSING_LEVEL.get(importance, "warn")
+
+
+@runtime_checkable
+class Installer(Protocol):
+    name: str
+
+    def check(self, item: Item, target: Target) -> list[Outcome]: ...
+    def plan(self, item: Item, target: Target) -> list[Outcome]: ...
+    def install(self, item: Item, target: Target) -> list[Outcome]: ...
+    def bootstrap(self, item: Item, target: Target) -> list[Outcome]: ...
+
+
+class ShellInstaller:
+    """Shared base for installers that run a shell string from item.spec['run'],
+    gated by an optional check_cmd. Subclasses set `name` and may override the
+    message hooks to phrase plan/install output differently.
+    """
+
+    name = "shell"
+
+    def _satisfied(self, item: Item, target: Target) -> bool:
+        check_cmd = item.spec.get("check_cmd")
+        if not check_cmd:
+            return False
+        rc, _ = run_cmd(check_cmd, cwd=target.path)
+        return rc == 0
+
+    def _plan_message(self, body: str) -> str:
+        return f"would run: {body}"
+
+    def _install_message(self, item: Item, rc: int, body: str) -> str:
+        return f"ran: {body}"
+
+    def check(self, item: Item, target: Target) -> list[Outcome]:
+        if self._satisfied(item, target):
+            return [Outcome("ok", f"{item.name} satisfied")]
+        return [Outcome(level_for_missing(item.importance), f"{item.name} not satisfied")]
+
+    def plan(self, item: Item, target: Target) -> list[Outcome]:
+        if self._satisfied(item, target):
+            return [Outcome("ok", f"{item.name} already satisfied")]
+        return [Outcome("info", self._plan_message(item.spec.get("run", "")))]
+
+    def install(self, item: Item, target: Target) -> list[Outcome]:
+        if self._satisfied(item, target):
+            return [Outcome("ok", f"{item.name} already satisfied (skip)")]
+        body = item.spec.get("run", "")
+        rc, out = run_cmd(body, cwd=target.path)
+        level = "ok" if rc == 0 else level_for_missing(item.importance)
+        return [Outcome(level, self._install_message(item, rc, body), {"rc": rc, "output": out})]
+
+    def bootstrap(self, item: Item, target: Target) -> list[Outcome]:
+        return _run_bootstrap(item, target)
+
+
+def _run_bootstrap(item: Item, target: Target) -> list[Outcome]:
+    """Run item.spec['bootstrap']: a nested {run:...} or a list of them."""
+    boot = item.spec.get("bootstrap")
+    if not boot:
+        return []
+    steps = boot if isinstance(boot, list) else [boot]
+    outs: list[Outcome] = []
+    for step in steps:
+        cmd = step.get("run", "") if isinstance(step, dict) else str(step)
+        if not cmd:
+            continue
+        rc, out = run_cmd(cmd, cwd=target.path)
+        level = "ok" if rc == 0 else "warn"
+        outs.append(Outcome(level, f"bootstrap: {cmd}", {"rc": rc, "output": out}))
+    return outs

--- a/agent_sys/env_mgr/installers/bin.py
+++ b/agent_sys/env_mgr/installers/bin.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""bin installer: install one executable via a command; probe via check_cmd."""
+
+from __future__ import annotations
+
+from ..outcome import Outcome
+from ..recipe import Item, Target
+from ..versions import satisfies
+from .base import _run_bootstrap, level_for_missing, probe_version, run_cmd
+
+
+class BinInstaller:
+    name = "bin"
+
+    def check(self, item: Item, target: Target) -> list[Outcome]:
+        check_cmd = item.spec.get("check_cmd", "")
+        actual = probe_version(check_cmd, cwd=target.path) if check_cmd else None
+        present = actual is not None
+        ok_version = satisfies(actual, item.version)
+        if present and ok_version:
+            return [Outcome("ok", f"{item.name} present", {"version": actual})]
+        level = level_for_missing(item.importance)
+        msg = (
+            f"{item.name} missing"
+            if not present
+            else (f"{item.name} {actual} does not satisfy {item.version}")
+        )
+        return [Outcome(level, msg, {"version": actual, "want": item.version})]
+
+    def plan(self, item: Item, target: Target) -> list[Outcome]:
+        if self._satisfied(item, target):
+            return [Outcome("ok", f"{item.name} already present")]
+        return [Outcome("info", f"would run: {item.spec.get('install', '')}")]
+
+    def install(self, item: Item, target: Target) -> list[Outcome]:
+        if self._satisfied(item, target):
+            return [Outcome("ok", f"{item.name} already present (skip)")]
+        cmd = item.spec.get("install", "")
+        rc, out = run_cmd(cmd, cwd=target.path)
+        if rc == 0:
+            return [Outcome("ok", f"installed {item.name}", {"cmd": cmd})]
+        return [
+            Outcome(
+                level_for_missing(item.importance),
+                f"install failed for {item.name}",
+                {"cmd": cmd, "output": out},
+            )
+        ]
+
+    def bootstrap(self, item: Item, target: Target) -> list[Outcome]:
+        return _run_bootstrap(item, target)
+
+    def _satisfied(self, item: Item, target: Target) -> bool:
+        check_cmd = item.spec.get("check_cmd", "")
+        actual = probe_version(check_cmd, cwd=target.path) if check_cmd else None
+        return actual is not None and satisfies(actual, item.version)

--- a/agent_sys/env_mgr/installers/claude.py
+++ b/agent_sys/env_mgr/installers/claude.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""claude installer: install Claude Code plugins."""
+
+from __future__ import annotations
+
+from ..outcome import Outcome
+from ..recipe import Item, Target
+from .base import _run_bootstrap, level_for_missing, run_cmd
+
+
+class ClaudeInstaller:
+    name = "claude"
+
+    def _installed(self) -> tuple[bool, str]:
+        rc, out = run_cmd("claude plugin list")
+        return rc == 0, out
+
+    @staticmethod
+    def _present_names(out: str) -> set[str]:
+        # `claude plugin list` prints one plugin per line, name first. Match the
+        # bare name of each non-empty line exactly, so a prefix name (e.g.
+        # "super") is not falsely matched against "superpowers".
+        names = set()
+        for line in out.splitlines():
+            line = line.strip()
+            if line:
+                names.add(line.split()[0])
+        return names
+
+    def check(self, item: Item, target: Target) -> list[Outcome]:
+        ok, out = self._installed()
+        if not ok:
+            return [Outcome(level_for_missing(item.importance), "claude CLI not available")]
+        present = self._present_names(out)
+        missing = [p for p in item.spec.get("plugins", []) if p.split("@")[0] not in present]
+        if missing:
+            return [
+                Outcome(
+                    level_for_missing(item.importance),
+                    f"missing plugins: {', '.join(missing)}",
+                    {"missing": missing},
+                )
+            ]
+        return [Outcome("ok", "all claude plugins present")]
+
+    def plan(self, item: Item, target: Target) -> list[Outcome]:
+        return [Outcome("info", f"would install plugins: {item.spec.get('plugins', [])}")]
+
+    def install(self, item: Item, target: Target) -> list[Outcome]:
+        ok, out = self._installed()
+        if not ok:
+            return [Outcome(level_for_missing(item.importance), "claude CLI not available")]
+        present = self._present_names(out)
+        outs: list[Outcome] = []
+        for spec in item.spec.get("plugins", []):
+            if spec.split("@")[0] in present:
+                outs.append(Outcome("ok", f"{spec} already installed"))
+                continue
+            rc, o = run_cmd(f"claude plugin install {spec}")
+            outs.append(
+                Outcome("ok" if rc == 0 else "warn", f"plugin {spec} rc={rc}", {"output": o})
+            )
+        return outs
+
+    def bootstrap(self, item: Item, target: Target) -> list[Outcome]:
+        return _run_bootstrap(item, target)

--- a/agent_sys/env_mgr/installers/embed.py
+++ b/agent_sys/env_mgr/installers/embed.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""embed installer: a multi-line script body, optionally gated by check_cmd."""
+
+from __future__ import annotations
+
+from ..recipe import Item
+from .base import ShellInstaller
+
+
+class EmbedInstaller(ShellInstaller):
+    name = "embed"
+
+    def _plan_message(self, body: str) -> str:
+        return f"would run script:\n{body}"
+
+    def _install_message(self, item: Item, rc: int, body: str) -> str:
+        return f"{item.name} script rc={rc}"

--- a/agent_sys/env_mgr/installers/oneline.py
+++ b/agent_sys/env_mgr/installers/oneline.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""oneline installer: a single-line run command, optionally gated by check_cmd."""
+
+from __future__ import annotations
+
+from .base import ShellInstaller
+
+
+class OnelineInstaller(ShellInstaller):
+    name = "oneline"

--- a/agent_sys/env_mgr/installers/uv.py
+++ b/agent_sys/env_mgr/installers/uv.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""uv installer: ref form (uv pip install -e) and tool form (uv tool install)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..outcome import Outcome
+from ..recipe import Item, Target
+from .base import _run_bootstrap, level_for_missing, probe_version, run_cmd
+
+
+class UvInstaller:
+    name = "uv"
+
+    def _is_tool(self, item: Item) -> bool:
+        return "tool" in item.spec
+
+    def check(self, item: Item, target: Target) -> list[Outcome]:
+        if probe_version("uv --version") is None:
+            return [Outcome(level_for_missing(item.importance), "uv not on PATH")]
+        if self._is_tool(item):
+            prov = item.spec.get("provides", "")
+            rc, _ = run_cmd(f"command -v {prov}") if prov else (1, "")
+            if rc == 0:
+                return [Outcome("ok", f"{prov} present (uv tool)")]
+            return [Outcome(level_for_missing(item.importance), f"{prov} missing (uv tool)")]
+        ref = item.spec.get("ref", "")
+        if not ref:
+            return [Outcome("warn", f"{item.name}: uv item declares neither 'ref' nor 'tool'")]
+        if not (Path(target.path) / ref).exists():
+            return [
+                Outcome(
+                    level_for_missing(item.importance), f"ref {ref} not found under {target.path}"
+                )
+            ]
+        return [Outcome("ok", f"uv ref {ref} present")]
+
+    def plan(self, item: Item, target: Target) -> list[Outcome]:
+        # ref form: preview via uv's own --dry-run instead of a hand-written
+        # string. This is read-only (no mutation) and shows uv's own "already
+        # satisfied / would install" view, so plan never needs to duplicate
+        # uv's logic. `uv pip install --dry-run` is supported.
+        #
+        # tool form: `uv tool install` has no --dry-run flag (it errors on
+        # unknown argument), so plan is a static, non-executing preview here.
+        if self._is_tool(item):
+            cmd = self._cmd(item)
+            return [
+                Outcome(
+                    "info",
+                    f"would run: {cmd}",
+                    {
+                        "cmd": cmd,
+                        "dry_run": False,
+                        "note": "uv tool install has no dry-run flag; static preview only",
+                    },
+                )
+            ]
+        cmd = f"{self._cmd(item)} --dry-run"
+        rc, out = run_cmd(cmd, cwd=target.path)
+        return [Outcome("info", f"dry-run: {cmd}", {"rc": rc, "output": out})]
+
+    def install(self, item: Item, target: Target) -> list[Outcome]:
+        # No hand-rolled "already satisfied" gate here: uv itself is idempotent
+        # (an already-installed package/tool is left as-is unless
+        # --reinstall/--force is passed), so re-running the install command is
+        # already a safe no-op.
+        cmd = self._cmd(item)
+        rc, out = run_cmd(cmd, cwd=target.path)
+        level = "ok" if rc == 0 else level_for_missing(item.importance)
+        return [Outcome(level, f"ran: {cmd}", {"rc": rc, "output": out})]
+
+    def bootstrap(self, item: Item, target: Target) -> list[Outcome]:
+        return _run_bootstrap(item, target)
+
+    def _cmd(self, item: Item) -> str:
+        if self._is_tool(item):
+            return f"uv tool install {item.spec['tool']}"
+        extras = item.spec.get("extras", [])
+        spec = ".[" + ",".join(extras) + "]" if extras else "."
+        return f"uv pip install -e {spec}"

--- a/agent_sys/env_mgr/layer.py
+++ b/agent_sys/env_mgr/layer.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Five-layer model. Override runs left -> right (system most general)."""
+
+from __future__ import annotations
+
+LAYER_ORDER = ("system", "workspace", "project", "repo", "worktree")
+
+
+def layer_index(name: str) -> int:
+    try:
+        return LAYER_ORDER.index(name)
+    except ValueError as e:
+        raise ValueError(f"unknown layer: {name!r} (expected one of {LAYER_ORDER})") from e

--- a/agent_sys/env_mgr/outcome.py
+++ b/agent_sys/env_mgr/outcome.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Outcome — the result of running one stage against one item."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Any
+
+# Severity ascending; index = severity rank.
+LEVELS = ("ok", "info", "warn", "fail")
+
+
+@dataclass
+class Outcome:
+    level: str  # one of LEVELS
+    message: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+def worst_level(outcomes: Iterable[Outcome]) -> str:
+    """Highest-severity level among outcomes; 'ok' if empty."""
+    worst = 0
+    for o in outcomes:
+        worst = max(worst, LEVELS.index(o.level))
+    return LEVELS[worst]
+
+
+def status_from(outcomes: Iterable[Outcome]) -> str:
+    """Roll a list of outcomes up to OK / WARN / FAIL."""
+    level = worst_level(outcomes)
+    if level == "fail":
+        return "FAIL"
+    if level == "warn":
+        return "WARN"
+    return "OK"

--- a/agent_sys/env_mgr/recipe.py
+++ b/agent_sys/env_mgr/recipe.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Recipe parsing: YAML -> Target + [Item], with validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .layer import LAYER_ORDER
+
+IMPORTANCE = ("required", "strongly-suggested", "suggested")
+
+# Keys the CLI understands directly; everything else goes into Item.spec.
+_CLI_KEYS = {"installer", "importance", "layer", "tags", "version"}
+
+
+class RecipeError(Exception):
+    pass
+
+
+@dataclass
+class Target:
+    kind: str
+    name: str
+    path: str
+    parent: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class Item:
+    installer: str
+    importance: str
+    layer: str
+    tags: list[str] = field(default_factory=list)
+    version: str | None = None
+    spec: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def name(self) -> str:
+        provides = self.spec.get("provides")
+        if not isinstance(provides, str):
+            provides = None
+        return self.spec.get("name") or provides or self.installer
+
+
+def _parse_item(raw: dict[str, Any], idx: int) -> Item:
+    where = f"items[{idx}]"
+    for key in ("installer", "importance", "layer"):
+        if key not in raw:
+            raise RecipeError(f"{where}: missing required field '{key}'")
+    importance = raw["importance"]
+    if importance not in IMPORTANCE:
+        raise RecipeError(f"{where}: bad importance {importance!r} (expected {IMPORTANCE})")
+    layer = raw["layer"]
+    if layer not in LAYER_ORDER:
+        raise RecipeError(f"{where}: bad layer {layer!r} (expected {LAYER_ORDER})")
+    spec = {k: v for k, v in raw.items() if k not in _CLI_KEYS}
+    if raw["installer"] == "oneline":
+        run = spec.get("run", "")
+        if isinstance(run, str) and "\n" in run.rstrip("\n"):
+            raise RecipeError(f"{where}: oneline.run must be exactly one line")
+    return Item(
+        installer=raw["installer"],
+        importance=importance,
+        layer=layer,
+        tags=list(raw.get("tags", [])),
+        version=raw.get("version"),
+        spec=spec,
+    )
+
+
+def load_recipe(path: str | Path) -> tuple[Target, list[Item]]:
+    try:
+        data = yaml.safe_load(Path(path).read_text())
+    except (OSError, yaml.YAMLError) as e:
+        raise RecipeError(f"cannot load recipe {path}: {e}") from e
+    if not isinstance(data, dict):
+        raise RecipeError("recipe root must be a mapping")
+    t = data.get("target")
+    if not isinstance(t, dict) or "kind" not in t or "path" not in t:
+        raise RecipeError("target must have at least 'kind' and 'path'")
+    target = Target(
+        kind=t["kind"],
+        name=t.get("name", ""),
+        path=t["path"],
+        parent=dict(t.get("parent", {})),
+    )
+    raw_items = data.get("items", [])
+    if not isinstance(raw_items, list):
+        raise RecipeError("items must be a list")
+    items = [_parse_item(r, i) for i, r in enumerate(raw_items)]
+    return target, items

--- a/agent_sys/env_mgr/recipes/sglang.repo.yaml
+++ b/agent_sys/env_mgr/recipes/sglang.repo.yaml
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: MIT
+# v1 self-contained recipe. target = the sglang repo; items span layers.
+# Set target.path via --path and parent.workspace via --workspace, or edit the
+# placeholders below. Paths are intentionally not hardcoded to a machine.
+version: 1
+
+target:
+  kind: repo
+  name: sglang
+  path: /path/to/your/repo
+  parent:
+    workspace: /path/to/your/workspace
+
+items:
+  # --- system: uv toolchain (from install_lsp_serena.sh) ---
+  - installer: bin
+    importance: strongly-suggested
+    layer: system
+    name: uv
+    check_cmd: "uv --version"
+    install: "pip install uv"
+    tags: [toolchain]
+
+  # --- system: pyright LSP backend (from install_lsp_serena.sh) ---
+  - installer: bin
+    importance: suggested
+    layer: system
+    name: pyright-langserver
+    check_cmd: "pyright-langserver --version"
+    install: "npm install -g pyright"
+    tags: [lsp]
+
+  # --- system: serena itself + MCP registration (from install_lsp_serena.sh) ---
+  - installer: uv
+    importance: required
+    layer: system
+    tool: "git+https://github.com/oraios/serena"
+    provides: serena
+    tags: [lsp, serena]
+    bootstrap:
+      installer: oneline
+      run: "claude mcp list | grep -q '^serena' || claude mcp add --scope user serena -- serena start-mcp-server --context claude-code --project-from-cwd"
+
+  # --- system: agentic-grep tools (from install_system_deps.sh) ---
+  - installer: apt
+    importance: suggested
+    layer: system
+    packages: [ripgrep, fd-find, jq]
+    provides: {ripgrep: rg, fd-find: fdfind, jq: jq}
+    tags: [system, agentic-grep]
+
+  # --- repo: per-project serena index (from bootstrap_project.sh) ---
+  - installer: embed
+    importance: required
+    layer: repo
+    tags: [lsp, serena, per-project]
+    check_cmd: "test -d .serena/cache"
+    run: |
+      mkdir -p .serena
+      printf 'language: python\n' > .serena/project.yml
+      grep -qxF '.serena/cache/' .gitignore 2>/dev/null || printf '\n.serena/cache/\n' >> .gitignore
+      serena project index
+
+  # --- worktree: Claude plugins (from install_claude_plugins.sh; empty by default) ---
+  - installer: claude
+    importance: suggested
+    layer: worktree
+    plugins: []
+    tags: [agent]

--- a/agent_sys/env_mgr/registry.py
+++ b/agent_sys/env_mgr/registry.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Installer registry: name -> instance. v1 is a simple dict."""
+
+from __future__ import annotations
+
+from .installers.apt import AptInstaller
+from .installers.base import Installer
+from .installers.bin import BinInstaller
+from .installers.claude import ClaudeInstaller
+from .installers.embed import EmbedInstaller
+from .installers.oneline import OnelineInstaller
+from .installers.uv import UvInstaller
+
+REGISTRY: dict[str, Installer] = {
+    "uv": UvInstaller(),
+    "apt": AptInstaller(),
+    "bin": BinInstaller(),
+    "oneline": OnelineInstaller(),
+    "embed": EmbedInstaller(),
+    "claude": ClaudeInstaller(),
+}
+
+
+def get_installer(name: str) -> Installer:
+    try:
+        return REGISTRY[name]
+    except KeyError as e:
+        raise KeyError(f"unknown installer {name!r} (have {sorted(REGISTRY)})") from e

--- a/agent_sys/env_mgr/report.py
+++ b/agent_sys/env_mgr/report.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Render Outcomes for humans and machines."""
+
+from __future__ import annotations
+
+import json
+
+from .outcome import Outcome
+
+_ICON = {"ok": "OK ", "info": "INFO", "warn": "WARN", "fail": "FAIL"}
+
+
+def render_human(outcomes: list[Outcome], status: str) -> str:
+    lines = [f"[{_ICON.get(o.level, o.level)}] {o.message}" for o in outcomes]
+    lines.append("")
+    lines.append(f"status: {status}")
+    return "\n".join(lines)
+
+
+def render_json(outcomes: list[Outcome], status: str) -> str:
+    return json.dumps(
+        {
+            "status": status,
+            "outcomes": [
+                {"level": o.level, "message": o.message, "details": o.details} for o in outcomes
+            ],
+        },
+        indent=2,
+    )

--- a/agent_sys/env_mgr/runner.py
+++ b/agent_sys/env_mgr/runner.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Runner: select items, detect conflicts, dispatch stages, roll up status."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+from .outcome import Outcome, status_from
+from .recipe import IMPORTANCE, Item, Target
+from .registry import get_installer
+from .versions import constraints_conflict
+
+STAGES = ("check", "dry-run", "install", "bootstrap")
+
+
+@dataclass
+class Filters:
+    tags: list[str] = field(default_factory=list)
+    installer: str | None = None
+    importance: str | None = None
+    item: str | None = None
+
+
+def _importance_rank(name: str) -> int:
+    # required strictest (0) ... suggested loosest (2)
+    return IMPORTANCE.index(name)
+
+
+def select(items: list[Item], filters: Filters) -> list[Item]:
+    out = []
+    for it in items:
+        if filters.tags and not (set(filters.tags) & set(it.tags)):
+            continue
+        if filters.installer and it.installer != filters.installer:
+            continue
+        if filters.importance and _importance_rank(it.importance) > _importance_rank(
+            filters.importance
+        ):
+            continue
+        if filters.item and it.name != filters.item:
+            continue
+        out.append(it)
+    return out
+
+
+def _has_explicit_identity(it: Item) -> bool:
+    """True if the item declares a real identity (name/provides), not just
+    the installer-fallback used by `Item.name`."""
+    provides = it.spec.get("provides")
+    if not isinstance(provides, str):
+        provides = None
+    return bool(it.spec.get("name") or provides)
+
+
+def detect_conflicts(items: list[Item]) -> list[Outcome]:
+    by_name: dict[str, list[Item]] = defaultdict(list)
+    for it in items:
+        if not _has_explicit_identity(it):
+            continue
+        by_name[it.name].append(it)
+    outs: list[Outcome] = []
+    for name, group in by_name.items():
+        versions = [g.version for g in group]
+        conflict = any(
+            constraints_conflict(versions[i], versions[j])
+            for i in range(len(versions))
+            for j in range(i + 1, len(versions))
+        )
+        if conflict:
+            outs.append(
+                Outcome(
+                    "fail",
+                    f"cross-layer version conflict for {name}",
+                    {"versions": {g.layer: g.version for g in group}},
+                )
+            )
+    return outs
+
+
+def run(
+    target: Target,
+    items: list[Item],
+    stage: str,
+    filters: Filters,
+    on_conflict: str = "fail",
+) -> tuple[list[Outcome], str]:
+    selected = select(items, filters)
+    outs: list[Outcome] = []
+
+    conflicts = detect_conflicts(selected)
+    if conflicts and on_conflict == "fail":
+        # fail = halt: record the conflict and return before any installer runs,
+        # for every stage. install/bootstrap side effects (embed/oneline/claude)
+        # are not idempotent, so we must not mutate the host on a fatal conflict.
+        outs.extend(conflicts)
+        return outs, status_from(outs)
+
+    for it in selected:
+        inst = get_installer(it.installer)
+        if stage == "check":
+            outs.extend(inst.check(it, target))
+        elif stage == "dry-run":
+            outs.extend(inst.plan(it, target))
+        elif stage == "install":
+            outs.extend(inst.install(it, target))
+        elif stage == "bootstrap":
+            outs.extend(inst.install(it, target))
+            outs.extend(inst.bootstrap(it, target))
+        else:
+            raise ValueError(f"unknown stage {stage!r} (expected {STAGES})")
+
+    return outs, status_from(outs)

--- a/agent_sys/env_mgr/versions.py
+++ b/agent_sys/env_mgr/versions.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Version constraint handling. Thin wrapper over `packaging`."""
+
+from __future__ import annotations
+
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion, Version
+
+
+def _as_specifier(constraint: str) -> SpecifierSet:
+    """A bare version ('1.2.3') means '>=1.2.3'; operators pass through."""
+    c = constraint.strip()
+    if c and c[0].isdigit():
+        c = f">={c}"
+    return SpecifierSet(c)
+
+
+def satisfies(actual: str | None, constraint: str | None) -> bool:
+    if constraint is None:
+        return True
+    if actual is None:
+        return False
+    try:
+        return Version(actual) in _as_specifier(constraint)
+    except (InvalidVersion, InvalidSpecifier):
+        return False
+
+
+def constraints_conflict(a: str | None, b: str | None) -> bool:
+    """True if two non-empty constraints are NOT semantically equivalent.
+
+    Uses the same bare-version normalization as `satisfies` (via
+    `_as_specifier`), so "0.5" and ">=0.5" are equal, not a conflict. If either
+    constraint is unparseable, fall back to a textual comparison.
+    """
+    if a is None or b is None:
+        return False
+    try:
+        return _as_specifier(a) != _as_specifier(b)
+    except InvalidSpecifier:
+        return a.strip() != b.strip()

--- a/agent_sys/pyproject.toml
+++ b/agent_sys/pyproject.toml
@@ -1,0 +1,33 @@
+[project]
+name = "agent-sys-helper"
+version = "0.1.0"
+description = "Agent work-system environment manager (env_mgr) and helpers"
+readme = "README.md"
+authors = [
+    { name = "yihou", email = "yihou@amd.com" }
+]
+requires-python = ">=3.10"
+dependencies = [
+    "pyyaml>=6",
+    "packaging>=23",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+]
+
+[project.scripts]
+agent-sys-helper = "agent_sys_helper:main"
+env-mgr = "env_mgr.cli:main"
+
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = [".", "src"]
+include = ["env_mgr*", "agent_sys_helper*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/agent_sys/tests/env_mgr/__init__.py
+++ b/agent_sys/tests/env_mgr/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.

--- a/agent_sys/tests/env_mgr/test_cli.py
+++ b/agent_sys/tests/env_mgr/test_cli.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+import json
+import textwrap
+
+from env_mgr.cli import main
+
+
+def _recipe(tmp_path, body):
+    p = tmp_path / "r.yaml"
+    p.write_text(textwrap.dedent(body))
+    return str(p)
+
+
+def test_check_ok_exit_zero(tmp_path, capsys):
+    r = _recipe(
+        tmp_path,
+        f"""
+        version: 1
+        target: {{kind: repo, name: x, path: {tmp_path}}}
+        items:
+          - installer: oneline
+            importance: suggested
+            layer: system
+            check_cmd: "true"
+            run: "true"
+    """,
+    )
+    rc = main(["check", r])
+    assert rc == 0
+
+
+def test_check_required_missing_exit_two(tmp_path):
+    r = _recipe(
+        tmp_path,
+        f"""
+        version: 1
+        target: {{kind: repo, name: x, path: {tmp_path}}}
+        items:
+          - installer: bin
+            importance: required
+            layer: system
+            name: definitely-not-real-xyz
+            check_cmd: "definitely-not-real-xyz --version"
+    """,
+    )
+    rc = main(["check", r])
+    assert rc == 2
+
+
+def test_path_override_reaches_runner(tmp_path):
+    # recipe target.path is a bogus dir; --path overrides it to a real one where
+    # the check_cmd (test -f marker) succeeds, proving the override is applied.
+    (tmp_path / "marker").write_text("x")
+    r = _recipe(
+        tmp_path,
+        """
+        version: 1
+        target: {kind: repo, name: x, path: /nonexistent/bogus/dir}
+        items:
+          - installer: oneline
+            importance: required
+            layer: repo
+            check_cmd: "test -f marker"
+            run: "true"
+    """,
+    )
+    # without override it would fail (bogus cwd); with --path it runs in tmp_path
+    assert main(["check", r, "--path", str(tmp_path)]) == 0
+
+
+def test_workspace_override_accepted(tmp_path):
+    r = _recipe(
+        tmp_path,
+        f"""
+        version: 1
+        target:
+          kind: repo
+          name: x
+          path: {tmp_path}
+          parent: {{workspace: /placeholder}}
+        items:
+          - installer: oneline
+            importance: suggested
+            layer: system
+            check_cmd: "true"
+            run: "true"
+    """,
+    )
+    assert main(["check", r, "--workspace", "/some/ws"]) == 0
+
+
+def test_json_output_parses(tmp_path, capsys):
+    r = _recipe(
+        tmp_path,
+        f"""
+        version: 1
+        target: {{kind: repo, name: x, path: {tmp_path}}}
+        items:
+          - installer: oneline
+            importance: suggested
+            layer: system
+            check_cmd: "true"
+            run: "true"
+    """,
+    )
+    main(["check", r, "--json"])
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["status"] in ("OK", "WARN", "FAIL")
+    assert "outcomes" in data
+
+
+def test_main_malformed_recipe_returns_two(tmp_path):
+    # missing the required 'installer' field -> RecipeError, must not crash
+    r = _recipe(
+        tmp_path,
+        f"""
+        version: 1
+        target: {{kind: repo, name: x, path: {tmp_path}}}
+        items:
+          - importance: suggested
+            layer: system
+            run: "true"
+    """,
+    )
+    assert main(["check", r]) == 2
+
+
+def test_main_unknown_installer_returns_two(tmp_path):
+    # installer name is not in the registry -> KeyError, must not crash
+    r = _recipe(
+        tmp_path,
+        f"""
+        version: 1
+        target: {{kind: repo, name: x, path: {tmp_path}}}
+        items:
+          - installer: sh
+            importance: suggested
+            layer: system
+            run: "true"
+    """,
+    )
+    assert main(["check", r]) == 2
+
+
+def test_main_bad_importance_flag_returns_two(tmp_path):
+    # --importance bogus reaches _importance_rank -> ValueError, must not crash
+    r = _recipe(
+        tmp_path,
+        f"""
+        version: 1
+        target: {{kind: repo, name: x, path: {tmp_path}}}
+        items:
+          - installer: oneline
+            importance: suggested
+            layer: system
+            check_cmd: "true"
+            run: "true"
+    """,
+    )
+    assert main(["check", r, "--importance", "bogus"]) == 2
+
+
+def test_main_missing_recipe_file_returns_two(tmp_path):
+    # nonexistent recipe path -> FileNotFoundError normalized to RecipeError -> exit 2
+    missing = str(tmp_path / "does-not-exist.yaml")
+    assert main(["check", missing]) == 2
+
+
+def test_main_malformed_yaml_returns_two(tmp_path):
+    # syntactically broken YAML -> yaml.YAMLError normalized to RecipeError -> exit 2
+    p = tmp_path / "bad.yaml"
+    p.write_text("items: [unclosed\n")
+    assert main(["check", str(p)]) == 2

--- a/agent_sys/tests/env_mgr/test_installers.py
+++ b/agent_sys/tests/env_mgr/test_installers.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+import pytest
+
+from env_mgr.installers.base import (
+    level_for_missing,
+    probe_version,
+    run_cmd,
+)
+from env_mgr.recipe import Item, Target
+from env_mgr.registry import REGISTRY, get_installer
+
+
+def test_run_cmd_success():
+    rc, out = run_cmd("echo hello")
+    assert rc == 0
+    assert "hello" in out
+
+
+def test_run_cmd_nonzero_does_not_raise():
+    rc, _ = run_cmd("exit 3")
+    assert rc == 3
+
+
+def test_probe_version_extracts_token():
+    assert probe_version("echo 'tool 1.2.3 (linux)'") == "1.2.3"
+
+
+def test_probe_version_none_on_failure():
+    assert probe_version("false") is None
+
+
+def test_level_for_missing():
+    assert level_for_missing("required") == "fail"
+    assert level_for_missing("strongly-suggested") == "warn"
+    assert level_for_missing("suggested") == "info"
+
+
+def _target(tmp_path):
+    return Target(kind="repo", name="x", path=str(tmp_path))
+
+
+def test_registry_has_all_installers():
+    for name in ("uv", "apt", "bin", "oneline", "embed", "claude"):
+        assert name in REGISTRY
+        assert get_installer(name).name == name
+
+
+def test_get_installer_unknown_raises():
+    with pytest.raises(KeyError):
+        get_installer("nope")
+
+
+def test_bin_check_missing_is_fail_for_required(tmp_path):
+    item = Item(
+        installer="bin",
+        importance="required",
+        layer="system",
+        spec={
+            "name": "definitely-not-a-real-bin-xyz",
+            "check_cmd": "definitely-not-a-real-bin-xyz --version",
+        },
+    )
+    outs = get_installer("bin").check(item, _target(tmp_path))
+    assert any(o.level == "fail" for o in outs)
+
+
+def test_oneline_check_uses_check_cmd(tmp_path):
+    item = Item(
+        installer="oneline",
+        importance="suggested",
+        layer="system",
+        spec={"check_cmd": "true", "run": "echo would-install"},
+    )
+    outs = get_installer("oneline").check(item, _target(tmp_path))
+    assert any(o.level == "ok" for o in outs)
+
+
+def test_apt_plan_prints_command_never_sudos(tmp_path):
+    item = Item(
+        installer="apt",
+        importance="suggested",
+        layer="system",
+        spec={"packages": ["definitely-not-installed-pkg-xyz"]},
+    )
+    outs = get_installer("apt").plan(item, _target(tmp_path))
+    joined = " ".join(o.message + " " + str(o.details) for o in outs)
+    assert "apt-get install" in joined
+
+
+def test_embed_plan_shows_body_without_running(tmp_path):
+    marker = tmp_path / "side_effect"
+    item = Item(
+        installer="embed",
+        importance="required",
+        layer="repo",
+        spec={"run": f"touch {marker}"},
+    )
+    outs = get_installer("embed").plan(item, _target(tmp_path))
+    assert not marker.exists()  # plan must not run it
+    assert outs  # produced at least one Outcome
+
+
+def test_uv_plan_is_dry_run_and_nonmutating(tmp_path):
+    # a ref-form uv item; plan must preview via uv --dry-run without installing
+    item = Item(
+        installer="uv",
+        importance="required",
+        layer="repo",
+        spec={"name": "uv", "ref": "pyproject.toml"},
+    )
+    outs = get_installer("uv").plan(item, Target(kind="repo", name="x", path=str(tmp_path)))
+    assert outs and all(o.level == "info" for o in outs)
+    joined = " ".join(o.message + " " + str(o.details) for o in outs)
+    assert "--dry-run" in joined
+
+
+def test_uv_plan_tool_form_no_dry_run(tmp_path):
+    # uv tool install has no --dry-run flag (it errors on it); plan for the
+    # tool form must be a static preview, not a command it actually runs.
+    item = Item(
+        installer="uv",
+        importance="required",
+        layer="system",
+        spec={"tool": "git+https://example.invalid/pkg", "provides": "pkg"},
+    )
+    outs = get_installer("uv").plan(item, Target(kind="repo", name="x", path=str(tmp_path)))
+    assert outs and all(o.level == "info" for o in outs)
+    joined = " ".join(o.message + " " + str(o.details) for o in outs)
+    assert "--dry-run" not in joined
+    assert "uv tool install" in joined
+
+
+def test_uv_check_warns_when_no_ref_or_tool(tmp_path):
+    # a uv item with neither ref nor tool is misconfigured; check must NOT say ok
+    item = Item(installer="uv", importance="required", layer="repo", spec={})
+    outs = get_installer("uv").check(item, _target(tmp_path))
+    assert outs and all(o.level == "warn" for o in outs)
+
+
+def test_uv_check_ok_with_valid_ref(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+    item = Item(installer="uv", importance="required", layer="repo", spec={"ref": "pyproject.toml"})
+    outs = get_installer("uv").check(item, _target(tmp_path))
+    assert any(o.level == "ok" for o in outs)
+
+
+def test_claude_present_names_exact_per_line():
+    from env_mgr.installers.claude import ClaudeInstaller
+
+    out = "superpowers 1.0\ncode-review 2.1\n"
+    names = ClaudeInstaller._present_names(out)
+    assert names == {"superpowers", "code-review"}
+
+
+def test_claude_present_names_no_substring_false_positive():
+    from env_mgr.installers.claude import ClaudeInstaller
+
+    # "super" must NOT be considered present just because "superpowers" is
+    names = ClaudeInstaller._present_names("superpowers 1.0\n")
+    assert "super" not in names
+
+
+def test_oneline_plan_message_style(tmp_path):
+    # oneline previews as a single-line "would run:" message, no "script" wording
+    item = Item(
+        installer="oneline", importance="suggested", layer="system", spec={"run": "echo hi"}
+    )
+    outs = get_installer("oneline").plan(item, _target(tmp_path))
+    msg = " ".join(o.message for o in outs)
+    assert "would run:" in msg
+    assert "script" not in msg
+
+
+def test_embed_plan_message_style(tmp_path):
+    # embed previews a multi-line script body, flagged with "script" wording
+    item = Item(
+        installer="embed", importance="required", layer="repo", spec={"run": "echo hi\necho bye"}
+    )
+    outs = get_installer("embed").plan(item, _target(tmp_path))
+    msg = " ".join(o.message for o in outs)
+    assert "script" in msg

--- a/agent_sys/tests/env_mgr/test_layer.py
+++ b/agent_sys/tests/env_mgr/test_layer.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+import pytest
+
+from env_mgr.layer import LAYER_ORDER, layer_index
+
+
+def test_layer_order():
+    assert LAYER_ORDER == ("system", "workspace", "project", "repo", "worktree")
+
+
+def test_layer_index():
+    assert layer_index("system") == 0
+    assert layer_index("worktree") == 4
+
+
+def test_layer_index_unknown_raises():
+    with pytest.raises(ValueError):
+        layer_index("galaxy")

--- a/agent_sys/tests/env_mgr/test_outcome.py
+++ b/agent_sys/tests/env_mgr/test_outcome.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+from env_mgr.outcome import Outcome, status_from, worst_level
+
+
+def test_outcome_defaults_empty_details():
+    o = Outcome("ok", "present")
+    assert o.details == {}
+
+
+def test_status_from_empty_is_ok():
+    assert status_from([]) == "OK"
+
+
+def test_status_from_warn_beats_ok_info():
+    outs = [Outcome("ok", "a"), Outcome("info", "b"), Outcome("warn", "c")]
+    assert status_from(outs) == "WARN"
+
+
+def test_status_from_fail_beats_all():
+    outs = [Outcome("warn", "a"), Outcome("fail", "b")]
+    assert status_from(outs) == "FAIL"
+
+
+def test_worst_level_empty_is_ok():
+    assert worst_level([]) == "ok"
+
+
+def test_worst_level_picks_highest():
+    assert worst_level([Outcome("ok", "a"), Outcome("fail", "b")]) == "fail"

--- a/agent_sys/tests/env_mgr/test_recipe.py
+++ b/agent_sys/tests/env_mgr/test_recipe.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+import textwrap
+
+import pytest
+
+from env_mgr.recipe import Item, RecipeError, load_recipe
+from env_mgr.runner import detect_conflicts
+
+
+def _write(tmp_path, body):
+    p = tmp_path / "recipe.yaml"
+    p.write_text(textwrap.dedent(body))
+    return p
+
+
+def test_load_minimal_recipe(tmp_path):
+    p = _write(
+        tmp_path,
+        """
+        version: 1
+        target:
+          kind: repo
+          name: sglang
+          path: /tmp/sglang
+        items:
+          - installer: uv
+            importance: required
+            layer: repo
+            ref: pyproject.toml
+            version: ">=0.5"
+            tags: [python, runtime]
+    """,
+    )
+    target, items = load_recipe(p)
+    assert target.kind == "repo"
+    assert target.name == "sglang"
+    assert len(items) == 1
+    it = items[0]
+    assert it.installer == "uv"
+    assert it.importance == "required"
+    assert it.layer == "repo"
+    assert it.version == ">=0.5"
+    assert it.tags == ["python", "runtime"]
+    assert it.spec["ref"] == "pyproject.toml"
+
+
+def test_item_name_prefers_name_then_provides_then_installer(tmp_path):
+    p = _write(
+        tmp_path,
+        """
+        version: 1
+        target: {kind: repo, name: x, path: /tmp/x}
+        items:
+          - installer: bin
+            importance: suggested
+            layer: system
+            name: pyright-langserver
+          - installer: uv
+            importance: required
+            layer: system
+            provides: serena
+          - installer: apt
+            importance: suggested
+            layer: system
+            packages: [jq]
+    """,
+    )
+    _, items = load_recipe(p)
+    assert items[0].name == "pyright-langserver"
+    assert items[1].name == "serena"
+    assert items[2].name == "apt"
+
+
+def test_item_name_falls_back_to_installer_when_provides_is_dict():
+    # apt items use `provides` as a package->command dict (e.g. ripgrep -> rg),
+    # not a name candidate. Item.name must not return that dict.
+    it = Item(
+        installer="apt",
+        importance="suggested",
+        layer="system",
+        spec={"packages": ["jq"], "provides": {"jq": "jq"}},
+    )
+    assert it.name == "apt"
+    assert isinstance(it.name, str)
+    assert {it.name: "usable as dict key"}  # must be hashable
+
+
+def test_item_name_uses_provides_when_it_is_a_string():
+    it = Item(
+        installer="uv",
+        importance="required",
+        layer="system",
+        spec={"provides": "serena"},
+    )
+    assert it.name == "serena"
+
+
+def test_detect_conflicts_does_not_crash_on_dict_provides():
+    items = [
+        Item(
+            installer="apt",
+            importance="suggested",
+            layer="system",
+            spec={"packages": ["ripgrep"], "provides": {"ripgrep": "rg"}},
+        ),
+        Item(
+            installer="apt",
+            importance="suggested",
+            layer="system",
+            spec={"packages": ["fd-find"], "provides": {"fd-find": "fdfind"}},
+        ),
+    ]
+    assert detect_conflicts(items) == []
+
+
+def test_missing_installer_raises(tmp_path):
+    p = _write(
+        tmp_path,
+        """
+        version: 1
+        target: {kind: repo, name: x, path: /tmp/x}
+        items:
+          - importance: required
+            layer: repo
+    """,
+    )
+    with pytest.raises(RecipeError, match="installer"):
+        load_recipe(p)
+
+
+def test_bad_importance_raises(tmp_path):
+    p = _write(
+        tmp_path,
+        """
+        version: 1
+        target: {kind: repo, name: x, path: /tmp/x}
+        items:
+          - installer: uv
+            importance: nice-to-have
+            layer: repo
+    """,
+    )
+    with pytest.raises(RecipeError, match="importance"):
+        load_recipe(p)
+
+
+def test_bad_layer_raises(tmp_path):
+    p = _write(
+        tmp_path,
+        """
+        version: 1
+        target: {kind: repo, name: x, path: /tmp/x}
+        items:
+          - installer: uv
+            importance: required
+            layer: galaxy
+    """,
+    )
+    with pytest.raises(RecipeError, match="layer"):
+        load_recipe(p)
+
+
+def test_oneline_run_multiline_raises(tmp_path):
+    p = _write(
+        tmp_path,
+        """
+        version: 1
+        target: {kind: repo, name: x, path: /tmp/x}
+        items:
+          - installer: oneline
+            importance: suggested
+            layer: system
+            run: |
+              echo one
+              echo two
+    """,
+    )
+    with pytest.raises(RecipeError, match="one line"):
+        load_recipe(p)

--- a/agent_sys/tests/env_mgr/test_runner.py
+++ b/agent_sys/tests/env_mgr/test_runner.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+from env_mgr.recipe import Item, Target
+from env_mgr.runner import Filters, detect_conflicts, run, select
+
+
+def _items():
+    return [
+        Item(
+            installer="oneline",
+            importance="required",
+            layer="repo",
+            tags=["lsp"],
+            spec={"name": "a", "check_cmd": "true", "run": "true"},
+        ),
+        Item(
+            installer="oneline",
+            importance="suggested",
+            layer="system",
+            tags=["agent"],
+            spec={"name": "b", "check_cmd": "false", "run": "true"},
+        ),
+    ]
+
+
+def test_select_by_tag():
+    got = select(_items(), Filters(tags=["lsp"]))
+    assert [i.name for i in got] == ["a"]
+
+
+def test_select_by_installer_and_importance():
+    got = select(_items(), Filters(importance="required"))
+    assert [i.name for i in got] == ["a"]
+
+
+def test_detect_conflicts_flags_differing_versions():
+    items = [
+        Item(
+            installer="uv",
+            importance="required",
+            layer="system",
+            version=">=0.5",
+            spec={"name": "uv"},
+        ),
+        Item(
+            installer="uv",
+            importance="required",
+            layer="repo",
+            version=">=0.6",
+            spec={"name": "uv"},
+        ),
+    ]
+    outs = detect_conflicts(items)
+    assert any(o.level == "fail" and "uv" in o.message for o in outs)
+
+
+def test_detect_conflicts_ignores_installer_fallback_names():
+    items = [
+        Item(
+            installer="oneline",
+            importance="suggested",
+            layer="system",
+            version=">=1.0",
+            spec={"run": "true"},
+        ),
+        Item(
+            installer="oneline",
+            importance="suggested",
+            layer="repo",
+            version=">=2.0",
+            spec={"run": "true"},
+        ),
+    ]
+    assert detect_conflicts(items) == []
+
+
+def test_detect_conflicts_none_when_same():
+    items = [
+        Item(
+            installer="uv",
+            importance="required",
+            layer="system",
+            version=">=0.5",
+            spec={"name": "uv"},
+        ),
+        Item(
+            installer="uv",
+            importance="required",
+            layer="repo",
+            version=">=0.5",
+            spec={"name": "uv"},
+        ),
+    ]
+    assert detect_conflicts(items) == []
+
+
+def test_run_check_rolls_status(tmp_path):
+    target = Target(kind="repo", name="x", path=str(tmp_path))
+    outs, status = run(target, _items(), "check", Filters())
+    assert status in ("OK", "WARN", "FAIL")
+    # item b's check_cmd is false + suggested -> info, not fail
+    assert status in ("OK", "WARN")
+
+
+def test_run_dry_run_conflict_fails(tmp_path):
+    target = Target(kind="repo", name="x", path=str(tmp_path))
+    items = [
+        Item(
+            installer="uv",
+            importance="required",
+            layer="system",
+            version=">=0.5",
+            spec={"name": "uv", "ref": "pyproject.toml"},
+        ),
+        Item(
+            installer="uv",
+            importance="required",
+            layer="repo",
+            version=">=0.6",
+            spec={"name": "uv", "ref": "pyproject.toml"},
+        ),
+    ]
+    outs, status = run(target, items, "dry-run", Filters(), on_conflict="fail")
+    assert status == "FAIL"
+
+
+def test_run_install_conflict_fail_does_not_mutate(tmp_path):
+    # two same-named items with conflicting versions -> fatal conflict under fail.
+    # install must NOT run the oneline 'run' (which would touch the marker).
+    marker = tmp_path / "marker"
+    items = [
+        Item(
+            installer="oneline",
+            importance="required",
+            layer="system",
+            version=">=1.0",
+            spec={"name": "x", "run": f"touch {marker}"},
+        ),
+        Item(
+            installer="oneline",
+            importance="required",
+            layer="repo",
+            version=">=2.0",
+            spec={"name": "x", "run": f"touch {marker}"},
+        ),
+    ]
+    target = Target(kind="repo", name="t", path=str(tmp_path))
+    outs, status = run(target, items, "install", Filters(), on_conflict="fail")
+    assert status == "FAIL"
+    assert not marker.exists()
+
+
+def test_run_install_conflict_weak_proceeds(tmp_path):
+    # under weak the conflict is a no-op: install proceeds and the marker appears.
+    marker = tmp_path / "marker"
+    items = [
+        Item(
+            installer="oneline",
+            importance="required",
+            layer="system",
+            version=">=1.0",
+            spec={"name": "x", "run": f"touch {marker}"},
+        ),
+        Item(
+            installer="oneline",
+            importance="required",
+            layer="repo",
+            version=">=2.0",
+            spec={"name": "x", "run": f"touch {marker}"},
+        ),
+    ]
+    target = Target(kind="repo", name="t", path=str(tmp_path))
+    outs, status = run(target, items, "install", Filters(), on_conflict="weak")
+    assert marker.exists()

--- a/agent_sys/tests/env_mgr/test_versions.py
+++ b/agent_sys/tests/env_mgr/test_versions.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+from env_mgr.versions import constraints_conflict, satisfies
+
+
+def test_no_constraint_is_always_satisfied():
+    assert satisfies("1.0.0", None) is True
+    assert satisfies(None, None) is True
+
+
+def test_missing_actual_fails_a_constraint():
+    assert satisfies(None, ">=1.0") is False
+
+
+def test_specifier_constraint():
+    assert satisfies("1.2.0", ">=1.1") is True
+    assert satisfies("1.0.0", ">=1.1") is False
+
+
+def test_malformed_actual_version_fails():
+    assert satisfies("not-a-version", ">=1.0") is False
+
+
+def test_malformed_constraint_fails_instead_of_raising():
+    assert satisfies("1.2.0", "v1.0.0") is False
+    assert satisfies("1.2.0", "not-a-constraint") is False
+
+
+def test_bare_version_means_gte():
+    assert satisfies("1.2.0", "1.1.0") is True
+    assert satisfies("1.0.0", "1.1.0") is False
+
+
+def test_conflict_detection():
+    assert constraints_conflict(">=0.5", ">=0.6") is True
+    assert constraints_conflict(">=0.5", ">=0.5") is False
+    assert constraints_conflict(None, ">=0.5") is False
+    assert constraints_conflict(">=0.5", None) is False
+
+
+def test_conflict_semantic_equivalence_is_not_a_conflict():
+    # bare version normalizes to >=, so these are equal, not conflicts
+    assert constraints_conflict("0.5", ">=0.5") is False
+    assert constraints_conflict(">=0.5", ">=0.5.0") is False
+
+
+def test_conflict_unparseable_falls_back_to_text():
+    assert constraints_conflict("garbage", "other-garbage") is True
+    assert constraints_conflict("garbage", "garbage") is False


### PR DESCRIPTION
## Summary

`env_mgr` is a self-contained CLI (under `agent_sys/`) that provisions an agent work environment from a single declarative YAML **recipe**. It can **check / dry-run / install / bootstrap** an environment and returns a CI-style exit code (`2` on any FAIL, else `0`).

## Architecture

Three decoupled layers:

- **cli / report** — parse stage + filters, render human/JSON output, produce the exit code.
- **runner** — select items, detect cross-layer version conflicts, dispatch each stage to installers, roll up status.
- **installer registry** — each installer thin-wraps one mature tool and returns `Outcome` objects; swappable without touching the CLI or recipe.

## Installers (6)

| installer | wraps | notes |
|---|---|---|
| `uv` | uv | ref form (`uv pip install -e`) and tool form (`uv tool install`); previews via uv's own `--dry-run`, relies on uv-native idempotency |
| `apt` | dpkg/apt-get | v1 **detect-and-print only**, never sudo |
| `bin` | check_cmd + install one-liner | standalone binaries with no project manifest |
| `oneline` / `embed` | a shell string | share a `ShellInstaller` base; `oneline` is exactly one line, `embed` is a multi-line body |
| `claude` | `claude plugin` | Claude Code plugin/MCP registration |

## Model

Recipe items span five layers (`system → workspace → project → repo → worktree`, override left→right). `--on-conflict fail` (default) records a cross-layer version conflict and **halts before mutating the host**; `weak` is a v1 no-op that proceeds (exit 0).

The CLI never crashes on malformed input: bad recipe / unknown installer / bad `--importance` / broken YAML / missing file all render a `fail` Outcome and return `2`.

Fully self-contained — no dependency on any parent package. Ships a v1 sglang recipe.

## Test plan

- [x] `uv run pytest tests/env_mgr` — 65 passing (recipe parse/validate, version compare, conflict detection, CLI exit-code contract, per-installer behavior)
- [x] `uv run ruff check` + `uv run ruff format` clean
- [x] shipped recipe `check` / `dry-run` return exit 0 with `--path` override

## Notes

v1 scope is documented in `agent_sys/env_mgr/README.md` (§ v1 limitations): cross-layer skip-with-warning, workspace-layer wiring, and apt auto-install are deferred. Process/design docs are intentionally kept out of this PR.