### PR TITLE
feat(agent_sys): task_graph — task-management substrate for the agent loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ deploy/docker/third_party/
 .review-drafts/
 temp/
 CLAUDE.md
+# A task definition handed to an agent session: local input, never a deliverable.
+mission.md
 # ...except the shared repo conventions, which are meant for review and for
 # everyone's agent sessions. Excluding `.claude/*` rather than `.claude/` is what
 # makes the negation possible — git will not descend into an excluded directory,

--- a/agent_sys/README.md
+++ b/agent_sys/README.md
@@ -1,0 +1,42 @@
+# agent_sys
+
+The agent work system. Two independent components, each a top-level package
+declared by `pyproject.toml` here.
+
+| | |
+|---|---|
+| [`env_mgr/`](env_mgr/README.md) | Layered environment manager. One YAML recipe drives check / dry-run / install / bootstrap |
+| [`task_graph/`](task_graph/README.md) | Task-management substrate: decides **which task runs when**, and nothing else |
+
+They share this manifest and a test tree, and nothing else — neither imports
+the other.
+
+## Layout
+
+```
+agent_sys/
+├── pyproject.toml       declares both packages; ruff and pytest settings
+├── env_mgr/
+│   └── README.md
+├── task_graph/
+│   ├── README.md
+│   └── docs/            spec.md, design.md
+└── tests/
+    ├── env_mgr/
+    └── task_graph/
+```
+
+Each component's own README is the entry point for it; this file only says
+which is which.
+
+## Running
+
+```bash
+pip install -e agent_sys              # once, from the repository root
+pytest agent_sys                      # both components
+pytest agent_sys/tests/task_graph     # one of them
+```
+
+The repository's own `pyproject.toml` is untouched: its
+`[tool.setuptools.packages.find] include = ["infera*"]` does not cover
+`agent_sys`, and does not need to.

--- a/agent_sys/pyproject.toml
+++ b/agent_sys/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "agent-sys-helper"
 version = "0.1.0"
-description = "Agent work-system environment manager (env_mgr) and helpers"
+description = "Agent work system: environment manager (env_mgr) and task graph (task_graph)"
 readme = "README.md"
 authors = [
     { name = "yihou", email = "yihou@amd.com" }
@@ -10,6 +10,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pyyaml>=6",
     "packaging>=23",
+    "pydantic>=2",  # task_graph only; the repository already installs it via fastapi
 ]
 
 [project.optional-dependencies]
@@ -27,7 +28,16 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = [".", "src"]
-include = ["env_mgr*", "agent_sys_helper*"]
+include = ["env_mgr*", "task_graph*", "agent_sys_helper*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+# Inherits the repository's ruff settings; adds only what is local to agent_sys.
+[tool.ruff]
+extend = "../pyproject.toml"
+
+[tool.ruff.lint.isort]
+# Neither package is in the repository's `packages.find include = ["infera*"]`,
+# so ruff cannot infer that they are first-party.
+known-first-party = ["env_mgr", "task_graph"]

--- a/agent_sys/scratch/.gitignore
+++ b/agent_sys/scratch/.gitignore
@@ -1,0 +1,3 @@
+# Scratch workspace: temporary experiments only. Nothing here is committed.
+*
+!.gitignore

--- a/agent_sys/task_graph/README.md
+++ b/agent_sys/task_graph/README.md
@@ -1,0 +1,79 @@
+# task_graph
+
+Task-management substrate for Infera's agent-driven performance-optimization
+loop.
+
+An AI agent is treated as a function that is not very procedural. A handoff is
+that function's input or output. This system decides **which task runs when**,
+and nothing else — it never inspects what a task does.
+
+## Documents
+
+| | |
+|---|---|
+| [`docs/spec.md`](docs/spec.md) | What the system must do. 35 acceptance criteria |
+| [`docs/design.md`](docs/design.md) | How it is built: files, classes, interfaces, test plan |
+
+Read the spec first. The design implements it and records, in its §13, every
+place where implementing it literally did not work.
+
+## Layout
+
+`task_graph` is one of the two components under `agent_sys/`, alongside
+`env_mgr`; both are declared by `agent_sys/pyproject.toml`.
+
+```
+agent_sys/
+├── pyproject.toml       declares env_mgr and task_graph
+├── env_mgr/             the sibling component
+├── task_graph/          this package
+│   ├── docs/            spec.md, design.md
+│   └── *.py
+└── tests/
+    ├── env_mgr/
+    └── task_graph/
+```
+
+## Status
+
+Implemented. 358 tests, all 35 acceptance criteria covered.
+
+```bash
+pip install -e agent_sys      # once
+pytest agent_sys/tests/task_graph
+```
+
+## Dependencies
+
+**pydantic v2**, which the repository already installs — `fastapi` pulls it.
+Everything else is Python ≥ 3.10 standard library, plus `pytest` for the tests,
+already a dev dependency.
+
+The task definition requires researching whether a mature solution exists before
+building, and recording the outcome. It does, for parts of this; the table below
+is that record. `docs/design.md` §10 carries the same table with the full
+reasoning, and `docs/spec.md` §9 records the platform-level rejections that came
+out of the prior-art survey.
+
+| Module | Considered | Chosen | Why |
+|---|---|---|---|
+| `models` | dataclasses, msgspec, attrs | **pydantic v2** | Already installed via `fastapi`, so it costs nothing. `model_dump` / `model_validate` remove the two hand-written deserialisers `dataclasses.asdict` would need — it has no inverse — and which would drift from the models on every field added. `validate_assignment` makes in-place mutation checked, which matters because status is assigned directly. |
+| `ids` | bare `str`, `NewType` | `uuid.UUID` subclasses | `NewType` erases at runtime, so two ids of different kinds would still compare equal and collide in one dict. Subclassing gives both static and runtime distinctness. It costs a ten-line `__get_pydantic_core_schema__`: pydantic raises on a `UUID` subclass without one. |
+| `registry` | dependency-injector, pluggy, punq | `dict` | All three are built around constructor injection; the spec requires resolve-at-use-time. What is left is a name→instance map: nine lines. |
+| `store` | sqlite3, shelve, tinydb, diskcache | `json` + `pathlib` | Records stay readable with `cat` while the schema is still moving. `Path.replace` gives per-record atomicity. **sqlite3 is the named upgrade path** — stdlib, and it would supply the cross-manager transaction the spec leaves open. `StoreMgr` is a Protocol so the swap is one file. |
+| `handoff` | content-addressed stores (git, DVC, S3) | own | Versioning here is metadata bookkeeping. Where payloads live is deliberately open (spec §8.2); a content store plugs in behind `Handoff.content`. |
+| `resource` | `threading.Semaphore`, Prefect concurrency limits | own | A semaphore cannot express reserve-then-settle for consumables, nor all-or-nothing multi-pool acquisition. Prefect's limits do exactly the right thing but live server-side — adopting a server to obtain one primitive. |
+| `runner` | Claude Code / Codex / Cursor CLIs, subprocess | Protocol + a fake | The real implementations are harness-specific and out of scope. What this system owes is the seam. |
+| `policy` | graphlib, networkx, OR-Tools | `sorted()` | No graph algorithm is required — the only graph operation is asking whether a task's inputs are valid. `graphlib.TopologicalSorter` additionally cannot accept nodes after `prepare()`, and this graph grows at runtime. |
+| `scheduler` | Prefect, Hatchet, Temporal, Ray, Airflow, Slurm | own | Every one is a platform whose scheduling core is not separable. See spec §9. |
+
+The short version: pydantic is adopted; for everything else each candidate is
+either a platform (adopt the server to get the primitive) or a library for a
+problem this system does not have — graph traversal, dependency injection. The
+named upgrade path, `sqlite3` for the store, sits behind an interface that
+already exists.
+
+Adopted from the prior-art survey as *design* rather than as a dependency:
+RCPSP terminology and its two waiting sets, the parallel schedule generation
+scheme, the A2A task-state vocabulary, reserve-then-settle for consumable pools,
+and "the engine owns routing".

--- a/agent_sys/task_graph/__init__.py
+++ b/agent_sys/task_graph/__init__.py
@@ -1,0 +1,5 @@
+"""Task-management substrate for Infera's agent-driven optimization loop."""
+
+from task_graph.ids import AgentId, HandoffId, TaskId
+
+__all__ = ["TaskId", "AgentId", "HandoffId"]

--- a/agent_sys/task_graph/agent.py
+++ b/agent_sys/task_graph/agent.py
@@ -1,0 +1,107 @@
+"""The agent collection.
+
+Two of them: the **spec table** of what kinds of agent exist, and the
+**instances** of what has been created. Only the instances persist — the spec
+table is configuration, and restoring it would resurrect a spec the operator
+has since removed.
+"""
+
+from typing import Any
+
+from task_graph.ids import AgentId, TaskId
+from task_graph.models import Agent
+from task_graph.registry import Registry
+
+__all__ = ["AgentMgr"]
+
+KIND = "agent"
+
+
+class AgentMgr:
+    def __init__(self, registry: Registry) -> None:
+        self._r = registry
+        self._specs: dict[str, dict[str, Any]] = {}
+        self._agents: dict[AgentId, Agent] = {}
+
+    # ---- the spec table ----
+
+    def register(self, spec: str, **config: Any) -> None:
+        self._specs[spec] = dict(config)
+
+    def specs(self) -> list[str]:
+        return list(self._specs)
+
+    def is_registered(self, spec: str) -> bool:
+        return spec in self._specs
+
+    # ---- the instance collection ----
+
+    def instantiate(self, spec: str, task_id: TaskId) -> Agent:
+        """Mint an Agent with a fresh AgentId, bound to that task, and keep it.
+
+        A fresh id every call is forced by criterion 21: after a resume the
+        stack top must report a different agent than the entry beneath it.
+        """
+        if spec not in self._specs:
+            raise KeyError(f"unknown agent spec {spec!r}; registered: {sorted(self._specs)}")
+        return self._mint(spec, task_id)
+
+    def get(self, ref: AgentId | str) -> Agent:
+        """By id: that instance. By spec name: a new unbound one.
+
+        The second form is the `get(name) -> agent` the task definition asks for.
+        Dispatch calls `instantiate` explicitly — relying on the overload there
+        would make "a new agent is created here" invisible at the call site.
+        """
+        if isinstance(ref, AgentId):
+            try:
+                return self._agents[ref]
+            except KeyError:
+                raise KeyError(f"no agent {ref}") from None
+        if ref not in self._specs:
+            raise KeyError(f"unknown agent spec {ref!r}; registered: {sorted(self._specs)}")
+        return self._mint(ref, None)
+
+    def by_spec(self, spec: str) -> list[Agent]:
+        return [a for a in self._agents.values() if a.spec == spec]
+
+    def by_task(self, tid: TaskId) -> list[Agent]:
+        return [a for a in self._agents.values() if a.task_id == tid]
+
+    def all(self) -> list[Agent]:
+        return list(self._agents.values())
+
+    def retire(self, aid: AgentId) -> None:
+        self.get(aid)
+        del self._agents[aid]
+        self._store.delete(KIND, str(aid))
+
+    # ---- persistence ----
+
+    def persist(self, aid: AgentId) -> None:
+        """Write an agent back after it appended to its `handoffs`."""
+        self._store.update(KIND, str(aid), self.get(aid).model_dump(mode="json"))
+
+    def resume_system(self) -> None:
+        """Reload instances. The spec table is NOT restored.
+
+        A restored instance is a record, not a live agent: nothing resumes the
+        agent's own process and nothing dispatches against one. Restoration
+        exists so the audit trail resolves.
+        """
+        self._agents = {
+            agent.id: agent
+            for agent in (Agent.model_validate(r) for r in self._store.read_all(KIND))
+        }
+
+    # ---- internals ----
+
+    def _mint(self, spec: str, task_id: TaskId | None) -> Agent:
+        agent = Agent(spec=spec, task_id=task_id, config=dict(self._specs[spec]))
+        self._agents[agent.id] = agent
+        self._store.create(KIND, str(agent.id), agent.model_dump(mode="json"))
+        return agent
+
+    @property
+    def _store(self):
+        return self._r.get("store_mgr")

--- a/agent_sys/task_graph/bootstrap.py
+++ b/agent_sys/task_graph/bootstrap.py
@@ -1,0 +1,45 @@
+"""The composition root.
+
+The only module that imports every manager. Registration order is free —
+components resolve at use time, not construction time — so this reads top-down
+for a human rather than being constrained by dependencies.
+"""
+
+from collections.abc import Sequence
+
+from task_graph.agent import AgentMgr
+from task_graph.handoff import HandoffMgr
+from task_graph.policy import FifoPolicy, SchedulePolicy
+from task_graph.registry import Registry
+from task_graph.resource import GpuMgr, ResourceMgr, TokenMgr
+from task_graph.runner import FakeRunner, TaskRunner
+from task_graph.scheduler import Scheduler
+from task_graph.store import MemoryStoreMgr, StoreMgr
+from task_graph.task import TaskMgr
+
+__all__ = ["build_registry"]
+
+
+def build_registry(
+    store: StoreMgr | None = None,
+    runner: TaskRunner | None = None,
+    policy: SchedulePolicy | None = None,
+    resources: Sequence[ResourceMgr] | None = None,
+) -> Registry:
+    """Wire a system. Every default is overridable, which is how a test
+    substitutes a fake runner, a spy manager, or a different policy."""
+    r = Registry()
+    r.register("store_mgr", store or MemoryStoreMgr())
+    r.register("handoff_mgr", HandoffMgr(r))
+    r.register("task_mgr", TaskMgr(r))
+    r.register("agent_mgr", AgentMgr(r))
+    r.register("runner", runner or FakeRunner())
+    r.register("policy", policy or FifoPolicy())
+    for pool in resources if resources is not None else _default_resources(r):
+        r.register(f"resource:{pool.name}", pool)
+    r.register("scheduler", Scheduler(r))
+    return r
+
+
+def _default_resources(r: Registry) -> list[ResourceMgr]:
+    return [GpuMgr(r, capacity=8), TokenMgr(r, capacity=1_000_000)]

--- a/agent_sys/task_graph/docs/design.md
+++ b/agent_sys/task_graph/docs/design.md
@@ -1,0 +1,1230 @@
+# Agent Task Graph — Design
+
+| | |
+|---|---|
+| Status | Implemented — `task_graph/` and `tests/task_graph/` follow this document |
+| Revision | 10 — 2026-08-20. References to the task-definition file made self-contained. (rev. 9: renamed `agent_sys` → `task_graph`, flattened alongside `env_mgr`) |
+| Implements | `docs/spec.md` rev. 7 |
+| Language | Python ≥ 3.10. Standard library plus pydantic v2 |
+
+---
+
+## 1. Scope
+
+This document turns `spec.md` into files, classes, and interfaces. It adds no
+requirements. Where it makes a choice the spec left open, the choice is stated
+here; where implementing the spec exposed a contradiction in it, §13 says so
+rather than papering over it.
+
+The spec's 35 acceptance criteria are the definition of done. §11 maps every one
+of them to a named test.
+
+**This document specifies interfaces, not bodies.** A method appears as a
+signature and a sentence of semantics; a body appears only where the ordering of
+steps *is* the design decision — which is `try_dispatch` (§8.3) and nothing
+else.
+
+The only runtime dependency is **pydantic v2**, which the repository already
+installs — `fastapi` pulls it. §10 records why, per module, as the task
+definition requires.
+
+---
+
+## 2. Layout and import graph
+
+`agent_sys/` is a container holding two independent components, `env_mgr` and
+this one. Each is a top-level package declared by `agent_sys/pyproject.toml`,
+each owns its own `docs/` and `README.md`, and their tests are siblings under a
+shared `tests/`. Nothing importable sits at the `agent_sys/` top level.
+
+```
+agent_sys/
+├── pyproject.toml         declares both packages; ruff and pytest settings
+├── env_mgr/               the sibling component — not this document's subject
+├── task_graph/            this package
+│   ├── README.md          build-versus-adopt record
+│   ├── docs/
+│   │   ├── spec.md
+│   │   └── design.md
+│   ├── __init__.py        re-exports the public names
+│   ├── ids.py             TaskId, AgentId, HandoffId
+│   ├── models.py          Handoff, HandoffVersion, Task, Execution, Agent + enums
+│   ├── registry.py        Registry, Resumable, RESUME_ORDER, resume_all
+│   ├── store.py           StoreMgr Protocol, JsonFileStoreMgr, MemoryStoreMgr
+│   ├── handoff.py         HandoffMgr
+│   ├── task.py            TaskMgr
+│   ├── resource.py        ResourceMgr, RenewableMgr, ConsumableMgr, GpuMgr, TokenMgr
+│   ├── agent.py           AgentMgr
+│   ├── runner.py          TaskRunner Protocol, FakeRunner
+│   ├── policy.py          SchedulePolicy Protocol, FifoPolicy
+│   ├── scheduler.py       Scheduler
+│   └── bootstrap.py       build_registry() — the composition root
+└── tests/
+    ├── env_mgr/
+    └── task_graph/
+```
+
+**Why not `src/`.** Revisions 1–8 of this document specified `src/task_graph/`
+with a `conftest.py` injecting it into `sys.path` — the two-line editable
+install — chosen so the repository's `pyproject.toml` stayed untouched. That
+reasoning expired when `env_mgr` arrived with its own `agent_sys/pyproject.toml`:
+there is now a manifest to declare this package in, so declaring it is strictly
+better than a path hack, and matching `env_mgr`'s flat layout matters more than
+the `src/` convention's one guarantee. `pip install -e agent_sys` installs both.
+
+### Import graph
+
+```
+                     ids.py             (uuid only)
+                        ▲
+                    models.py           (pydantic + ids)
+                        ▲
+   ┌─────────┬─────────┬┴────────┬──────────┬─────────┐
+handoff    task     runner    policy   scheduler   agent
+   ▲         ▲         ▲         ▲         ▲         ▲
+   └─────────┴─────────┴────┬────┴─────────┴─────────┘
+                            │
+                      bootstrap.py      (the only module that imports managers)
+
+registry.py — imported by the managers for the `Registry` type annotation only
+store.py, resource.py — imported by nobody but bootstrap and tests
+```
+
+`ids.py` is separate from `models.py` because everything imports the ids and
+almost nothing needs to import the models — the managers deal in ids. Splitting
+them keeps that visible in the import lines.
+
+**No manager imports another manager.** A component holds the `Registry` and
+resolves collaborators by name at call time. `bootstrap.py` is the single
+composition root; it is the only place with a wide import fan-in, which is what a
+composition root is for.
+
+That `ids.py` and `models.py` import nothing from this package is load-bearing:
+it is what keeps the graph acyclic without anyone thinking about it.
+
+---
+
+## 3. Data model — `ids.py`, `models.py`
+
+Every model owns its own state machine and touches no other component. What it
+does *not* own is its collection — that is the manager's (§6).
+
+### 3.1 Typed identities — `ids.py`
+
+```python
+class _Id(uuid.UUID):
+    """A UUID that is not interchangeable with a UUID of another kind."""
+    __slots__ = ()
+
+    @classmethod
+    def new(cls) -> "Self":
+        return cls(uuid.uuid4().hex)
+
+    def __eq__(self, other) -> bool:
+        return type(other) is type(self) and self.int == other.int
+
+    def __hash__(self) -> int:
+        return hash((type(self).__name__, self.int))
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self})"
+
+    @classmethod
+    def _coerce(cls, v) -> "Self":
+        if isinstance(v, cls):
+            return v
+        if isinstance(v, uuid.UUID):
+            return cls(v.hex)
+        return cls(str(v))                      # UUID.__init__ rejects a malformed one
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source, handler):
+        return core_schema.no_info_plain_validator_function(
+            cls._coerce,
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                str, return_schema=core_schema.str_schema(), when_used="json"),
+        )
+
+class TaskId(_Id): ...
+class AgentId(_Id): ...
+class HandoffId(_Id): ...
+```
+
+Subclassing `uuid.UUID` rather than wrapping it: generation, parsing, ordering,
+and `str()` come from the standard library, and `UUID.__init__` already rejects a
+malformed value.
+
+The equality overrides are what make criterion 27 pass. `UUID.__eq__` compares
+`self.int` against any `UUID`, so without them a `TaskId` and a `HandoffId` built
+from the same bytes would be equal and would collide in one dict. Overriding
+`__eq__` alone silently sets `__hash__` to `None` and makes the type unhashable,
+so both are defined together.
+
+**`__get_pydantic_core_schema__` is required, not optional.** pydantic does *not*
+handle a `UUID` subclass natively — it raises `PydanticSchemaGenerationError` on
+the unknown type. The plain validator is the smallest thing that works, and
+`when_used="json"` keeps `model_dump()` returning real id objects while
+`model_dump(mode="json")` returns strings. Verified against pydantic 2.13:
+round-trip preserves the type for both plain fields and `dict[HandoffId, int]`
+keys.
+
+One thing it does not buy: `_coerce` accepts any string, so a `HandoffId`'s
+digits parsed into a `TaskId`-annotated field become a `TaskId`. Deserialisation
+cannot detect a mix-up that the serialised form does not record. The protection
+is static — `TaskId` and `HandoffId` are distinct classes, so passing one where
+the other is annotated is an error the checker reports — plus runtime
+distinctness for values that were never flattened to a string.
+
+### 3.2 Models — `models.py`
+
+```python
+class Model(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",              # a typo'd field is an error, not a silent drop
+        validate_assignment=True,    # task.status = X is validated
+        use_enum_values=False,       # keep enum members; compare with `is`
+    )
+```
+
+`validate_assignment` is the point of using pydantic here. State is mutated in
+place — `task.status = RUNNING` — and this makes every such assignment go
+through validation rather than trusting the caller.
+
+```python
+class TaskStatus(str, Enum):
+    WAITING_HANDOFF  = "waiting_handoff"
+    WAITING_RESOURCE = "waiting_resource"
+    RUNNING          = "running"
+    STOPPING         = "stopping"
+    SUCCEEDED        = "succeeded"
+    FAILED           = "failed"
+    SUSPENDED        = "suspended"
+    CANCELLED        = "cancelled"
+
+# module level, alongside the enum
+WAITING   = frozenset({TaskStatus.WAITING_HANDOFF, TaskStatus.WAITING_RESOURCE})
+RESUMABLE = frozenset({TaskStatus.FAILED, TaskStatus.SUSPENDED})
+
+class HandoffStatus(str, Enum):
+    CREATED    = "created"       # declared; nothing written yet
+    GENERATING = "generating"    # an agent has it open
+    VALID      = "valid"         # sealed, usable
+    INVALID    = "invalid"       # sealed, not usable
+```
+
+Both enums subclass `str` so a dumped record is plain JSON. Python 3.11's
+`StrEnum` is the same thing; the repo targets 3.10, so `(str, Enum)` it is.
+
+These two exist because the guards in `remove_queued`, `update_task`, and
+`resume_task` would otherwise repeat the same tuple literal. There is no
+`LIVE` or `FINAL` set: every other guard tests a single status, and a constant
+with one call site is worse than the literal.
+
+#### `Handoff` and `HandoffVersion`
+
+The handoff is the slot; the version is what fills it. The slot owns version
+bookkeeping, the version owns its own transition.
+
+```python
+class HandoffVersion(Model):
+    version: int
+    status: HandoffStatus = HandoffStatus.CREATED
+    producer_task_id: TaskId | None = None
+    producer_agent_id: AgentId | None = None       # None until opened
+    timestamp: datetime = Field(default_factory=_now)
+    content: Any = None
+
+    @property
+    def is_valid(self) -> bool: ...                # status is VALID
+
+    def seal(self, status: HandoffStatus, content: Any = None) -> None:
+        """GENERATING -> VALID | INVALID.
+        Raises HandoffStateError unless currently GENERATING, and unless
+        `status` is one of the two verdicts."""
+
+class Handoff(Model):
+    id: HandoffId
+    type: str = ""
+    versions: list[HandoffVersion]                 # index == version; never empty
+
+    @property
+    def latest(self) -> HandoffVersion: ...        # versions[-1]
+    @property
+    def is_latest_valid(self) -> bool: ...         # latest.is_valid
+    def get(self, version: int) -> HandoffVersion: ...
+
+    def open_next(self, task_id: TaskId, agent_id: AgentId) -> HandoffVersion:
+        """Hand an agent a version to write, GENERATING, and return it.
+        Adopts `latest` in place if it is still CREATED; otherwise appends
+        v+1. Raises if `latest` is GENERATING — someone else has it open."""
+```
+
+`open_next` is one verb where the previous revision had two (`open` for the first
+run, `successor` for a re-run). The caller says "I am about to write this" and
+does not have to know which case it is in. Two consequences fall out:
+
+- **Version numbers are contiguous structurally.** The list index *is* the
+  version, so nothing checks it. The previous design had `HandoffMgr.append`
+  validating `v == last.v + 1` — a rule that only existed because versions were
+  loose objects a caller assembled.
+- **`versions` is never empty.** `declare` creates v0, so `latest` needs no
+  `None` branch and neither does anything downstream of it.
+
+The guards are the state machine, and criterion 26 tests them directly. Refusing
+`open_next` on a `GENERATING` latest is new: two agents writing one slot
+concurrently is a contradiction in the model, and it should raise rather than
+silently fork.
+
+#### `Task` and `Execution`
+
+```python
+class Execution(Model):
+    attempt: int
+    agent_id: AgentId
+    input_versions: dict[HandoffId, int] = Field(default_factory=dict)
+    output_versions: dict[HandoffId, int] = Field(default_factory=dict)
+    started_at: datetime = Field(default_factory=_now)
+    ended_at: datetime | None = None
+    outcome: TaskStatus | None = None
+    detail: str = ""                               # from the runner; for a human
+
+    @property
+    def is_open(self) -> bool: ...                 # ended_at is None
+
+class Task(Model):
+    id: TaskId = Field(default_factory=TaskId.new)
+    agent_spec: str                                # a SPEC NAME, not an agent
+    inputs: list[HandoffId] = Field(default_factory=list)
+    outputs: list[HandoffId] = Field(default_factory=list)
+    depends_on: list[TaskId] = Field(default_factory=list)      # the graph edge
+    resources: dict[str, float] = Field(default_factory=dict)   # pool NAME -> amount
+    status: TaskStatus = TaskStatus.WAITING_HANDOFF
+    created_at: datetime = Field(default_factory=_now)
+    expedited: bool = False
+    history: list[Execution] = Field(default_factory=list)
+
+    @property
+    def current(self) -> Execution | None: ...     # history[-1], the live binding
+    @property
+    def is_running(self) -> bool: ...              # current is not None and current.is_open
+
+    def push_execution(self, agent_id, input_versions) -> Execution:
+        """Bind an agent by appending an open record, attempt = len(history).
+        Raises TaskStateError if an attempt is already open."""
+
+    def close_execution(self, output_versions, outcome: TaskStatus,
+                        detail: str = "") -> None:
+        """Seal the stack top. Raises TaskStateError if none is open."""
+```
+
+`push_execution` refusing to stack a second open attempt is what makes
+`is_running` trustworthy, and it is why `on_stopped` must close the record —
+otherwise the next `resume_task` trips this guard.
+
+`agent_spec` and the keys of `resources` are the two `str`s that are genuinely
+names. `agent_spec` says *spec* because `AgentMgr` holds two collections and this
+one names an entry in the spec table, not an `Agent`.
+
+`depends_on` is read by nothing in this design. It is the graph, recorded for
+traversal, display, and analysis; the scheduler's dependency question stays
+`inputs` + `check_if_latest_valid`. Criterion 31 asserts both halves — that a
+topological sort works, and that blanking the field changes no scheduling
+behaviour.
+
+#### `Agent`
+
+```python
+class HandoffRef(Model):
+    handoff_id: HandoffId
+    version: int
+
+class Agent(Model):
+    id: AgentId = Field(default_factory=AgentId.new)
+    spec: str                                      # which kind
+    task_id: TaskId | None = None                  # what it is bound to
+    handoffs: list[HandoffRef] = Field(default_factory=list)   # what it touched
+    knowledge: Any = None                          # left empty by the task definition
+    config: dict[str, Any] = Field(default_factory=dict)
+```
+
+`task_id` and `handoffs` are the agent's half of the two-way links (spec §3.1).
+Without them a run is reconstructible only from the task end, and criterion 22
+fails. They are written by whoever binds and whoever writes — `instantiate` sets
+`task_id`, and the agent appends a `HandoffRef` each time it calls `open_next`.
+
+There is **no result or outcome model.** The runner calls
+`on_done(task_id, status, usage)` and everything else the scheduler reads for
+itself (spec §6.3).
+
+### Serialisation
+
+`model_dump(mode="json")` out, `model_validate` in. Nothing hand-written per
+model: no `*_from_dict` constructors, no enum coercion, no `datetime` parsing.
+The `HandoffId` keys of `input_versions` survive the round trip, validated back
+into the declared key type by the schema in §3.1 — checked against pydantic 2.13,
+not assumed.
+
+This is the concrete payoff of adopting pydantic over `dataclasses`: the read
+side of persistence was going to be two hand-maintained constructors that drift
+from the models every time a field is added, and `asdict` has no inverse.
+
+---
+
+## 4. Registry and recovery — `registry.py`
+
+```python
+class Registry:
+    def __init__(self) -> None:
+        self._items: dict[str, Any] = {}
+
+    def register(self, name: str, component: Any) -> None:
+        self._items[name] = component            # replacement is the swap mechanism
+
+    def get(self, name: str) -> Any:
+        try:
+            return self._items[name]
+        except KeyError:
+            raise KeyError(f"no component registered as {name!r}") from None
+
+    def resolve(self, pattern: str) -> list[Any]:
+        if pattern.endswith(":*"):
+            prefix = pattern[:-1]                # "resource:*" -> "resource:"
+            return [c for n, c in self._items.items() if n.startswith(prefix)]
+        return [self.get(pattern)]
+```
+
+`register` **overwrites deliberately.** Spec §4.1 requires that a test can swap an
+implementation after wiring; rejecting duplicates would forbid exactly that. The
+protection against typos is `get`'s loud failure, not a registration guard.
+
+`resolve` honours `prefix:*` and nothing else — no globbing, no regex. It exists
+for `resource:*` and returns registration order, which `dict` preserves.
+
+```python
+@runtime_checkable
+class Resumable(Protocol):
+    def resume_system(self) -> None: ...
+
+RESUME_ORDER = ["handoff_mgr", "agent_mgr", "task_mgr", "resource:*", "scheduler"]
+
+def resume_all(registry: Registry) -> None:
+    for pattern in RESUME_ORDER:
+        for component in registry.resolve(pattern):
+            if isinstance(component, Resumable):
+                component.resume_system()
+```
+
+`@runtime_checkable` is mandatory: an unmarked Protocol raises on `isinstance`
+rather than returning `False`.
+
+One caveat this creates and the implementation must respect: `isinstance` against
+a runtime-checkable Protocol checks *method presence only*. Any component that
+happens to have a zero-argument `resume` will be called. That is why
+`Scheduler`'s task-level resume is named `resume_task` (§13, D1) — otherwise the
+scheduler would satisfy `Resumable` by accident with the wrong method.
+
+---
+
+## 5. Persistence — `store.py`
+
+A full CRUD interface — spec §4.2.
+
+```python
+class StoreMgr(Protocol):
+    def create(self, kind: str, key: str, record: dict) -> None: ...   # raises if present
+    def read(self, kind: str, key: str) -> dict | None: ...
+    def read_all(self, kind: str) -> list[dict]: ...
+    def update(self, kind: str, key: str, record: dict) -> None: ...   # raises if absent
+    def delete(self, kind: str, key: str) -> None: ...                 # raises if absent
+    def exists(self, kind: str, key: str) -> bool: ...
+```
+
+`create` and `update` are separate because their preconditions differ and both
+are worth enforcing: `TaskMgr.add` means *new* and a collision is a bug;
+`persist` means *existing* and writing a vanished record is equally a bug. An
+upsert would accept both mistakes silently. Criterion 29 tests the two
+rejections.
+
+Two implementations:
+
+```python
+class MemoryStoreMgr:
+    """dict[kind][key] -> deepcopy(record). Survives a manager restart because
+       the store object does; that is exactly what recovery needs to be testable."""
+
+class JsonFileStoreMgr:
+    """<root>/<kind>/<quoted-key>.json, one file per record."""
+```
+
+`MemoryStoreMgr` deep-copies on the way in and out. Without it a caller would
+hold a live reference into the store, and "reload from persistence" in a test
+would return the same objects it never actually wrote — recovery tests would
+pass vacuously.
+
+`JsonFileStoreMgr` writes to `<name>.json.tmp` and calls `Path.replace`, which is
+atomic on POSIX. That gives per-record atomicity for free. It does *not* give
+cross-record or cross-manager atomicity — spec §7 says so and §10 leaves it open.
+
+Keys arrive as `str(some_id)` and become filenames, so they go through
+`urllib.parse.quote(key, safe="")`. Callers pass opaque strings and should not
+have to know they become paths.
+
+The store never sees a model — managers pass `model_dump(mode="json")` and
+validate on the way back. That is what lets one implementation serve both kinds.
+
+`MemoryStoreMgr` is the default in tests. Recovery is still testable with it:
+"restart" means constructing fresh managers over the *same* store object, which
+is precisely what recovery does. `test_store.py` and one end-to-end case in
+`test_recovery.py` exercise the JSON implementation against `tmp_path`.
+
+### On-disk shape
+
+```
+<root>/
+├── task/
+│   └── 3f2b...c1.json        {"id": "3f2b...c1", "agent": "profiler",
+│                              "status": "running", "created_at": "2026-08-20T...",
+│                              "history": [{"attempt": 0, "agent_id": "9a4e...",
+│                                           "input_versions": {"7d1c...": 0}}]}
+├── handoff/
+│   └── 7d1c...9f.json        {"id": "7d1c...9f", "type": "profile",
+│                              "versions": [{"version": 0, "status": "valid",
+│                                            "producer_task_id": "3f2b...c1",
+│                                            "producer_agent_id": "9a4e..."}]}
+├── agent/
+│   └── 9a4e...20.json        {"id": "9a4e...20", "spec": "profiler",
+│                              "task_id": "3f2b...c1",
+│                              "handoffs": [{"handoff_id": "7d1c...9f", "version": 0}]}
+└── resource/
+    └── token.json            {"name": "token", "available": 700000.0}
+```
+
+**Four kinds, one record each** — spec §7. A handoff's versions nest inside it
+rather than being separate files; the previous revision keyed on
+`f"{uuid}:{version}"`, which forced `resume_system` to regroup and sort because
+directory order is not version order.
+
+The `resource` directory holds one file per *consumable* pool and nothing else.
+A renewable pool writes no record, so its absence is not a missing file — it is
+the correct representation of a thing with no durable state.
+
+Directly readable, which is the whole reason for choosing files over sqlite while
+the shape of the data is still settling.
+
+---
+
+## 6. Managers
+
+Each manages a collection: add / get / query / remove over a set of one kind of
+thing, plus persistence of it. Transitions belong to the members (§3.2), so no
+manager has a `seal` or a `set_status`.
+
+`ResourceMgr` is the acknowledged exception — it manages a quantity, not a set.
+The name is kept because the task definition uses it.
+
+### 6.1 `HandoffMgr` — `handoff.py`
+
+Owns `dict[HandoffId, Handoff]`, persisted under kind `"handoff"` — one record
+per handoff, its versions nested inside it.
+
+```python
+class HandoffMgr:
+    def __init__(self, registry: Registry) -> None: ...
+
+    # ---- scheduler-facing: read only ----
+    def declare(self, ids, producer_task_id, types=None) -> None:
+        """Create each handoff with a single CREATED v0. Idempotent: an id
+        already present is skipped, never overwritten (D6)."""
+    def check_if_latest_valid(self, hid) -> bool:
+        """`self._handoffs[hid].is_latest_valid`; False if unknown (D5)."""
+    def latest(self, hid) -> HandoffVersion | None: ...
+    def get(self, hid) -> Handoff: ...                     # raises KeyError
+    def get_many(self, ids) -> list[Handoff]: ...
+    def all_ids(self) -> list[HandoffId]: ...
+    def produced_by_task(self, tid) -> list[HandoffId]: ...
+
+    # ---- agent-facing: write ----
+    def persist(self, hid) -> None:
+        """Write the handoff back after open_next() or seal() mutated it."""
+
+    def resume_system(self) -> None:
+        """Reload from the store. No regrouping: one record per handoff."""
+```
+
+**One write verb.** The previous revision needed `append` *and* `persist`,
+because a first run mutated v0 in place while a re-run created a loose object
+someone had to insert. With `open_next` on the handoff, every write is "this
+handoff changed, store it" — and the mgr no longer validates version contiguity,
+because the list index guarantees it.
+
+**One record per handoff, not per version.** The previous revision keyed on
+`f"{uuid}:{version}"`, which required `resume_system` to regroup and sort because
+directory order is not version order. Nesting removes that. The spec's "a sealed
+version is never rewritten" still holds — it is a rule about the version's fields,
+which nothing touches after sealing, not about file granularity.
+
+**`check_if_latest_valid` delegates** to `Handoff.is_latest_valid`, which
+delegates to `HandoffVersion.is_valid`. One definition of "usable", on the object
+that has it.
+
+**An unknown id returns `False`, not an exception** (D5). A consumer may be
+submitted before its producer declares the handoff; "not ready" is the right
+answer and keeps submission order unconstrained.
+
+The mgr decides nothing. Criterion 14 tests that.
+
+### 6.2 `TaskMgr` — `task.py`
+
+Owns `dict[TaskId, Task]`, persisted under kind `"task"`.
+
+| Method | Effect |
+|---|---|
+| `add(task)` | `store.create`; raises if the id exists and is not `CANCELLED` (D3) |
+| `get(tid)` / `all()` | Read |
+| `by_status(status)` | The collection query the pools index would otherwise be the only way to get |
+| `remove(tid)` | Drop and `store.delete` |
+| `persist(tid)` | `store.update` after a caller mutated the task through its own methods |
+| `resume_system()` | Reload; close any dangling stack top as `SUSPENDED` |
+
+There is no `set_status` and no `push_execution` here. A caller does
+`task.status = RUNNING` or `task.push_execution(...)` — the transitions are the
+`Task`'s (§3.2), with its own guards — and then `mgr.persist(tid)`. The mgr's
+job is durability and lookup, not proxying its members' behaviour.
+
+`resume_system` reloads every record and, for any task whose stack top is still
+open, closes it with `outcome = SUSPENDED`: the restart cut the attempt short, it
+was not judged (D8). The *task's* landing state is a separate decision
+`Scheduler.resume_system()` makes a moment later, and it is `WAITING_RESOURCE`;
+a new attempt gets pushed on top.
+
+Closing it here is not tidiness. `Task.push_execution` refuses to stack on an
+open attempt, so leaving it open would make the first `resume_task` after a
+restart raise.
+
+### 6.3 `ResourceMgr` — `resource.py`
+
+The one place inheritance appears (spec §2 principle 1).
+
+```python
+class ResourceMgr(ABC):
+    def __init__(self, name: str, capacity: float) -> None:
+        self.name, self.capacity, self.available = name, capacity, capacity
+
+    @abstractmethod
+    def can_afford(self, amount: float) -> bool: ...
+    @abstractmethod
+    def take(self, amount: float) -> None: ...
+    @abstractmethod
+    def give_back(self, amount: float, actual: float | None = None) -> None: ...
+
+    @abstractmethod
+    def resume_system(self) -> None: ...     # the classes differ here — spec §3.4
+
+class RenewableMgr(ResourceMgr):
+    def can_afford(self, amount) -> bool: ...        # amount <= available
+    def take(self, amount) -> None: ...              # raises if it does not fit
+    def give_back(self, amount, actual=None) -> None:
+        """Return the full amount. `actual` is meaningless for a renewable."""
+    def resume_system(self) -> None:
+        """available = capacity. No lease survives a restart, so nothing is held.
+        Persists nothing: there is nothing to remember."""
+
+class ConsumableMgr(ResourceMgr):
+    # can_afford / take identical to renewable; release and recovery differ
+    def give_back(self, amount, actual=None) -> None:
+        """Return `amount - spent`, where spent is `actual` (clamped to amount),
+        or the whole reservation when `actual` is None. THEN persist the
+        balance: this is the moment spend becomes final."""
+    def resume_system(self) -> None:
+        """Read the balance back. Missing record -> capacity (first run)."""
+
+class GpuMgr(RenewableMgr):    # name defaults to "gpu"
+class TokenMgr(ConsumableMgr): # name defaults to "token"
+```
+
+**Only `give_back` persists, never `take`.** A reservation is a lease and dies
+with its process; a settlement is spend and must not be un-spent. The store write
+therefore sits in exactly one place, and a crash mid-run costs the reservation —
+which is correct, because the task holding it is not running any more (criterion
+33).
+
+The record is one row under kind `"resource"`, keyed by pool name:
+`{"name": "token", "available": 700000.0}`. Renewable pools write nothing, so
+the directory holds one file per consumable and no more.
+
+`GpuMgr` and `TokenMgr` add nothing today beyond a default name. They exist
+because the task definition names them and because GPU-specific accounting (topology,
+per-node pools) has an obvious home when it arrives. That they are currently
+empty is the honest state, not an oversight.
+
+`actual=None` on a consumable means "consumed everything reserved" — the
+conservative reading for a budget. `on_stopped` relies on it (D7).
+
+The `resume_system` split is why the renewable/consumable distinction lives at
+the abstract-base level rather than being a boolean flag: the two classes differ
+in *three* behaviours — release, persistence, recovery — and a flag would mean
+three conditionals kept in agreement by hand.
+
+### 6.4 `AgentMgr` — `agent.py`
+
+Owns two collections: the **spec table**, `dict[str, dict]`, of what kinds of
+agent exist, and the **instances**, `dict[AgentId, Agent]`, of what has been
+created.
+
+```python
+class AgentMgr:
+    # ---- the spec table ----
+    def register(self, spec: str, **config) -> None: ...
+    def specs(self) -> list[str]: ...
+    def is_registered(self, spec: str) -> bool: ...
+
+    # ---- the instance collection ----
+    def instantiate(self, spec: str, task_id: TaskId) -> Agent:
+        """Mint an Agent with a fresh AgentId, bound to that task, and keep it.
+        Raises KeyError naming the registered specs if the spec is unknown."""
+    def get(self, ref: AgentId | str) -> Agent:
+        """By id: that instance. By spec name: instantiate one, unbound — the
+        `get(name) -> agent` the task definition asks for."""
+    def by_spec(self, spec: str) -> list[Agent]: ...
+    def by_task(self, tid: TaskId) -> list[Agent]: ...
+    def all(self) -> list[Agent]: ...
+    def retire(self, aid: AgentId) -> None: ...
+
+    # ---- persistence ----
+    def persist(self, aid: AgentId) -> None:
+        """Write an agent back after it appended to its `handoffs`."""
+    def resume_system(self) -> None:
+        """Reload instances under kind "agent". The spec table is NOT restored."""
+```
+
+**The mgr keeps what it creates.** Previously it was a factory that instantiated
+and forgot, which left `Execution.agent_id` pointing at nothing — the audit trail
+would name agents nobody could resolve. Criterion 28 tests retention.
+
+**`instantiate` mints a fresh id every call and binds `task_id`.** The fresh id
+is forced by criterion 21: after a resume the stack top must report a different
+`agent_id` than the entry beneath. The binding is the agent's half of the
+two-way link (§3.2).
+
+`get` accepts both forms because the task definition asks for "submit an agent
+name, get back an agent object" and the audit path needs lookup by id. Dispatch
+calls `instantiate` explicitly —
+relying on the overload there would make "a new agent is created here" invisible
+at the call site, and `instantiate` is where the task binding is supplied.
+
+**Instances persist; the spec table does not.** The asymmetry is the point:
+
+| | Restored by | Because |
+|---|---|---|
+| instances | `resume_system` | They are state — `task_id` and `handoffs` are links nothing else records, and every `agent_id` in a restored execution history points at one |
+| spec table | whoever builds the registry | It is configuration. Reading it back from a store would mean the system remembers a spec the operator has since removed |
+
+A restored instance is a *record*, not a live agent. Nothing tries to resume the
+agent's own process — that is out of scope (spec §1.2) — and nothing dispatches
+against a restored instance either: `instantiate` always creates a new one.
+Restoration exists so the audit trail resolves (criterion 34).
+
+`AgentMgr` therefore implements `Resumable` and sits at position 2 in
+`RESUME_ORDER` (§8.4). Nothing depends on it being there — no other component
+reads an agent during recovery — so the position is free; it is early because
+grouping the three independent reloads together reads better than scattering
+them.
+
+`knowledge` and `config` stay empty, as the task definition requires.
+
+---
+
+## 7. Runner and policy
+
+### 7.1 `TaskRunner` — `runner.py`
+
+```python
+OnDone = Callable[[TaskId, TaskStatus, dict[str, float]], None]
+
+class TaskRunner(Protocol):
+    def start(self, task: Task, agent: Agent, on_done: OnDone) -> None: ...
+    def stop(self, task_id: TaskId,
+             on_stopped: Callable[[TaskId], None]) -> None: ...
+```
+
+`on_done` carries the terminal status (`SUCCEEDED` or `FAILED`) and what was
+spent. Nothing else: the scheduler reads output versions from `HandoffMgr`
+itself, exactly as it read the input versions at dispatch (spec §6.3).
+
+`stop` takes a callback, symmetric with `start` (D2). The alternative — the
+runner resolving `scheduler` from the registry — would make the runner the one
+component that knows the scheduler by name, and would invert the dependency the
+whole design keeps one-way.
+
+```python
+class FakeRunner:
+    """Records what was started. The test drives completion explicitly."""
+    def start(self, task, agent, on_done):
+        self.running[task.id] = (task, agent, on_done)
+    def stop(self, task_id, on_stopped):
+        self.stop_requested.append(task_id)
+        self._acks[task_id] = on_stopped
+
+    # ---- test-driven, standing in for the agent ----
+    def produce(self, registry, task_id, *, valid=True, content=None) -> None:
+        """What a real agent does to its outputs: take a version and seal it."""
+        hm, task = registry.get("handoff_mgr"), registry.get("task_mgr").get(task_id)
+        agent = registry.get("agent_mgr").get(task.current.agent_id)
+        for hid in task.outputs:
+            version = hm.get(hid).open_next(task_id, agent.id)
+            version.seal(VALID if valid else INVALID, content)
+            hm.persist(hid)
+            agent.handoffs.append(HandoffRef(handoff_id=hid, version=version.version))
+
+    def finish(self, task_id, status=TaskStatus.SUCCEEDED, usage=None) -> None:
+        _, _, on_done = self.running.pop(task_id)
+        on_done(task_id, status, usage or {})
+
+    def ack_stop(self, task_id) -> None:
+        self.running.pop(task_id, None)
+        self._acks.pop(task_id)(task_id)
+```
+
+`FakeRunner` never calls `on_done` from inside `start`. Tests stay deterministic,
+and dispatch is not re-entered on the common path. Re-entrancy is still handled
+(§9) because a real synchronous runner is a reasonable implementation and must
+not deadlock or recurse.
+
+`produce` is the agent's half of the contract in one place: it is the *only*
+thing in the test suite that calls `open_next` or `seal`. That is what makes
+criterion 14 meaningful — if the scheduler ever started writing handoff state,
+this would no longer be the only writer and the test would catch it.
+
+`open_next` collapses what used to be a two-branch conditional here (adopt v0 on
+a first run, fork v+1 on a re-run). The fake no longer knows which case it is in,
+which is the same simplification a real runner gets.
+
+Appending the `HandoffRef` is the agent-side half of the two-way link. It is
+`produce`'s job because it is the agent's job (spec §3.3) — the scheduler never
+writes it, and criterion 22 checks both directions resolve.
+
+### 7.2 `SchedulePolicy` — `policy.py`
+
+```python
+class SchedulePolicy(Protocol):
+    def select(self, eligible: list[Task],
+               snapshot: dict[str, float]) -> list[TaskId]: ...
+
+class FifoPolicy:
+    def select(self, eligible, snapshot):
+        return [t.id for t in sorted(eligible,
+                                     key=lambda t: (not t.expedited, t.created_at))]
+```
+
+`not t.expedited` sorts `False` (expedited) before `True`. Expedited tasks go
+first, then submission order — that is the whole of `expedite`'s effect on
+ordering, and it lives in the policy rather than in the scheduler, where a
+replacement policy is free to ignore it.
+
+`snapshot` is unused by FIFO. It is in the signature because a cost- or
+fit-aware policy needs it and changing the signature later would break every
+implementation.
+
+---
+
+## 8. Scheduler — `scheduler.py`
+
+```python
+class Scheduler:
+    def __init__(self, registry: Registry) -> None:
+        self._r = registry
+        self.pools: dict[TaskStatus, set[TaskId]] = {s: set() for s in TaskStatus}
+        self._lock = threading.RLock()
+        self._in_dispatch = False
+        self._dispatch_again = False
+```
+
+One bucket per status, so a task is in exactly one pool. Only three are
+load-bearing for scheduling; the rest make "which tasks are suspended" a lookup.
+
+### 8.1 The single writer
+
+```python
+def _move(self, tid: TaskId, status: TaskStatus) -> None:
+    task_mgr = self._r.get("task_mgr")
+    for pool in self.pools.values():
+        pool.discard(tid)
+    self.pools[status].add(tid)
+    task = task_mgr.get(tid)
+    if task.status is not status:
+        task.status = status          # the Task's own field, validated on assignment
+        task_mgr.persist(tid)         # the mgr's job: durability
+```
+
+Every transition in the system goes through this method, and nothing else assigns
+`task.status` or writes `pools`. Criterion 12 — the index never disagrees with
+`TaskMgr` — holds by construction because there is exactly one writer.
+
+Discarding from all eight pools rather than from the task's recorded status makes
+`_move` idempotent and self-healing: it cannot leave a stale entry behind even if
+called on a task whose stored status was already wrong.
+
+### 8.2 The API
+
+| Method | Body |
+|---|---|
+| `submit(task)` | validate the agent spec, the resource names, and the resource **amounts** (D9) → `task_mgr.add` → `handoff_mgr.declare(task.outputs, task.id)` → `_warn_depends_on(task)` → `_move` to the pool `_ready` dictates → `try_dispatch` |
+| `expedite(task)` | reject unless every input passes `check_if_latest_valid` → `task.expedited = True` → `submit(task)` |
+| `remove_queued(tid)` | reject unless status in `WAITING` → `_move(CANCELLED)` |
+| `stop(tid)` | reject unless `RUNNING` → `_move(STOPPING)` → `runner.stop(tid, self.on_stopped)` |
+| `resume_task(tid)` | reject unless status in `RESUMABLE` → `_move` to the recomputed waiting pool → `try_dispatch` |
+| `update_task(tid, **fields)` | `remove_queued(tid)` → `submit(model_copy(old, update={**fields, "status": WAITING_HANDOFF, "history": []}))` |
+| `on_task_done(tid, status, usage)` | reject unless `RUNNING` → release, settling consumables at `usage` → read `output_versions` from `handoff_mgr` → `task.close_execution` → `_move(status)` → `try_dispatch` |
+| `on_stopped(tid)` | reject unless `STOPPING` → release (consumables at full reservation) → `task.close_execution(..., SUSPENDED)` → `_move(SUSPENDED)` → `try_dispatch` |
+| `resume_system()` | `Resumable`: rebuild the index, demote interrupted runs, `try_dispatch` |
+| `try_dispatch()` | §8.3. A task that cannot be launched is released and moved to `FAILED` (D10); the pass continues |
+
+`update_task` is written as literally those two calls, not as an equivalent
+reimplementation. Criterion 23 then holds by construction rather than by
+assertion — spec §2 principle 7.
+
+`model_copy(update=...)` preserves `created_at`, so an update does not cost a
+task its place in FIFO order. Criterion 23 compares the two arms field by field with
+`created_at` excluded, since the manually re-submitted task is constructed later
+and will differ there and only there.
+
+`resume_task` is *not* named `resume`; §13 D1 explains why the spec's naming
+cannot stand.
+
+### 8.3 Dispatch
+
+```python
+def try_dispatch(self) -> None:
+    with self._lock:
+        if self._in_dispatch:                 # re-entered from a synchronous runner
+            self._dispatch_again = True
+            return
+        self._in_dispatch = True
+        try:
+            while True:
+                self._dispatch_pass()
+                if not self._dispatch_again:
+                    return
+                self._dispatch_again = False
+        finally:
+            self._in_dispatch = False
+
+def _dispatch_pass(self) -> None:
+    handoff_mgr, task_mgr = self._r.get("handoff_mgr"), self._r.get("task_mgr")
+
+    # 1. re-check eligibility. Snapshot: _move mutates the sets being scanned.
+    for tid in list(self.pools[WAITING_HANDOFF] | self.pools[WAITING_RESOURCE]):
+        task = task_mgr.get(tid)
+        self._move(tid, WAITING_RESOURCE if self._ready(task) else WAITING_HANDOFF)
+
+    # 2. order the eligible set — the one scheduling decision in the system
+    eligible = [task_mgr.get(t) for t in self.pools[WAITING_RESOURCE]]
+    for tid in self._r.get("policy").select(eligible, self._snapshot()):
+        task = task_mgr.get(tid)
+        if task.status is not TaskStatus.WAITING_RESOURCE:
+            continue            # moved since selection — see §9, case 1
+
+        # 3. all-or-nothing: verify the FULL set before mutating anything
+        pools = {r: self._r.get(f"resource:{r}") for r in task.resources}
+        if not all(pools[r].can_afford(n) for r, n in task.resources.items()):
+            continue                                     # take nothing; stay queued
+        for r, n in task.resources.items():
+            pools[r].take(n)
+
+        # 4. bind an agent by PUSHING a record; the stack top is the binding
+        agent = self._r.get("agent_mgr").instantiate(task.agent_spec, tid)
+        task.push_execution(                          # the Task's own transition
+            agent_id=agent.id,
+            input_versions={h: handoff_mgr.latest(h).version for h in task.inputs},
+        )   # instantiate() bound agent.task_id; the agent fills agent.handoffs
+        self._move(tid, RUNNING)                      # _move persists both
+        self._r.get("runner").start(task, agent, on_done=self.on_task_done)
+```
+
+The `list(...)` in step 1 is not defensive style: `_move` mutates the two sets
+being iterated, and without the snapshot this raises `RuntimeError`.
+
+Step 3 verifies before mutating. A task that does not fit takes nothing, so no
+queued task ever holds a resource, so hold-and-wait deadlock is structurally
+impossible. The cost is one extra loop over a dict that has at most a handful of
+entries.
+
+Step 4 pins input versions *before* the run starts. The history then records what
+the run actually saw, and a later re-run of an upstream producer cannot
+retroactively rewrite it.
+
+Step 4 is also the only part of the loop that can fail for reasons outside the
+scheduler's control — an unknown spec, an agent factory that is down, an
+unreachable harness — and by the time it runs the lease is already held. It is
+therefore wrapped: `_abort_launch` gives the whole reservation back at
+`actual=0`, closes the half-open attempt, and parks the task in `FAILED` without
+re-raising (D10). Both halves matter. Without the release, one bad task shrinks
+a pool permanently; without swallowing, one bad task aborts the pass and every
+other queued task stays queued with no later event to release it.
+
+The status re-check in the loop guards the one way the ordered list can go stale
+between selection and use: a synchronous runner that completes inside `start`
+re-enters the scheduler and may move a *later* entry of the same list (§9).
+Selecting once and dispatching from a snapshot is what keeps the policy call
+cheap; the re-check is what makes that safe.
+
+`_ready(task)` is `all(check_if_latest_valid(h) for h in task.inputs)` — the query
+that replaces a dependency counter. `_snapshot()` is
+`{m.name: m.available for m in self._r.resolve("resource:*")}`, passed to the
+policy so a future cost-aware implementation has what it needs; FIFO ignores it.
+
+### 8.4 Recovery
+
+`_warn_depends_on` implements spec §3.2's check: for each input, look up its
+latest version's `producer_task_id` and warn through `logging` if it is absent
+from `task.depends_on`. It warns and continues — rejecting would make declaration
+order matter, and repairing would make `depends_on` derived and unable to express
+a dependency that shares no handoff. Criterion 35 asserts both the warning and
+the submission.
+
+```python
+def resume_system(self) -> None:
+    self.pools = {s: set() for s in TaskStatus}
+    for task in self._r.get("task_mgr").all():
+        status = {TaskStatus.RUNNING:  TaskStatus.WAITING_RESOURCE,  # lease is gone
+                  TaskStatus.STOPPING: TaskStatus.SUSPENDED,         # runner is gone
+                  }.get(task.status, task.status)
+        self._move(task.id, status)
+    self.try_dispatch()
+```
+
+Eligibility is not restored — it is recomputed by `try_dispatch`, which is why
+`HandoffMgr` must have resumed first. Criterion 25 asserts that failure directly:
+resume the scheduler against an unresumed `HandoffMgr` and every waiting task
+stays blocked, with no later event to unblock it.
+
+### 8.5 `bootstrap.py` — the composition root
+
+```python
+def build_registry(store=None, runner=None, policy=None, resources=None) -> Registry:
+    r = Registry()
+    r.register("store_mgr",  store  or MemoryStoreMgr())
+    r.register("handoff_mgr", HandoffMgr(r))
+    r.register("task_mgr",    TaskMgr(r))
+    r.register("agent_mgr",   AgentMgr())
+    r.register("runner",      runner or FakeRunner())
+    r.register("policy",      policy or FifoPolicy())
+    for m in resources or [GpuMgr(capacity=8), TokenMgr(capacity=1_000_000)]:
+        r.register(f"resource:{m.name}", m)
+    r.register("scheduler",   Scheduler(r))
+    return r
+```
+
+Registration order is free — components resolve at use time, not construction
+time (spec §4.1) — so this reads top-down for a human rather than being
+constrained by dependencies. Every default is overridable, which is how a test
+substitutes `FakeRunner`, a spy `HandoffMgr`, or a different policy.
+
+This is the only module that imports every manager. Nothing imports it except
+tests and an eventual entry point.
+
+---
+
+## 9. Concurrency
+
+The task definition asks for the most optimistic simple implementation and no extra code
+for atomicity. The design is therefore:
+
+**Single-threaded by default.** All mutation happens on the caller's thread. The
+`FakeRunner` never calls back spontaneously.
+
+**One `threading.RLock` in `Scheduler`, and nothing else.** It guards
+`try_dispatch` and covers the two ways a real runner can violate the
+single-thread assumption:
+
+| Case | Behaviour |
+|---|---|
+| A synchronous runner calls `on_done` from inside `start` | Same thread, so the `RLock` is re-entrant and does not deadlock. `_in_dispatch` is already set, so the nested call sets `_dispatch_again` and returns; the outer loop makes another pass. No recursion. |
+| An async runner calls `on_done` from its own thread | Blocks on the lock until the current pass finishes. |
+
+The `_dispatch_again` flag is what makes case 1 a loop instead of a stack. Without
+it, a synchronous runner would recurse once per dispatched task and a long queue
+would exhaust the stack.
+
+The managers are not individually locked. Their mutations happen under the
+scheduler's lock in every path the scheduler drives; an agent writing handoffs
+from its own thread races only with other agents on the same handoff, which is a
+contradiction in the model (one producer per handoff) rather than a case to
+defend against.
+
+---
+
+## 10. Build versus adopt
+
+The task definition requires recording, per module, which library was chosen and
+why. `README.md` carries the same table for readers who never open `docs/`.
+
+| Module | Considered | Chosen | Why |
+|---|---|---|---|
+| `ids` | bare `str`, `NewType`, `typing.Annotated` | `uuid.UUID` subclasses | Generation, parsing, and formatting are solved in the stdlib. `NewType` gives static distinctness but erases at runtime, so two ids of different kinds would still be equal and collide in one dict. Subclassing gives both. It costs a ten-line `__get_pydantic_core_schema__` — pydantic does not accept a `UUID` subclass without one (§3.1). |
+| `models` | `dataclasses`, `msgspec`, `attrs` | **pydantic v2** | Already installed — `fastapi` pulls it, so this adds nothing to the dependency set. It supplies `model_dump` / `model_validate`, which removes the two hand-written `*_from_dict` constructors `dataclasses.asdict` would have required (it has no inverse) and which would drift from the models on every field added. `validate_assignment` also makes in-place mutation checked, which matters because status is assigned directly. `msgspec` is faster and also present, but has no validation-on-assignment and a thinner enum/`datetime` story. |
+| `registry` | `dependency-injector`, `pluggy`, `punq` | stdlib `dict` | Every candidate is built around constructor injection, which spec §4.1 explicitly rejects in favour of resolve-at-use-time. Their remaining feature — a name→instance map — is nine lines. |
+| `store` | `sqlite3` (stdlib), `shelve` (stdlib), `tinydb`, `diskcache` | `json` + `pathlib` | The user asked for filesystem + JSON. Records are inspectable with `cat`, which matters while the schema is still moving. `Path.replace` gives per-record atomicity. **`sqlite3` is the named upgrade path** — it is stdlib, and it would supply the cross-manager transaction spec §10 wants — but it hides the data behind a client and buys nothing else today. The `StoreMgr` Protocol exists so that swap is a one-file change. |
+| `handoff` | content-addressed stores (git, DVC, S3) | own implementation | Versioning here is metadata bookkeeping, not content storage. Where payloads live is deliberately open (spec §8.2); when it is decided, a content store plugs in behind `Handoff.content` without touching this module. |
+| `task` | — | own implementation | A dict with write-through. Nothing to adopt. |
+| `resource` | `threading.Semaphore`, Prefect global concurrency limits | own implementation | A semaphore cannot express the consumable (reserve-then-settle) half, and cannot do the all-or-nothing multi-pool acquisition of §8.3 without a second layer on top. Prefect's limits do exactly what is wanted but live server-side; adopting a server for one primitive is the trade spec §9 rejected. |
+| `agent` | any agent framework | own implementation | Two methods, both trivial. The task definition leaves agent internals empty on purpose. |
+| `runner` | Claude Code / Codex / Cursor CLIs, `subprocess` | Protocol + a fake | The real implementations are harness-specific and out of scope (spec §1.2). What this system owes is the seam. |
+| `policy` | `graphlib.TopologicalSorter`, `networkx`, OR-Tools | `sorted()` | Spec §9 records the rejections. FIFO is one `sorted` call; the composite priority rule from the prior art is a drop-in replacement behind the same Protocol. |
+| `scheduler` | Prefect, Hatchet, Temporal, Ray, Airflow, Slurm | own implementation | Spec §9, from the prior-art survey. Every candidate is a platform whose scheduling core is not separable. |
+| tests | — | `pytest` | Already a dev dependency of the repository. |
+
+**pydantic v2 is adopted; everything else is standard library.** For the rest,
+every candidate is either a platform (adopt the server to get the primitive) or a
+library for a problem this system does not have — graph traversal, dependency
+injection. The named upgrade path is `sqlite3` for the store, and it sits behind
+an interface that already exists.
+
+---
+
+## 11. Test plan
+
+`pytest`. Run with `pytest agent_sys/tests/task_graph` from the repository root,
+or `pytest agent_sys` for both components. The repository's root
+`testpaths = ["tests"]` only supplies a default when no path is given, so a bare
+`pytest` at the root still collects exactly the existing suite and nothing
+changes for it.
+
+The package is declared in `agent_sys/pyproject.toml` and reached by
+`pip install -e agent_sys`. The repository's own `pyproject.toml` is untouched:
+`[tool.setuptools.packages.find] include = ["infera*"]` does not cover
+`agent_sys`, and does not need to.
+
+`agent_sys/tests/task_graph/` gets an `__init__.py` so pytest's `prepend` import
+mode does not put the test directory itself on `sys.path` — and so its module
+basenames cannot collide with `tests/env_mgr/`'s.
+
+Every test builds its own `Registry` via `bootstrap.build_registry(...)` with a
+`MemoryStoreMgr` and a `FakeRunner`. Nothing is process-global.
+
+| File | Covers | Criteria |
+|---|---|---|
+| `test_ids.py` | cross-type inequality, hashing, `new()`, round-trip through `str` | 27 |
+| `test_models.py` | `HandoffVersion.seal` and `Task.push/close_execution` guards; `open_next` adopt-then-append; round-trip incl. `HandoffId` dict keys | 26, 30 |
+| `test_registry.py` | isolation, loud failure, `resolve` wildcard, replacement | 15 |
+| `test_store.py` | CRUD, `create` on existing, `update` on missing, key quoting, atomic replace | 29 |
+| `test_resource.py` | renewable vs consumable release, settle-at-actual, balance persists across a rebuild, unsettled reservation is not charged | 4, 32, 33 |
+| `test_handoff.py` | declare/idempotence, `check_if_latest_valid` on unknown/created/generating/valid, `get_many`, `produced_by_task` | 16 (part) |
+| `test_task.py` | `add`/`by_status`/`remove`/`persist`, attempt numbering | 18 |
+| `test_agent.py` | spec table, `instantiate` retains and binds `task_id`, fresh id per call, `get` by id vs spec, `by_spec`, `by_task` | 28 |
+| `test_policy.py` | FIFO order, expedited first, swap changes order only | 10 |
+| `test_submit.py` | landing pool from input state, undeclared-resource rejection, the `depends_on` warning and that it does not reject | 1, 2, 35 |
+| `test_dispatch.py` | all-or-nothing, agent binding, pinned input versions | 3, 18 |
+| `test_lifecycle.py` | stop → on_stopped → resume_task, rejections, `update_task` | 5, 6, 11, 23 |
+| `test_completion.py` | resource release, `ok` vs validity independence, failure path | 4, 7, 13 |
+| `test_expedite.py` | ordering ahead of earlier tasks, rejection on invalid input | 9 |
+| `test_versioning.py` | append not overwrite, earlier versions untouched, consumer sees new version, no invalidation call | 16, 17, 20 |
+| `test_linkage.py` | both link directions resolve; agent readable only from `history[-1]`; `depends_on` sorts topologically and drives no scheduling | 21, 22, 31 |
+| `test_authority.py` | the `HandoffMgr` spy: scheduler reads only | 14 |
+| `test_invariants.py` | pools vs `TaskMgr`, after arbitrary operation sequences | 12 |
+| `test_recovery.py` | `resume_all` order, skipping non-`Resumable`, demotion, verdicts not re-derived, agents resolve after a restart, the scheduler-first failure | 8, 19, 24, 25, 34 |
+
+Two of these carry more weight than their size suggests:
+
+**`test_authority.py`** registers a `HandoffMgr` subclass that appends every call
+to a log, then drives a full submit → dispatch → complete → resume → re-dispatch
+cycle in which `FakeRunner.produce` makes the agent's writes. `produce` brackets
+itself with a marker in the same log, so "who called this" is recorded rather
+than inferred from the call stack. The assertion: every `persist` entry falls
+between a pair of markers, and every entry outside them is one of `declare`,
+`check_if_latest_valid`, `latest`. This is the one mechanical check
+that spec §3.1's authority boundary has not eroded.
+
+**`test_invariants.py`** runs a fixed sequence of a few dozen operations and, after
+each, asserts that the union of the pools equals the set of all task ids and that
+each task sits in the pool matching its stored status. It is the check that `_move`
+really is the only writer.
+
+Criterion 25 deserves its own note: it asserts a *failure*. Resume the scheduler
+before `HandoffMgr` and every waiting task stays in `WAITING_HANDOFF` with no
+subsequent event to release it. Without this test the ordering in `RESUME_ORDER`
+is a comment.
+
+---
+
+## 12. Implementation order
+
+Test first, in dependency order. Each step is independently runnable and green
+before the next begins.
+
+| # | Module | Depends on |
+|---|---|---|
+| 1 | `ids` | — |
+| 2 | `models` | 1 |
+| 3 | `registry` | — |
+| 4 | `store` | 2 (for the round-trip test only) |
+| 5 | `resource` | — |
+| 6 | `handoff` | 1–4 |
+| 7 | `task` | 1–4 |
+| 8 | `agent`, `runner`, `policy` | 1, 2 |
+| 9 | `bootstrap` | 1–8 |
+| 10 | `scheduler` — submit and dispatch | 1–9 |
+| 11 | `scheduler` — lifecycle, completion, expedite | 10 |
+| 12 | `resume_all` and recovery | 10, 11 |
+
+Steps 1–9 are small enough that the interesting work is entirely in 10–12. That
+is the intent: the components are dull so the scheduler can be read in one
+sitting. Step 2 carries more than its size suggests — the state-machine guards
+live there, and everything downstream relies on them holding.
+
+Scratch experiments stay in `agent_sys/scratch/`, which is gitignored. No
+temporary experiment leaves it.
+
+---
+
+## 13. Deviations from the spec
+
+Each of these is a place where implementing the spec literally does not work.
+None changes an acceptance criterion; several are forced *by* one.
+
+Four deviations from revision 1 of this document — the `resume` name collision,
+`TaskRunner.stop`'s callback, `on_stopped` closing the execution record, and the
+`declare(types=...)` argument — are gone from this table because spec rev. 4
+adopted them. They are now specification, not deviation.
+
+| # | Spec says | Design does | Why |
+|---|---|---|---|
+| D3 | `submit` rejects a duplicate id | rejects an id that exists and is **not** `CANCELLED` | Forced by criterion 23. `update_task` must be `remove_queued` + `submit` under the same id, and `remove_queued` leaves the task `CANCELLED`. Reviving a cancelled id replaces the record with fresh history. **The exemption is wider than the reason for it** (noted by review): it lives on `TaskMgr.add`, not on the update path, so *any* caller can resubmit a cancelled id and spec §3.2's "`CANCELLED` is final" is weaker than it reads. Scoping it — a private `revive=True` only `update_task` passes — is a one-line change deliberately not made, because nothing in the system depends on finality and the narrower API would exist only to enforce a rule no caller wants to break. |
+| D5 | `check_if_latest_valid(hid)` | returns `False` for an unknown id rather than raising | A consumer may be submitted before its producer declares the handoff. "Not ready" is the right answer and it keeps submission order unconstrained. |
+| D6 | `declare(ids, producer_task_id)` | idempotent; skips ids already known | `update_task` re-declares. Overwriting would delete versions an agent had already written. |
+| D7 | `on_stopped` releases resources | consumables settle at the **full reservation** | `on_stopped` carries no usage figures, so actual spend is unknown. Assuming the agent spent what it reserved is the safe direction for a budget. |
+| D8 | "a dangling stack top is closed as interrupted" | `outcome = SUSPENDED`, `ended_at = now` | The spec does not name the outcome. `SUSPENDED` says the attempt was cut short rather than judged. |
+| D9 | `submit` validates resource **names** | also rejects an amount that is negative or non-finite, and `can_afford` returns `False` for a negative one | Found by review during implementation. A negative amount passes `can_afford`, so step 3's all-or-nothing check succeeds — and then `take` raises partway through step 3's loop, after earlier pools were already debited. That is precisely the partial reservation criterion 3 exists to make impossible. Rejecting at submit keeps a malformed task out of the dispatch loop entirely; the `can_afford` guard makes a pool safe regardless of who calls it. |
+| D10 | dispatch is "take, then bind, then start" | steps 3–4 are wrapped: a failure anywhere after `take` releases the whole reservation at `actual=0`, closes the half-open attempt, moves the task to `FAILED`, logs, and **does not re-raise** | Found by review. The lease is acquired before the agent is minted and before the runner is called, so an unknown spec, a downed agent factory, or an unreachable harness leaked it permanently — the same shape as D9, one step later. Two separate consequences needed fixing: the leak, and that the exception aborted the whole dispatch pass, so one bad task stopped every other queued task from ever starting. `FAILED` rather than back in the queue, because the next pass would retry it and fail identically forever; `resume_task` is the operator's move once the cause is fixed. This also keeps `resume_all` alive when the operator has removed a spec that persisted tasks still name. |
+| D11 | `update_task` is `remove_queued` + `submit` | if the `submit` rejects, the original is re-submitted before the error propagates | Found by review. The cancel has already happened by then, so a rejected update — an unknown pool name, an unregistered spec — left the task `CANCELLED` and gone: the call silently destroyed the thing it was asked to change. The rollback keeps criterion 23 intact, since the successful path is still literally those two calls. |
+| D12 | a consumable persists its balance | persists **`spent`**, the running total of settlements, and derives `available = capacity - spent` on resume | Found by review, and the most serious bug in the implementation. `available` is live and nets out every *outstanding reservation*, so persisting it baked each in-flight lease into the durable record — and a lease is supposed to die with its process (spec §3.4, criterion 33). Every interrupted run permanently shrank the budget by its reservation, and it compounded across restarts: measured a 400-token overcharge from one interrupted task. `spent` is a function of settlements alone and cannot carry a lease. `available` is still written to the record for a human with `cat`, and is not read back. |
+| D13 | `_release` gives every lease back | one pool raising is logged and the rest still release | The run is over and cannot be un-finished. An escaping exception left the task `RUNNING` with an open execution record and its other leases held, escapable only by a restart. Same shape as D10, on the completion path instead of the dispatch path. |
+| D14 | D10 wraps the launch | `_abort_launch` guards **each of its own steps** too, and pool resolution moved *inside* the guard | Found by the second review. D10 fixed the launch but left the handler itself bare, and a handler that raises has nowhere to go: the exception propagated out of `submit`, leaving the task `RUNNING` with a half-open attempt that only a restart clears. Two live triggers — a wedged pool's `give_back`, and `ConsumableMgr._persist` hitting a full disk. Separately, `self._r.get(f"resource:{name}")` sat *outside* the wrapped block, so a pool an operator deleted between restarts raised a `KeyError` that escaped the whole dispatch pass: `resume_all` died and every healthy task stayed queued. That is the exact failure D10 fixed for a removed *agent spec*, in the sibling case it did not reach. Reaching `FAILED` matters more than any single cleanup step succeeding. |
+| D15 | eligibility is re-checked once per dispatch pass | `_ready(task)` is re-asked **per task**, immediately before its lease is taken | Found by the second review. Step 1 clears every queued task, then the loop starts them one at a time — and each `runner.start` can run agent code. A producer that opens its output slot on start invalidates a handoff a *later* task in the same pass was already cleared for; that task then pinned a `GENERATING` version, recording an input whose content does not exist yet and making criterion 18's audit record false. Reproduced single-threaded with a synchronous runner; the threaded case is the same bug via an agent thread. The re-check sits before `take`, so a task found stale returns to `WAITING_HANDOFF` without ever holding a lease. |
+| D16 | `update_task(tid, **fields)` | validates `fields` against `Task.model_fields` and refuses `id` / `status` / `history` / `created_at` | Found by the second review. `model_copy(update=...)` writes straight to `__dict__`, honouring neither `extra="forbid"` nor `validate_assignment`. A misspelled field name was therefore accepted, reported success, and changed nothing; `id=` was worse — it left the original `CANCELLED` and created a *second* task under the new id, violating criterion 11's "under the same id" while keeping the pool invariant intact, so `test_invariants.py` could not see it. |
+| D17 | `TaskMgr.remove(tid)` | refuses a task the scheduler still indexes | Found by the second review. `remove` deleted the record but nothing told the scheduler, leaving an id in a pool with no task behind it — and every subsequent dispatch pass then raised `KeyError` at the eligibility re-check, permanently. Nothing in the system calls it today, but it is a public method on a public manager that breaks "one writer per invariant" from the outside. The guard resolves the scheduler at use time and tolerates its absence, so `TaskMgr` still depends on no manager. |
+| D18 | `ConsumableMgr.resume_system` sets `available = capacity - spent` | clamps at zero and warns | Found by the second review; the sibling of O7. An operator lowering a budget below what is already spent produced a negative `available`, and `can_afford` then returned `False` for *every* request including zero — each task naming the pool queued forever with no diagnostic. Clamping makes an exhausted budget behave like an exhausted budget. |
+
+---
+
+## 14. New open questions
+
+These are found by this design and are **not** in spec §10.
+
+Three entries from revision 3 are gone: O1 (consumable balances), O5 (agent
+persistence), and O6 (`depends_on` unchecked) were accepted and are now
+specified — spec §3.4, §7, and §3.2 respectively. They were spec decisions, which
+is why they were raised here rather than fixed here.
+
+| # | Question |
+|---|---|
+| **O2** | A completion that arrives after `stop()` **raises into the runner**. `on_task_done` rejects a non-`RUNNING` task per spec §5.1, so a runner that finishes in the window between `stop()` and its own acknowledgement gets an exception where it expected a callback — and the finished work is discarded, since the task then goes `SUSPENDED`. Nothing leaks, because `on_stopped` still releases the resources. Two candidate fixes: accept `STOPPING` in `on_task_done` and treat the run as complete, or make the rejection a no-op return rather than a raise. The first is better and changes the state machine. Neither is done. |
+| **O3** | `Task.resources` names pools that must already be registered, and `submit` rejects unknown ones. Nothing yet rejects a task whose declared amount exceeds a pool's total capacity: it is accepted and waits in `WAITING_RESOURCE` forever. A one-line check at submit would surface it immediately. Not built. |
+| **O4** | **`Handoff.type` has no route from `submit`.** Spec §3.1 gives a handoff a `type`, but `Task` has no field naming the types of its outputs, so the scheduler declares them with `type=""` and nothing later fills it in. Either `Task` gains an `output_types: dict[HandoffId, str]` — a §3.2 change — or `type` is acknowledged as being for directly-declared external handoffs only. Nothing depends on it today: the scheduler is content-agnostic and never reads it. |
+| **O7** | **A consumable's capacity and its balance can disagree after a config change.** `resume_system` reads the stored `available` and ignores the `capacity` passed to the constructor, so raising a budget from 1M to 2M has no effect until the record is deleted by hand. That is the right default — the operator did not intend to hand back spend — but it means the constructor argument silently stops mattering. Either log when the two disagree at startup, or add the explicit `refill` that spec §10 already wants. Not built. |
+| **O8** | **`_warn_depends_on` reads a version that may not exist yet.** The check looks up each input's `producer_task_id`, which is `None` until the producing task is submitted and `declare`s the slot. Submitting a consumer before its producer therefore warns about nothing — the check silently passes on exactly the graph most likely to be miswired. Re-running it at dispatch would catch that, at the cost of warning repeatedly. Accepted for now: the warning is a convenience, and the scheduling behaviour it guards is unaffected either way. |
+| **O9** | **A handoff payload must be JSON-serialisable.** The scheduler is content-agnostic and `test_authority.py` proves it never inspects a payload — but `HandoffMgr.persist` dumps the whole handoff, so an arbitrary Python object raises `PydanticSerializationError` at the agent's `seal`, not at the scheduler. Found while writing the authority test and asserted there rather than left to be discovered by the first agent that returns a live object. The fix is the same one spec §8.2 already leaves open: decide where payloads live, and put a content store behind `Handoff.content`. |
+| **O10** | **A version left `GENERATING` by a crash deadlocks its own retry.** Spec §6.4 requires that recovery not re-derive a verdict, and it does not — but `Handoff.open_next` refuses a slot that is already open, and nothing seals the abandoned one: the agent that opened it is dead, and the scheduler is forbidden from writing handoff state. The task is demoted, re-dispatched, and its new agent cannot write its own output. Found by review; asserted as it behaves in `test_recovery.py`. Criterion 20 is therefore satisfied only for the case where *something* closes the abandoned version off, not for a crash. Three candidate fixes, all of them spec decisions: let `open_next` adopt a version whose producing execution is no longer open; have `TaskMgr.resume_system` seal it `INVALID` alongside the execution it already closes (but that is a manager writing handoff state); or state that an operator seals abandoned versions by hand. |
+| **O11** | **Criterion 27's static half is not enforced by anything.** The criterion says passing a `TaskId` where a `HandoffId` is expected is "a type error the checker reports", but no `mypy` or `pyright` configuration exists in the repository, so no checker runs in CI. `test_ids.py` asserts the structural fact the claim rests on — three unrelated leaf classes — and the runtime half is thoroughly covered, but the static half is an assertion about a tool nobody invokes. Either add a `mypy --strict` gate over `agent_sys/task_graph/` or reword the criterion. Raised by review. |
+| **O12** | **`test_authority.py` cannot see `open_next` or `seal`.** Criterion 14 is worded as "no `open_next` or `seal` is called from a scheduler frame", but those are methods on `Handoff` / `HandoffVersion`, and the spy wraps `HandoffMgr`. What is actually enforced is that `persist` only happens inside an agent span. Since the scheduler does hold live `Handoff` objects (through `get` and `latest`), a scheduler that mutated one and did not persist would pass. The inference is strong — an unpersisted mutation is a bug in its own right — but it is an inference. Closing it means wrapping the returned `Handoff` in the spy, or asserting on version-status transitions rather than on `persist`. Raised by review. |
+| **O13** | **`output_versions` is misattributed when two tasks produce the same handoff.** `on_task_done` records `handoff_mgr.latest(h).version`, which is whatever the handoff holds *at completion time* — not what this run's agent wrote. With A and B both outputting `h`: A writes v0, B writes v1, A completes, and A's execution records `{h: 1}` while A's own agent's `handoffs` correctly says `[0]`. Criterion 22's "reconstructible from either end" then disagrees with itself depending on which end you read from. **This is spec-mandated, not an oversight**: criterion 13 requires the scheduler to record `output_versions` "by reading `HandoffMgr`, not from anything the runner passed", and spec §8.2 calls `latest(h)` the authoritative answer. `agent.handoffs` is the accurate source and reading it would not violate the authority rule — it is an agent record, not handoff state — but switching would contradict a criterion, so it is a spec decision. Raised by review; not fixed. |

--- a/agent_sys/task_graph/docs/spec.md
+++ b/agent_sys/task_graph/docs/spec.md
@@ -1,0 +1,1305 @@
+# Agent Task Graph — Specification
+
+| | |
+|---|---|
+| Status | Draft, pending review |
+| Revision | 7 — 2026-08-20. References to the task-definition file made self-contained. (rev. 6: consumable balances and agents persist; `depends_on` checked at submit) |
+| Date | 2026-08-19 |
+| Scope | Task management substrate for the Infera AI-optimization agent loop |
+| Source | The task definition; an internal prior-art survey (rev. 2, 2026-08-18) |
+
+---
+
+## 1. Purpose
+
+Provide the task-management substrate for Infera's agent-driven performance
+optimization loop.
+
+An AI agent is treated as a *function that is not very procedural*. A handoff is
+that function's input or output. This system decides **which task runs when**,
+and nothing else. It never inspects what a task does.
+
+### 1.1 In scope
+
+- Task lifecycle: declaration, state, persistence.
+- Dependency resolution through handoffs.
+- Resource admission control for two resource classes: GPU and token.
+- Scheduling decisions, with the algorithm itself replaceable.
+- Recovery of the whole system from persisted state.
+
+### 1.2 Out of scope
+
+A task is assumed to succeed, and its input handoffs are assumed to arrive.
+The following are explicitly delegated to other mechanisms; this system only
+guarantees it does not obstruct them:
+
+- Retry, backoff, and failure recovery.
+- Cascading invalidation of downstream tasks.
+- Re-running a `SUCCEEDED` task. That state is final; a caller dissatisfied with
+  a result submits a *new* task and wires up its dependencies. (`FAILED` and
+  `SUSPENDED` tasks *are* resumable — see §3.2.)
+- Agent internals: knowledge, prompts, agent configuration.
+- **An agent's own process, history, and recovery.** An agent is responsible for
+  its own durability, including re-establishing what it was doing after a restart.
+  This system records the binding between a task, an agent, and the handoff
+  versions it wrote (§3.3); it does not manage the agent's lifecycle.
+- The runtime that actually executes an agent. That is `TaskRunner`, a registered
+  interface; this system defines the interface and ships only a fake.
+- Judging whether produced content is usable, and **advancing handoff state at
+  all**. Agents own both; the scheduler only asks whether a handoff's latest
+  version is valid (§3.1).
+
+---
+
+## 2. Design principles
+
+| # | Principle | Consequence |
+|---|---|---|
+| 1 | Composition over inheritance | Inheritance appears only in the `ResourceMgr` hierarchy. Everything else is a `Protocol` resolved from the registry. |
+| 2 | Content-agnostic scheduler | A resource is a `(name, amount)` pair the task declares. The scheduler does arithmetic on counters and asks one yes/no question about each input. |
+| 3 | Single source of truth | Task state lives in `TaskMgr`; handoff state lives in `HandoffMgr`. The scheduler's pools are a derived index, never a second copy. |
+| 4 | The engine decides when, the agent decides what | The scheduler owns task state and never writes handoff state. An agent owns its handoffs' content and validity, and may submit tasks, but may not redirect the graph. |
+| 5 | Algorithm decoupled from mechanism | Ordering lives behind `SchedulePolicy`. The first implementation is naive FIFO. |
+| 6 | Simplicity is a requirement | Where a mature solution exists, use it (§9). Where none fits, the implementation stays small enough to read in one sitting. |
+| 7 | One fact, one place — reuse the implementation | Where two operations mean the same thing, one is expressed in terms of the other rather than reimplemented. `update_task` is `remove_queued` + `submit` (§5.1); "which agent is running this" is `history[-1].agent_id`, not a field (§3.2); eligibility is a query, not a cached counter (§3.2). Structural clarity comes first — this is not licence to collapse two genuinely different concerns into one. |
+
+---
+
+## 3. Domain model
+
+### 3.1 Handoff
+
+A handoff is the unit of transfer between tasks. It is **instantiated when its
+producing task is created**, not when its content is produced. A downstream task
+therefore holds the handoff — and its `uuid` — from birth. The upstream task only
+fills in the content later.
+
+This is what makes dependency resolution a lookup by uuid rather than a matching
+engine.
+
+#### A handoff owns its versions
+
+A `Handoff` is the **slot** in the graph: one stable identity, one place a
+downstream task points at. What fills it is a `HandoffVersion`, and a handoff
+holds an append-only list of them.
+
+| `Handoff` field | Type | Meaning |
+|---|---|---|
+| `id` | `HandoffId` | Stable identity of the slot |
+| `type` | `str` | Opaque to the scheduler; meaningful to agents |
+| `versions` | `list[HandoffVersion]` | Append-only. The last is *latest* |
+
+| `HandoffVersion` field | Type | Meaning |
+|---|---|---|
+| `version` | `int` | Monotonic from 0. `(handoff id, version)` names this artefact |
+| `status` | `HandoffStatus` | `CREATED → GENERATING → VALID \| INVALID` |
+| `producer_task_id` | `TaskId \| None` | Task that produced **this version**; `None` if externally supplied |
+| `producer_agent_id` | `AgentId \| None` | Agent run that wrote it. `None` until opened |
+| `timestamp` | `datetime` | When this version was opened |
+| `content` | `Any` | Content, or a reference to it (§8.2) |
+
+**Provenance is per version, not per slot.** A re-run writes a new version with a
+different `producer_agent_id`; `update_task` can even change which task produces
+a slot, so `producer_task_id` belongs on the version too. A slot-level producer
+field could not say who wrote v0 after either of those.
+
+The names say what they hold. A field called `produced_by` on a type with two
+different kinds of producer is the ambiguity typed ids (below) exist to remove,
+and leaving it in the name would undo half of that.
+
+```
+declare           v0 [CREATED]                        check_if_latest_valid -> False
+  agent opens ──→ v0 [GENERATING]                                           -> False
+  agent seals ──→ v0 [VALID]                                                -> True
+  re-run      ──→ v0 [VALID], v1 [GENERATING]                               -> False
+  agent seals ──→ v0 [VALID], v1 [VALID]         ← latest                   -> True
+```
+
+`CREATED` is the declared-but-untouched state: the slot exists so downstream
+tasks can name it, and nothing has been written. It is a real state, not the
+absence of one, and it is what a `declare` produces.
+
+**A sealed version is never rewritten.** Re-running a producer appends `v+1`;
+`v` stays exactly as it was, which is what makes the execution history (§3.2)
+auditable.
+
+`HandoffStatus` is `CREATED | GENERATING | VALID | INVALID`. The scheduler
+distinguishes none of them — it asks one question, `check_if_latest_valid`, and
+the first three answer it identically. Agents read the status directly.
+
+#### Behaviour belongs to the objects
+
+Version bookkeeping is the handoff's own business, and each version owns its
+transitions. Neither is the manager's:
+
+| On `Handoff` | Effect |
+|---|---|
+| `latest` | The newest version, or `None` |
+| `is_latest_valid` | `latest is not None and latest.is_valid` |
+| `open_next(task_id, agent_id)` | Give an agent a version to write. Adopts an untouched `CREATED` v0 in place; otherwise appends `v+1` as `GENERATING` |
+| `get(version)` | One version by number |
+
+| On `HandoffVersion` | Effect |
+|---|---|
+| `is_valid` | `status is VALID` |
+| `seal(status, content)` | `GENERATING → VALID \| INVALID`. Raises if not open |
+
+`open_next` is one verb, not two, and that is the point: the caller says "I am
+about to write this handoff" and does not have to know whether it is the first
+run or the fourth. Contiguity of version numbers is then structural — the list
+index is the version — rather than something a manager has to check.
+
+`HandoffMgr` reimplements none of this. It manages the *collection*: which
+handoffs exist, and how they persist (§4.3).
+
+#### Everything links back by uuid
+
+Three identities exist — task, agent, handoff — and each artefact records which
+task it belongs to. The links are uuid references, resolved through the owning
+manager; no object holds a pointer to another.
+
+**Each has its own type.** `TaskId`, `AgentId`, and `HandoffId` are distinct
+types, not interchangeable `str`s. A signature reading `list[str]` says nothing
+about which of the three it wants; `list[HandoffId]` says it exactly. They wrap
+`uuid.UUID`, so identity generation, comparison, and formatting come from the
+standard library rather than from string conventions.
+
+| From | To | Where | Purpose |
+|---|---|---|---|
+| version | task | `HandoffVersion.producer_task_id` | which task produced this version |
+| version | agent | `HandoffVersion.producer_agent_id` | which run wrote it |
+| agent | task | `Agent.task_id` | which task the agent is bound to |
+| agent | version | `Agent.handoffs: list[HandoffRef]` | which artefacts it touched |
+| task | agent | `history[-1].agent_id` | which agent is running it now (§3.2) |
+| task | handoff | `Task.inputs` / `Task.outputs`: `list[HandoffId]` | declared slots |
+| task | task | `Task.depends_on: list[TaskId]` | the dependency edge, for traversal (§3.2) |
+
+`HandoffRef` is `(HandoffId, version)` — the pair that names a concrete artefact.
+An agent records the slot alone only when it has not written yet.
+
+**Both directions are stored.** A version names the agent that wrote it, and the
+agent names the versions it touched. Neither side is authoritative for the other;
+the pair is what makes a run reconstructible from either end, which is what
+acceptance criterion 22 asserts.
+
+References are ids, never objects. Two reasons, and the first is the load-bearing
+one:
+
+- **Serialisation would copy.** A `Task` holding `list[Handoff]` dumps the whole
+  handoff record inside the task record, so handoff state exists in the handoff
+  store *and* in every consumer's record. Validating back produces distinct
+  objects — the aliasing that made it one fact in memory is gone.
+- **The graph has cycles.** `HandoffVersion → Task` and `Task → Handoff` point at
+  each other; object references would recurse on dump.
+
+In memory a Python reference is genuinely shared, so nothing is duplicated
+there — the problem appears the moment state crosses the store, which is every
+mutation (§7).
+
+#### Agents own handoff state entirely
+
+**No manager and no scheduler advances a handoff.** Whether content is usable is a
+question about the content, and only the agents on either side can answer it. The
+producing agent opens a new version when it starts writing and records the verdict
+when it finishes. A consuming agent may re-check its inputs on its own terms.
+
+`HandoffMgr` holds the handoffs and serves queries over them. It has no
+validation logic, no content schema, and no opinion. It does not open versions on
+its own initiative and it never derives a status. Version bookkeeping is
+`Handoff.open_next`; sealing is `HandoffVersion.seal` (§3.1). The mgr persists
+what those produced.
+
+The scheduler touches handoffs in exactly three ways, none of which set a status:
+
+| Call | When | Effect on state |
+|---|---|---|
+| `declare(ids, producer_task_id)` | at `submit` | creates v0 in state `CREATED` |
+| `check_if_latest_valid(hid)` | at each decision point | none — a read |
+| `latest(hid)` | at dispatch, to pin the history | none — a read |
+
+Asking is not deciding: the scheduler reads a fact an agent established. This
+keeps it content-agnostic (§2, principle 2) while still resolving dependencies.
+
+#### Why versioning removes the need for propagation
+
+Re-running an upstream task does not disturb anything downstream:
+
+- Older versions are immutable, so a consumer that already ran against `v0`
+  retains a truthful record of what it consumed (§3.2).
+- A consumer that has not yet run re-asks `check_if_latest_valid` at dispatch
+  time, so it sees whatever is current then — no cached counter to invalidate.
+- A consumer currently running is unaffected; it holds the version it was given.
+
+The system therefore contains **no invalidation-propagation logic at all**, and
+did not have to forbid re-running a producer to achieve that.
+
+One consequence is deliberate and stated plainly: because a new version is opened
+by the producing agent when it starts writing, there is a window between resuming
+a task and its agent actually beginning. During that window `latest` is still the
+previous version, so a downstream task may be dispatched against it. See §10.
+
+### 3.2 Task
+
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | `TaskId` | Identity |
+| `agent_spec` | `str` | *Which kind* of agent to run. Names an entry in `AgentMgr`'s spec table |
+| `inputs` | `list[HandoffId]` | Handoff slots required to run |
+| `outputs` | `list[HandoffId]` | Handoff slots this task will fill |
+| `depends_on` | `list[TaskId]` | Upstream tasks. The graph edge (below) |
+| `resources` | `dict[str, float]` | Pool **name** → amount. Declared, never inferred, e.g. `{"gpu": 2, "token": 100_000}` |
+| `status` | `TaskStatus` | See below |
+| `created_at` | `datetime` | FIFO ordering key |
+| `expedited` | `bool` | Set by `expedite()`; a policy hint |
+| `history` | `list[Execution]` | Append-only; one entry per run |
+
+`outputs` holds ids, not handoffs. Verdicts live on the handoff version (§3.1),
+not on the task.
+
+`agent_spec` is a *spec* name, not an agent. An `Agent` is a concrete object with
+an `AgentId`, created per run; the task says which kind to create. `AgentMgr`
+holds both — the spec table and the instances (§4.3) — and the field name has to
+distinguish them or every reader has to guess.
+
+`resources` is keyed by pool *name*, and that `str` is genuinely a name, not an
+identity. Resource pools are singletons registered under `resource:<name>`; there
+is no fourth id type.
+
+#### `depends_on` is the graph; the scheduler does not use it
+
+`depends_on` records the dependency edges directly. Nothing in scheduling reads
+it: eligibility is `check_if_latest_valid` over `inputs` (§3.2 below), and that
+stays true. The field exists because **everything else** needs the graph —
+topological order for display, impact analysis, cycle detection (§10), progress
+reporting — and reconstructing it by joining `outputs` against `inputs` across
+every task is an O(n²) scan of something the submitter knew for free.
+
+Three fields, three jobs, and they are not redundant:
+
+| Field | Answers | Read by |
+|---|---|---|
+| `depends_on` | which *tasks* must come first | traversal, display, analysis |
+| `inputs` | which *slots* must be valid | the scheduler, at every decision point |
+| `history[-1].input_versions` | which *artefacts* this run actually consumed | audit |
+
+The first is structure, the second is the readiness question, the third is what
+happened. `inputs` cannot be replaced by `input_versions`: a queued task has no
+history yet, and that is precisely when the scheduler needs to know what it
+depends on.
+
+#### The two are checked against each other, not derived
+
+Two fields recording one dependency at two granularities can disagree, and a
+`depends_on` that omits the producer of one of its own `inputs` is silently
+wrong: the task still schedules correctly — scheduling reads `inputs` — but every
+traversal built on the graph places it wrongly.
+
+`submit` therefore **warns**, and does not reject or repair:
+
+```
+for each h in task.inputs:
+      producer = handoff_mgr.get(h).latest.producer_task_id
+      if producer is not None and producer not in task.depends_on:
+            warn(f"{task.id}: depends_on omits {producer}, which produces {h}")
+```
+
+Three deliberate choices in that:
+
+- **Warn, not reject.** A submitter may legitimately be building the graph out of
+  order, and a hard failure at submit would make declaration order matter — which
+  §6.1 is otherwise careful to avoid.
+- **Warn, not repair.** Filling the field in would make `depends_on` derived, and
+  then it could not express the case it exists for: a dependency on a task that
+  shares no handoff — an ordering constraint, an external side effect.
+- **Producers only.** The reverse direction — a `depends_on` entry with no
+  corresponding input — is legal by construction and is not checked.
+
+The check is one-directional, cheap, and catches the mistake that actually
+happens: adding an input and forgetting the edge.
+
+#### Execution history — a stack, not an archive
+
+A task may run more than once — `resume` after `FAILED` or `SUSPENDED`. Each run
+appends a record.
+
+**The top of the stack is the current run.** It is not merely the newest history
+entry; it *is* where the live facts about an executing task are kept. "Which
+agent is running this, against which handoff versions" is read from
+`history[-1]`, never from a field duplicating it on the task. A run is in
+progress exactly when `history[-1].ended_at is None`.
+
+Everything below the top is immutable history.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `attempt` | `int` | 0-based |
+| `agent_id` | `AgentId` | Which agent instance ran it |
+| `input_versions` | `dict[HandoffId, int]` | Handoff → version actually consumed |
+| `output_versions` | `dict[HandoffId, int]` | Handoff → version produced |
+| `started_at` / `ended_at` | `datetime \| None` | `ended_at` is `None` while running |
+| `outcome` | `TaskStatus \| None` | Terminal status of this attempt |
+
+This is what makes a re-run auditable rather than destructive. `input_versions`
+pins exactly which upstream content a run saw, so a later re-run of an upstream
+producer cannot retroactively change the record of what happened.
+
+`Task` carries no `agent_id` of its own. Binding an agent means pushing a record
+whose `agent_id` is set; asking which agent is bound means reading the top. One
+fact, one place (§2, principle 7).
+
+`Task.status` is *not* derived from the stack, and the two are not redundant.
+Status is a scheduling fact the scheduler owns; the stack is an execution fact the
+agent's run produces. Most of the statuses — `WAITING_HANDOFF`,
+`WAITING_RESOURCE`, `SUSPENDED`, `CANCELLED` — describe a task that is not running
+and have nothing to derive from.
+
+```
+      submit
+        │
+        ├──────────────────┐
+        ↓                  ↓
+WAITING_HANDOFF ──→ WAITING_RESOURCE ──→ RUNNING ──→ SUCCEEDED  [final]
+  (Ineligible)         (Eligible)          │  │
+       ↑                    ↑              │  └─→ FAILED     ┐
+       │                    │              ↓                 │ resumable
+       │                    │          STOPPING ─→ SUSPENDED ┘
+       └────────────────────┴───── resume ──────────────────┘
+
+remove_queued:  WAITING_HANDOFF | WAITING_RESOURCE  ──→  CANCELLED  [final]
+```
+
+| State | Meaning | Exit |
+|---|---|---|
+| `WAITING_HANDOFF` | Not every input's latest version is `VALID` | Re-checked at each decision point; all valid → `WAITING_RESOURCE` |
+| `WAITING_RESOURCE` | Inputs ready, competing for resources | Full resource set granted atomically → `RUNNING` |
+| `RUNNING` | Holds a lease; the runner is executing | Runner reports done, or `stop()` → `STOPPING` |
+| `STOPPING` | Stop requested; the runner has not confirmed | `on_stopped()` → `SUSPENDED` |
+| `SUCCEEDED` | The task ran to completion. Its outputs carry whatever verdict the agent recorded — not necessarily `VALID` (§6.3). **Final** | — |
+| `FAILED` | Finished unsuccessfully. Resumable | `resume_task()` |
+| `SUSPENDED` | Stopped on request. Resumable | `resume_task()` |
+| `CANCELLED` | Removed while queued. **Final** | — |
+
+`STOPPING` is a transient of `RUNNING`, present because a runner cannot terminate
+a process instantaneously. It holds its resources until `on_stopped()` confirms.
+Recovery treats it as `SUSPENDED` (§6.4).
+
+`resume_task()` accepts `FAILED` and `SUSPENDED`. It rejects `SUCCEEDED` and
+`CANCELLED`. The resumed task re-enters `WAITING_RESOURCE` if
+`check_if_latest_valid` holds for every input, otherwise `WAITING_HANDOFF` — the
+landing pool is recomputed, not remembered. `resume_task()` does **not** touch the
+task's output handoffs; the agent opens new versions when it starts (§3.1).
+
+**Eligibility is a query, not a cached counter.** A task's readiness is
+recomputed by asking `check_if_latest_valid` for each input at every decision
+point. There is no dependency counter to keep in sync, and therefore nothing that
+can go stale when an upstream producer re-runs.
+
+**Why the two waits are separate collections.** `WAITING_HANDOFF` is an unordered
+set: there is no decision to make there, only a question to re-ask.
+`WAITING_RESOURCE` is ordered: it is the single place in the system where a
+scheduling decision occurs. Merging them into one queue with a filter would hide
+that distinction.
+
+### 3.3 Agent
+
+A spec is a *kind* of agent; an `Agent` is one created to run one task.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | `AgentId` | Identity of this instance |
+| `spec` | `str` | Which kind — the name `Task.agent_spec` gave |
+| `task_id` | `TaskId \| None` | The task it is bound to |
+| `handoffs` | `list[HandoffRef]` | Versions it touched, as `(HandoffId, version)` |
+| `knowledge` | `Any` | Left empty by the task definition |
+| `config` | `dict` | Left empty by the task definition |
+
+`task_id` and `handoffs` are the agent's half of the two-way links (§3.1). Without
+them a run is reconstructible only from the task end, and the pairing the spec
+claims does not exist.
+
+One agent, one run. A re-run creates a new agent with a new id, which is what
+makes `Execution.agent_id` distinguish attempts.
+
+What an agent *does* — its process, its prompts, its own durability — is out of
+scope (§1.2). This record is the system's index of it, not its state.
+
+### 3.4 Resource
+
+Two release semantics, distinguished at the abstract-base level:
+
+| Class | On release | Example |
+|---|---|---|
+| Renewable | Returned in full | GPU |
+| Consumable | Only the unused reservation is returned | Token budget |
+
+Consumables follow **reserve-then-settle**: reserve an estimate before the task
+starts, settle the actual amount on completion. An estimate alone overspends;
+post-hoc accounting alone bounds nothing.
+
+#### The two classes recover differently
+
+This follows from what they *are*, and it is the reason the distinction sits at
+the abstract-base level rather than being a flag:
+
+| Class | On restart | Because |
+|---|---|---|
+| Renewable | Reset to full capacity | A lease is held by a process that no longer exists. Nothing is outstanding, so everything is free |
+| Consumable | **Restore the balance from the store** | Spending already happened. A restart does not un-spend it |
+
+A consumable pool that reset to capacity would resurrect every token ever
+charged, and the budget would be bounded only by the interval between restarts.
+`ConsumableMgr` therefore persists its balance — the third thing this system
+stores (§7).
+
+The reservation part is still discarded: a reservation is a lease like any other,
+and its task is not running any more. Only the settled spend survives, which is
+exactly the part that was never a lease.
+
+---
+
+## 4. Architecture
+
+```
+                    ┌───────────────────────────────┐
+                    │           Registry            │
+                    │   register(name, component)   │
+                    │   get(name) -> component      │
+                    └───────────────┬───────────────┘
+                                    │
+      everything registers here; everything resolves from here
+                                    │
+   ┌────────────┬─────────────┬─────┴──────┬──────────────┬─────────────┐
+   │            │             │            │              │             │
+┌──▼───────┐ ┌──▼────────┐ ┌──▼───────┐ ┌──▼─────────┐ ┌──▼───────┐ ┌───▼────────┐
+│Scheduler │ │HandoffMgr │ │ TaskMgr  │ │ResourceMgr │ │ AgentMgr │ │ TaskRunner │
+│          │ │           │ │          │ │ ├ GpuMgr   │ │          │ │            │
+│ pools =  │ │ handoffs  │ │  tasks   │ │ └ TokenMgr │ │  agents  │ │ start/stop │
+│  status  │ │ keyed by  │ │ keyed by │ │            │ │ keyed by │ │            │
+│  index   │ │ HandoffId │ │  TaskId  │ │ a counter  │ │ AgentId  │ │            │
+└────┬─────┘ └─────▲─────┘ └──────────┘ └────────────┘ └──────────┘ └─────┬──────┘
+     │             │                                                       │
+     │  check_if_latest_valid (read only)                                  │
+     └─────────────┘                    open/seal, then append ────────────┘
+                                           (agent, via the runner)
+
+              ┌────────────┐  ┌──────────────┐
+              │  StoreMgr  │  │SchedulePolicy│
+              │ (json file)│  │ (FIFO first) │
+              └─────▲──────┘  └──────────────┘
+                    │  write-through, four kinds (§7):
+                    │  task · handoff · agent · resource
+```
+
+The two arrows into `HandoffMgr` are the whole story of §3.1: the scheduler only
+reads, and only agents write.
+
+Module dependency remains strictly one-way and acyclic. The registry decouples
+*instance wiring*, not *import direction*:
+
+```
+core     ← everyone      (pure data: dataclasses and enums, no behaviour)
+registry ← everyone      (holds instances; imports nothing but core)
+```
+
+No module imports another module's implementation. A component that needs a
+collaborator resolves it by name at use time.
+
+### 4.1 Registry
+
+**Every component is registered — managers, the store, the runner, the policy,
+the scheduler itself.** There is no separate dependency-injection path: a
+component that needs a collaborator calls `registry.get(name)`.
+
+| Registered name | Component |
+|---|---|
+| `handoff_mgr` | `HandoffMgr` |
+| `task_mgr` | `TaskMgr` |
+| `store_mgr` | `StoreMgr` — the persistence backend, shared by every manager that writes (§7) |
+| `agent_mgr` | `AgentMgr` |
+| `runner` | a `TaskRunner` implementation |
+| `policy` | a `SchedulePolicy` implementation |
+| `scheduler` | `Scheduler` |
+| `resource:<name>` | one `ResourceMgr` per pool, e.g. `resource:gpu`, `resource:token` |
+
+Requirements:
+
+- **`Registry()` is constructible.** Each instance is isolated. A test builds its
+  own registry, populates it, and discards it; nothing leaks between tests. A
+  process-wide default instance exists for convenience but is never mandatory.
+- **Resolution happens at use time, not construction time.** A component holds
+  the registry, not its collaborators. This is what allows any registration order
+  and lets a test swap an implementation after wiring.
+- **Missing registration fails loudly.** `get()` on an unregistered name raises
+  immediately with the name in the message. A silent `None` would surface far
+  from its cause.
+- **`resolve(pattern)` handles the one-to-many case.** `resource:*` expands to
+  every registered pool, in registration order. This exists because recovery
+  (§6.4) and dispatch both need "all resource managers" and neither should hold a
+  hard-coded list of pool names.
+
+The trade-off is accepted deliberately: the registry makes dependencies implicit
+at the call site rather than visible in a constructor signature. The mitigations
+are the three requirements above — isolated instances, loud failure, and the
+fixed name table.
+
+### 4.2 StoreMgr
+
+Persistence is a registered component like any other, not a sub-object of
+`TaskMgr`. `TaskMgr` resolves `store_mgr` when it writes.
+
+A store is a CRUD store; it offers all four operations.
+
+```python
+class StoreMgr(Protocol):
+    def create(self, kind: str, key: str, record: dict) -> None: ...  # raises if present
+    def read(self, kind: str, key: str) -> dict | None: ...
+    def read_all(self, kind: str) -> list[dict]: ...
+    def update(self, kind: str, key: str, record: dict) -> None: ...  # raises if absent
+    def delete(self, kind: str, key: str) -> None: ...
+    def exists(self, kind: str, key: str) -> bool: ...
+```
+
+`create` and `update` are separate rather than one upsert because their
+preconditions differ and are worth enforcing: `TaskMgr.add` means *new*, and a
+collision is a bug the store should surface; `set_status` means *existing*, and
+writing a record that vanished is equally a bug. A single `save` would silently
+accept both mistakes.
+
+`read` exists as the single-key counterpart to `read_all`. Recovery uses
+`read_all`; nothing in the scheduler path reads a single record today, because
+the managers hold their collections in memory. It is in the interface because a
+store missing point reads is not a store.
+
+`kind` separates the key spaces: `TaskMgr` writes `"task"`, `HandoffMgr` writes
+`"handoff"` (§7). Keeping the store ignorant of both types is what lets one
+implementation serve both managers.
+
+The first implementation is `JsonFileStoreMgr`: one JSON file per record, in a
+directory per kind. No database. Chosen for inspectability while the shape of the
+data is still settling.
+
+### 4.3 Managers
+
+**A manager owns a collection.** That is the word's basic meaning and every one
+of these honours it: a manager holds a set of things of one kind, and offers
+add / get / query / remove over that set, plus persistence of it. Behaviour
+belonging to a single member is a method on that member, not on its manager.
+
+| Manager | Owns the collection of | Offers | Does *not* |
+|---|---|---|---|
+| `HandoffMgr` | handoffs, keyed by `HandoffId` | declare, get, query, persist | **Judge validity, or transition anything** (§3.1) — `Handoff.open_next` and `HandoffVersion.seal` do that. Store large payloads inline (§8.2) |
+| `TaskMgr` | tasks, keyed by `TaskId` | add, get, all, by-status, remove, persist | Make scheduling decisions. Own the execution *transitions* — `Task.push_execution` / `.close_execution` do that |
+| `AgentMgr` | agents, keyed by `AgentId`, plus the spec table | register a spec, instantiate, get by id, list by spec or task, retire, persist | Run an agent, or know what it does |
+| `ResourceMgr` | one named pool's accounting | can_afford, take, give_back | Know about tasks. This is the one that manages a *quantity*, not a set — §3.4 |
+
+`ResourceMgr` is deliberately the exception, and the name is kept because
+the task definition uses it. What it manages is a counter with two release disciplines,
+not a collection.
+
+`AgentMgr` is no longer a bare factory. The task definition asks for `get(name) ->
+agent`, which stays, but an agent that is instantiated and then forgotten leaves
+`Execution.agent_id` pointing at nothing — the audit trail (§3.2) would name
+agents the system cannot resolve. So the mgr keeps what it created.
+
+### 4.4 Pools as an index
+
+The scheduler keeps `pools: dict[TaskStatus, set[task_id]]` — one bucket per
+`TaskStatus`, so a task is in exactly one. Only three are load-bearing for
+scheduling (`WAITING_HANDOFF`, `WAITING_RESOURCE`, `RUNNING`); the rest exist so
+that "which tasks are suspended" is a lookup rather than a scan.
+
+The pools are an index over task state, not a second copy of it. Every transition
+goes through one internal method that updates `TaskMgr` and the index together,
+so the two cannot drift **as long as that method is the only writer**. It is an
+invariant maintained by construction, not one enforced by the type system;
+acceptance criterion 12 asserts it directly.
+
+Because eligibility is a query (§3.2), `WAITING_HANDOFF` membership is a hint
+about where a task was last seen, not a claim about its current readiness.
+Dispatch re-checks.
+
+---
+
+## 5. Interfaces
+
+All of the following are registered in the `Registry` (§4.1) and resolved by name.
+
+```python
+# ---- registry ----
+class Registry:
+    def register(self, name: str, component: Any) -> None: ...
+    def get(self, name: str) -> Any: ...          # exact; raises KeyError if absent
+    def resolve(self, pattern: str) -> list[Any]:  # "resource:*" -> every pool (§6.4)
+        ...
+
+# ---- recovery ----  (§6.4)
+@runtime_checkable
+class Resumable(Protocol):
+    def resume_system(self) -> None: ...
+    # Implemented by HandoffMgr, AgentMgr, TaskMgr, ResourceMgr, Scheduler.
+    # Not implemented by SchedulePolicy or StoreMgr — they hold no state.
+    # Named resume_system, not resume: "rebuild yourself from persistence" is a
+    # different act from Scheduler.resume_task(tid), and one class needs both.
+
+RESUME_ORDER = ["handoff_mgr", "agent_mgr", "task_mgr", "resource:*", "scheduler"]
+
+def resume_all(registry: Registry) -> None: ...
+
+# ---- store ----  (registered as "store_mgr", see §4.2)
+class StoreMgr(Protocol):
+    def create(self, kind: str, key: str, record: dict) -> None: ...
+    def read(self, kind: str, key: str) -> dict | None: ...
+    def read_all(self, kind: str) -> list[dict]: ...
+    def update(self, kind: str, key: str, record: dict) -> None: ...
+    def delete(self, kind: str, key: str) -> None: ...
+    def exists(self, kind: str, key: str) -> bool: ...
+
+# ---- handoff: the objects own their transitions ----
+class HandoffVersion(Model):
+    version: int
+    status: HandoffStatus
+    producer_task_id: TaskId | None
+    producer_agent_id: AgentId | None
+    ...
+    @property
+    def is_valid(self) -> bool: ...
+    def seal(self, status: HandoffStatus, content: Any = None) -> None:
+        """GENERATING -> VALID | INVALID. Raises if not open."""
+
+class Handoff(Model):
+    id: HandoffId
+    type: str
+    versions: list[HandoffVersion]
+    @property
+    def latest(self) -> HandoffVersion | None: ...
+    @property
+    def is_latest_valid(self) -> bool: ...
+    def get(self, version: int) -> HandoffVersion: ...
+    def open_next(self, task_id: TaskId, agent_id: AgentId) -> HandoffVersion:
+        """Adopt an untouched CREATED v0, else append v+1. Returns it GENERATING."""
+
+# ---- handoff: the mgr owns the collection ----
+# Called by the SCHEDULER (read-only):
+class HandoffMgr:
+    def declare(self, ids: list[HandoffId], producer_task_id: TaskId,
+                types: dict[HandoffId, str] | None = None) -> None:
+        """Create each with v0 in state CREATED. Idempotent."""
+    def check_if_latest_valid(self, hid: HandoffId) -> bool:
+        """`get(hid).is_latest_valid`, False if unknown. A read, not a judgement."""
+    def latest(self, hid: HandoffId) -> HandoffVersion | None:
+        """For pinning into an Execution record (§3.2)."""
+    def get(self, hid: HandoffId) -> Handoff: ...
+    def get_many(self, ids: list[HandoffId]) -> list[Handoff]: ...
+    def all_ids(self) -> list[HandoffId]: ...
+    def produced_by_task(self, tid: TaskId) -> list[HandoffId]: ...
+    def resume_system(self) -> None:
+        """Reload every handoff from the store, at startup (§6.4)."""
+
+# Called by the AGENT, through its runner (write):
+    def persist(self, hid: HandoffId) -> None:
+        """Write a handoff back after open_next() or seal() mutated it."""
+
+# ---- resource ----
+class ResourceMgr(ABC):
+    name: str
+    @abstractmethod
+    def can_afford(self, amount: float) -> bool: ...
+    @abstractmethod
+    def take(self, amount: float) -> None: ...
+    @abstractmethod
+    def give_back(self, amount: float, actual: float | None = None) -> None: ...
+    @abstractmethod
+    def resume_system(self) -> None: ...        # the two classes differ here (§3.4)
+
+class RenewableMgr(ResourceMgr):
+    # give_back returns the full amount; resume_system resets to capacity
+class ConsumableMgr(ResourceMgr):
+    # give_back returns amount - actual and PERSISTS the balance;
+    # resume_system reads it back
+
+# ---- agent ----
+class AgentMgr:
+    def register(self, spec: str, **config) -> None:
+        """Declare a kind of agent. Specs are the vocabulary Task.agent_spec draws on."""
+    def instantiate(self, spec: str, task_id: TaskId) -> Agent:
+        """Mint a new Agent with a fresh AgentId, bound to that task, and keep it."""
+    def get(self, ref: AgentId | str) -> Agent:
+        """By id: that agent. By spec name: the required `get(name) -> agent`."""
+    def by_spec(self, spec: str) -> list[Agent]: ...
+    def by_task(self, tid: TaskId) -> list[Agent]: ...
+    def all(self) -> list[Agent]: ...
+    def retire(self, aid: AgentId) -> None: ...
+    def persist(self, aid: AgentId) -> None:
+        """Write an agent back after it appended to its `handoffs`."""
+    def resume_system(self) -> None:
+        """Reload instances. The spec table is configuration, not state (§6.4)."""
+
+# ---- task ----
+class TaskMgr:
+    def add(self, task: Task) -> None: ...
+    def get(self, tid: TaskId) -> Task: ...
+    def all(self) -> list[Task]: ...
+    def by_status(self, status: TaskStatus) -> list[Task]: ...
+    def remove(self, tid: TaskId) -> None: ...
+    def persist(self, tid: TaskId) -> None:
+        """Write a task back after a caller mutated it through Task's own methods."""
+    def resume_system(self) -> None: ...
+
+# ---- runner ----
+class TaskRunner(Protocol):
+    def start(self, task: Task, agent: Agent, on_done: OnDone) -> None: ...
+    def stop(self, task_id: TaskId, on_stopped: Callable[[TaskId], None]) -> None: ...
+
+# on_done(task_id, status, usage) — status is SUCCEEDED or FAILED; usage is
+# pool name -> amount spent, for consumable settlement (§6.3). There is no
+# result object: everything else the scheduler needs it can read itself.
+OnDone = Callable[[TaskId, TaskStatus, dict[str, float]], None]
+
+# ---- policy ----
+class SchedulePolicy(Protocol):
+    def select(self, eligible: list[Task],
+               snapshot: dict[str, float]) -> list[TaskId]: ...
+```
+
+The splits are deliberate:
+
+- `can_afford` / `take` are separate so the scheduler can check every declared
+  resource before mutating any of them (§6.2).
+- The two halves of `HandoffMgr` are separate so the read/write asymmetry of
+  §3.1 is visible in the interface: the scheduler calls only the first group,
+  agents only the second.
+- Transitions are on `Handoff` and `Task`; collection operations are on their
+  managers. `HandoffMgr` has no `seal`, and `TaskMgr` no `set_status` — a caller
+  mutates the object and asks the mgr to `persist` it. The mgr is not a proxy
+  for its members' behaviour.
+
+### 5.1 Scheduler API
+
+| Method | Effect | Rejects |
+|---|---|---|
+| `submit(task)` | `declare` its output handoffs; warn on a `depends_on` gap (§3.2); place in the pool its inputs dictate; dispatch | Duplicate id; undeclared resource pool |
+| `expedite(task)` | `submit`, but requires every input already valid and marks the task for front-of-queue ordering | Any input failing `check_if_latest_valid` |
+| `remove_queued(tid)` | `→ CANCELLED` | Task not in a waiting pool |
+| `stop(tid)` | `RUNNING → STOPPING`; calls `runner.stop(tid, self.on_stopped)` | Task not `RUNNING` |
+| `resume_task(tid)` | `FAILED \| SUSPENDED →` recomputed waiting pool; dispatch. Does not touch handoffs | `SUCCEEDED`, `CANCELLED`, or any live state |
+| `update_task(tid, ...)` | Sugar: remove and re-submit under the same id, with new inputs/outputs/resources | Task not queued |
+| `on_task_done(tid, outcome)` | Release resources; close the execution record; dispatch | Task not `RUNNING` |
+| `on_stopped(tid)` | `STOPPING → SUSPENDED`; release resources; close the execution record | Task not `STOPPING` |
+| `resume_system()` | Rebuild the pool index from task status; demote interrupted runs. Called by `resume_all`, last (§6.4) | — |
+| `try_dispatch()` | Grant resources and start tasks, as capacity allows | — |
+
+`stop()` records intent and delegates; `on_stopped()` completes the transition
+(§3.2). A task in `STOPPING` still holds its resources.
+
+The two resumes are named apart: `resume_task(tid)` puts one task back in a
+queue; `resume_system()` rebuilds this component from persistence. They are
+different acts, one class needs both, and `@runtime_checkable` matches on method
+*name* alone — so a single `resume` would have `resume_all` calling the
+task-level one with no argument. `on_stopped` takes the
+callback the runner was handed, which is why `TaskRunner.stop` carries one: a
+runner that had to resolve `scheduler` from the registry would be the only
+component depending on it by name.
+
+---
+
+## 6. Data flow
+
+### 6.1 Submit
+
+```
+submit(task)
+  ├─ TaskMgr.add(task)                          → persisted
+  ├─ HandoffMgr.declare(task.outputs, task.id)  → identity only, no version yet
+  ├─ pool = all(check_if_latest_valid(h) for h in task.inputs)
+  │            ? WAITING_RESOURCE : WAITING_HANDOFF
+  └─ try_dispatch()
+```
+
+`declare` creates v0 in state `CREATED` so downstream tasks can reference the id.
+It does not open it — the producing agent does that when it starts (§3.1).
+
+### 6.2 Dispatch — atomic, all-or-nothing
+
+Called at every decision point: after `submit`, `expedite`, `resume`,
+`on_task_done`, `on_stopped`.
+
+```python
+handoff_mgr = registry.get("handoff_mgr")
+task_mgr    = registry.get("task_mgr")
+
+# 1. re-check eligibility; a hint in WAITING_HANDOFF may have become ready,
+#    and one in WAITING_RESOURCE may have gone stale. Snapshot first: move()
+#    mutates the very sets being scanned.
+for tid in list(pools[WAITING_HANDOFF] | pools[WAITING_RESOURCE]):
+      task  = task_mgr.get(tid)
+      ready = all(handoff_mgr.check_if_latest_valid(h) for h in task.inputs)
+      move(tid, WAITING_RESOURCE if ready else WAITING_HANDOFF)
+
+# 2. order the eligible set — the one scheduling decision in the system
+eligible = [task_mgr.get(t) for t in pools[WAITING_RESOURCE]]
+for tid in registry.get("policy").select(eligible, resource_snapshot()):
+      task = task_mgr.get(tid)
+      pool = lambda r: registry.get(f"resource:{r}")
+
+      # 3. all-or-nothing: verify the FULL set before mutating anything
+      if not all(pool(r).can_afford(n) for r, n in task.resources.items()):
+            continue                          # grant nothing; leave it queued
+      for r, n in task.resources.items():
+            pool(r).take(n)
+
+      # 4. bind an agent by PUSHING a record; the stack top is the binding (§3.2)
+      agent = registry.get("agent_mgr").instantiate(task.agent_spec, tid)
+      task.push_execution(                          # the Task's own transition
+            agent_id=agent.id,
+            input_versions={h: handoff_mgr.latest(h).version for h in task.inputs},
+      )
+      task.status = RUNNING
+      task_mgr.persist(tid)                         # the mgr's job: durability
+      registry.get("runner").start(task, agent, on_done=self.on_task_done)
+```
+
+**The whole declared set is verified before anything is mutated.** A task that
+does not fit takes nothing and stays queued. Never acquire incrementally; never
+let a queued task hold anything. This makes hold-and-wait deadlock structurally
+impossible, and costs one extra loop.
+
+Step 1 is what replaces a dependency counter. Re-checking every waiting task at
+each decision point is O(waiting × inputs) — acceptable at this scale, and it
+means no cached readiness can ever be wrong. If the waiting set grows large
+enough to matter, a reverse index from handoff to consumers is the optimisation,
+and it does not change any of the semantics above.
+
+Step 4 pins the input versions into the record *before* the run starts, so the
+history says what the run actually saw. Pushing the record *is* the act of binding
+an agent — there is no separate field to assign (§3.2).
+
+### 6.3 Completion
+
+The runner reports the terminal status and what it spent. Handoff state has
+**already been written by the agent** through `open_next` / `seal`; the
+scheduler neither sets nor infers it.
+
+```python
+on_done(task_id, status: TaskStatus, usage: dict[str, float]) -> None
+```
+
+**There is no result object.** Taking the previous `TaskResult` field by field:
+
+| Field | Verdict |
+|---|---|
+| `ok` / `outcome` | It *was* the task status, one indirection away. `SUCCEEDED` and `FAILED` are already `TaskStatus` members; a boolean or a parallel enum said the same thing in a second vocabulary the scheduler then translated. The runner says the status. |
+| `output_versions` | Redundant and less accurate. At completion `handoff_mgr.latest(h)` is the authoritative answer, and the scheduler reads it directly — the same way it obtained `input_versions` at dispatch. |
+| `actual_usage` | Kept, as the `usage` argument. Only the runtime knows what was spent, and consumable settlement needs it. |
+| `detail` | Belongs on the `Execution` record, which is where a human looks. |
+
+One dict does not need a class. The earlier argument for the struct — that the
+scheduler must apply everything as one step — survives, and a single call with
+three arguments satisfies it exactly as well.
+
+The cost is that a runner must know `TaskStatus`. It already knows `Task`.
+
+Completion and validity remain independent (§3.1): an agent may finish cleanly
+and still seal its output `INVALID`. That is why the runner reports a *task*
+status and never touches the handoff. It is also why a boolean was the wrong
+shape — "true" reads as "it worked", and whether it worked is not the runner's
+to say.
+
+```
+on_task_done(tid, status, usage)
+  ├─ release lease   (renewable: full; consumable: settle `usage`)
+  ├─ output_versions = {h: handoff_mgr.latest(h).version for h in task.outputs}
+  ├─ task.close_execution(output_versions, status)     # seals the stack top
+  ├─ task.status = status
+  ├─ TaskMgr.persist(tid)
+  └─ try_dispatch()          # step 1 re-checks every waiter against latest
+```
+
+The scheduler **reads** the output versions rather than being told them, exactly
+as it read the input versions at dispatch. Symmetry aside, the read is the more
+truthful of the two: it reports what the handoff actually holds.
+
+There is still no handoff *manipulation* here. Downstream promotion is not pushed;
+it falls out of the re-check in `try_dispatch`.
+
+A task is `SUCCEEDED` when its run completed, whatever verdict its agent sealed.
+An agent that ran fine and concluded the output is unusable leaves its consumers
+in `WAITING_HANDOFF` — a `SUCCEEDED` task with an `INVALID` output is a legal and
+expected state.
+
+A failed task releases its resources and is recorded `FAILED`. Whatever its agent
+last wrote to the handoff stands; if the agent opened a version and never sealed
+it, that version remains `GENERATING`, and `check_if_latest_valid` is false — so
+consumers correctly stay blocked. Downstream tasks are not cancelled. That is
+deliberate: the system does not cancel them, and does not pretend to.
+
+### 6.4 Recovery
+
+Recovery is not one component's job. Rebuilding handoff versions, task state,
+resource pools, and the scheduler's index are four different reconstructions, and
+`Scheduler.resume_system()` doing all four would put a component in charge of
+state it does not own (§2, principle 3).
+
+**Each component restores itself.** A separate `resume_all` sequences them.
+
+```python
+class Resumable(Protocol):
+    def resume(self) -> None:
+        """Rebuild this component's own state from whatever it persisted."""
+```
+
+Components with nothing to restore — `SchedulePolicy`, `StoreMgr` itself, and a
+renewable pool's lease state — simply do not implement it, or restore trivially.
+`AgentMgr` used to be in that list and no longer is: an `Agent` carries the
+`task_id` and `handoffs` links (§3.3), which is real state. Not implementing `Resumable` is the
+declaration that a component is stateless; an empty `resume_system()` would be
+indistinguishable from one somebody forgot to write.
+
+#### Order matters
+
+The sequence is a real dependency, not a convention:
+
+| # | Component | Restores | Depends on |
+|---|---|---|---|
+| 1 | `HandoffMgr` | handoffs and their versions | nothing |
+| 2 | `AgentMgr` | agent instances and their bindings | nothing |
+| 3 | `TaskMgr` | tasks and their execution stacks | nothing |
+| 4 | `ResourceMgr` (each) | renewable: full capacity. consumable: the stored balance | nothing |
+| 5 | `Scheduler` | its pool index; demotes interrupted runs | 1–4 |
+
+The scheduler is last because everything it rebuilds is derived: its index is a
+projection of task status (§4.4), and the eligibility it recomputes reads handoff
+versions (§3.2). Restoring it against an empty `HandoffMgr` would classify every
+waiting task as blocked and then never re-check, because nothing would have
+changed to trigger a decision point.
+
+1 through 4 are mutually independent, so the order among them is free; only
+"scheduler last" is load-bearing. `AgentMgr` in particular is not a dependency of
+anything here — the scheduler never resolves an agent during recovery, and
+`instantiate` creates the *next* one. It is restored so that the ids already in
+the execution history resolve.
+
+```python
+RESUME_ORDER = ["handoff_mgr", "agent_mgr", "task_mgr", "resource:*", "scheduler"]
+
+def resume_all(registry) -> None:
+    for pattern in RESUME_ORDER:                    # declared, not discovered
+        for component in registry.resolve(pattern): # "resource:*" expands to every pool
+            if isinstance(component, Resumable):
+                component.resume_system()
+```
+
+`Registry.resolve(pattern)` returns one component for a plain name and all
+matching ones for a `prefix:*` pattern, in registration order. It is the only
+place a wildcard is honoured; `get()` stays exact.
+
+`Resumable` must be `@runtime_checkable` for that `isinstance` to work — it is a
+Protocol, and an unmarked one raises at runtime rather than returning `False`.
+
+The order is declared rather than inferred. Inferring it would mean a dependency
+graph among managers, which is exactly the machinery the registry exists to avoid;
+a five-entry list that fails loudly when a name is missing is the smaller thing.
+
+#### What each restore does
+
+```
+HandoffMgr.resume_system()
+  └─ load handoffs and versions. A version left GENERATING stays GENERATING:
+     its agent is gone and will never seal it, so check_if_latest_valid remains
+     false and consumers stay blocked — the same outcome as the crash case in §6.3
+
+TaskMgr.resume_system()
+  └─ load tasks with their execution stacks. A dangling stack top (ended_at
+     unset) is closed as interrupted
+
+AgentMgr.resume_system()
+  └─ load agent instances with their task_id and handoffs. The spec table is not
+     restored: it is configuration, supplied by whoever builds the registry
+
+ResourceMgr.resume_system()
+  ├─ renewable: reset to capacity. Leases do not survive a restart
+  └─ consumable: read the stored balance. Spend does survive (§3.4)
+
+Scheduler.resume_system()
+  ├─ rebuild the pool index from each task's stored status
+  ├─ RUNNING  → WAITING_RESOURCE      (its lease is gone)
+  ├─ STOPPING → SUSPENDED             (the runner it was waiting on is gone)
+  └─ try_dispatch()                   # eligibility is recomputed, never restored
+```
+
+Eligibility needs no reconstruction: it is a query, so recovery only has to
+ensure the handoff versions the query reads are present.
+
+`resume_all` is the whole-system entry point. `Scheduler.resume_system()` no
+longer exists; calling one component's resume without the others is a partial
+recovery and the API should not offer it.
+
+#### Why handoffs persist themselves
+
+`HandoffMgr` restores from its own records, not from task records. The reason is
+not a crash window — it is that **the information is nowhere else.**
+
+A run's terminal status and a version's verdict are independent facts (§6.3): an agent may
+finish cleanly and still seal its output `INVALID`. A task record carries only
+the run outcome. Rebuilding handoff state from task records would therefore mean
+guessing `COMPLETED → VALID`, which is wrong in exactly the case §6.3 describes —
+not because of restart timing, but because the verdict was never written there at
+all. Guessing it would also be the inference §3.1 exists to prevent.
+
+Two further gaps: a handoff supplied externally has no producing task to replay,
+and a version abandoned mid-write by a crashed agent appears in no completed
+execution record.
+
+## 7. Persistence
+
+Four things are persisted. Each manager persists what it owns; nothing is derived
+from another manager's records.
+
+| Kind | Owner | Why it cannot be derived |
+|---|---|---|
+| `task` | `TaskMgr` | Status and execution history exist nowhere else |
+| `handoff` | `HandoffMgr` | A version's verdict is independent of the producing run's terminal status (§6.4), so no task record implies it |
+| `agent` | `AgentMgr` | Every `Execution.agent_id` and `producer_agent_id` in the restored records points at one. Without them the audit trail names agents that cannot be resolved (§3.3) |
+| `resource` | `ConsumableMgr` | Spend already happened; a restart must not un-spend it (§3.4) |
+
+**Persisting an `Agent` record is not managing an agent's lifecycle.** What is
+stored is this system's index of the binding — id, spec, `task_id`, the
+`HandoffRef`s it wrote. The agent's own process, prompts, and working state
+remain its business and are still out of scope (§1.2). The distinction is the
+same one `Task.agent_spec` makes: the system knows *that* an agent ran and what
+it touched, never *what it did*.
+
+The scheduler persists nothing of its own — its pools are an index over task
+status (§4.4), so reading tasks back rebuilds them. Renewable pools persist
+nothing either: no lease survives a restart, so full capacity is the correct
+starting point.
+
+**Balances are written on settlement, not on reservation.** `take` is a lease and
+is deliberately not durable; `give_back` is where spend becomes final, and that
+is the write. A crash between the two loses the reservation, which is right —
+the task it was held for is not running any more.
+
+Handoff persistence is a larger subject than this document treats it as — a
+handoff is the durable artefact the whole system exists to pass around, and
+archival, retention, and content addressing all belong to it. `HandoffMgr` is
+where that lives. Only the part the scheduler depends on is specified here.
+
+- `StoreMgr` is a `Protocol`, registered under `store_mgr` (§4.2). `TaskMgr`
+  resolves it from the registry when it writes; it is not a sub-object.
+- The first implementation is `JsonFileStoreMgr`: one JSON file per task, in a
+  directory. No database. Chosen for inspectability while the shape of the data
+  is still settling.
+- Every state-mutating operation on `TaskMgr` writes through. Completion is the
+  principal trigger but not the only one — submission, cancellation, and stop all
+  mutate state and must survive a crash.
+
+The persisted task record includes its **execution history** (§3.2), not merely
+its current status. The history is the audit trail — which agent ran, against
+which input versions — and it is recoverable from nowhere else.
+
+`HandoffMgr` follows the same write-through discipline: `declare` and `persist`
+each write. Because `persist` is called by agents, a handoff is stored at the
+moment the agent acts rather than at task completion.
+
+Handoff *content* is a different question, deliberately left open (§8.2). The
+persisted record holds a reference, not a payload.
+
+`AgentMgr` writes on `instantiate` and whenever an agent's `handoffs` list grows.
+The second is the agent's own act, so like a handoff an agent record is stored
+when the agent acts.
+
+**Not atomic.** A crash between `TaskMgr`'s write and `HandoffMgr`'s can leave the
+two disagreeing. Recovery tolerates this in the safe direction: anything short of
+a sealed `VALID` version reads as not-valid, so a consumer stays blocked rather
+than running against unverified content. Cross-manager atomicity is not attempted
+(§10).
+
+---
+
+## 8. Deliberate omissions
+
+### 8.1 Not built
+
+| Omitted | Why |
+|---|---|
+| Resource kinds beyond a name | The scheduler cannot tell a GPU from an API quota. That is the point. |
+| Duration model | Agent durations are unknown, heavy-tailed, and not reproducible. |
+| Graph library | The only graph operation is asking whether a task's inputs are valid. No traversal, no topological order. |
+| Cascading failure | Out of scope by §1.2. Versioning (§3.1) removes the need for it in the re-run case. |
+| Event bus | Deferred. A hook callback is left at each transition point, and the registry (§4.1) gives a later bus a natural place to live. |
+| Lease TTL sweep | Deferred; noted in §10. |
+
+### 8.2 Handoff content storage
+
+`HandoffMgr` keeps handoff *metadata* and versions. Where large payloads live is a
+larger question, deliberately left open — `content` accommodates a reference
+rather than mandating inline storage. Storing large agent payloads in the state
+record is a known way to make the state store the bottleneck.
+
+Versioning sharpens the question rather than answering it: N runs of a producer
+mean N payloads, and nothing here says when an old one may be discarded.
+
+---
+
+## 9. Build-versus-adopt
+
+The task definition requires preferring a mature solution where one exists. The prior-art survey
+(rev. 2) evaluated the field and concluded: build it.
+
+| Candidate | Verdict |
+|---|---|
+| `graphlib.TopologicalSorter` | **Rejected.** `add()` raises after `prepare()`. This graph grows at runtime, so the sorter would have to be rebuilt on every submission, losing completion state. CPython issue 91301 tracks the limitation. |
+| `networkx` | **Rejected.** No graph algorithms are required. Importing it invites modelling the system as a graph object that must then be kept in sync with the state machine doing the real work. |
+| Prefect global concurrency limits | **Rejected.** The closest existing match to the resource stage, including atomic multi-pool acquisition. But limits live server-side: adopting a server to obtain one primitive. |
+| Hatchet concurrency keys | **Rejected.** A platform, not a library. DAGs must be declared; this graph is dynamic. |
+| Ray, Temporal/Restate/Inngest/DBOS, Airflow/Dagster, Slurm/K8s | **Rejected.** Wrong layer or wrong problem; see the prior-art survey §08. |
+
+Adopted as dependencies:
+
+| Adopted | For | Why |
+|---|---|---|
+| **pydantic v2** | every domain model in §3 | Already installed — `fastapi` is a repository dependency and pulls it. It supplies validation, `model_dump` / `model_validate` for §7, and enum and `datetime` coercion, all of which would otherwise be hand-written `*_from_dict` constructors with no inverse. The state machines of §3.1 and §3.2 are exactly what a validator should enforce rather than a comment. |
+| **`uuid.UUID`** | `TaskId`, `AgentId`, `HandoffId` | Identity generation, comparison, and formatting are a solved problem in the standard library. The three types wrap it so they stay mutually incompatible; a bare `str` makes `list[str]` unreadable and lets a `TaskId` be passed where a `HandoffId` belongs. |
+
+Adopted from prior art, as design rather than dependency:
+
+- **RCPSP** (Hartmann & Briskorn, EJOR 2021) — the formal name for this model.
+  The two waiting pools are its *ineligible* and *eligible* activity sets.
+- **Parallel schedule generation scheme** — at each decision point, consider the
+  eligible set in priority order and start everything that fits.
+- **A2A task-state vocabulary** — state names adopted rather than invented.
+- **Reserve-then-settle** (HiveMind, arXiv 2604.17111) — for consumable pools.
+- **The engine owns routing** (GraphBit, arXiv 2605.13848) — agents submit; the
+  scheduler decides.
+
+Two departures from that survey, both consequences of decisions taken here:
+
+- It recommends a **dependency counter** as the graph representation. This design
+  queries `check_if_latest_valid` at each decision point instead, because
+  versioned handoffs make a cached counter the thing most likely to go stale
+  (§3.1). The counter remains the optimisation if the waiting set grows (§10).
+- It treats a produced artefact as **immutable and singular**. Versioning is an
+  addition, and it is what lets a producer be re-run without the cascading
+  invalidation the survey identifies as an unresolved design gap.
+
+The rationale is recorded in `agent_sys/task_graph/README.md`, as the task definition requires.
+
+---
+
+## 10. Open questions
+
+| Item | Status |
+|---|---|
+| Lease TTL and sweep | A runner that dies while `RUNNING` never reports done, and its resources leak until the next `resume_all`. Deferred, not solved. A TTL plus a periodic sweep is the known fix. |
+| Handoff payload storage | §8.2. The interface is left open. |
+| Fairness across submitters | Naive FIFO lets one submitter monopolise a pool. A future `SchedulePolicy` keyed by submitter is the reference solution. |
+| Better ordering than FIFO | The composite rule from the prior art (priority tier → estimated cost → most-total-successors → FIFO) is a drop-in `SchedulePolicy`. Not built first. |
+| Cycle detection | A task whose inputs transitively depend on its own outputs will never run. Now cheaper than before: `depends_on` (§3.2) is the edge list, so this is a DFS over it at submit rather than a join across every task's `outputs`. Still not in the first version. |
+| **Re-run window** | A new version is opened by the producing agent when it starts writing (§3.1), so between `resume_task(t)` and that moment, `latest` is still the previous version. A downstream task dispatched in that window runs against stale-but-valid content. Accepted as the price of the scheduler never touching handoff state. Mitigations if it bites: have the runner open versions at `start`, or have `resume` mark outputs pending. Neither is built. |
+| Cross-manager atomicity | Four managers now persist independently (§7), so a crash between any two writes leaves them briefly inconsistent. Recovery fails safe in the handoff direction — a consumer stays blocked — and in the consumable direction the worst case is a settlement lost, which under-charges by one task. A shared transaction, or a single append-only log every manager writes to, is the known fix. Not built. |
+| Version retention | Nothing says when an old version's content may be discarded (§8.2). Unbounded re-runs mean unbounded payloads. |
+| Re-check cost | Eligibility is recomputed for every waiting task at every decision point (§6.2, step 1). Fine at this scale; a reverse handoff→consumer index is the known optimisation. |
+| Agent retirement | Agent records now persist (§7) and one is created per run, so the store grows with every attempt ever made and `retire` is the only thing that shrinks it. Nothing calls it. A retention rule — or archiving agents whose task is final — is the answer; not built. |
+| Consumable top-up | A persisted balance is never replenished. A token budget that is meant to reset monthly has no way to say so, and raising `capacity` does not raise `available`. An explicit `refill(amount)` is the obvious API; deliberately not invented before there is a caller. |
+
+---
+
+## 11. Acceptance criteria
+
+The implementation is complete when each of the following is demonstrated by a
+test:
+
+1. A task whose inputs all report `check_if_latest_valid` lands in
+   `WAITING_RESOURCE` at submit.
+2. A task with an unfilled input lands in `WAITING_HANDOFF` and is dispatched
+   exactly when a later decision point finds its last input valid.
+3. A task requiring more of any pool than is available starts nothing and
+   **consumes nothing** — verified by asserting every pool is unchanged.
+4. A renewable pool returns to its prior level after completion; a consumable
+   pool is debited by the settled actual, not the reservation.
+5. `stop` → `on_stopped` → `resume_task` returns a task to the correct pool,
+   recomputed from its inputs.
+6. `resume_task` on a `SUCCEEDED` or `CANCELLED` task is rejected.
+7. A failed task releases its resources and leaves its dependents in
+   `WAITING_HANDOFF`; an output whose version the agent left `GENERATING` does not
+   satisfy `check_if_latest_valid`.
+8. `resume_all` reconstructs pools from persisted tasks and versions from
+   persisted handoffs, with `RUNNING` and `STOPPING` tasks demoted to
+   `WAITING_RESOURCE` and `SUSPENDED` respectively.
+9. `expedite` places a task ahead of earlier-submitted eligible tasks, and is
+   rejected when any input is not valid.
+10. Swapping `SchedulePolicy` changes dispatch order and nothing else.
+11. `update_task` on a queued task replaces its inputs/outputs/resources under the
+    same id and recomputes its pool; on a `RUNNING` task it is rejected.
+12. A pool never disagrees with `TaskMgr`: after any sequence of operations, the
+    union of the pools equals the set of all tasks, and each task appears in
+    exactly the pool matching its stored status.
+13. A run reporting `SUCCEEDED` whose agent sealed its output `INVALID` leaves its
+    consumers in `WAITING_HANDOFF` — completion and validity are independent
+    (§6.3). The scheduler records `output_versions` by reading `HandoffMgr`, not
+    from anything the runner passed.
+14. **The scheduler never writes handoff state.** Across a full submit → dispatch →
+    complete → resume → re-dispatch cycle, a `HandoffMgr` spy records `persist`
+    originating only from the agent, and calls from the scheduler only to
+    `declare`, `check_if_latest_valid`, and `latest`. No `open_next` or `seal` is
+    called from a scheduler frame.
+15. Two isolated `Registry()` instances do not share components, and `get()` on an
+    unregistered name raises with that name in the message.
+16. Re-running a producer appends a version and leaves earlier ones byte-identical;
+    a consumer that already ran retains `input_versions` pointing at the version it
+    actually consumed.
+17. A consumer dispatched after a producer's re-run reads the new version, with no
+    invalidation call made anywhere in the system.
+18. Execution history grows by exactly one entry per run, each carrying the bound
+    `agent_id` and the pinned input/output versions.
+19. A handoff sealed `INVALID` before a restart is still `INVALID` after
+    `resume_all`, and one left `GENERATING` is still `GENERATING` — neither is
+    re-derived from the producing run's terminal status (§6.4).
+20. Resuming a task whose previous run left a `GENERATING` version appends a new
+    version rather than reusing the abandoned one.
+21. The bound agent is readable only from `history[-1]`: `Task` exposes no
+    `agent_id`, and after a `resume_task` the top reports the new run's agent
+    while the entry beneath still reports the previous one.
+22. **A run is reconstructible from either end.** From the task:
+    `history[-1].agent_id` resolves through `AgentMgr`, and its `input_versions`
+    keys resolve through `HandoffMgr`. From the handoff: a version's
+    `producer_task_id` and `producer_agent_id` both resolve, and that agent's own
+    `task_id` and `handoffs` name the same pair back (§3.1).
+23. `update_task` produces the same observable state as `remove_queued` followed
+    by `submit` with the new arguments — verified by comparing against that
+    sequence, not by re-asserting the outcome (§2, principle 7).
+24. `resume_all` calls `resume_system()` on every `Resumable` in the declared order and
+    skips components that do not implement it, with the scheduler last.
+25. Resuming the scheduler against a `HandoffMgr` that has not resumed yet leaves
+    every waiting task blocked — the failure the order exists to prevent, asserted
+    directly so the ordering constraint is tested rather than assumed.
+26. A `HandoffVersion` refuses an illegal transition: `seal` on a `CREATED` one
+    and a second `seal` each raise. The state machine is enforced by the object,
+    not by whoever calls it.
+27. `TaskId`, `AgentId`, and `HandoffId` are mutually incompatible: passing one
+    where another is expected is a type error the checker reports, and equality
+    across two types with the same underlying UUID is `False`.
+28. `AgentMgr` retains what it instantiates: after a run, `get(execution.agent_id)`
+    returns that agent with its `task_id` and `handoffs` populated, and `by_spec`
+    lists every instance made under a spec name.
+29. A store rejects `create` on an existing key and `update` on a missing one, and
+    a round-trip through `read` returns a record equal to the one written.
+30. `Handoff.open_next` adopts an untouched `CREATED` v0 in place — the list stays
+    length 1 — and appends `v+1` on every later call, so version numbers are
+    contiguous without anyone checking.
+31. `Task.depends_on` supports a topological sort of the submitted graph, and no
+    scheduling path reads it: blanking it on every task changes no dispatch order
+    and no pool membership.
+32. **A consumable balance survives a restart; a renewable pool does not carry a
+    lease across one.** Spend 300 of a 1000 token budget, settle, `resume_all`,
+    and 700 remain. Hold 4 GPUs at the moment of restart and all 8 are free
+    afterwards (§3.4).
+33. A reservation that was never settled is *not* charged: `take` then
+    `resume_all` with no `give_back` leaves the balance where it was before the
+    `take`.
+34. `resume_all` restores agents, so every `agent_id` in a restored execution
+    history and every `producer_agent_id` on a restored handoff version resolves
+    through `AgentMgr` — criterion 22 holds across a restart, not only within one
+    process.
+35. `submit` warns when `depends_on` omits the producer of one of the task's
+    `inputs`, and submits the task anyway; it does not warn when `depends_on`
+    names a task the inputs do not point at (§3.2).

--- a/agent_sys/task_graph/handoff.py
+++ b/agent_sys/task_graph/handoff.py
@@ -1,0 +1,95 @@
+"""The handoff collection.
+
+The mgr decides nothing. Version bookkeeping belongs to `Handoff` and the
+transition belongs to `HandoffVersion`; what is left here is add / get / query
+and durability.
+"""
+
+from collections.abc import Iterable
+
+from task_graph.ids import HandoffId, TaskId
+from task_graph.models import Handoff, HandoffVersion
+from task_graph.registry import Registry
+
+__all__ = ["HandoffMgr"]
+
+KIND = "handoff"
+
+
+class HandoffMgr:
+    def __init__(self, registry: Registry) -> None:
+        self._r = registry
+        self._handoffs: dict[HandoffId, Handoff] = {}
+
+    # ---- scheduler-facing: read only ----
+
+    def declare(
+        self,
+        ids: Iterable[HandoffId],
+        producer_task_id: TaskId,
+        types: dict[HandoffId, str] | None = None,
+    ) -> None:
+        """Create each handoff with a single CREATED v0.
+
+        Idempotent: an id already present is skipped, never overwritten.
+        `update_task` re-declares, and overwriting would delete versions an
+        agent had already written.
+        """
+        types = types or {}
+        for hid in ids:
+            if hid in self._handoffs:
+                continue
+            self._handoffs[hid] = Handoff(
+                id=hid,
+                type=types.get(hid, ""),
+                versions=[HandoffVersion(version=0, producer_task_id=producer_task_id)],
+            )
+            self._store.create(KIND, str(hid), self._handoffs[hid].model_dump(mode="json"))
+
+    def check_if_latest_valid(self, hid: HandoffId) -> bool:
+        """False for an unknown id rather than an error.
+
+        A consumer may be submitted before its producer declares the slot;
+        "not ready" is the right answer and keeps submission order free.
+        """
+        handoff = self._handoffs.get(hid)
+        return handoff is not None and handoff.is_latest_valid
+
+    def latest(self, hid: HandoffId) -> HandoffVersion | None:
+        handoff = self._handoffs.get(hid)
+        return handoff.latest if handoff is not None else None
+
+    def get(self, hid: HandoffId) -> Handoff:
+        try:
+            return self._handoffs[hid]
+        except KeyError:
+            raise KeyError(f"no handoff {hid}") from None
+
+    def get_many(self, ids: Iterable[HandoffId]) -> list[Handoff]:
+        return [self.get(hid) for hid in ids]
+
+    def all_ids(self) -> list[HandoffId]:
+        return list(self._handoffs)
+
+    def produced_by_task(self, tid: TaskId) -> list[HandoffId]:
+        return [h.id for h in self._handoffs.values() if h.latest.producer_task_id == tid]
+
+    # ---- agent-facing: write ----
+
+    def persist(self, hid: HandoffId) -> None:
+        """Write the handoff back after `open_next()` or `seal()` mutated it.
+
+        One write verb: every change is "this handoff changed, store it".
+        """
+        self._store.update(KIND, str(hid), self.get(hid).model_dump(mode="json"))
+
+    def resume_system(self) -> None:
+        """Reload from the store. No regrouping: one record per handoff."""
+        self._handoffs = {
+            handoff.id: handoff
+            for handoff in (Handoff.model_validate(r) for r in self._store.read_all(KIND))
+        }
+
+    @property
+    def _store(self):
+        return self._r.get("store_mgr")

--- a/agent_sys/task_graph/ids.py
+++ b/agent_sys/task_graph/ids.py
@@ -1,0 +1,73 @@
+"""Typed identities.
+
+A ``TaskId`` and a ``HandoffId`` built from the same bytes are different values.
+``typing.NewType`` would give that statically and erase at runtime, so the two
+would still compare equal and collide in one dict; subclassing ``uuid.UUID``
+gives both, and generation, parsing and formatting come from the stdlib.
+"""
+
+import uuid
+from typing import Any, TypeVar
+
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import core_schema
+
+__all__ = ["TaskId", "AgentId", "HandoffId"]
+
+# `typing.Self` is 3.11; the repository targets 3.10.
+_S = TypeVar("_S", bound="_Id")
+
+
+class _Id(uuid.UUID):
+    """A UUID that is not interchangeable with a UUID of another kind."""
+
+    __slots__ = ()
+
+    @classmethod
+    def new(cls: type[_S]) -> _S:
+        return cls(uuid.uuid4().hex)
+
+    def __eq__(self, other: object) -> bool:
+        return type(other) is type(self) and self.int == other.int
+
+    def __hash__(self) -> int:
+        # Overriding __eq__ alone sets __hash__ to None. The kind is part of the
+        # hash so two kinds sharing bytes land in different buckets.
+        return hash((type(self).__name__, self.int))
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self})"
+
+    @classmethod
+    def _coerce(cls: type[_S], value: Any) -> _S:
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, uuid.UUID):
+            return cls(value.hex)
+        return cls(str(value))  # UUID.__init__ rejects a malformed one
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source: Any, handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        # Required, not optional: pydantic raises PydanticSchemaGenerationError
+        # on a UUID subclass it has no schema for. `when_used="json"` keeps
+        # model_dump() returning real id objects while mode="json" gives strings.
+        return core_schema.no_info_plain_validator_function(
+            cls._coerce,
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                str, return_schema=core_schema.str_schema(), when_used="json"
+            ),
+        )
+
+
+class TaskId(_Id):
+    __slots__ = ()
+
+
+class AgentId(_Id):
+    __slots__ = ()
+
+
+class HandoffId(_Id):
+    __slots__ = ()

--- a/agent_sys/task_graph/models.py
+++ b/agent_sys/task_graph/models.py
@@ -1,0 +1,235 @@
+"""Domain models.
+
+Every model owns its own state machine and touches no other component. What it
+does *not* own is its collection — that is the manager's.
+"""
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from task_graph.ids import AgentId, HandoffId, TaskId
+
+__all__ = [
+    "Model",
+    "TaskStatus",
+    "HandoffStatus",
+    "WAITING",
+    "RESUMABLE",
+    "HandoffStateError",
+    "TaskStateError",
+    "HandoffVersion",
+    "Handoff",
+    "Execution",
+    "Task",
+    "HandoffRef",
+    "Agent",
+]
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class Model(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",  # a typo'd field is an error, not a silent drop
+        validate_assignment=True,  # task.status = X is validated
+        use_enum_values=False,  # keep enum members; compare with `is`
+    )
+
+
+class TaskStatus(str, Enum):
+    WAITING_HANDOFF = "waiting_handoff"
+    WAITING_RESOURCE = "waiting_resource"
+    RUNNING = "running"
+    STOPPING = "stopping"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    SUSPENDED = "suspended"
+    CANCELLED = "cancelled"
+
+
+WAITING = frozenset({TaskStatus.WAITING_HANDOFF, TaskStatus.WAITING_RESOURCE})
+RESUMABLE = frozenset({TaskStatus.FAILED, TaskStatus.SUSPENDED})
+
+
+class HandoffStatus(str, Enum):
+    CREATED = "created"  # declared; nothing written yet
+    GENERATING = "generating"  # an agent has it open
+    VALID = "valid"  # sealed, usable
+    INVALID = "invalid"  # sealed, not usable
+
+
+_VERDICTS = frozenset({HandoffStatus.VALID, HandoffStatus.INVALID})
+
+
+class HandoffStateError(RuntimeError):
+    """An illegal handoff transition."""
+
+
+class TaskStateError(RuntimeError):
+    """An illegal task transition."""
+
+
+# ------------------------------------------------------------------ handoff
+
+
+class HandoffVersion(Model):
+    """One attempt at filling a slot. Immutable once sealed."""
+
+    version: int
+    status: HandoffStatus = HandoffStatus.CREATED
+    producer_task_id: TaskId | None = None
+    producer_agent_id: AgentId | None = None  # None until opened
+    timestamp: datetime = Field(default_factory=_now)
+    content: Any = None
+
+    @property
+    def is_valid(self) -> bool:
+        return self.status is HandoffStatus.VALID
+
+    def seal(self, status: HandoffStatus, content: Any = None) -> None:
+        """GENERATING -> VALID | INVALID."""
+        if self.status is not HandoffStatus.GENERATING:
+            raise HandoffStateError(
+                f"v{self.version} is {self.status.value}; only a GENERATING version can be sealed"
+            )
+        if status not in _VERDICTS:
+            raise HandoffStateError(f"{status.value} is not a verdict; use VALID or INVALID")
+        self.status = status
+        self.content = content
+        self.timestamp = _now()
+
+
+class Handoff(Model):
+    """The slot. `versions` is append-only and the list index is the version."""
+
+    id: HandoffId
+    type: str = ""
+    versions: list[HandoffVersion] = Field(min_length=1)
+
+    @property
+    def latest(self) -> HandoffVersion:
+        return self.versions[-1]
+
+    @property
+    def is_latest_valid(self) -> bool:
+        return self.latest.is_valid
+
+    def get(self, version: int) -> HandoffVersion:
+        if not 0 <= version < len(self.versions):
+            raise IndexError(f"{self.id} has no version {version}")
+        return self.versions[version]
+
+    def open_next(self, task_id: TaskId, agent_id: AgentId) -> HandoffVersion:
+        """Hand an agent a version to write, GENERATING, and return it.
+
+        Adopts `latest` in place if it is still CREATED; otherwise appends v+1.
+        Raises if `latest` is GENERATING — someone else has it open.
+        """
+        latest = self.latest
+        if latest.status is HandoffStatus.GENERATING:
+            raise HandoffStateError(
+                f"{self.id} v{latest.version} is already open by task {latest.producer_task_id}"
+            )
+        if latest.status is HandoffStatus.CREATED:
+            version = latest
+        else:
+            version = HandoffVersion(version=len(self.versions))
+            self.versions.append(version)
+        version.producer_task_id = task_id
+        version.producer_agent_id = agent_id
+        version.timestamp = _now()
+        version.status = HandoffStatus.GENERATING
+        return version
+
+
+# --------------------------------------------------------------------- task
+
+
+class Execution(Model):
+    """One attempt at running a task. The stack top is the live binding."""
+
+    attempt: int
+    agent_id: AgentId
+    input_versions: dict[HandoffId, int] = Field(default_factory=dict)
+    output_versions: dict[HandoffId, int] = Field(default_factory=dict)
+    started_at: datetime = Field(default_factory=_now)
+    ended_at: datetime | None = None
+    outcome: TaskStatus | None = None
+    detail: str = ""  # from the runner; for a human
+
+    @property
+    def is_open(self) -> bool:
+        return self.ended_at is None
+
+
+class Task(Model):
+    id: TaskId = Field(default_factory=TaskId.new)
+    agent_spec: str  # a SPEC NAME, not an agent
+    inputs: list[HandoffId] = Field(default_factory=list)
+    outputs: list[HandoffId] = Field(default_factory=list)
+    depends_on: list[TaskId] = Field(default_factory=list)  # the graph edge
+    resources: dict[str, float] = Field(default_factory=dict)  # pool NAME -> amount
+    status: TaskStatus = TaskStatus.WAITING_HANDOFF
+    created_at: datetime = Field(default_factory=_now)
+    expedited: bool = False
+    history: list[Execution] = Field(default_factory=list)
+
+    @property
+    def current(self) -> Execution | None:
+        return self.history[-1] if self.history else None
+
+    @property
+    def is_running(self) -> bool:
+        current = self.current
+        return current is not None and current.is_open
+
+    def push_execution(
+        self, agent_id: AgentId, input_versions: dict[HandoffId, int] | None = None
+    ) -> Execution:
+        """Bind an agent by appending an open record, attempt = len(history)."""
+        if self.is_running:
+            raise TaskStateError(f"{self.id} already has an attempt open")
+        execution = Execution(
+            attempt=len(self.history),
+            agent_id=agent_id,
+            input_versions=dict(input_versions or {}),
+        )
+        self.history.append(execution)
+        return execution
+
+    def close_execution(
+        self,
+        output_versions: dict[HandoffId, int] | None,
+        outcome: TaskStatus,
+        detail: str = "",
+    ) -> None:
+        """Seal the stack top."""
+        if not self.is_running:
+            raise TaskStateError(f"{self.id} has no open attempt to close")
+        top = self.history[-1]
+        top.output_versions = dict(output_versions or {})
+        top.outcome = outcome
+        top.detail = detail
+        top.ended_at = _now()
+
+
+# -------------------------------------------------------------------- agent
+
+
+class HandoffRef(Model):
+    handoff_id: HandoffId
+    version: int
+
+
+class Agent(Model):
+    id: AgentId = Field(default_factory=AgentId.new)
+    spec: str  # which kind
+    task_id: TaskId | None = None  # what it is bound to
+    handoffs: list[HandoffRef] = Field(default_factory=list)  # what it touched
+    knowledge: Any = None  # left empty by the task definition
+    config: dict[str, Any] = Field(default_factory=dict)

--- a/agent_sys/task_graph/policy.py
+++ b/agent_sys/task_graph/policy.py
@@ -1,0 +1,26 @@
+"""Ordering the eligible set — the one scheduling decision in the system.
+
+No graph algorithm is required: the only graph operation anywhere is asking
+whether a task's inputs are valid, and that is a query on the handoff.
+"""
+
+from typing import Protocol
+
+from task_graph.ids import TaskId
+from task_graph.models import Task
+
+__all__ = ["SchedulePolicy", "FifoPolicy"]
+
+
+class SchedulePolicy(Protocol):
+    def select(self, eligible: list[Task], snapshot: dict[str, float]) -> list[TaskId]: ...
+
+
+class FifoPolicy:
+    """Expedited first, then submission order."""
+
+    def select(self, eligible: list[Task], snapshot: dict[str, float]) -> list[TaskId]:
+        # `not t.expedited` sorts False (expedited) before True. `snapshot` is
+        # unused here; it is in the signature because a cost- or fit-aware
+        # policy needs it and changing it later would break every implementation.
+        return [t.id for t in sorted(eligible, key=lambda t: (not t.expedited, t.created_at))]

--- a/agent_sys/task_graph/registry.py
+++ b/agent_sys/task_graph/registry.py
@@ -1,0 +1,65 @@
+"""Component registry and the recovery protocol.
+
+Components are registered by name and resolved at use time, never injected
+through a constructor. That is what lets a test swap an implementation after
+the system is wired, and it is what keeps the import graph acyclic: no manager
+imports another manager.
+"""
+
+from typing import Any, Protocol, runtime_checkable
+
+__all__ = ["Registry", "Resumable", "RESUME_ORDER", "resume_all"]
+
+
+class Registry:
+    def __init__(self) -> None:
+        self._items: dict[str, Any] = {}
+
+    def register(self, name: str, component: Any) -> None:
+        """Register, replacing any existing entry.
+
+        Replacement is deliberate: it is the swap mechanism. The protection
+        against a typo is `get`'s loud failure, not a registration guard.
+        """
+        self._items[name] = component
+
+    def get(self, name: str) -> Any:
+        try:
+            return self._items[name]
+        except KeyError:
+            raise KeyError(f"no component registered as {name!r}") from None
+
+    def resolve(self, pattern: str) -> list[Any]:
+        """`"resource:*"` -> the whole group, in registration order.
+
+        Honours a `prefix:*` suffix and nothing else — no globbing, no regex.
+        """
+        if pattern.endswith(":*"):
+            prefix = pattern[:-1]  # "resource:*" -> "resource:"
+            return [c for n, c in self._items.items() if n.startswith(prefix)]
+        return [self.get(pattern)]
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._items
+
+
+@runtime_checkable
+class Resumable(Protocol):
+    def resume_system(self) -> None: ...
+
+
+# Only "scheduler last" is load-bearing: it recomputes eligibility and needs
+# every handoff already reloaded.
+RESUME_ORDER = ["handoff_mgr", "agent_mgr", "task_mgr", "resource:*", "scheduler"]
+
+
+def resume_all(registry: Registry) -> None:
+    for pattern in RESUME_ORDER:
+        if not pattern.endswith(":*") and pattern not in registry:
+            continue
+        for component in registry.resolve(pattern):
+            # `isinstance` against a runtime-checkable Protocol matches on
+            # method *name* alone. That is why the scheduler's per-task resume
+            # is `resume_task` — otherwise it would satisfy this by accident.
+            if isinstance(component, Resumable):
+                component.resume_system()

--- a/agent_sys/task_graph/resource.py
+++ b/agent_sys/task_graph/resource.py
@@ -1,0 +1,138 @@
+"""Resource pools.
+
+The one place inheritance appears. Renewable and consumable differ in *three*
+behaviours — release, persistence, recovery — so a boolean flag would mean three
+conditionals kept in agreement by hand.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+
+from task_graph.registry import Registry
+
+__all__ = ["ResourceMgr", "RenewableMgr", "ConsumableMgr", "GpuMgr", "TokenMgr"]
+
+KIND = "resource"
+
+log = logging.getLogger(__name__)
+
+
+class ResourceMgr(ABC):
+    """A quantity, not a collection — the acknowledged exception to §6's rule.
+
+    The name is kept because the task definition uses it.
+    """
+
+    def __init__(self, registry: Registry, name: str, capacity: float) -> None:
+        self._r = registry
+        self.name = name
+        self.capacity = float(capacity)
+        self.available = float(capacity)
+
+    def can_afford(self, amount: float) -> bool:
+        # A negative amount is not "affordable": answering True would let a
+        # caller past its own guard and into `take`, which then raises after
+        # earlier pools in the same acquisition were already taken.
+        return 0 <= amount <= self.available
+
+    def take(self, amount: float) -> None:
+        """Reserve. Raises if it does not fit — the caller must check first."""
+        self._check(amount)
+        if not self.can_afford(amount):
+            raise ValueError(f"{self.name}: cannot take {amount}, only {self.available} available")
+        self.available -= amount
+
+    @abstractmethod
+    def give_back(self, amount: float, actual: float | None = None) -> None:
+        """Release a reservation of `amount`, of which `actual` was consumed."""
+
+    @abstractmethod
+    def resume_system(self) -> None:
+        """The two classes genuinely differ here."""
+
+    @staticmethod
+    def _check(amount: float) -> None:
+        if amount < 0:
+            raise ValueError(f"amount must not be negative, got {amount}")
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self.name}: {self.available}/{self.capacity})"
+
+
+class RenewableMgr(ResourceMgr):
+    """A GPU: held, then handed back whole."""
+
+    def give_back(self, amount: float, actual: float | None = None) -> None:
+        """Return the full amount. `actual` is meaningless for a renewable."""
+        self._check(amount)
+        self.available = min(self.capacity, self.available + amount)
+
+    def resume_system(self) -> None:
+        """No lease survives a restart, so nothing is held.
+
+        Persists nothing: there is nothing to remember.
+        """
+        self.available = self.capacity
+
+
+class ConsumableMgr(ResourceMgr):
+    """A token budget: reserved, then settled at what was actually spent.
+
+    Two quantities, and the distinction is the whole design. ``available`` is
+    live and includes every outstanding *reservation*; ``spent`` is the running
+    total of what was actually consumed. Only ``spent`` is durable — a
+    reservation is a lease that dies with its process, so persisting
+    ``available`` would bake every in-flight lease into the record and charge
+    for it again on the next run.
+    """
+
+    def __init__(self, registry: Registry, name: str, capacity: float) -> None:
+        super().__init__(registry, name, capacity)
+        self.spent = 0.0
+
+    def give_back(self, amount: float, actual: float | None = None) -> None:
+        self._check(amount)
+        spent = amount if actual is None else min(max(actual, 0.0), amount)
+        self.available = min(self.capacity, self.available + (amount - spent))
+        self.spent = min(self.capacity, self.spent + spent)
+        # Only here, never in `take`: a settlement is spend and must not be
+        # un-spent, while a reservation must never become durable.
+        self._persist()
+
+    def resume_system(self) -> None:
+        record = self._r.get("store_mgr").read(KIND, self.name)
+        self.spent = float(record["spent"]) if record is not None else 0.0
+        # Nothing is reserved after a restart, so available is exactly what has
+        # not been spent — but an operator may have *lowered* capacity below
+        # what is already spent. Unclamped that makes `available` negative, and
+        # `can_afford` then refuses even a request for zero: every task naming
+        # this pool queues forever with no diagnostic. Sibling of O7.
+        if self.spent > self.capacity:
+            log.warning(
+                "%s: %s already spent exceeds the capacity of %s; the budget is exhausted",
+                self.name,
+                self.spent,
+                self.capacity,
+            )
+        self.available = max(0.0, self.capacity - self.spent)
+
+    def _persist(self) -> None:
+        store = self._r.get("store_mgr")
+        # `spent` is the record. `available` is written for a human reading the
+        # file with `cat` and is NOT read back — at this instant it still nets
+        # out every in-flight reservation.
+        record = {"name": self.name, "spent": self.spent, "available": self.available}
+        if store.exists(KIND, self.name):
+            store.update(KIND, self.name, record)
+        else:
+            store.create(KIND, self.name, record)
+
+
+class GpuMgr(RenewableMgr):
+    def __init__(self, registry: Registry, capacity: float, name: str = "gpu") -> None:
+        super().__init__(registry, name, capacity)
+
+
+class TokenMgr(ConsumableMgr):
+    def __init__(self, registry: Registry, capacity: float, name: str = "token") -> None:
+        super().__init__(registry, name, capacity)

--- a/agent_sys/task_graph/runner.py
+++ b/agent_sys/task_graph/runner.py
@@ -1,0 +1,82 @@
+"""The runner seam.
+
+What actually executes an agent is harness-specific and out of scope. What this
+system owes is the interface, and a fake that lets the whole scheduler be tested
+without one.
+"""
+
+from collections.abc import Callable
+from typing import Any, Protocol
+
+from task_graph.ids import TaskId
+from task_graph.models import Agent, HandoffRef, HandoffStatus, Task, TaskStatus
+from task_graph.registry import Registry
+
+__all__ = ["OnDone", "OnStopped", "TaskRunner", "FakeRunner"]
+
+OnDone = Callable[[TaskId, TaskStatus, dict[str, float]], None]
+OnStopped = Callable[[TaskId], None]
+
+
+class TaskRunner(Protocol):
+    def start(self, task: Task, agent: Agent, on_done: OnDone) -> None: ...
+
+    def stop(self, task_id: TaskId, on_stopped: OnStopped) -> None: ...
+
+
+class FakeRunner:
+    """Records what was started. The test drives completion explicitly.
+
+    Never calls `on_done` from inside `start`, which keeps tests deterministic.
+    Re-entrancy is still handled by the scheduler, because a real synchronous
+    runner is a reasonable implementation.
+    """
+
+    def __init__(self) -> None:
+        self.running: dict[TaskId, tuple[Task, Agent, OnDone]] = {}
+        self.started: list[TaskId] = []
+        self.stop_requested: list[TaskId] = []
+        self._acks: dict[TaskId, OnStopped] = {}
+
+    def start(self, task: Task, agent: Agent, on_done: OnDone) -> None:
+        self.running[task.id] = (task, agent, on_done)
+        self.started.append(task.id)
+
+    def stop(self, task_id: TaskId, on_stopped: OnStopped) -> None:
+        self.stop_requested.append(task_id)
+        self._acks[task_id] = on_stopped
+
+    # ---- test-driven, standing in for the agent ----
+
+    def produce(
+        self, registry: Registry, task_id: TaskId, *, valid: bool = True, content: Any = None
+    ) -> None:
+        """What a real agent does to its outputs: take a version and seal it.
+
+        The only thing in the test suite that writes handoff state. That is what
+        makes the authority test meaningful.
+        """
+        handoff_mgr = registry.get("handoff_mgr")
+        task = registry.get("task_mgr").get(task_id)
+        agent = registry.get("agent_mgr").get(task.current.agent_id)
+        verdict = HandoffStatus.VALID if valid else HandoffStatus.INVALID
+
+        for hid in task.outputs:
+            version = handoff_mgr.get(hid).open_next(task_id, agent.id)
+            version.seal(verdict, content)
+            handoff_mgr.persist(hid)
+            agent.handoffs.append(HandoffRef(handoff_id=hid, version=version.version))
+        registry.get("agent_mgr").persist(agent.id)
+
+    def finish(
+        self,
+        task_id: TaskId,
+        status: TaskStatus = TaskStatus.SUCCEEDED,
+        usage: dict[str, float] | None = None,
+    ) -> None:
+        _, _, on_done = self.running.pop(task_id)
+        on_done(task_id, status, usage or {})
+
+    def ack_stop(self, task_id: TaskId) -> None:
+        self.running.pop(task_id, None)
+        self._acks.pop(task_id)(task_id)

--- a/agent_sys/task_graph/scheduler.py
+++ b/agent_sys/task_graph/scheduler.py
@@ -1,0 +1,367 @@
+"""The scheduler.
+
+Decides *when* a task runs and nothing else: it never inspects what a task does
+and never writes handoff state. Eligibility is a query re-asked at each decision
+point, not a counter maintained across events.
+"""
+
+import logging
+import threading
+from math import isfinite
+
+from task_graph.ids import TaskId
+from task_graph.models import RESUMABLE, WAITING, Task, TaskStatus
+from task_graph.registry import Registry
+
+__all__ = ["Scheduler"]
+
+log = logging.getLogger(__name__)
+
+
+class Scheduler:
+    def __init__(self, registry: Registry) -> None:
+        self._r = registry
+        # One bucket per status, so a task is in exactly one pool. Only three
+        # are load-bearing; the rest make "which tasks are suspended" a lookup.
+        self.pools: dict[TaskStatus, set[TaskId]] = {s: set() for s in TaskStatus}
+        self._lock = threading.RLock()
+        self._in_dispatch = False
+        self._dispatch_again = False
+
+    # ------------------------------------------------------------------ API
+
+    def submit(self, task: Task) -> None:
+        """Accept a task, declare its outputs, and try to place it."""
+        agent_mgr, task_mgr = self._r.get("agent_mgr"), self._r.get("task_mgr")
+        with self._lock:
+            if not agent_mgr.is_registered(task.agent_spec):
+                raise KeyError(
+                    f"unknown agent spec {task.agent_spec!r}; registered: "
+                    f"{sorted(agent_mgr.specs())}"
+                )
+            for name, amount in task.resources.items():
+                if f"resource:{name}" not in self._r:
+                    raise ValueError(f"task {task.id}: no resource pool named {name!r}")
+                # A negative or non-finite amount passes `can_afford` and then
+                # raises inside `take` — after earlier pools in the same
+                # acquisition have already been taken, which is exactly the
+                # partial reservation all-or-nothing exists to prevent.
+                if not isfinite(amount) or amount < 0:
+                    raise ValueError(
+                        f"task {task.id}: {name!r} amount must be a non-negative "
+                        f"finite number, got {amount}"
+                    )
+
+            task_mgr.add(task)
+            self._r.get("handoff_mgr").declare(task.outputs, producer_task_id=task.id)
+            self._warn_depends_on(task)
+            self._move(task.id, self._landing(task))
+            self.try_dispatch()
+
+    def expedite(self, task: Task) -> None:
+        """Submit a handoff-complete closure straight to the front of the queue."""
+        handoff_mgr = self._r.get("handoff_mgr")
+        with self._lock:
+            unmet = [h for h in task.inputs if not handoff_mgr.check_if_latest_valid(h)]
+            if unmet:
+                raise ValueError(
+                    f"cannot expedite {task.id}: inputs not valid: {[str(h) for h in unmet]}"
+                )
+            # Set the flag only once submit has accepted: otherwise a rejection
+            # for some *other* reason — a duplicate id, an unknown spec — still
+            # leaves the caller's object mutated.
+            was = task.expedited
+            task.expedited = True
+            try:
+                self.submit(task)
+            except Exception:
+                task.expedited = was
+                raise
+
+    def remove_queued(self, tid: TaskId) -> None:
+        with self._lock:
+            self._require(tid, WAITING, "remove")
+            self._move(tid, TaskStatus.CANCELLED)
+
+    def stop(self, tid: TaskId) -> None:
+        """Ask the runner to stop. The task is SUSPENDED when it acknowledges."""
+        with self._lock:
+            self._require(tid, {TaskStatus.RUNNING}, "stop")
+            self._move(tid, TaskStatus.STOPPING)
+            self._r.get("runner").stop(tid, self.on_stopped)
+
+    def resume_task(self, tid: TaskId) -> None:
+        """Requeue a stopped or failed task. A new attempt is pushed on top.
+
+        Not named `resume`: `Resumable` is a runtime-checkable Protocol matching
+        on method name alone, and `resume_all` would then call this with no
+        argument.
+        """
+        with self._lock:
+            self._require(tid, RESUMABLE, "resume")
+            task = self._r.get("task_mgr").get(tid)
+            self._move(tid, self._landing(task))
+            self.try_dispatch()
+
+    def update_task(self, tid: TaskId, **fields) -> Task:
+        """Replace a queued task's definition, keeping its id and its place.
+
+        Literally cancel-then-submit, so "an update behaves exactly like a
+        resubmission" holds by construction rather than by assertion.
+        """
+        with self._lock:
+            # `model_copy(update=...)` writes straight to __dict__: it honours
+            # neither `extra="forbid"` nor `validate_assignment`. Unchecked, a
+            # misspelled field would be accepted and silently do nothing, and
+            # `id=` would leave the original cancelled and create a second task.
+            unknown = set(fields) - set(Task.model_fields)
+            if unknown:
+                raise ValueError(f"unknown task field(s): {sorted(unknown)}")
+            managed = set(fields) & {"id", "status", "history", "created_at"}
+            if managed:
+                raise ValueError(f"{sorted(managed)} cannot be set by an update")
+
+            old = self._r.get("task_mgr").get(tid).model_copy(deep=True)
+            self.remove_queued(tid)
+            # model_copy preserves created_at: an update does not cost a task
+            # its place in FIFO order.
+            replacement = old.model_copy(
+                update={**fields, "status": TaskStatus.WAITING_HANDOFF, "history": []},
+                deep=True,
+            )
+            try:
+                self.submit(replacement)
+            except Exception:
+                # The cancel already happened. Without this the task is simply
+                # gone — a rejected update would silently destroy the thing it
+                # was asked to change.
+                old.status = TaskStatus.WAITING_HANDOFF
+                self.submit(old)
+                raise
+            return replacement
+
+    # --------------------------------------------------------- runner callbacks
+
+    def on_task_done(self, tid: TaskId, status: TaskStatus, usage: dict[str, float]) -> None:
+        """The runner finished. Release, record what was written, move on."""
+        with self._lock:
+            self._require(tid, {TaskStatus.RUNNING}, "complete")
+            task = self._r.get("task_mgr").get(tid)
+            self._release(task, usage)
+            handoff_mgr = self._r.get("handoff_mgr")
+            # The scheduler reads output versions for itself, exactly as it read
+            # the input versions at dispatch.
+            output_versions = {
+                hid: version.version
+                for hid in task.outputs
+                if (version := handoff_mgr.latest(hid)) is not None
+            }
+            task.close_execution(output_versions, status)
+            self._move(tid, status)
+            self.try_dispatch()
+
+    def on_stopped(self, tid: TaskId) -> None:
+        """The runner acknowledged a stop."""
+        with self._lock:
+            self._require(tid, {TaskStatus.STOPPING}, "acknowledge a stop for")
+            task = self._r.get("task_mgr").get(tid)
+            # No usage figures here, so a consumable settles at the full
+            # reservation — the safe direction for a budget.
+            self._release(task, usage=None)
+            task.close_execution({}, TaskStatus.SUSPENDED, detail="stopped on request")
+            self._move(tid, TaskStatus.SUSPENDED)
+            self.try_dispatch()
+
+    # ------------------------------------------------------------- dispatch
+
+    def try_dispatch(self) -> None:
+        with self._lock:
+            if self._in_dispatch:  # re-entered from a synchronous runner
+                self._dispatch_again = True
+                return
+            self._in_dispatch = True
+            try:
+                while True:
+                    self._dispatch_pass()
+                    if not self._dispatch_again:
+                        return
+                    self._dispatch_again = False
+            finally:
+                self._in_dispatch = False
+
+    def _dispatch_pass(self) -> None:
+        handoff_mgr, task_mgr = self._r.get("handoff_mgr"), self._r.get("task_mgr")
+
+        # 1. re-check eligibility. Snapshot: _move mutates the sets being scanned.
+        for tid in list(
+            self.pools[TaskStatus.WAITING_HANDOFF] | self.pools[TaskStatus.WAITING_RESOURCE]
+        ):
+            self._move(tid, self._landing(task_mgr.get(tid)))
+
+        # 2. order the eligible set — the one scheduling decision in the system
+        eligible = [task_mgr.get(t) for t in self.pools[TaskStatus.WAITING_RESOURCE]]
+        for tid in self._r.get("policy").select(eligible, self._snapshot()):
+            task = task_mgr.get(tid)
+            if task.status is not TaskStatus.WAITING_RESOURCE:
+                continue  # moved since selection — a synchronous runner re-entered
+
+            # An input can have gone stale since step 1: an earlier task in this
+            # same pass may have opened one of them for writing. Pinning a
+            # GENERATING version would record an input whose content does not
+            # exist yet. Re-asked here, before any lease is taken.
+            if not self._ready(task):
+                self._move(tid, TaskStatus.WAITING_HANDOFF)
+                continue
+
+            # 3. all-or-nothing: verify the FULL set before mutating anything.
+            # Resolving the pools is inside the guard, not before it: a pool an
+            # operator removed between restarts raises here, and outside the
+            # guard that KeyError would escape the whole pass — taking every
+            # healthy task's recovery down with it.
+            pools: dict = {}
+            try:
+                pools = {name: self._r.get(f"resource:{name}") for name in task.resources}
+                if not all(pools[n].can_afford(amount) for n, amount in task.resources.items()):
+                    continue  # take nothing; stay queued
+                for name, amount in task.resources.items():
+                    pools[name].take(amount)
+
+                # 4. bind an agent and launch. Everything from here on can fail
+                # — an unknown spec, an agent factory that is down, a runner
+                # whose harness is unreachable — and by then the lease is
+                # already taken. Releasing it is what stops one bad task from
+                # permanently shrinking a pool; not re-raising is what stops it
+                # from aborting the pass for every other queued task.
+                # PUSH a record; the stack top is the binding
+                agent = self._r.get("agent_mgr").instantiate(task.agent_spec, tid)
+                task.push_execution(
+                    agent_id=agent.id,
+                    input_versions={
+                        hid: version.version
+                        for hid in task.inputs
+                        if (version := handoff_mgr.latest(hid)) is not None
+                    },
+                )  # instantiate() bound agent.task_id; the agent fills agent.handoffs
+                self._move(tid, TaskStatus.RUNNING)  # _move persists both
+                self._r.get("runner").start(task, agent, on_done=self.on_task_done)
+            except Exception:
+                self._abort_launch(tid, task, pools)
+
+    # -------------------------------------------------------------- recovery
+
+    def resume_system(self) -> None:
+        """Rebuild the index and demote runs the restart interrupted."""
+        with self._lock:
+            self.pools = {s: set() for s in TaskStatus}
+            for task in self._r.get("task_mgr").all():
+                status = {
+                    TaskStatus.RUNNING: TaskStatus.WAITING_RESOURCE,  # the lease is gone
+                    TaskStatus.STOPPING: TaskStatus.SUSPENDED,  # the runner is gone
+                }.get(task.status, task.status)
+                self._move(task.id, status)
+            # Eligibility is not restored, it is recomputed — which is why
+            # HandoffMgr must have resumed first.
+            self.try_dispatch()
+
+    # ------------------------------------------------------------- internals
+
+    def _move(self, tid: TaskId, status: TaskStatus) -> None:
+        """The single writer. Nothing else assigns task.status or writes pools."""
+        task_mgr = self._r.get("task_mgr")
+        # Discarding from every pool rather than from the recorded status makes
+        # this idempotent and self-healing.
+        for pool in self.pools.values():
+            pool.discard(tid)
+        self.pools[status].add(tid)
+        task = task_mgr.get(tid)
+        if task.status is not status:
+            task.status = status
+            task_mgr.persist(tid)
+
+    def _abort_launch(self, tid: TaskId, task: Task, pools: dict) -> None:
+        """Undo a dispatch that raised between `take` and a live runner.
+
+        Returns the whole reservation — nothing ran, so a consumable spent
+        nothing — closes the half-open attempt if one was pushed, and parks the
+        task in FAILED. FAILED rather than back in the queue: the pass would
+        pick it up again on the next iteration and fail identically, forever.
+        An operator resumes it once the cause is fixed.
+
+        Every step is individually guarded. This is the handler, so an exception
+        escaping *here* has nowhere left to go: it would propagate out of
+        `submit` or `resume_all` leaving the task RUNNING with a half-open
+        attempt, which nothing but a restart can clear. Reaching FAILED matters
+        more than any single step succeeding.
+        """
+        # `pools` is empty when resolution itself failed — nothing was taken.
+        for name, amount in task.resources.items():
+            pool = pools.get(name)
+            if pool is None:
+                continue
+            try:
+                pool.give_back(amount, actual=0.0)
+            except Exception:
+                log.exception("%s: could not release %s of %r", tid, amount, name)
+        try:
+            if task.is_running:
+                task.close_execution({}, TaskStatus.FAILED, detail="failed to launch")
+        except Exception:
+            log.exception("%s: could not close the half-open attempt", tid)
+        log.exception("%s: failed to launch; the reservation was released", tid)
+        self._move(tid, TaskStatus.FAILED)
+
+    def _landing(self, task: Task) -> TaskStatus:
+        return TaskStatus.WAITING_RESOURCE if self._ready(task) else TaskStatus.WAITING_HANDOFF
+
+    def _ready(self, task: Task) -> bool:
+        """The query that replaces a dependency counter."""
+        handoff_mgr = self._r.get("handoff_mgr")
+        return all(handoff_mgr.check_if_latest_valid(hid) for hid in task.inputs)
+
+    def _release(self, task: Task, usage: dict[str, float] | None) -> None:
+        """Give every lease back. One pool failing must not strand the rest.
+
+        The task is finishing either way — the run is over and the scheduler
+        cannot un-finish it. Letting an exception escape here would leave the
+        task `RUNNING` with an open execution record and its *other* leases
+        still held, recoverable only by a restart. Failing loudly per pool and
+        continuing is strictly better.
+        """
+        for name, amount in task.resources.items():
+            actual = None if usage is None else usage.get(name)
+            try:
+                self._r.get(f"resource:{name}").give_back(amount, actual)
+            except Exception:
+                log.exception("%s: could not release %s of %r", task.id, amount, name)
+
+    def _snapshot(self) -> dict[str, float]:
+        return {pool.name: pool.available for pool in self._r.resolve("resource:*")}
+
+    def _require(self, tid: TaskId, allowed, verb: str) -> Task:
+        task = self._r.get("task_mgr").get(tid)
+        if task.status not in allowed:
+            raise ValueError(
+                f"cannot {verb} {tid}: it is {task.status.value}, expected one of "
+                f"{sorted(s.value for s in allowed)}"
+            )
+        return task
+
+    def _warn_depends_on(self, task: Task) -> None:
+        """Warn when `depends_on` omits the producer of one of the inputs.
+
+        Warn, not reject: rejecting would make declaration order matter, and
+        repairing would make `depends_on` derived and unable to express a
+        dependency that shares no handoff.
+        """
+        handoff_mgr = self._r.get("handoff_mgr")
+        for hid in task.inputs:
+            version = handoff_mgr.latest(hid)
+            if version is None or version.producer_task_id is None:
+                continue
+            if version.producer_task_id not in task.depends_on:
+                log.warning(
+                    "%s: depends_on omits %s, which produces %s",
+                    task.id,
+                    version.producer_task_id,
+                    hid,
+                )

--- a/agent_sys/task_graph/store.py
+++ b/agent_sys/task_graph/store.py
@@ -1,0 +1,129 @@
+"""Record persistence.
+
+Full CRUD, keyed by (kind, key). The store never sees a model — managers pass
+``model_dump(mode="json")`` and validate on the way back, which is what lets one
+implementation serve every kind.
+
+``sqlite3`` is the named upgrade path: it is stdlib and would supply the
+cross-manager transaction this design leaves open. ``StoreMgr`` is a Protocol so
+that swap is one file.
+"""
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Protocol
+from urllib.parse import quote
+
+__all__ = ["StoreMgr", "MemoryStoreMgr", "JsonFileStoreMgr"]
+
+
+class StoreMgr(Protocol):
+    def create(self, kind: str, key: str, record: dict) -> None:
+        """Write a new record. Raises KeyError if one is already present."""
+
+    def read(self, kind: str, key: str) -> dict | None: ...
+
+    def read_all(self, kind: str) -> list[dict]: ...
+
+    def update(self, kind: str, key: str, record: dict) -> None:
+        """Replace an existing record. Raises KeyError if absent."""
+
+    def delete(self, kind: str, key: str) -> None:
+        """Remove a record. Raises KeyError if absent."""
+
+    def exists(self, kind: str, key: str) -> bool: ...
+
+
+class MemoryStoreMgr:
+    """``dict[kind][key] -> deepcopy(record)``.
+
+    Survives a manager restart because the store object does; that is exactly
+    what makes recovery testable. The deep copy is not caution — without it a
+    caller holds a live reference into the store and a reload returns objects
+    nobody ever wrote.
+    """
+
+    def __init__(self) -> None:
+        self._kinds: dict[str, dict[str, dict]] = {}
+
+    def create(self, kind: str, key: str, record: dict) -> None:
+        bucket = self._kinds.setdefault(kind, {})
+        if key in bucket:
+            raise KeyError(f"{kind}/{key} already exists")
+        bucket[key] = deepcopy(record)
+
+    def read(self, kind: str, key: str) -> dict | None:
+        record = self._kinds.get(kind, {}).get(key)
+        return deepcopy(record) if record is not None else None
+
+    def read_all(self, kind: str) -> list[dict]:
+        return [deepcopy(r) for r in self._kinds.get(kind, {}).values()]
+
+    def update(self, kind: str, key: str, record: dict) -> None:
+        bucket = self._kinds.setdefault(kind, {})
+        if key not in bucket:
+            raise KeyError(f"{kind}/{key} does not exist")
+        bucket[key] = deepcopy(record)
+
+    def delete(self, kind: str, key: str) -> None:
+        bucket = self._kinds.get(kind, {})
+        if key not in bucket:
+            raise KeyError(f"{kind}/{key} does not exist")
+        del bucket[key]
+
+    def exists(self, kind: str, key: str) -> bool:
+        return key in self._kinds.get(kind, {})
+
+
+class JsonFileStoreMgr:
+    """``<root>/<kind>/<quoted-key>.json``, one file per record.
+
+    Records stay readable with ``cat`` while the schema is still moving, which
+    is the whole reason for choosing files over sqlite today.
+    """
+
+    def __init__(self, root: Path | str) -> None:
+        self.root = Path(root)
+
+    def _path(self, kind: str, key: str) -> Path:
+        # Keys are opaque strings that become filenames; callers should not
+        # have to know that.
+        return self.root / kind / f"{quote(key, safe='')}.json"
+
+    def _write(self, path: Path, record: dict) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(record, indent=2, sort_keys=True))
+        tmp.replace(path)  # atomic on POSIX — per-record atomicity for free
+
+    def create(self, kind: str, key: str, record: dict) -> None:
+        path = self._path(kind, key)
+        if path.exists():
+            raise KeyError(f"{kind}/{key} already exists")
+        self._write(path, record)
+
+    def read(self, kind: str, key: str) -> dict | None:
+        path = self._path(kind, key)
+        return json.loads(path.read_text()) if path.exists() else None
+
+    def read_all(self, kind: str) -> list[dict]:
+        directory = self.root / kind
+        if not directory.is_dir():
+            return []
+        return [json.loads(p.read_text()) for p in sorted(directory.glob("*.json"))]
+
+    def update(self, kind: str, key: str, record: dict) -> None:
+        path = self._path(kind, key)
+        if not path.exists():
+            raise KeyError(f"{kind}/{key} does not exist")
+        self._write(path, record)
+
+    def delete(self, kind: str, key: str) -> None:
+        path = self._path(kind, key)
+        if not path.exists():
+            raise KeyError(f"{kind}/{key} does not exist")
+        path.unlink()
+
+    def exists(self, kind: str, key: str) -> bool:
+        return self._path(kind, key).exists()

--- a/agent_sys/task_graph/task.py
+++ b/agent_sys/task_graph/task.py
@@ -1,0 +1,92 @@
+"""The task collection.
+
+Durability and lookup. Transitions are the `Task`'s own, so there is no
+`set_status` here — a caller does `task.status = X` and then `mgr.persist(tid)`.
+"""
+
+from task_graph.ids import TaskId
+from task_graph.models import Task, TaskStatus
+from task_graph.registry import Registry
+
+__all__ = ["TaskMgr"]
+
+KIND = "task"
+
+
+class TaskMgr:
+    def __init__(self, registry: Registry) -> None:
+        self._r = registry
+        self._tasks: dict[TaskId, Task] = {}
+
+    def add(self, task: Task) -> None:
+        """Register a new task.
+
+        Rejects an id that exists and is not CANCELLED. Reviving a cancelled id
+        is forced by `update_task`, which is `remove_queued` + `submit` under
+        the same id; it replaces the record, fresh history included.
+        """
+        existing = self._tasks.get(task.id)
+        if existing is not None and existing.status is not TaskStatus.CANCELLED:
+            raise KeyError(f"task {task.id} already exists ({existing.status.value})")
+        self._tasks[task.id] = task
+        record = task.model_dump(mode="json")
+        if existing is not None:
+            self._store.update(KIND, str(task.id), record)
+        else:
+            self._store.create(KIND, str(task.id), record)
+
+    def get(self, tid: TaskId) -> Task:
+        try:
+            return self._tasks[tid]
+        except KeyError:
+            raise KeyError(f"no task {tid}") from None
+
+    def all(self) -> list[Task]:
+        return list(self._tasks.values())
+
+    def by_status(self, status: TaskStatus) -> list[Task]:
+        return [t for t in self._tasks.values() if t.status is status]
+
+    def remove(self, tid: TaskId) -> None:
+        """Forget a task entirely. Refuses one the scheduler still indexes.
+
+        Cancellation is `Scheduler.remove_queued`; this is the harder delete,
+        for a record an operator wants gone. Without the guard it leaves an id
+        in a pool with no task behind it, and every subsequent dispatch pass
+        raises `KeyError` at the eligibility re-check — permanently. The
+        scheduler is resolved at use time and its absence tolerated, so this
+        stays a lookup rather than a dependency.
+        """
+        self.get(tid)
+        scheduler = self._r.get("scheduler") if "scheduler" in self._r else None
+        if scheduler is not None and any(tid in pool for pool in scheduler.pools.values()):
+            raise ValueError(
+                f"cannot remove {tid}: the scheduler still indexes it; "
+                f"cancel or let it finish first"
+            )
+        del self._tasks[tid]
+        self._store.delete(KIND, str(tid))
+
+    def persist(self, tid: TaskId) -> None:
+        """Write the task back after a caller mutated it through its own methods."""
+        self._store.update(KIND, str(tid), self.get(tid).model_dump(mode="json"))
+
+    def resume_system(self) -> None:
+        """Reload; close any dangling stack top as SUSPENDED.
+
+        The restart cut the attempt short, it was not judged. Closing it is not
+        tidiness: `push_execution` refuses to stack on an open attempt, so
+        leaving it open would make the first `resume_task` raise. Where the
+        *task* lands is a separate decision the scheduler makes a moment later.
+        """
+        self._tasks = {}
+        for record in self._store.read_all(KIND):
+            task = Task.model_validate(record)
+            self._tasks[task.id] = task
+            if task.is_running:
+                task.close_execution({}, TaskStatus.SUSPENDED, detail="interrupted by restart")
+                self.persist(task.id)
+
+    @property
+    def _store(self):
+        return self._r.get("store_mgr")

--- a/agent_sys/tests/task_graph/conftest.py
+++ b/agent_sys/tests/task_graph/conftest.py
@@ -1,0 +1,80 @@
+"""Shared fixtures. Every test builds its own registry; nothing is global."""
+
+import pytest
+
+from task_graph.bootstrap import build_registry
+from task_graph.ids import HandoffId
+from task_graph.models import Task
+from task_graph.resource import GpuMgr, TokenMgr
+from task_graph.store import MemoryStoreMgr
+
+
+@pytest.fixture
+def store():
+    return MemoryStoreMgr()
+
+
+@pytest.fixture
+def registry(store):
+    r = build_registry(store=store)
+    r.get("agent_mgr").register("profiler")
+    r.get("agent_mgr").register("tuner")
+    return r
+
+
+@pytest.fixture
+def scheduler(registry):
+    return registry.get("scheduler")
+
+
+@pytest.fixture
+def runner(registry):
+    return registry.get("runner")
+
+
+@pytest.fixture
+def handoff_mgr(registry):
+    return registry.get("handoff_mgr")
+
+
+@pytest.fixture
+def task_mgr(registry):
+    return registry.get("task_mgr")
+
+
+@pytest.fixture
+def agent_mgr(registry):
+    return registry.get("agent_mgr")
+
+
+def rebuild(store, **kw):
+    """A restart: fresh components over the same store."""
+    r = build_registry(store=store, **kw)
+    r.get("agent_mgr").register("profiler")
+    r.get("agent_mgr").register("tuner")
+    return r
+
+
+def make_task(*, spec: str = "profiler", **kw) -> Task:
+    return Task(agent_spec=spec, **kw)
+
+
+def new_handoffs(n: int = 1) -> list[HandoffId]:
+    return [HandoffId.new() for _ in range(n)]
+
+
+def gpu(registry) -> GpuMgr:
+    return registry.get("resource:gpu")
+
+
+def token(registry) -> TokenMgr:
+    return registry.get("resource:token")
+
+
+def run_to_completion(registry, task, *, valid=True, status=None, usage=None):
+    """Submit, let the fake agent write its outputs, and finish."""
+    from task_graph.models import TaskStatus
+
+    registry.get("scheduler").submit(task)
+    registry.get("runner").produce(registry, task.id, valid=valid)
+    registry.get("runner").finish(task.id, status or TaskStatus.SUCCEEDED, usage or {})

--- a/agent_sys/tests/task_graph/test_agent.py
+++ b/agent_sys/tests/task_graph/test_agent.py
@@ -1,0 +1,220 @@
+"""AgentMgr — criteria 28 and 34.
+
+Two collections: the spec table of what kinds exist, and the instances of what
+has been created. The mgr keeps what it creates; a factory that instantiated and
+forgot would leave every `Execution.agent_id` pointing at nothing.
+"""
+
+import pytest
+
+from task_graph.agent import AgentMgr
+from task_graph.ids import AgentId, HandoffId, TaskId
+from task_graph.models import HandoffRef
+from task_graph.registry import Registry
+from task_graph.store import MemoryStoreMgr
+
+
+@pytest.fixture
+def store():
+    return MemoryStoreMgr()
+
+
+@pytest.fixture
+def registry(store):
+    r = Registry()
+    r.register("store_mgr", store)
+    return r
+
+
+@pytest.fixture
+def mgr(registry):
+    manager = AgentMgr(registry)
+    registry.register("agent_mgr", manager)
+    manager.register("profiler")
+    return manager
+
+
+# -------------------------------------------------------------- spec table
+
+
+def test_register_and_list_specs(mgr):
+    mgr.register("tuner", model="opus")
+    assert sorted(mgr.specs()) == ["profiler", "tuner"]
+    assert mgr.is_registered("tuner")
+    assert not mgr.is_registered("nope")
+
+
+def test_a_spec_config_reaches_the_instance(mgr):
+    mgr.register("tuner", model="opus", retries=2)
+    agent = mgr.instantiate("tuner", TaskId.new())
+    assert agent.config == {"model": "opus", "retries": 2}
+
+
+def test_registering_a_spec_twice_replaces_its_config(mgr):
+    mgr.register("tuner", model="sonnet")
+    mgr.register("tuner", model="opus")
+    assert mgr.instantiate("tuner", TaskId.new()).config == {"model": "opus"}
+
+
+# ------------------------------------------------------------- instantiate
+
+
+def test_instantiate_retains_the_agent(mgr):
+    """Criterion 28: otherwise the audit trail names agents nobody can resolve."""
+    agent = mgr.instantiate("profiler", TaskId.new())
+    assert mgr.get(agent.id) is agent
+    assert mgr.all() == [agent]
+
+
+def test_instantiate_binds_the_task(mgr):
+    tid = TaskId.new()
+    agent = mgr.instantiate("profiler", tid)
+    assert agent.task_id == tid
+    assert agent.spec == "profiler"
+    assert agent.handoffs == []
+
+
+def test_instantiate_mints_a_fresh_id_every_call(mgr):
+    """Criterion 21: after a resume the stack top must report a different
+    agent_id than the entry beneath it."""
+    tid = TaskId.new()
+    first, second = mgr.instantiate("profiler", tid), mgr.instantiate("profiler", tid)
+    assert first.id != second.id
+    assert len(mgr.all()) == 2
+
+
+def test_instantiate_an_unknown_spec_names_the_registered_ones(mgr):
+    with pytest.raises(KeyError, match="profiler"):
+        mgr.instantiate("nope", TaskId.new())
+
+
+def test_instantiate_persists(mgr, store):
+    agent = mgr.instantiate("profiler", TaskId.new())
+    assert store.read("agent", str(agent.id))["spec"] == "profiler"
+
+
+# --------------------------------------------------------------- retrieval
+
+
+def test_get_by_id(mgr):
+    agent = mgr.instantiate("profiler", TaskId.new())
+    assert mgr.get(agent.id) is agent
+
+
+def test_get_an_unknown_id_raises(mgr):
+    with pytest.raises(KeyError):
+        mgr.get(AgentId.new())
+
+
+def test_get_by_spec_name_makes_an_unbound_agent(mgr):
+    """The `get(name) -> agent` the task definition asks for."""
+    agent = mgr.get("profiler")
+    assert agent.spec == "profiler"
+    assert agent.task_id is None
+    assert mgr.get(agent.id) is agent
+
+
+def test_get_by_an_unknown_spec_name_raises(mgr):
+    with pytest.raises(KeyError):
+        mgr.get("nope")
+
+
+def test_by_spec(mgr):
+    mgr.register("tuner")
+    profilers = [mgr.instantiate("profiler", TaskId.new()) for _ in range(2)]
+    tuner = mgr.instantiate("tuner", TaskId.new())
+
+    assert sorted(a.id for a in mgr.by_spec("profiler")) == sorted(a.id for a in profilers)
+    assert [a.id for a in mgr.by_spec("tuner")] == [tuner.id]
+    assert mgr.by_spec("nope") == []
+
+
+def test_by_task_returns_every_attempt_in_order(mgr):
+    tid = TaskId.new()
+    first, second = mgr.instantiate("profiler", tid), mgr.instantiate("profiler", tid)
+    mgr.instantiate("profiler", TaskId.new())
+
+    assert [a.id for a in mgr.by_task(tid)] == [first.id, second.id]
+    assert mgr.by_task(TaskId.new()) == []
+
+
+def test_retire(mgr, store):
+    agent = mgr.instantiate("profiler", TaskId.new())
+    mgr.retire(agent.id)
+
+    assert mgr.all() == []
+    assert not store.exists("agent", str(agent.id))
+    with pytest.raises(KeyError):
+        mgr.retire(agent.id)
+
+
+# -------------------------------------------------------------- persistence
+
+
+def test_persist_writes_back_what_the_agent_appended(mgr, store):
+    agent = mgr.instantiate("profiler", TaskId.new())
+    hid = HandoffId.new()
+    agent.handoffs.append(HandoffRef(handoff_id=hid, version=1))
+
+    assert store.read("agent", str(agent.id))["handoffs"] == []
+    mgr.persist(agent.id)
+    assert store.read("agent", str(agent.id))["handoffs"] == [
+        {"handoff_id": str(hid), "version": 1}
+    ]
+
+
+def test_persist_an_unknown_id_raises(mgr):
+    with pytest.raises(KeyError):
+        mgr.persist(AgentId.new())
+
+
+def test_instances_are_restored_so_the_audit_trail_resolves(mgr, registry):
+    """Criterion 34."""
+    tid, hid = TaskId.new(), HandoffId.new()
+    agent = mgr.instantiate("profiler", tid)
+    agent.handoffs.append(HandoffRef(handoff_id=hid, version=0))
+    mgr.persist(agent.id)
+
+    fresh = AgentMgr(registry)
+    assert fresh.all() == []
+    fresh.resume_system()
+
+    restored = fresh.get(agent.id)
+    assert restored.spec == "profiler"
+    assert restored.task_id == tid
+    assert restored.handoffs[0].handoff_id == hid
+    assert [a.id for a in fresh.by_task(tid)] == [agent.id]
+
+
+def test_the_spec_table_is_not_restored(mgr, registry):
+    """It is configuration. Reading it back would resurrect a spec the operator
+    has since removed."""
+    mgr.instantiate("profiler", TaskId.new())
+
+    fresh = AgentMgr(registry)
+    fresh.resume_system()
+
+    assert fresh.specs() == []
+    with pytest.raises(KeyError):
+        fresh.instantiate("profiler", TaskId.new())
+
+
+def test_a_restored_instance_is_a_record_not_a_live_agent(mgr, registry):
+    """Nothing dispatches against one: instantiate always creates a new one."""
+    agent = mgr.instantiate("profiler", TaskId.new())
+
+    fresh = AgentMgr(registry)
+    fresh.resume_system()
+    fresh.register("profiler")
+    replacement = fresh.instantiate("profiler", TaskId.new())
+
+    assert replacement.id != agent.id
+    assert len(fresh.all()) == 2
+
+
+def test_resume_replaces_rather_than_merging(mgr, store):
+    agent = mgr.instantiate("profiler", TaskId.new())
+    store.delete("agent", str(agent.id))
+
+    mgr.resume_system()
+    assert mgr.all() == []

--- a/agent_sys/tests/task_graph/test_authority.py
+++ b/agent_sys/tests/task_graph/test_authority.py
@@ -1,0 +1,217 @@
+"""The authority boundary — criterion 14.
+
+The scheduler decides *when*, never *what*. It never writes handoff state. This
+is the one mechanical check that the boundary has not eroded: a spy HandoffMgr
+logs every call, `produce` brackets its own writes with a marker, and the
+assertion is that every write falls inside a pair of markers.
+
+"Who called this" is recorded rather than inferred from the call stack, which
+would be unimplementable in any honest way.
+"""
+
+from task_graph.bootstrap import build_registry
+from task_graph.handoff import HandoffMgr
+from task_graph.models import TaskStatus
+from task_graph.runner import FakeRunner
+from task_graph.store import MemoryStoreMgr
+
+from .conftest import make_task, new_handoffs
+
+WRITES = {"persist"}
+# `get` and `latest` hand back a *live, mutable* Handoff, so they are only reads
+# by convention — a drifting scheduler would reach state through exactly these.
+# Nothing in `scheduler.py` calls `handoff_mgr.get`, which
+# `test_the_scheduler_never_takes_a_mutable_handle` pins down; `latest` it does
+# call, and reads one integer off. See design O12 for what the spy cannot see.
+HANDLE_RETURNING = {"get", "latest"}
+READS = {"declare", "check_if_latest_valid", "get_many", "all_ids"} | HANDLE_RETURNING
+
+
+class SpyHandoffMgr(HandoffMgr):
+    def __init__(self, registry) -> None:
+        super().__init__(registry)
+        self.log: list[str] = []
+
+    def declare(self, ids, producer_task_id, types=None):
+        self.log.append("declare")
+        return super().declare(ids, producer_task_id, types)
+
+    def check_if_latest_valid(self, hid):
+        self.log.append("check_if_latest_valid")
+        return super().check_if_latest_valid(hid)
+
+    def latest(self, hid):
+        self.log.append("latest")
+        return super().latest(hid)
+
+    def get(self, hid):
+        self.log.append("get")
+        return super().get(hid)
+
+    def persist(self, hid):
+        self.log.append("persist")
+        return super().persist(hid)
+
+
+class MarkingRunner(FakeRunner):
+    """Brackets the agent's writes so the log says who made them."""
+
+    def produce(self, registry, task_id, **kw):
+        log = registry.get("handoff_mgr").log
+        log.append("<agent>")
+        try:
+            super().produce(registry, task_id, **kw)
+        finally:
+            log.append("</agent>")
+
+
+def spans(log: list[str]) -> list[range]:
+    """Index ranges between an `<agent>` marker and its close."""
+    out, start = [], None
+    for i, entry in enumerate(log):
+        if entry == "<agent>":
+            start = i
+        elif entry == "</agent>":
+            out.append(range(start, i))
+            start = None
+    return out
+
+
+def test_only_the_agent_writes_handoff_state(store):
+    """A full submit -> dispatch -> complete -> resume -> re-dispatch cycle."""
+    registry = build_registry(store=store, runner=MarkingRunner())
+    registry.register("handoff_mgr", SpyHandoffMgr(registry))
+    registry.get("agent_mgr").register("profiler")
+    scheduler, runner = registry.get("scheduler"), registry.get("runner")
+    spy = registry.get("handoff_mgr")
+
+    (mid,) = new_handoffs(1)
+    producer = make_task(outputs=[mid])
+    consumer = make_task(inputs=[mid], outputs=new_handoffs(1))
+    scheduler.submit(producer)
+    scheduler.submit(consumer)
+
+    runner.produce(registry, producer.id)
+    runner.finish(producer.id, TaskStatus.FAILED)
+
+    scheduler.resume_task(producer.id)
+    runner.produce(registry, producer.id)
+    runner.finish(producer.id)
+
+    runner.produce(registry, consumer.id)
+    runner.finish(consumer.id)
+
+    agent_spans = spans(spy.log)
+    assert len(agent_spans) == 3
+    inside = {i for span in agent_spans for i in span}
+
+    for i, entry in enumerate(spy.log):
+        if entry in WRITES:
+            assert i in inside, f"{entry} at {i} was called outside an agent"
+        elif entry in READS:
+            pass  # a read from anywhere is fine
+        elif entry not in ("<agent>", "</agent>"):
+            raise AssertionError(f"unexpected call {entry!r}")
+
+
+def test_the_scheduler_alone_only_reads(store):
+    """No agent runs at all: the log must contain no write."""
+    registry = build_registry(store=store, runner=MarkingRunner())
+    registry.register("handoff_mgr", SpyHandoffMgr(registry))
+    registry.get("agent_mgr").register("profiler")
+    scheduler, runner = registry.get("scheduler"), registry.get("runner")
+    spy = registry.get("handoff_mgr")
+
+    producer = make_task(outputs=new_handoffs(1))
+    scheduler.submit(producer)
+    scheduler.submit(make_task(inputs=producer.outputs))
+    runner.finish(producer.id)  # completes without writing anything
+
+    assert not any(entry in WRITES for entry in spy.log)
+    assert "check_if_latest_valid" in spy.log
+
+
+def test_the_spy_would_catch_a_scheduler_write(store):
+    """The test is only meaningful if it can fail. Simulate the erosion."""
+    registry = build_registry(store=store, runner=MarkingRunner())
+    registry.register("handoff_mgr", SpyHandoffMgr(registry))
+    registry.get("agent_mgr").register("profiler")
+    spy = registry.get("handoff_mgr")
+
+    task = make_task(outputs=new_handoffs(1))
+    registry.get("scheduler").submit(task)
+    spy.persist(task.outputs[0])  # a write from outside any agent span
+
+    inside = {i for span in spans(spy.log) for i in span}
+    offenders = [i for i, e in enumerate(spy.log) if e in WRITES and i not in inside]
+    assert offenders, "the spy failed to notice a write outside an agent"
+
+
+def test_scheduling_never_looks_at_a_handoff_payload():
+    """A payload that raises if anyone inspects it must still flow through."""
+
+    class Untouchable(dict):
+        """A dict, so it serialises — but it screams if anyone looks inside."""
+
+        def __getitem__(self, key):
+            raise AssertionError("something read the content")
+
+        def __bool__(self):
+            raise AssertionError("something tested the content for truth")
+
+    registry = build_registry(store=MemoryStoreMgr())
+    registry.get("agent_mgr").register("profiler")
+    scheduler, runner = registry.get("scheduler"), registry.get("runner")
+    payload = Untouchable(verdict="do not read me")
+
+    producer = make_task(outputs=new_handoffs(1))
+    consumer = make_task(inputs=producer.outputs)
+    scheduler.submit(producer)
+    scheduler.submit(consumer)
+
+    runner.produce(registry, producer.id, content=payload)
+    runner.finish(producer.id)
+
+    assert registry.get("task_mgr").get(consumer.id).status is TaskStatus.RUNNING
+
+
+def test_a_payload_must_be_serialisable(store):
+    """Design open question O9. The *scheduler* is content-agnostic, but
+    `persist` dumps the whole handoff, so an arbitrary Python object cannot be
+    a payload today. Asserted so the constraint is visible rather than
+    discovered by the first agent that returns one."""
+    import pytest
+    from pydantic_core import PydanticSerializationError
+
+    class Opaque:
+        pass
+
+    registry = build_registry(store=store)
+    registry.get("agent_mgr").register("profiler")
+    task = make_task(outputs=new_handoffs(1))
+    registry.get("scheduler").submit(task)
+
+    with pytest.raises(PydanticSerializationError):
+        registry.get("runner").produce(registry, task.id, content=Opaque())
+
+
+def test_the_scheduler_never_takes_a_mutable_handle():
+    """`persist` is not the only way to write handoff state.
+
+    `HandoffMgr.get` returns a live `Handoff`, on which `open_next` and `seal`
+    are one call away — and those live on the model, where the spy cannot see
+    them (design O12). The boundary therefore rests on the scheduler never
+    taking such a handle in the first place, which is a property of the source,
+    not of a run. Checked statically because no test can observe it.
+    """
+    import inspect
+
+    from task_graph import scheduler as scheduler_module
+
+    source = inspect.getsource(scheduler_module)
+    assert "handoff_mgr.get(" not in source, (
+        "the scheduler took a mutable Handoff; open_next and seal are one call away "
+        "and the authority spy cannot see them"
+    )
+    for verb in ("open_next", "seal("):
+        assert verb not in source, f"the scheduler calls {verb} directly"

--- a/agent_sys/tests/task_graph/test_completion.py
+++ b/agent_sys/tests/task_graph/test_completion.py
@@ -1,0 +1,228 @@
+"""Completion — criteria 4, 7 and 13.
+
+There is no result object. The runner reports a status and what it spent; the
+scheduler reads output versions from the HandoffMgr for itself, exactly as it
+read the input versions at dispatch.
+"""
+
+import pytest
+
+from task_graph.models import TaskStatus
+
+from .conftest import gpu, make_task, new_handoffs, token
+
+
+def test_completion_releases_a_renewable_in_full(scheduler, runner, registry):
+    """Criterion 4."""
+    task = make_task(resources={"gpu": 3})
+    scheduler.submit(task)
+    runner.finish(task.id)
+    assert gpu(registry).available == 8
+
+
+def test_completion_settles_a_consumable_at_reported_usage(scheduler, runner, registry):
+    task = make_task(resources={"token": 500})
+    scheduler.submit(task)
+    runner.finish(task.id, usage={"token": 120})
+    assert token(registry).available == 1_000_000 - 120
+
+
+def test_a_completion_reporting_no_usage_charges_the_whole_reservation(scheduler, runner, registry):
+    task = make_task(resources={"token": 500})
+    scheduler.submit(task)
+    runner.finish(task.id, usage={})
+    assert token(registry).available == 1_000_000 - 500
+
+
+def test_usage_for_a_renewable_is_ignored(scheduler, runner, registry):
+    task = make_task(resources={"gpu": 3})
+    scheduler.submit(task)
+    runner.finish(task.id, usage={"gpu": 1})
+    assert gpu(registry).available == 8
+
+
+def test_a_failure_releases_just_as_a_success_does(scheduler, runner, registry):
+    task = make_task(resources={"gpu": 3, "token": 500})
+    scheduler.submit(task)
+    runner.finish(task.id, TaskStatus.FAILED, usage={"token": 200})
+
+    assert gpu(registry).available == 8
+    assert token(registry).available == 1_000_000 - 200
+
+
+# -------------------------------------------------------------- the record
+
+
+def test_completion_records_the_output_versions_the_run_wrote(scheduler, runner, registry):
+    task = make_task(outputs=new_handoffs(2))
+    scheduler.submit(task)
+    runner.produce(registry, task.id)
+    runner.finish(task.id)
+
+    execution = registry.get("task_mgr").get(task.id).current
+    assert execution.output_versions == dict.fromkeys(task.outputs, 0)
+    assert execution.outcome is TaskStatus.SUCCEEDED
+    assert not execution.is_open
+
+
+def test_an_output_the_agent_never_wrote_is_still_recorded_at_its_declared_version(
+    scheduler, runner, registry
+):
+    task = make_task(outputs=new_handoffs(1))
+    scheduler.submit(task)
+    runner.finish(task.id)  # no produce()
+
+    assert registry.get("task_mgr").get(task.id).current.output_versions == {task.outputs[0]: 0}
+    assert not registry.get("handoff_mgr").check_if_latest_valid(task.outputs[0])
+
+
+def test_completion_persists(scheduler, runner, store):
+    task = make_task()
+    scheduler.submit(task)
+    runner.finish(task.id)
+
+    record = store.read("task", str(task.id))
+    assert record["status"] == "succeeded"
+    assert record["history"][0]["outcome"] == "succeeded"
+
+
+# ----------------------------------- status and handoff validity are separate
+
+
+def test_a_succeeded_task_may_leave_an_invalid_output(scheduler, runner, registry):
+    """Criterion 13: the two say different things and the scheduler conflates
+    neither. Whether the work is usable is the handoff's answer."""
+    task = make_task(outputs=new_handoffs(1))
+    scheduler.submit(task)
+    runner.produce(registry, task.id, valid=False)
+    runner.finish(task.id, TaskStatus.SUCCEEDED)
+
+    assert registry.get("task_mgr").get(task.id).status is TaskStatus.SUCCEEDED
+    assert not registry.get("handoff_mgr").check_if_latest_valid(task.outputs[0])
+
+
+def test_a_failed_task_may_leave_a_valid_output(scheduler, runner, registry):
+    task = make_task(outputs=new_handoffs(1))
+    scheduler.submit(task)
+    runner.produce(registry, task.id, valid=True)
+    runner.finish(task.id, TaskStatus.FAILED)
+
+    assert registry.get("task_mgr").get(task.id).status is TaskStatus.FAILED
+    assert registry.get("handoff_mgr").check_if_latest_valid(task.outputs[0])
+
+
+def test_a_consumer_unblocks_on_handoff_validity_not_on_task_success(scheduler, runner, registry):
+    producer = make_task(outputs=new_handoffs(1))
+    consumer = make_task(inputs=producer.outputs)
+    scheduler.submit(producer)
+    scheduler.submit(consumer)
+
+    runner.produce(registry, producer.id, valid=True)
+    runner.finish(producer.id, TaskStatus.FAILED)
+
+    assert registry.get("task_mgr").get(consumer.id).status is TaskStatus.RUNNING
+
+
+def test_a_consumer_stays_blocked_when_a_succeeded_producer_wrote_nothing_valid(
+    scheduler, runner, registry
+):
+    producer = make_task(outputs=new_handoffs(1))
+    consumer = make_task(inputs=producer.outputs)
+    scheduler.submit(producer)
+    scheduler.submit(consumer)
+
+    runner.produce(registry, producer.id, valid=False)
+    runner.finish(producer.id, TaskStatus.SUCCEEDED)
+
+    assert registry.get("task_mgr").get(consumer.id).status is TaskStatus.WAITING_HANDOFF
+
+
+# --------------------------------------------------------------- rejections
+
+
+def test_completing_a_task_that_is_not_running_is_rejected(scheduler, runner):
+    task = make_task()
+    scheduler.submit(task)
+    runner.finish(task.id)
+
+    with pytest.raises(ValueError, match="succeeded"):
+        scheduler.on_task_done(task.id, TaskStatus.SUCCEEDED, {})
+
+
+def test_a_completion_arriving_after_a_stop_raises_into_the_runner(scheduler, runner):
+    """Open question O2, asserted so the behaviour is deliberate rather than
+    discovered. Nothing leaks: on_stopped still releases the resources."""
+    task = make_task(resources={"gpu": 2})
+    scheduler.submit(task)
+    scheduler.stop(task.id)
+
+    with pytest.raises(ValueError, match="stopping"):
+        runner.finish(task.id)
+
+
+def test_completion_triggers_the_next_dispatch(scheduler, runner, task_mgr):
+    hog = make_task(resources={"gpu": 8})
+    scheduler.submit(hog)
+    queued = make_task(resources={"gpu": 8})
+    scheduler.submit(queued)
+
+    runner.finish(hog.id)
+    assert task_mgr.get(queued.id).status is TaskStatus.RUNNING
+
+
+def test_a_failed_run_leaves_its_dependents_waiting(scheduler, runner, registry):
+    """Criterion 7: released, and nothing downstream moved."""
+    producer = make_task(outputs=new_handoffs(1), resources={"gpu": 3})
+    consumer = make_task(inputs=producer.outputs)
+    scheduler.submit(producer)
+    scheduler.submit(consumer)
+
+    runner.finish(producer.id, TaskStatus.FAILED)
+
+    assert gpu(registry).available == 8
+    assert registry.get("task_mgr").get(consumer.id).status is TaskStatus.WAITING_HANDOFF
+
+
+def test_an_output_left_generating_does_not_satisfy_a_consumer(
+    scheduler, runner, registry, handoff_mgr, task_mgr
+):
+    """Criterion 7's second half."""
+    producer = make_task(outputs=new_handoffs(1))
+    consumer = make_task(inputs=producer.outputs)
+    scheduler.submit(producer)
+    scheduler.submit(consumer)
+
+    handoff_mgr.get(producer.outputs[0]).open_next(
+        producer.id, task_mgr.get(producer.id).current.agent_id
+    )
+    handoff_mgr.persist(producer.outputs[0])
+    runner.finish(producer.id)
+
+    assert not handoff_mgr.check_if_latest_valid(producer.outputs[0])
+    assert task_mgr.get(consumer.id).status is TaskStatus.WAITING_HANDOFF
+
+
+def test_one_pool_failing_to_release_does_not_strand_the_task(scheduler, runner, registry, caplog):
+    """The run is over and cannot be un-finished. An exception escaping the
+    release would leave the task RUNNING with an open execution record and its
+    other leases held — recoverable only by a restart."""
+
+    class WedgedPool:
+        name = "gpu"
+        available = 0.0
+
+        def give_back(self, amount, actual=None):
+            raise RuntimeError("pool wedged")
+
+    task = make_task(resources={"gpu": 2, "token": 100})
+    scheduler.submit(task)
+    registry.register("resource:gpu", WedgedPool())
+
+    with caplog.at_level("ERROR"):
+        runner.finish(task.id, usage={"token": 40})
+
+    finished = registry.get("task_mgr").get(task.id)
+    assert finished.status is TaskStatus.SUCCEEDED
+    assert not finished.is_running
+    assert token(registry).available == 1_000_000 - 40  # the healthy pool settled
+    assert "could not release" in caplog.text

--- a/agent_sys/tests/task_graph/test_dispatch.py
+++ b/agent_sys/tests/task_graph/test_dispatch.py
@@ -1,0 +1,366 @@
+"""Dispatch — criteria 3 and 18.
+
+All-or-nothing acquisition is what makes hold-and-wait deadlock structurally
+impossible: a task that does not fit takes nothing, so no queued task ever holds
+a resource.
+"""
+
+from task_graph.bootstrap import build_registry
+from task_graph.models import HandoffStatus, TaskStatus
+
+from .conftest import gpu, make_task, new_handoffs, token
+
+
+def test_an_eligible_task_that_fits_starts(scheduler, task_mgr, runner):
+    task = make_task(resources={"gpu": 2})
+    scheduler.submit(task)
+
+    assert task_mgr.get(task.id).status is TaskStatus.RUNNING
+    assert runner.started == [task.id]
+
+
+def test_starting_takes_the_resources(scheduler, registry):
+    scheduler.submit(make_task(resources={"gpu": 2, "token": 500}))
+    assert gpu(registry).available == 6
+    assert token(registry).available == 1_000_000 - 500
+
+
+def test_a_task_that_does_not_fit_stays_queued(scheduler, task_mgr, registry, runner):
+    scheduler.submit(make_task(resources={"gpu": 8}))
+    blocked = make_task(resources={"gpu": 1})
+    scheduler.submit(blocked)
+
+    assert task_mgr.get(blocked.id).status is TaskStatus.WAITING_RESOURCE
+    assert blocked.id not in runner.started
+    assert gpu(registry).available == 0
+
+
+def test_a_task_that_does_not_fit_takes_nothing(scheduler, registry):
+    """Criterion 3: the full set is verified before anything is mutated, so a
+    queued task never holds a partial reservation."""
+    scheduler.submit(make_task(resources={"gpu": 8}))
+    scheduler.submit(make_task(resources={"gpu": 1, "token": 500}))
+
+    assert gpu(registry).available == 0
+    assert token(registry).available == 1_000_000  # the affordable half untouched
+
+
+def test_a_blocked_task_starts_once_the_resource_comes_back(scheduler, task_mgr, runner, registry):
+    hog = make_task(resources={"gpu": 8})
+    scheduler.submit(hog)
+    blocked = make_task(resources={"gpu": 1})
+    scheduler.submit(blocked)
+
+    runner.finish(hog.id)
+
+    assert task_mgr.get(blocked.id).status is TaskStatus.RUNNING
+    assert gpu(registry).available == 7
+
+
+def test_a_task_requesting_nothing_always_fits(scheduler, task_mgr):
+    scheduler.submit(make_task(resources={"gpu": 8}))
+    free = make_task()
+    scheduler.submit(free)
+    assert task_mgr.get(free.id).status is TaskStatus.RUNNING
+
+
+# ------------------------------------------------------------------ binding
+
+
+def test_dispatch_binds_a_fresh_agent(scheduler, task_mgr, agent_mgr, runner):
+    task = make_task()
+    scheduler.submit(task)
+
+    execution = task_mgr.get(task.id).current
+    agent = agent_mgr.get(execution.agent_id)
+    assert agent.spec == "profiler"
+    assert agent.task_id == task.id
+    assert runner.running[task.id][1] is agent
+
+
+def test_the_first_attempt_is_numbered_zero(scheduler, task_mgr):
+    task = make_task()
+    scheduler.submit(task)
+    assert task_mgr.get(task.id).current.attempt == 0
+    assert task_mgr.get(task.id).is_running
+
+
+def test_dispatch_pins_the_input_versions_it_actually_saw(scheduler, task_mgr, runner, registry):
+    """Criterion 18: a later re-run of the producer cannot rewrite history."""
+    producer = make_task(outputs=new_handoffs(1))
+    scheduler.submit(producer)
+    runner.produce(registry, producer.id)
+    runner.finish(producer.id)
+
+    consumer = make_task(inputs=producer.outputs)
+    scheduler.submit(consumer)
+    assert task_mgr.get(consumer.id).current.input_versions == {producer.outputs[0]: 0}
+
+    # something writes the slot again, appending v1
+    refresher = make_task(outputs=producer.outputs)
+    scheduler.submit(refresher)
+    runner.produce(registry, refresher.id)
+    runner.finish(refresher.id)
+
+    assert registry.get("handoff_mgr").latest(producer.outputs[0]).version == 1
+    assert task_mgr.get(consumer.id).history[0].input_versions == {producer.outputs[0]: 0}
+
+
+def test_a_task_with_no_inputs_pins_nothing(scheduler, task_mgr):
+    task = make_task()
+    scheduler.submit(task)
+    assert task_mgr.get(task.id).current.input_versions == {}
+
+
+def test_dispatch_persists_the_running_state(scheduler, store):
+    task = make_task()
+    scheduler.submit(task)
+
+    record = store.read("task", str(task.id))
+    assert record["status"] == "running"
+    assert len(record["history"]) == 1
+    assert record["history"][0]["ended_at"] is None
+
+
+# ------------------------------------------------------------------ ordering
+
+
+def test_dispatch_follows_the_policy_order(scheduler, runner, registry):
+    """Two tasks, room for one: the earlier goes first."""
+    first, second = make_task(resources={"gpu": 8}), make_task(resources={"gpu": 8})
+    scheduler.submit(first)
+    scheduler.submit(second)
+
+    assert runner.started == [first.id]
+    runner.finish(first.id)
+    assert runner.started == [first.id, second.id]
+
+
+def test_dispatch_keeps_trying_later_entries_after_one_does_not_fit(scheduler, task_mgr, runner):
+    """Not a head-of-line block: the pass continues down the ordered list."""
+    scheduler.submit(make_task(resources={"gpu": 6}))
+    big, small = make_task(resources={"gpu": 4}), make_task(resources={"gpu": 2})
+    scheduler.submit(big)
+    scheduler.submit(small)
+
+    assert task_mgr.get(big.id).status is TaskStatus.WAITING_RESOURCE
+    assert task_mgr.get(small.id).status is TaskStatus.RUNNING
+
+
+def test_a_chain_flows_without_any_external_prompt(scheduler, task_mgr, runner, registry):
+    """The completion of one task is what re-checks eligibility for the next."""
+    (mid,) = new_handoffs(1)
+    (out,) = new_handoffs(1)
+    first = make_task(outputs=[mid])
+    second = make_task(inputs=[mid], outputs=[out])
+    third = make_task(inputs=[out])
+    for task in (third, second, first):  # submitted in reverse dependency order
+        scheduler.submit(task)
+
+    assert task_mgr.get(second.id).status is TaskStatus.WAITING_HANDOFF
+
+    runner.produce(registry, first.id)
+    runner.finish(first.id)
+    assert task_mgr.get(second.id).status is TaskStatus.RUNNING
+
+    runner.produce(registry, second.id)
+    runner.finish(second.id)
+    assert task_mgr.get(third.id).status is TaskStatus.RUNNING
+
+
+# ---------------------------------------------------------------- re-entrancy
+
+
+class SynchronousRunner:
+    """Completes inside `start`, which re-enters the scheduler."""
+
+    def __init__(self) -> None:
+        self.started: list = []
+        self.depth, self.max_depth = 0, 0
+
+    def start(self, task, agent, on_done) -> None:
+        self.started.append(task.id)
+        self.depth += 1
+        self.max_depth = max(self.max_depth, self.depth)
+        try:
+            on_done(task.id, TaskStatus.SUCCEEDED, {})
+        finally:
+            self.depth -= 1
+
+    def stop(self, task_id, on_stopped) -> None:
+        on_stopped(task_id)
+
+
+def test_a_synchronous_runner_does_not_recurse_per_task(store):
+    """The `_dispatch_again` flag turns re-entry into a loop, not a stack."""
+    from task_graph.bootstrap import build_registry
+
+    runner = SynchronousRunner()
+    registry = build_registry(store=store, runner=runner)
+    registry.get("agent_mgr").register("profiler")
+    scheduler = registry.get("scheduler")
+
+    tasks = [make_task(resources={"gpu": 8}) for _ in range(5)]
+    for task in tasks:
+        scheduler.submit(task)
+
+    assert runner.started == [t.id for t in tasks]
+    assert runner.max_depth == 1
+    assert all(registry.get("task_mgr").get(t.id).status is TaskStatus.SUCCEEDED for t in tasks)
+
+
+# ------------------------------------------------- a launch that never happens
+
+
+class BrokenRunner:
+    """`start` raises for the first task and works thereafter."""
+
+    def __init__(self) -> None:
+        self.started: list = []
+        self.n = 0
+
+    def start(self, task, agent, on_done) -> None:
+        self.n += 1
+        if self.n == 1:
+            raise RuntimeError("harness unreachable")
+        self.started.append(task.id)
+
+    def stop(self, task_id, on_stopped) -> None:
+        on_stopped(task_id)
+
+
+def test_a_runner_that_cannot_start_does_not_leak_the_lease(store, caplog):
+    """The reservation is taken before the runner is called, so a launch that
+    raises would otherwise shrink the pool permanently — the same shape as the
+    negative-amount bug, one step later in the sequence."""
+    from task_graph.bootstrap import build_registry
+
+    registry = build_registry(store=store, runner=BrokenRunner())
+    registry.get("agent_mgr").register("profiler")
+    scheduler = registry.get("scheduler")
+
+    task = make_task(resources={"gpu": 3, "token": 500})
+    with caplog.at_level("ERROR"):
+        scheduler.submit(task)  # must not raise into the caller
+
+    assert gpu(registry).available == 8
+    assert token(registry).available == 1_000_000  # nothing ran, so nothing spent
+    assert registry.get("task_mgr").get(task.id).status is TaskStatus.FAILED
+    assert not registry.get("task_mgr").get(task.id).is_running
+    assert "failed to launch" in caplog.text
+
+
+def test_one_failed_launch_does_not_abort_the_pass(store):
+    """The other half: a raise must not take the rest of the queue with it."""
+    from task_graph.bootstrap import build_registry
+
+    registry = build_registry(store=store, runner=BrokenRunner())
+    registry.get("agent_mgr").register("profiler")
+    scheduler = registry.get("scheduler")
+
+    doomed = make_task(resources={"gpu": 3})
+    healthy = make_task(resources={"gpu": 6})
+    scheduler.submit(doomed)
+    scheduler.submit(healthy)
+
+    assert registry.get("task_mgr").get(doomed.id).status is TaskStatus.FAILED
+    assert registry.get("task_mgr").get(healthy.id).status is TaskStatus.RUNNING
+    assert registry.get("runner").started == [healthy.id]
+
+
+def test_a_failed_launch_is_not_retried_forever(store):
+    """FAILED rather than back in the queue: the next pass would pick it up and
+    fail identically. An operator resumes it once the cause is fixed."""
+    from task_graph.bootstrap import build_registry
+
+    registry = build_registry(store=store, runner=BrokenRunner())
+    registry.get("agent_mgr").register("profiler")
+    scheduler = registry.get("scheduler")
+
+    task = make_task()
+    scheduler.submit(task)
+    scheduler.try_dispatch()
+    scheduler.try_dispatch()
+
+    assert registry.get("task_mgr").get(task.id).status is TaskStatus.FAILED
+    assert len(registry.get("task_mgr").get(task.id).history) == 1
+
+    scheduler.resume_task(task.id)  # the operator's call, once it is fixed
+    assert registry.get("task_mgr").get(task.id).status is TaskStatus.RUNNING
+
+
+def test_an_agent_factory_that_is_down_releases_the_lease(store):
+    """`instantiate` raises after `take` — the narrowest window there is."""
+    from task_graph.bootstrap import build_registry
+
+    registry = build_registry(store=store)
+    registry.get("agent_mgr").register("profiler")
+    scheduler = registry.get("scheduler")
+
+    def refuse(spec, task_id):
+        raise RuntimeError("agent factory down")
+
+    registry.get("agent_mgr").instantiate = refuse
+
+    task = make_task(resources={"gpu": 3, "token": 500})
+    scheduler.submit(task)
+
+    assert gpu(registry).available == 8
+    assert token(registry).available == 1_000_000
+    assert registry.get("task_mgr").get(task.id).status is TaskStatus.FAILED
+
+
+def test_an_input_opened_earlier_in_the_same_pass_is_not_dispatched_against(store):
+    """Eligibility is re-asked per task, not once per pass.
+
+    Step 1 re-checks every queued task, then the loop starts them one by one —
+    and each `start` can run agent code. A producer that opens its output slot
+    on start invalidates a handoff that a *later* task in the same pass has
+    already been cleared for. Without the per-task re-check that task pins a
+    GENERATING version: an input whose content does not exist yet, recorded in
+    the audit trail criterion 18 requires.
+    """
+    from task_graph.runner import FakeRunner
+
+    (hid,) = new_handoffs(1)
+
+    class OpeningRunner(FakeRunner):
+        """A realistic producer: its agent opens the slot as the run starts."""
+
+        registry = None
+        armed = False
+
+        def start(self, task, agent, on_done):
+            super().start(task, agent, on_done)
+            if self.armed and hid in task.outputs:
+                self.registry.get("handoff_mgr").get(hid).open_next(task.id, agent.id)
+                self.registry.get("handoff_mgr").persist(hid)
+
+    runner = OpeningRunner()
+    registry = build_registry(store=store, runner=runner)
+    runner.registry = registry
+    registry.get("agent_mgr").register("profiler")
+    scheduler, task_mgr = registry.get("scheduler"), registry.get("task_mgr")
+
+    seed = make_task(outputs=[hid])
+    scheduler.submit(seed)
+    runner.produce(registry, seed.id)
+    runner.finish(seed.id)
+    assert registry.get("handoff_mgr").check_if_latest_valid(hid)
+
+    runner.armed = True
+    hog = make_task(resources={"gpu": 8})
+    scheduler.submit(hog)
+    # Both queue behind the hog; the refresher sorts first and so starts first.
+    refresher = make_task(outputs=[hid], resources={"gpu": 1})
+    consumer = make_task(inputs=[hid], resources={"gpu": 1})
+    scheduler.submit(refresher)
+    scheduler.submit(consumer)
+
+    runner.finish(hog.id)  # frees the pool: one pass selects both
+
+    assert registry.get("handoff_mgr").get(hid).latest.status is HandoffStatus.GENERATING
+    consumer_task = task_mgr.get(consumer.id)
+    assert consumer_task.status is TaskStatus.WAITING_HANDOFF
+    assert consumer_task.history == []  # nothing was pinned
+    assert registry.get("resource:gpu").available == 7  # only the refresher holds a lease

--- a/agent_sys/tests/task_graph/test_expedite.py
+++ b/agent_sys/tests/task_graph/test_expedite.py
@@ -1,0 +1,121 @@
+"""Expedite — criterion 9.
+
+A handoff-complete closure goes to the front. The rejection is what makes the
+word mean something: an expedited task that still had to wait would be a
+priority flag, not an expedite.
+"""
+
+import pytest
+
+from task_graph.models import TaskStatus
+
+from .conftest import make_task, new_handoffs
+
+
+def test_an_expedited_task_runs_before_earlier_ones(scheduler, runner):
+    scheduler.submit(make_task(resources={"gpu": 8}))  # occupy the pool
+    early = make_task(resources={"gpu": 8})
+    scheduler.submit(early)
+
+    urgent = make_task(resources={"gpu": 8})
+    scheduler.expedite(urgent)
+
+    runner.finish(runner.started[0])
+    assert runner.started[-1] == urgent.id
+
+
+def test_expedite_marks_the_task(scheduler, task_mgr):
+    task = make_task(resources={"gpu": 1})
+    scheduler.expedite(task)
+    assert task_mgr.get(task.id).expedited
+
+
+def test_an_ordinary_submission_is_not_expedited(scheduler, task_mgr):
+    task = make_task()
+    scheduler.submit(task)
+    assert not task_mgr.get(task.id).expedited
+
+
+def test_expediting_a_task_with_an_unmet_input_is_rejected(scheduler, task_mgr):
+    task = make_task(inputs=new_handoffs(1))
+    with pytest.raises(ValueError, match="not valid"):
+        scheduler.expedite(task)
+    assert task_mgr.all() == []
+
+
+def test_expediting_a_task_with_a_declared_but_unwritten_input_is_rejected(scheduler, handoff_mgr):
+    producer = make_task(outputs=new_handoffs(1))
+    scheduler.submit(producer)  # declared, still CREATED
+
+    with pytest.raises(ValueError, match="not valid"):
+        scheduler.expedite(make_task(inputs=producer.outputs))
+
+
+def test_expediting_a_task_whose_inputs_are_valid_is_accepted(
+    scheduler, task_mgr, runner, registry
+):
+    producer = make_task(outputs=new_handoffs(1))
+    scheduler.submit(producer)
+    runner.produce(registry, producer.id)
+    runner.finish(producer.id)
+
+    urgent = make_task(inputs=producer.outputs)
+    scheduler.expedite(urgent)
+    assert task_mgr.get(urgent.id).status is TaskStatus.RUNNING
+
+
+def test_an_expedited_task_with_no_inputs_is_accepted(scheduler, task_mgr):
+    """Vacuously handoff-complete."""
+    task = make_task()
+    scheduler.expedite(task)
+    assert task_mgr.get(task.id).status is TaskStatus.RUNNING
+
+
+def test_expedited_tasks_keep_fifo_order_among_themselves(scheduler, runner):
+    scheduler.submit(make_task(resources={"gpu": 8}))
+    first, second = make_task(resources={"gpu": 8}), make_task(resources={"gpu": 8})
+    scheduler.expedite(first)
+    scheduler.expedite(second)
+
+    runner.finish(runner.started[0])
+    assert runner.started[-1] == first.id
+    runner.finish(first.id)
+    assert runner.started[-1] == second.id
+
+
+def test_expedite_still_waits_for_resources(scheduler, task_mgr):
+    """It reorders the queue; it does not preempt a running task."""
+    scheduler.submit(make_task(resources={"gpu": 8}))
+    urgent = make_task(resources={"gpu": 1})
+    scheduler.expedite(urgent)
+    assert task_mgr.get(urgent.id).status is TaskStatus.WAITING_RESOURCE
+
+
+def test_a_rejected_expedite_leaves_no_trace(scheduler, task_mgr, handoff_mgr):
+    task = make_task(inputs=new_handoffs(1), outputs=new_handoffs(1))
+    with pytest.raises(ValueError):
+        scheduler.expedite(task)
+
+    assert task_mgr.all() == []
+    assert handoff_mgr.all_ids() == []
+    assert not task.expedited
+
+
+def test_a_rejection_for_any_reason_leaves_the_caller_s_object_unmarked(scheduler):
+    """Not just the not-valid rejection: a duplicate id is refused by `submit`
+    after `expedite` has already set the flag, and the caller's object must not
+    be left mutated by a call that failed."""
+    original = make_task()
+    scheduler.submit(original)
+
+    from task_graph.models import Task
+
+    duplicate = Task(id=original.id, agent_spec="profiler")
+    with pytest.raises(KeyError):
+        scheduler.expedite(duplicate)
+    assert not duplicate.expedited
+
+    unknown = make_task(spec="nope")
+    with pytest.raises(KeyError):
+        scheduler.expedite(unknown)
+    assert not unknown.expedited

--- a/agent_sys/tests/task_graph/test_handoff.py
+++ b/agent_sys/tests/task_graph/test_handoff.py
@@ -1,0 +1,244 @@
+"""HandoffMgr — the collection, and nothing more.
+
+The mgr decides nothing: `check_if_latest_valid` delegates to the handoff, which
+delegates to the version. One definition of "usable", on the object that has it.
+"""
+
+import pytest
+
+from task_graph.handoff import HandoffMgr
+from task_graph.ids import AgentId, HandoffId, TaskId
+from task_graph.models import HandoffStatus
+from task_graph.registry import Registry
+from task_graph.store import MemoryStoreMgr
+
+
+@pytest.fixture
+def store():
+    return MemoryStoreMgr()
+
+
+@pytest.fixture
+def mgr(store):
+    registry = Registry()
+    registry.register("store_mgr", store)
+    manager = HandoffMgr(registry)
+    registry.register("handoff_mgr", manager)
+    return manager
+
+
+def seal(mgr, hid, status=HandoffStatus.VALID, content=None):
+    """What an agent does: take a version and seal it."""
+    version = mgr.get(hid).open_next(TaskId.new(), AgentId.new())
+    version.seal(status, content)
+    mgr.persist(hid)
+    return version
+
+
+# ----------------------------------------------------------------- declare
+
+
+def test_declare_creates_one_created_v0(mgr):
+    hid, tid = HandoffId.new(), TaskId.new()
+    mgr.declare([hid], producer_task_id=tid)
+
+    handoff = mgr.get(hid)
+    assert len(handoff.versions) == 1
+    assert handoff.latest.version == 0
+    assert handoff.latest.status is HandoffStatus.CREATED
+    assert handoff.latest.producer_task_id == tid
+    assert handoff.latest.producer_agent_id is None
+
+
+def test_declare_persists(mgr, store):
+    hid = HandoffId.new()
+    mgr.declare([hid], producer_task_id=TaskId.new())
+    assert store.exists("handoff", str(hid))
+
+
+def test_declare_accepts_types(mgr):
+    a, b = HandoffId.new(), HandoffId.new()
+    mgr.declare([a, b], producer_task_id=TaskId.new(), types={a: "profile"})
+    assert mgr.get(a).type == "profile"
+    assert mgr.get(b).type == ""
+
+
+def test_declare_is_idempotent_and_never_overwrites(mgr):
+    """`update_task` re-declares; overwriting would delete written versions."""
+    hid, first_task = HandoffId.new(), TaskId.new()
+    mgr.declare([hid], producer_task_id=first_task)
+    seal(mgr, hid, content="already written")
+
+    mgr.declare([hid], producer_task_id=TaskId.new())
+
+    handoff = mgr.get(hid)
+    assert len(handoff.versions) == 1
+    assert handoff.latest.status is HandoffStatus.VALID
+    assert handoff.latest.content == "already written"
+
+
+def test_declare_of_an_empty_list_is_fine(mgr):
+    mgr.declare([], producer_task_id=TaskId.new())
+    assert mgr.all_ids() == []
+
+
+# ------------------------------------------------------ check_if_latest_valid
+
+
+def test_an_unknown_id_is_not_valid_rather_than_an_error(mgr):
+    """A consumer may be submitted before its producer declares the slot."""
+    assert mgr.check_if_latest_valid(HandoffId.new()) is False
+
+
+@pytest.mark.parametrize(
+    "make, expected",
+    [
+        (lambda m, h: None, False),  # CREATED
+        (lambda m, h: m.get(h).open_next(TaskId.new(), AgentId.new()), False),  # GENERATING
+        (lambda m, h: seal(m, h, HandoffStatus.VALID), True),
+        (lambda m, h: seal(m, h, HandoffStatus.INVALID), False),
+    ],
+    ids=["created", "generating", "valid", "invalid"],
+)
+def test_validity_tracks_the_latest_version(mgr, make, expected):
+    hid = HandoffId.new()
+    mgr.declare([hid], producer_task_id=TaskId.new())
+    make(mgr, hid)
+    assert mgr.check_if_latest_valid(hid) is expected
+
+
+def test_a_re_run_makes_a_valid_handoff_not_valid_again(mgr):
+    hid = HandoffId.new()
+    mgr.declare([hid], producer_task_id=TaskId.new())
+    seal(mgr, hid)
+    assert mgr.check_if_latest_valid(hid)
+
+    mgr.get(hid).open_next(TaskId.new(), AgentId.new())
+    assert not mgr.check_if_latest_valid(hid)
+
+
+# -------------------------------------------------------------------- reads
+
+
+def test_latest_returns_none_for_an_unknown_id(mgr):
+    assert mgr.latest(HandoffId.new()) is None
+
+
+def test_latest_returns_the_last_version(mgr):
+    hid = HandoffId.new()
+    mgr.declare([hid], producer_task_id=TaskId.new())
+    seal(mgr, hid)
+    seal(mgr, hid)
+    assert mgr.latest(hid).version == 1
+
+
+def test_get_raises_for_an_unknown_id(mgr):
+    """Unlike `check_if_latest_valid`: asking for the object is a bug."""
+    with pytest.raises(KeyError):
+        mgr.get(HandoffId.new())
+
+
+def test_get_many_preserves_order(mgr):
+    ids = [HandoffId.new() for _ in range(3)]
+    mgr.declare(ids, producer_task_id=TaskId.new())
+    assert [h.id for h in mgr.get_many(ids)] == ids
+
+
+def test_all_ids(mgr):
+    ids = [HandoffId.new() for _ in range(3)]
+    mgr.declare(ids, producer_task_id=TaskId.new())
+    assert sorted(mgr.all_ids(), key=str) == sorted(ids, key=str)
+
+
+def test_produced_by_task(mgr):
+    first, second = TaskId.new(), TaskId.new()
+    a, b, c = HandoffId.new(), HandoffId.new(), HandoffId.new()
+    mgr.declare([a, b], producer_task_id=first)
+    mgr.declare([c], producer_task_id=second)
+
+    assert sorted(mgr.produced_by_task(first), key=str) == sorted([a, b], key=str)
+    assert mgr.produced_by_task(second) == [c]
+    assert mgr.produced_by_task(TaskId.new()) == []
+
+
+def test_produced_by_task_follows_the_latest_producer(mgr):
+    """A re-run by a different task moves the handoff's attribution."""
+    original, rerun = TaskId.new(), TaskId.new()
+    hid = HandoffId.new()
+    mgr.declare([hid], producer_task_id=original)
+    seal(mgr, hid)
+
+    mgr.get(hid).open_next(rerun, AgentId.new())
+    mgr.persist(hid)
+
+    assert mgr.produced_by_task(rerun) == [hid]
+    assert mgr.produced_by_task(original) == []
+
+
+# -------------------------------------------------------------- persistence
+
+
+def test_persist_writes_the_whole_handoff_including_its_versions(mgr, store):
+    hid = HandoffId.new()
+    mgr.declare([hid], producer_task_id=TaskId.new())
+    seal(mgr, hid, content={"p50": 7})
+    seal(mgr, hid, HandoffStatus.INVALID)
+
+    record = store.read("handoff", str(hid))
+    assert len(record["versions"]) == 2
+    assert record["versions"][0]["content"] == {"p50": 7}
+    assert record["versions"][1]["status"] == "invalid"
+
+
+def test_persist_of_an_unknown_id_raises(mgr):
+    with pytest.raises(KeyError):
+        mgr.persist(HandoffId.new())
+
+
+def test_resume_reloads_everything_with_versions_intact(mgr, store):
+    ids = [HandoffId.new() for _ in range(3)]
+    mgr.declare(ids, producer_task_id=TaskId.new(), types={ids[0]: "profile"})
+    seal(mgr, ids[0], content="v0")
+    seal(mgr, ids[0], content="v1")
+    seal(mgr, ids[1], HandoffStatus.INVALID)
+
+    registry = Registry()
+    registry.register("store_mgr", store)
+    fresh = HandoffMgr(registry)
+    assert fresh.all_ids() == []
+
+    fresh.resume_system()
+
+    assert sorted(fresh.all_ids(), key=str) == sorted(ids, key=str)
+    assert fresh.get(ids[0]).type == "profile"
+    assert [v.content for v in fresh.get(ids[0]).versions] == ["v0", "v1"]
+    assert fresh.check_if_latest_valid(ids[0])
+    assert not fresh.check_if_latest_valid(ids[1])
+    assert not fresh.check_if_latest_valid(ids[2])
+
+
+def test_resume_needs_no_regrouping_because_a_record_is_a_whole_handoff(mgr, store):
+    """One record per handoff, not per version: directory order is not version
+    order, and nesting removes the need to sort on the way back."""
+    hid = HandoffId.new()
+    mgr.declare([hid], producer_task_id=TaskId.new())
+    for i in range(5):
+        seal(mgr, hid, content=i)
+
+    assert len(store.read_all("handoff")) == 1
+
+    registry = Registry()
+    registry.register("store_mgr", store)
+    fresh = HandoffMgr(registry)
+    fresh.resume_system()
+    assert [v.version for v in fresh.get(hid).versions] == [0, 1, 2, 3, 4]
+    assert [v.content for v in fresh.get(hid).versions] == [0, 1, 2, 3, 4]
+
+
+def test_resume_replaces_rather_than_merges(mgr, store):
+    hid = HandoffId.new()
+    mgr.declare([hid], producer_task_id=TaskId.new())
+    store.delete("handoff", str(hid))
+
+    mgr.resume_system()
+    assert mgr.all_ids() == []

--- a/agent_sys/tests/task_graph/test_ids.py
+++ b/agent_sys/tests/task_graph/test_ids.py
@@ -1,0 +1,129 @@
+"""Typed identities — spec criterion 27.
+
+Two ids of different kinds built from the same bytes must not be equal and must
+not collide in one dict. ``uuid.UUID.__eq__`` compares ``self.int`` against any
+``UUID``, so this only holds because ``_Id`` overrides it.
+"""
+
+import uuid
+
+import pytest
+from pydantic import BaseModel
+
+from task_graph.ids import AgentId, HandoffId, TaskId
+
+KINDS = [TaskId, AgentId, HandoffId]
+
+
+def test_new_is_unique_and_typed():
+    for kind in KINDS:
+        a, b = kind.new(), kind.new()
+        assert a != b
+        assert isinstance(a, kind)
+        assert isinstance(a, uuid.UUID)
+
+
+def test_same_kind_same_bytes_is_equal():
+    raw = uuid.uuid4()
+    for kind in KINDS:
+        assert kind(raw.hex) == kind(raw.hex)
+        assert hash(kind(raw.hex)) == hash(kind(raw.hex))
+
+
+def test_cross_kind_same_bytes_is_not_equal():
+    raw = uuid.uuid4()
+    for left in KINDS:
+        for right in KINDS:
+            if left is right:
+                continue
+            assert left(raw.hex) != right(raw.hex), f"{left.__name__} == {right.__name__}"
+
+
+def test_cross_kind_does_not_collide_in_one_dict():
+    raw = uuid.uuid4()
+    d = {kind(raw.hex): kind.__name__ for kind in KINDS}
+    assert len(d) == len(KINDS)
+    for kind in KINDS:
+        assert d[kind(raw.hex)] == kind.__name__
+
+
+def test_a_plain_uuid_is_not_equal_to_a_typed_one():
+    raw = uuid.uuid4()
+    assert TaskId(raw.hex) != raw
+    assert raw != TaskId(raw.hex)
+
+
+def test_str_round_trip():
+    for kind in KINDS:
+        original = kind.new()
+        assert kind(str(original)) == original
+
+
+def test_repr_names_the_kind():
+    tid = TaskId.new()
+    assert repr(tid).startswith("TaskId(")
+    assert str(tid) in repr(tid)
+
+
+def test_malformed_value_is_rejected():
+    with pytest.raises(ValueError):
+        TaskId("not-a-uuid")
+
+
+# ---- pydantic integration: a bare UUID subclass raises without the schema ----
+
+
+class _Holder(BaseModel):
+    tid: TaskId
+    versions: dict[HandoffId, int] = {}
+
+
+def test_pydantic_accepts_a_typed_id():
+    tid = TaskId.new()
+    assert _Holder(tid=tid).tid == tid
+
+
+def test_pydantic_coerces_a_string():
+    tid = TaskId.new()
+    holder = _Holder(tid=str(tid))
+    assert holder.tid == tid
+    assert isinstance(holder.tid, TaskId)
+
+
+def test_pydantic_coerces_a_plain_uuid():
+    raw = uuid.uuid4()
+    holder = _Holder(tid=raw)
+    assert isinstance(holder.tid, TaskId)
+    assert holder.tid == TaskId(raw.hex)
+
+
+def test_json_mode_dumps_a_string_python_mode_keeps_the_object():
+    tid = TaskId.new()
+    holder = _Holder(tid=tid)
+    assert holder.model_dump(mode="json")["tid"] == str(tid)
+    assert holder.model_dump()["tid"] == tid
+
+
+def test_round_trip_preserves_the_type_of_a_dict_key():
+    hid = HandoffId.new()
+    holder = _Holder(tid=TaskId.new(), versions={hid: 3})
+    back = _Holder.model_validate(holder.model_dump(mode="json"))
+    assert back.versions == {hid: 3}
+    (restored_key,) = back.versions
+    assert isinstance(restored_key, HandoffId)
+
+
+def test_round_trip_survives_json_text():
+    import json
+
+    holder = _Holder(tid=TaskId.new(), versions={HandoffId.new(): 0})
+    assert _Holder.model_validate(json.loads(holder.model_dump_json())) == holder
+
+
+def test_the_types_are_statically_incompatible():
+    """Criterion 27's other half — the checker's job, asserted here as the
+    structural fact it rests on: three unrelated leaf classes."""
+    for left in KINDS:
+        for right in KINDS:
+            if left is not right:
+                assert not issubclass(left, right)

--- a/agent_sys/tests/task_graph/test_invariants.py
+++ b/agent_sys/tests/task_graph/test_invariants.py
@@ -1,0 +1,215 @@
+"""The index invariant — criterion 12.
+
+`_move` is the only thing that assigns `task.status` or mutates a pool, so the
+index cannot disagree with the TaskMgr. This drives a long sequence of
+operations and re-checks after every one.
+"""
+
+import logging
+import random
+
+from task_graph.models import TaskStatus
+from task_graph.resource import RenewableMgr
+
+from .conftest import make_task, new_handoffs, rebuild
+
+
+def check(scheduler, task_mgr, registry=None) -> None:
+    tasks = task_mgr.all()
+    indexed = set().union(*scheduler.pools.values()) if scheduler.pools else set()
+
+    assert indexed == {t.id for t in tasks}, "the index and the TaskMgr disagree"
+    for task in tasks:
+        assert task.id in scheduler.pools[task.status], (
+            f"{task.id} is {task.status.value} but not in that pool"
+        )
+    seen = [tid for pool in scheduler.pools.values() for tid in pool]
+    assert len(seen) == len(set(seen)), "a task is in two pools at once"
+
+    if registry is None:
+        return
+    # Resource conservation. Free capacity plus every live reservation — plus,
+    # for a consumable, everything already settled — must equal the total. This
+    # is what catches a leaked or double-booked lease, which the pool/status
+    # correspondence alone cannot see.
+    for pool_mgr in registry.resolve("resource:*"):
+        reserved = sum(
+            t.resources.get(pool_mgr.name, 0.0)
+            for t in tasks
+            if t.status in (TaskStatus.RUNNING, TaskStatus.STOPPING)
+        )
+        # A consumable shrinks as spend accrues, so `spent` is part of the sum.
+        # It is the half where the subtle accounting lives: D12's bug was a
+        # reservation leaking into the durable record, and a renewable-only
+        # check could never have seen it.
+        spent = 0.0 if isinstance(pool_mgr, RenewableMgr) else pool_mgr.spent
+        assert pool_mgr.available + reserved + spent == pool_mgr.capacity, (
+            f"{pool_mgr.name}: {pool_mgr.available} free + {reserved} reserved "
+            f"+ {spent} spent != {pool_mgr.capacity}"
+        )
+
+
+def test_the_invariant_holds_through_a_long_mixed_sequence(
+    scheduler, task_mgr, runner, registry, caplog
+):
+    """A fixed sequence — deterministic, so a failure is reproducible."""
+    # A spec whose agent cannot be built: the launch fails after the lease is
+    # taken, which is the path that exercises resource conservation.
+    registry.get("agent_mgr").register("doomed")
+    real_instantiate = registry.get("agent_mgr").instantiate
+
+    def instantiate(spec, task_id):
+        if spec == "doomed":
+            raise RuntimeError("agent factory down")
+        return real_instantiate(spec, task_id)
+
+    registry.get("agent_mgr").instantiate = instantiate
+    caplog.set_level(logging.CRITICAL, logger="task_graph.scheduler")  # the failures are expected
+
+    rng = random.Random(20260820)
+    (shared,) = new_handoffs(1)
+    live: list = []
+    performed: list[str] = []
+
+    check(scheduler, task_mgr, registry)
+
+    for _ in range(200):
+        choice = rng.randrange(8)
+
+        if choice == 0:
+            task = make_task(
+                inputs=[shared] if rng.random() < 0.4 else [],
+                outputs=[shared] if rng.random() < 0.3 else new_handoffs(1),
+                resources={"gpu": rng.choice([0, 1, 4]), "token": 100},
+            )
+            scheduler.submit(task)
+            live.append(task.id)
+            performed.append("submit")
+
+        elif choice == 7:
+            # A launch that fails after the lease is taken. Without this the
+            # conservation half of `check` is never exercised, and a leaked
+            # lease would pass the whole sequence.
+            doomed = make_task(spec="doomed", resources={"gpu": rng.choice([1, 4])})
+            scheduler.submit(doomed)
+            live.append(doomed.id)
+            performed.append("failed-launch")
+
+        elif choice == 1 and live:
+            tid = rng.choice(live)
+            if task_mgr.get(tid).status in (
+                TaskStatus.WAITING_HANDOFF,
+                TaskStatus.WAITING_RESOURCE,
+            ):
+                scheduler.remove_queued(tid)
+                performed.append("remove")
+
+        elif choice in (2, 3):
+            # `runner.running` still holds a task between stop() and its
+            # acknowledgement, so pick on status rather than on membership.
+            actually_running = [
+                tid for tid in runner.running if task_mgr.get(tid).status is TaskStatus.RUNNING
+            ]
+            if not actually_running:
+                pass
+            elif choice == 2:
+                tid = rng.choice(actually_running)
+                if rng.random() < 0.5:
+                    runner.produce(registry, tid)
+                runner.finish(
+                    tid, TaskStatus.SUCCEEDED if rng.random() < 0.7 else TaskStatus.FAILED
+                )
+                performed.append("finish")
+            else:
+                scheduler.stop(rng.choice(actually_running))
+                performed.append("stop")
+
+        elif choice == 4 and runner.stop_requested:
+            tid = runner.stop_requested.pop(0)
+            if task_mgr.get(tid).status is TaskStatus.STOPPING:
+                runner.ack_stop(tid)
+                performed.append("ack")
+
+        elif choice == 5 and live:
+            tid = rng.choice(live)
+            if task_mgr.get(tid).status in (TaskStatus.FAILED, TaskStatus.SUSPENDED):
+                scheduler.resume_task(tid)
+                performed.append("resume")
+
+        elif choice == 6 and live:
+            tid = rng.choice(live)
+            if task_mgr.get(tid).status in (
+                TaskStatus.WAITING_HANDOFF,
+                TaskStatus.WAITING_RESOURCE,
+            ):
+                scheduler.update_task(tid, resources={"gpu": rng.choice([0, 2])})
+                performed.append("update")
+
+        check(scheduler, task_mgr, registry)
+
+    # The sequence is only meaningful if it actually reached every operation.
+    assert set(performed) == {
+        "submit",
+        "remove",
+        "finish",
+        "stop",
+        "ack",
+        "resume",
+        "update",
+        "failed-launch",
+    }, sorted(set(performed))
+
+
+def test_no_resource_leaks_after_everything_settles(scheduler, task_mgr, runner, registry):
+    """A renewable pool must return to full once nothing is running."""
+    tasks = [make_task(resources={"gpu": 2}) for _ in range(6)]
+    for task in tasks:
+        scheduler.submit(task)
+
+    while runner.running:
+        tid = next(iter(runner.running))
+        runner.finish(tid)
+
+    assert registry.get("resource:gpu").available == 8
+    assert not scheduler.pools[TaskStatus.RUNNING]
+    check(scheduler, task_mgr, registry)
+
+
+def test_a_queued_task_never_holds_a_resource(scheduler, task_mgr, registry):
+    """The all-or-nothing consequence, stated as an invariant."""
+    scheduler.submit(make_task(resources={"gpu": 5}))
+    for _ in range(4):
+        scheduler.submit(make_task(resources={"gpu": 4, "token": 100}))
+
+    queued = task_mgr.by_status(TaskStatus.WAITING_RESOURCE)
+    assert queued
+    assert registry.get("resource:gpu").available == 3  # only the running task's 5
+    assert registry.get("resource:token").available == 1_000_000
+
+
+def test_the_invariant_survives_a_restart(scheduler, task_mgr, runner, registry, store):
+    for _ in range(4):
+        scheduler.submit(make_task(resources={"gpu": 3}, outputs=new_handoffs(1)))
+    scheduler.submit(make_task(inputs=new_handoffs(1)))
+    runner.finish(next(iter(runner.running)))
+
+    fresh = rebuild(store)
+    from task_graph.registry import resume_all
+
+    resume_all(fresh)
+
+    check(fresh.get("scheduler"), fresh.get("task_mgr"), fresh)
+    assert len(fresh.get("task_mgr").all()) == 5
+
+
+def test_move_is_idempotent_and_self_healing(scheduler, task_mgr):
+    """Discarding from every pool rather than from the recorded status means a
+    stale entry cannot survive, even if the stored status was already wrong."""
+    task = make_task(inputs=new_handoffs(1))
+    scheduler.submit(task)
+
+    scheduler.pools[TaskStatus.RUNNING].add(task.id)  # corrupt the index by hand
+    scheduler._move(task.id, TaskStatus.WAITING_HANDOFF)
+
+    check(scheduler, task_mgr)
+    assert scheduler.pools[TaskStatus.RUNNING] == set()

--- a/agent_sys/tests/task_graph/test_lifecycle.py
+++ b/agent_sys/tests/task_graph/test_lifecycle.py
@@ -1,0 +1,397 @@
+"""Lifecycle — criteria 5, 6, 11 and 23.
+
+Stop is a request, not a state change: the task is SUSPENDED only when the
+runner acknowledges.
+"""
+
+import pytest
+
+from task_graph.models import TaskStatus
+
+from .conftest import gpu, make_task, new_handoffs, token
+
+# --------------------------------------------------------------- remove_queued
+
+
+def test_removing_a_queued_task_cancels_it(scheduler, task_mgr, runner):
+    """Criterion 5."""
+    task = make_task(inputs=new_handoffs(1))
+    scheduler.submit(task)
+    scheduler.remove_queued(task.id)
+
+    assert task_mgr.get(task.id).status is TaskStatus.CANCELLED
+    assert scheduler.pools[TaskStatus.CANCELLED] == {task.id}
+    assert runner.started == []
+
+
+def test_removing_an_eligible_task_cancels_it(scheduler, task_mgr):
+    scheduler.submit(make_task(resources={"gpu": 8}))
+    queued = make_task(resources={"gpu": 1})
+    scheduler.submit(queued)
+
+    scheduler.remove_queued(queued.id)
+    assert task_mgr.get(queued.id).status is TaskStatus.CANCELLED
+
+
+def test_removing_a_running_task_is_rejected(scheduler, task_mgr):
+    """Criterion 11: stop it instead."""
+    task = make_task()
+    scheduler.submit(task)
+    with pytest.raises(ValueError, match="running"):
+        scheduler.remove_queued(task.id)
+    assert task_mgr.get(task.id).status is TaskStatus.RUNNING
+
+
+def test_a_cancelled_task_is_not_dispatched_when_room_appears(scheduler, runner):
+    hog = make_task(resources={"gpu": 8})
+    scheduler.submit(hog)
+    queued = make_task(resources={"gpu": 1})
+    scheduler.submit(queued)
+    scheduler.remove_queued(queued.id)
+
+    runner.finish(hog.id)
+    assert queued.id not in runner.started
+
+
+# ------------------------------------------------------------------ stop
+
+
+def test_stop_asks_the_runner_and_waits_for_the_acknowledgement(scheduler, task_mgr, runner):
+    """Criterion 6."""
+    task = make_task(resources={"gpu": 2})
+    scheduler.submit(task)
+
+    scheduler.stop(task.id)
+    assert task_mgr.get(task.id).status is TaskStatus.STOPPING
+    assert runner.stop_requested == [task.id]
+
+    runner.ack_stop(task.id)
+    assert task_mgr.get(task.id).status is TaskStatus.SUSPENDED
+
+
+def test_the_resources_are_held_until_the_acknowledgement(scheduler, runner, registry):
+    task = make_task(resources={"gpu": 2})
+    scheduler.submit(task)
+
+    scheduler.stop(task.id)
+    assert gpu(registry).available == 6
+
+    runner.ack_stop(task.id)
+    assert gpu(registry).available == 8
+
+
+def test_a_stop_settles_a_consumable_at_the_full_reservation(scheduler, runner, registry):
+    """No usage figures arrive with an acknowledgement, so assuming the agent
+    spent what it reserved is the safe direction for a budget."""
+    task = make_task(resources={"token": 500})
+    scheduler.submit(task)
+    scheduler.stop(task.id)
+    runner.ack_stop(task.id)
+
+    assert token(registry).available == 1_000_000 - 500
+
+
+def test_stopping_closes_the_execution_record(scheduler, task_mgr, runner):
+    task = make_task()
+    scheduler.submit(task)
+    scheduler.stop(task.id)
+    runner.ack_stop(task.id)
+
+    top = task_mgr.get(task.id).current
+    assert not top.is_open
+    assert top.outcome is TaskStatus.SUSPENDED
+
+
+def test_stopping_a_queued_task_is_rejected(scheduler):
+    task = make_task(inputs=new_handoffs(1))
+    scheduler.submit(task)
+    with pytest.raises(ValueError, match="waiting_handoff"):
+        scheduler.stop(task.id)
+
+
+def test_stopping_a_finished_task_is_rejected(scheduler, runner):
+    task = make_task()
+    scheduler.submit(task)
+    runner.finish(task.id)
+    with pytest.raises(ValueError, match="succeeded"):
+        scheduler.stop(task.id)
+
+
+def test_a_stop_frees_room_for_a_queued_task(scheduler, task_mgr, runner):
+    hog = make_task(resources={"gpu": 8})
+    scheduler.submit(hog)
+    queued = make_task(resources={"gpu": 8})
+    scheduler.submit(queued)
+
+    scheduler.stop(hog.id)
+    runner.ack_stop(hog.id)
+    assert task_mgr.get(queued.id).status is TaskStatus.RUNNING
+
+
+# ----------------------------------------------------------------- resume
+
+
+def test_a_suspended_task_resumes_with_a_new_attempt(scheduler, task_mgr, agent_mgr, runner):
+    task = make_task()
+    scheduler.submit(task)
+    first_agent = task_mgr.get(task.id).current.agent_id
+    scheduler.stop(task.id)
+    runner.ack_stop(task.id)
+
+    scheduler.resume_task(task.id)
+
+    restored = task_mgr.get(task.id)
+    assert restored.status is TaskStatus.RUNNING
+    assert [e.attempt for e in restored.history] == [0, 1]
+    assert restored.current.agent_id != first_agent
+    assert agent_mgr.get(restored.current.agent_id).task_id == task.id
+
+
+def test_a_failed_task_resumes(scheduler, task_mgr, runner):
+    task = make_task()
+    scheduler.submit(task)
+    runner.finish(task.id, TaskStatus.FAILED)
+
+    scheduler.resume_task(task.id)
+    assert task_mgr.get(task.id).status is TaskStatus.RUNNING
+
+
+def test_a_resumed_task_whose_inputs_went_stale_waits_again(scheduler, task_mgr, runner, registry):
+    """Eligibility is recomputed on resume, not remembered."""
+    producer = make_task(outputs=new_handoffs(1))
+    scheduler.submit(producer)
+    runner.produce(registry, producer.id)
+    runner.finish(producer.id)
+
+    consumer = make_task(inputs=producer.outputs)
+    scheduler.submit(consumer)
+    runner.finish(consumer.id, TaskStatus.FAILED)
+
+    # the slot is reopened by another producer and not yet sealed
+    refresher = make_task(outputs=producer.outputs)
+    scheduler.submit(refresher)
+    registry.get("handoff_mgr").get(producer.outputs[0]).open_next(
+        refresher.id, task_mgr.get(refresher.id).current.agent_id
+    )
+
+    scheduler.resume_task(consumer.id)
+    assert task_mgr.get(consumer.id).status is TaskStatus.WAITING_HANDOFF
+
+
+@pytest.mark.parametrize("status", ["waiting_handoff", "running", "succeeded", "cancelled"])
+def test_resuming_a_task_that_is_not_stopped_or_failed_is_rejected(scheduler, runner, status):
+    queued = status in ("waiting_handoff", "cancelled")
+    task = make_task(inputs=new_handoffs(1) if queued else [])
+    scheduler.submit(task)
+    if status == "succeeded":
+        runner.finish(task.id)
+    elif status == "cancelled":
+        scheduler.remove_queued(task.id)
+
+    with pytest.raises(ValueError, match=status):
+        scheduler.resume_task(task.id)
+
+
+# -------------------------------------------------------------- update_task
+
+
+def test_update_replaces_the_definition_and_keeps_the_id(scheduler, task_mgr):
+    task = make_task(inputs=new_handoffs(1), resources={"gpu": 1})
+    scheduler.submit(task)
+
+    scheduler.update_task(task.id, agent_spec="tuner", resources={"gpu": 4})
+
+    updated = task_mgr.get(task.id)
+    assert updated.id == task.id
+    assert updated.agent_spec == "tuner"
+    assert updated.resources == {"gpu": 4}
+    assert updated.status is TaskStatus.WAITING_HANDOFF
+
+
+def test_update_keeps_the_place_in_fifo_order(scheduler, runner, task_mgr):
+    """`model_copy` preserves created_at: an update does not cost a task its
+    place in the queue."""
+    scheduler.submit(make_task(resources={"gpu": 8}))
+    first = make_task(resources={"gpu": 8})
+    second = make_task(resources={"gpu": 8})
+    scheduler.submit(first)
+    scheduler.submit(second)
+
+    scheduler.update_task(first.id, agent_spec="tuner")
+    assert task_mgr.get(first.id).created_at == first.created_at
+
+    runner.finish(runner.started[0])
+    assert runner.started[-1] == first.id
+
+
+def test_update_is_rejected_on_a_task_that_is_not_queued(scheduler, task_mgr, runner):
+    task = make_task()
+    scheduler.submit(task)
+    runner.finish(task.id, TaskStatus.FAILED)
+    scheduler.resume_task(task.id)
+    runner.finish(task.id, TaskStatus.FAILED)
+    assert len(task_mgr.get(task.id).history) == 2
+
+    scheduler.resume_task(task.id)  # back to running; stop it to make it queued
+    scheduler.stop(task.id)
+    runner.ack_stop(task.id)
+    with pytest.raises(ValueError):
+        scheduler.update_task(task.id)  # SUSPENDED is not queued
+
+
+def test_update_clears_the_history(scheduler, task_mgr, runner):
+    """A replacement is a new definition, so it starts with no run behind it."""
+    hog = make_task(resources={"gpu": 8})
+    task = make_task(resources={"gpu": 1})
+    scheduler.submit(task)
+    runner.finish(task.id, TaskStatus.FAILED)  # one entry in the history
+    assert len(task_mgr.get(task.id).history) == 1
+
+    scheduler.submit(hog)  # saturate, so the resume leaves `task` queued
+    scheduler.resume_task(task.id)
+    assert task_mgr.get(task.id).status is TaskStatus.WAITING_RESOURCE
+
+    scheduler.update_task(task.id, agent_spec="tuner")
+    assert task_mgr.get(task.id).history == []
+
+
+def test_update_recomputes_the_pool_when_the_inputs_change(scheduler, task_mgr, runner, registry):
+    """Criterion 11's other half: replacing `inputs` re-asks eligibility."""
+    producer = make_task(outputs=new_handoffs(1))
+    scheduler.submit(producer)
+    runner.produce(registry, producer.id)
+    runner.finish(producer.id)
+
+    hog = make_task(resources={"gpu": 8})
+    scheduler.submit(hog)
+    task = make_task(inputs=producer.outputs, resources={"gpu": 1})
+    scheduler.submit(task)
+    assert task_mgr.get(task.id).status is TaskStatus.WAITING_RESOURCE  # inputs met
+
+    scheduler.update_task(task.id, inputs=new_handoffs(1))  # now unmet
+    assert task_mgr.get(task.id).status is TaskStatus.WAITING_HANDOFF
+
+    scheduler.update_task(task.id, inputs=producer.outputs)  # met again
+    assert task_mgr.get(task.id).status is TaskStatus.WAITING_RESOURCE
+
+
+def test_update_replaces_the_outputs_and_redeclares_them(scheduler, handoff_mgr):
+    task = make_task(inputs=new_handoffs(1), outputs=new_handoffs(1))
+    scheduler.submit(task)
+    fresh = new_handoffs(1)
+
+    scheduler.update_task(task.id, outputs=fresh)
+
+    assert handoff_mgr.get(fresh[0]).latest.producer_task_id == task.id
+
+
+@pytest.mark.parametrize(
+    "fields, match",
+    [
+        ({"resource": {"gpu": 4}}, "unknown task field"),
+        ({"agentspec": "tuner"}, "unknown task field"),
+        ({"id": "irrelevant"}, "cannot be set by an update"),
+        ({"status": TaskStatus.RUNNING}, "cannot be set by an update"),
+        ({"history": []}, "cannot be set by an update"),
+    ],
+)
+def test_update_rejects_a_field_it_cannot_honour(scheduler, task_mgr, fields, match):
+    """`model_copy(update=...)` writes straight to __dict__, honouring neither
+    `extra="forbid"` nor `validate_assignment`. Unchecked, a misspelled field is
+    accepted and silently does nothing, and `id=` leaves the original cancelled
+    while creating a second task under the new id."""
+    task = make_task(inputs=new_handoffs(1), resources={"gpu": 1})
+    scheduler.submit(task)
+
+    with pytest.raises(ValueError, match=match):
+        scheduler.update_task(task.id, **fields)
+
+    assert len(task_mgr.all()) == 1  # nothing was split off
+    assert task_mgr.get(task.id).status is TaskStatus.WAITING_HANDOFF  # still queued
+    assert task_mgr.get(task.id).resources == {"gpu": 1}  # unchanged
+
+
+def test_update_behaves_exactly_like_a_resubmission(scheduler, task_mgr, registry, store):
+    """Criterion 23. `update_task` is literally remove_queued + submit, so this
+    holds by construction; the test is what keeps it that way."""
+    from .conftest import rebuild
+
+    (hid,) = new_handoffs(1)
+    original = make_task(inputs=[hid], resources={"gpu": 1})
+    scheduler.submit(original)
+    updated = scheduler.update_task(original.id, agent_spec="tuner", resources={"gpu": 4})
+
+    # the manual arm: a fresh system, cancel then submit by hand
+    other = rebuild(store=type(store)())
+    twin = original.model_copy(deep=True)
+    other.get("scheduler").submit(twin)
+    other.get("scheduler").remove_queued(twin.id)
+    manual = twin.model_copy(
+        update={
+            "agent_spec": "tuner",
+            "resources": {"gpu": 4},
+            "status": TaskStatus.WAITING_HANDOFF,
+            "history": [],
+        },
+        deep=True,
+    )
+    other.get("scheduler").submit(manual)
+
+    exclude = {"created_at"}  # the manual arm is constructed later
+    assert updated.model_dump(exclude=exclude) == other.get("task_mgr").get(manual.id).model_dump(
+        exclude=exclude
+    )
+
+
+def test_update_of_a_running_task_is_rejected(scheduler, task_mgr):
+    task = make_task()
+    scheduler.submit(task)
+    with pytest.raises(ValueError, match="running"):
+        scheduler.update_task(task.id, agent_spec="tuner")
+    assert task_mgr.get(task.id).agent_spec == "profiler"
+
+
+def test_update_redeclares_outputs_without_destroying_written_versions(
+    scheduler, registry, runner, task_mgr
+):
+    """`declare` is idempotent, which is what makes this safe."""
+    (hid,) = new_handoffs(1)
+    producer = make_task(outputs=[hid])
+    scheduler.submit(producer)
+    runner.produce(registry, producer.id, content="written")
+    runner.finish(producer.id)
+
+    consumer = make_task(inputs=new_handoffs(1), outputs=[hid])
+    scheduler.submit(consumer)
+    scheduler.update_task(consumer.id, agent_spec="tuner")
+
+    handoff = registry.get("handoff_mgr").get(hid)
+    assert handoff.latest.content == "written"
+    assert len(handoff.versions) == 1
+
+
+def test_a_rejected_update_leaves_the_task_where_it_was(scheduler, task_mgr):
+    """`update_task` is cancel-then-submit, so a submit that rejects would
+    otherwise silently destroy the very task it was asked to change."""
+    task = make_task(inputs=new_handoffs(1), resources={"gpu": 2})
+    scheduler.submit(task)
+
+    with pytest.raises(ValueError, match="tpu"):
+        scheduler.update_task(task.id, resources={"tpu": 1})
+
+    survivor = task_mgr.get(task.id)
+    assert survivor.status is TaskStatus.WAITING_HANDOFF
+    assert survivor.resources == {"gpu": 2}  # the old definition, unchanged
+    assert survivor.created_at == task.created_at  # and its place in the queue
+    assert task.id in scheduler.pools[TaskStatus.WAITING_HANDOFF]
+
+
+def test_a_rejected_update_does_not_mutate_the_stored_task(scheduler, store):
+    task = make_task(inputs=new_handoffs(1), resources={"gpu": 2})
+    scheduler.submit(task)
+
+    with pytest.raises(KeyError):
+        scheduler.update_task(task.id, agent_spec="nope")
+
+    assert store.read("task", str(task.id))["agent_spec"] == "profiler"
+    assert store.read("task", str(task.id))["status"] == "waiting_handoff"

--- a/agent_sys/tests/task_graph/test_linkage.py
+++ b/agent_sys/tests/task_graph/test_linkage.py
@@ -1,0 +1,177 @@
+"""Two-way links and the graph edge — criteria 21, 22 and 31.
+
+`depends_on` is the graph, recorded for traversal and display. Scheduling never
+reads it: the dependency question is `inputs` + `check_if_latest_valid`.
+"""
+
+import graphlib
+
+from task_graph.models import TaskStatus
+
+from .conftest import make_task, new_handoffs
+
+# --------------------------------------------------------- the two-way links
+
+
+def test_both_directions_resolve(scheduler, task_mgr, agent_mgr, handoff_mgr, runner, registry):
+    """Criterion 22."""
+    task = make_task(outputs=new_handoffs(2))
+    scheduler.submit(task)
+    runner.produce(registry, task.id)
+    runner.finish(task.id)
+
+    # task -> agent -> handoffs
+    execution = task_mgr.get(task.id).current
+    agent = agent_mgr.get(execution.agent_id)
+    assert agent.task_id == task.id
+    assert {ref.handoff_id for ref in agent.handoffs} == set(task.outputs)
+
+    # handoff -> task and agent
+    for hid in task.outputs:
+        version = handoff_mgr.latest(hid)
+        assert version.producer_task_id == task.id
+        assert version.producer_agent_id == agent.id
+
+    # agent -> the version it wrote
+    for ref in agent.handoffs:
+        assert handoff_mgr.get(ref.handoff_id).get(ref.version).producer_agent_id == agent.id
+
+
+def test_the_live_agent_is_the_stack_top_and_earlier_ones_stay_readable(
+    scheduler, task_mgr, agent_mgr, runner
+):
+    """Criterion 21."""
+    task = make_task()
+    scheduler.submit(task)
+    first = task_mgr.get(task.id).current.agent_id
+    runner.finish(task.id, TaskStatus.FAILED)
+
+    scheduler.resume_task(task.id)
+    second = task_mgr.get(task.id).current.agent_id
+
+    assert first != second
+    assert [e.agent_id for e in task_mgr.get(task.id).history] == [first, second]
+    assert {a.id for a in agent_mgr.by_task(task.id)} == {first, second}
+
+
+def test_an_agent_from_an_earlier_attempt_is_still_resolvable(
+    scheduler, task_mgr, agent_mgr, runner, registry
+):
+    task = make_task(outputs=new_handoffs(1))
+    scheduler.submit(task)
+    runner.produce(registry, task.id, content="attempt 0")
+    runner.finish(task.id, TaskStatus.FAILED)
+    first = task_mgr.get(task.id).history[0].agent_id
+
+    scheduler.resume_task(task.id)
+    runner.produce(registry, task.id, content="attempt 1")
+    runner.finish(task.id)
+
+    old = agent_mgr.get(first)
+    assert [ref.version for ref in old.handoffs] == [0]
+    assert registry.get("handoff_mgr").get(task.outputs[0]).get(0).content == "attempt 0"
+
+
+def test_who_wrote_a_given_version_is_answerable_from_the_version_alone(
+    scheduler, handoff_mgr, agent_mgr, runner, registry
+):
+    (hid,) = new_handoffs(1)
+    for _ in range(2):
+        producer = make_task(outputs=[hid])
+        scheduler.submit(producer)
+        runner.produce(registry, producer.id)
+        runner.finish(producer.id)
+
+    for version in handoff_mgr.get(hid).versions:
+        agent = agent_mgr.get(version.producer_agent_id)
+        assert agent.task_id == version.producer_task_id
+
+
+# ------------------------------------------------------------- depends_on
+
+
+def build_diamond(scheduler):
+    """root -> {left, right} -> join, wired through both handoffs and edges."""
+    (a,) = new_handoffs(1)
+    (b,) = new_handoffs(1)
+    (c,) = new_handoffs(1)
+    root = make_task(outputs=[a])
+    left = make_task(inputs=[a], outputs=[b], depends_on=[root.id])
+    right = make_task(inputs=[a], outputs=[c], depends_on=[root.id])
+    join = make_task(inputs=[b, c], depends_on=[left.id, right.id])
+    for task in (root, left, right, join):
+        scheduler.submit(task)
+    return root, left, right, join
+
+
+def test_depends_on_sorts_topologically(scheduler, task_mgr):
+    """Criterion 31, first half: the edge is recorded so a display or an
+    analysis can traverse it."""
+    root, left, right, join = build_diamond(scheduler)
+
+    graph = {t.id: set(t.depends_on) for t in task_mgr.all()}
+    order = list(graphlib.TopologicalSorter(graph).static_order())
+
+    assert order.index(root.id) < order.index(left.id) < order.index(join.id)
+    assert order.index(root.id) < order.index(right.id) < order.index(join.id)
+
+
+def test_blanking_depends_on_changes_no_scheduling_behaviour(
+    scheduler, task_mgr, runner, registry, store
+):
+    """Criterion 31, second half. Two identical runs, one with the edges and one
+    without, must produce the same dispatch order."""
+    from .conftest import rebuild
+
+    def run(with_edges: bool) -> list:
+        registry_ = rebuild(type(store)())
+        scheduler_ = registry_.get("scheduler")
+        (a,) = new_handoffs(1)
+        (b,) = new_handoffs(1)
+        root = make_task(outputs=[a])
+        mid = make_task(inputs=[a], outputs=[b], depends_on=[root.id] if with_edges else [])
+        leaf = make_task(inputs=[b], depends_on=[mid.id] if with_edges else [])
+        for task in (leaf, mid, root):
+            scheduler_.submit(task)
+
+        runner_ = registry_.get("runner")
+        for task in (root, mid):
+            runner_.produce(registry_, task.id)
+            runner_.finish(task.id)
+        return [
+            registry_.get("task_mgr").get(t.id).status for t in (root, mid, leaf)
+        ], runner_.started.index(leaf.id)
+
+    assert run(with_edges=True) == run(with_edges=False)
+
+
+def test_a_declared_edge_does_not_gate_dispatch(scheduler, task_mgr):
+    """The scheduler asks the handoffs, not the edge list. A task depending on
+    an unfinished task but consuming nothing from it still runs."""
+    blocker = make_task(inputs=new_handoffs(1))
+    scheduler.submit(blocker)
+
+    dependent = make_task(depends_on=[blocker.id])
+    scheduler.submit(dependent)
+
+    assert task_mgr.get(blocker.id).status is TaskStatus.WAITING_HANDOFF
+    assert task_mgr.get(dependent.id).status is TaskStatus.RUNNING
+
+
+def test_depends_on_survives_a_restart(scheduler, store):
+    from .conftest import rebuild
+
+    root, left, right, join = build_diamond(scheduler)
+
+    fresh = rebuild(store)
+    fresh.get("task_mgr").resume_system()
+    assert set(fresh.get("task_mgr").get(join.id).depends_on) == {left.id, right.id}
+
+
+def test_a_task_exposes_no_agent_id_field():
+    """Criterion 21: the binding lives in the execution record, nowhere else."""
+    from task_graph.models import Task
+
+    assert "agent_id" not in Task.model_fields
+    assert "agent" not in Task.model_fields
+    assert "agent_spec" in Task.model_fields

--- a/agent_sys/tests/task_graph/test_models.py
+++ b/agent_sys/tests/task_graph/test_models.py
@@ -1,0 +1,364 @@
+"""Domain models and their state machines — criteria 26 and 30.
+
+The guards are the design: `seal` only from GENERATING, `open_next` refuses a
+slot someone else has open, `push_execution` refuses to stack a second attempt.
+Everything downstream trusts these to hold.
+"""
+
+import json
+from datetime import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from task_graph.ids import AgentId, HandoffId, TaskId
+from task_graph.models import (
+    RESUMABLE,
+    WAITING,
+    Agent,
+    Execution,
+    Handoff,
+    HandoffRef,
+    HandoffStateError,
+    HandoffStatus,
+    HandoffVersion,
+    Task,
+    TaskStateError,
+    TaskStatus,
+)
+
+
+def make_handoff(**kw) -> Handoff:
+    """A freshly declared slot: one CREATED v0, as `declare` makes it."""
+    kw.setdefault("id", HandoffId.new())
+    kw.setdefault("versions", [HandoffVersion(version=0)])
+    return Handoff(**kw)
+
+
+# ---------------------------------------------------------------- enums
+
+
+def test_enums_are_plain_strings_when_dumped():
+    assert TaskStatus.RUNNING.value == "running"
+    assert HandoffStatus.CREATED.value == "created"
+    assert json.dumps(TaskStatus.RUNNING) == '"running"'
+
+
+def test_waiting_and_resumable_sets():
+    assert WAITING == {TaskStatus.WAITING_HANDOFF, TaskStatus.WAITING_RESOURCE}
+    assert RESUMABLE == {TaskStatus.FAILED, TaskStatus.SUSPENDED}
+
+
+# ---------------------------------------------------------- model config
+
+
+def test_an_unknown_field_is_rejected_not_dropped():
+    with pytest.raises(ValidationError):
+        Task(agent_spec="profiler", agnet_spec="typo")
+
+
+def test_assignment_is_validated():
+    task = Task(agent_spec="profiler")
+    with pytest.raises(ValidationError):
+        task.status = "not-a-status"
+
+
+def test_a_valid_assignment_keeps_the_enum_member():
+    task = Task(agent_spec="profiler")
+    task.status = "running"
+    assert task.status is TaskStatus.RUNNING
+
+
+# ------------------------------------------------------- HandoffVersion
+
+
+def test_a_fresh_version_is_created_and_not_valid():
+    version = HandoffVersion(version=0)
+    assert version.status is HandoffStatus.CREATED
+    assert not version.is_valid
+    assert version.producer_task_id is None
+    assert version.producer_agent_id is None
+    assert isinstance(version.timestamp, datetime)
+
+
+def test_seal_from_generating_to_valid():
+    version = HandoffVersion(version=0, status=HandoffStatus.GENERATING)
+    version.seal(HandoffStatus.VALID, content={"latency": 12})
+    assert version.status is HandoffStatus.VALID
+    assert version.is_valid
+    assert version.content == {"latency": 12}
+
+
+def test_seal_from_generating_to_invalid():
+    version = HandoffVersion(version=0, status=HandoffStatus.GENERATING)
+    version.seal(HandoffStatus.INVALID)
+    assert version.status is HandoffStatus.INVALID
+    assert not version.is_valid
+
+
+@pytest.mark.parametrize(
+    "status", [HandoffStatus.CREATED, HandoffStatus.VALID, HandoffStatus.INVALID]
+)
+def test_seal_requires_generating(status):
+    version = HandoffVersion(version=0, status=status)
+    with pytest.raises(HandoffStateError):
+        version.seal(HandoffStatus.VALID)
+
+
+@pytest.mark.parametrize("verdict", [HandoffStatus.CREATED, HandoffStatus.GENERATING])
+def test_seal_requires_a_verdict(verdict):
+    version = HandoffVersion(version=0, status=HandoffStatus.GENERATING)
+    with pytest.raises(HandoffStateError):
+        version.seal(verdict)
+
+
+# --------------------------------------------------------------- Handoff
+
+
+def test_latest_is_the_last_version():
+    handoff = make_handoff()
+    assert handoff.latest is handoff.versions[-1]
+    assert handoff.latest.version == 0
+
+
+def test_versions_may_not_be_empty():
+    with pytest.raises(ValidationError):
+        Handoff(id=HandoffId.new(), versions=[])
+
+
+def test_get_by_version_number():
+    handoff = make_handoff()
+    assert handoff.get(0) is handoff.versions[0]
+    with pytest.raises(IndexError):
+        handoff.get(7)
+
+
+def test_is_latest_valid_tracks_the_latest_only():
+    handoff = make_handoff()
+    assert not handoff.is_latest_valid
+
+    handoff.open_next(TaskId.new(), AgentId.new()).seal(HandoffStatus.VALID)
+    assert handoff.is_latest_valid
+
+    handoff.open_next(TaskId.new(), AgentId.new())  # a re-run reopens the slot
+    assert not handoff.is_latest_valid
+
+
+def test_open_next_adopts_a_created_latest_in_place():
+    handoff = make_handoff()
+    tid, aid = TaskId.new(), AgentId.new()
+
+    version = handoff.open_next(tid, aid)
+
+    assert len(handoff.versions) == 1
+    assert version is handoff.versions[0]
+    assert version.version == 0
+    assert version.status is HandoffStatus.GENERATING
+    assert version.producer_task_id == tid
+    assert version.producer_agent_id == aid
+
+
+@pytest.mark.parametrize("verdict", [HandoffStatus.VALID, HandoffStatus.INVALID])
+def test_open_next_appends_after_a_sealed_latest(verdict):
+    handoff = make_handoff()
+    first_task, first_agent = TaskId.new(), AgentId.new()
+    handoff.open_next(first_task, first_agent).seal(verdict, content="v0")
+
+    second_task, second_agent = TaskId.new(), AgentId.new()
+    version = handoff.open_next(second_task, second_agent)
+
+    assert len(handoff.versions) == 2
+    assert version.version == 1
+    assert version.status is HandoffStatus.GENERATING
+    assert version.producer_task_id == second_task
+    assert version.producer_agent_id == second_agent
+
+    # the earlier version is untouched — criterion 17
+    assert handoff.get(0).status is verdict
+    assert handoff.get(0).content == "v0"
+    assert handoff.get(0).producer_task_id == first_task
+    assert handoff.get(0).producer_agent_id == first_agent
+
+
+def test_open_next_refuses_a_slot_someone_else_has_open():
+    handoff = make_handoff()
+    handoff.open_next(TaskId.new(), AgentId.new())
+    with pytest.raises(HandoffStateError):
+        handoff.open_next(TaskId.new(), AgentId.new())
+
+
+def test_the_list_index_is_the_version_number():
+    handoff = make_handoff()
+    for _ in range(4):
+        handoff.open_next(TaskId.new(), AgentId.new()).seal(HandoffStatus.VALID)
+    assert [v.version for v in handoff.versions] == [0, 1, 2, 3]
+    assert all(handoff.get(i).version == i for i in range(4))
+
+
+# ------------------------------------------------------------- Execution
+
+
+def test_an_execution_is_open_until_it_ends():
+    execution = Execution(attempt=0, agent_id=AgentId.new())
+    assert execution.is_open
+    assert execution.outcome is None
+    execution.ended_at = datetime.now()
+    assert not execution.is_open
+
+
+# ------------------------------------------------------------------ Task
+
+
+def test_a_fresh_task_has_an_id_and_waits_for_handoffs():
+    task = Task(agent_spec="profiler")
+    assert isinstance(task.id, TaskId)
+    assert task.status is TaskStatus.WAITING_HANDOFF
+    assert task.history == []
+    assert task.current is None
+    assert not task.is_running
+    assert not task.expedited
+
+
+def test_push_execution_numbers_attempts_from_zero():
+    task = Task(agent_spec="profiler")
+    hid = HandoffId.new()
+
+    first = task.push_execution(agent_id=AgentId.new(), input_versions={hid: 0})
+    assert first.attempt == 0
+    assert task.current is first
+    assert task.is_running
+    assert first.input_versions == {hid: 0}
+
+    task.close_execution({}, TaskStatus.FAILED)
+    second = task.push_execution(agent_id=AgentId.new(), input_versions={hid: 1})
+    assert second.attempt == 1
+    assert task.current is second
+    assert len(task.history) == 2
+
+
+def test_push_execution_refuses_to_stack_on_an_open_attempt():
+    task = Task(agent_spec="profiler")
+    task.push_execution(agent_id=AgentId.new(), input_versions={})
+    with pytest.raises(TaskStateError):
+        task.push_execution(agent_id=AgentId.new(), input_versions={})
+
+
+def test_close_execution_seals_the_stack_top():
+    task = Task(agent_spec="profiler")
+    hid = HandoffId.new()
+    task.push_execution(agent_id=AgentId.new(), input_versions={})
+
+    task.close_execution({hid: 2}, TaskStatus.SUCCEEDED, detail="done")
+
+    top = task.history[-1]
+    assert not top.is_open
+    assert top.ended_at is not None
+    assert top.outcome is TaskStatus.SUCCEEDED
+    assert top.output_versions == {hid: 2}
+    assert top.detail == "done"
+    assert not task.is_running
+    assert task.current is top  # `current` is the stack top, open or not
+
+
+def test_close_execution_requires_an_open_attempt():
+    task = Task(agent_spec="profiler")
+    with pytest.raises(TaskStateError):
+        task.close_execution({}, TaskStatus.SUCCEEDED)
+
+    task.push_execution(agent_id=AgentId.new(), input_versions={})
+    task.close_execution({}, TaskStatus.SUCCEEDED)
+    with pytest.raises(TaskStateError):
+        task.close_execution({}, TaskStatus.SUCCEEDED)
+
+
+def test_history_is_a_stack_and_earlier_attempts_survive():
+    task = Task(agent_spec="profiler")
+    first_agent, second_agent = AgentId.new(), AgentId.new()
+
+    task.push_execution(agent_id=first_agent, input_versions={})
+    task.close_execution({}, TaskStatus.FAILED)
+    task.push_execution(agent_id=second_agent, input_versions={})
+
+    assert [e.agent_id for e in task.history] == [first_agent, second_agent]
+    assert task.current.agent_id == second_agent
+
+
+# ----------------------------------------------------------------- Agent
+
+
+def test_an_agent_records_its_task_and_what_it_touched():
+    tid, hid = TaskId.new(), HandoffId.new()
+    agent = Agent(spec="profiler", task_id=tid)
+    agent.handoffs.append(HandoffRef(handoff_id=hid, version=1))
+
+    assert isinstance(agent.id, AgentId)
+    assert agent.task_id == tid
+    assert agent.handoffs[0].handoff_id == hid
+    assert agent.handoffs[0].version == 1
+    assert agent.knowledge is None
+    assert agent.config == {}
+
+
+# --------------------------------------------------------- serialisation
+# Criterion 30: round trip through JSON, nothing hand-written per model.
+
+
+def round_trip(model):
+    return type(model).model_validate(json.loads(model.model_dump_json()))
+
+
+def test_task_round_trip_including_handoff_id_dict_keys():
+    hid_in, hid_out = HandoffId.new(), HandoffId.new()
+    task = Task(
+        agent_spec="profiler",
+        inputs=[hid_in],
+        outputs=[hid_out],
+        depends_on=[TaskId.new()],
+        resources={"gpu": 2.0},
+        expedited=True,
+    )
+    task.push_execution(agent_id=AgentId.new(), input_versions={hid_in: 0})
+    task.close_execution({hid_out: 3}, TaskStatus.SUCCEEDED, detail="ok")
+
+    back = round_trip(task)
+    assert back == task
+    assert isinstance(back.id, TaskId)
+    assert isinstance(back.inputs[0], HandoffId)
+    assert isinstance(back.depends_on[0], TaskId)
+    assert back.status is TaskStatus.WAITING_HANDOFF
+    assert back.history[0].outcome is TaskStatus.SUCCEEDED
+    assert back.history[0].input_versions == {hid_in: 0}
+    assert back.history[0].output_versions == {hid_out: 3}
+    assert isinstance(next(iter(back.history[0].input_versions)), HandoffId)
+    assert back.created_at == task.created_at
+
+
+def test_handoff_round_trip():
+    handoff = make_handoff(type="profile")
+    handoff.open_next(TaskId.new(), AgentId.new()).seal(HandoffStatus.VALID, content={"p50": 7})
+    handoff.open_next(TaskId.new(), AgentId.new())
+
+    back = round_trip(handoff)
+    assert back == handoff
+    assert back.get(0).status is HandoffStatus.VALID
+    assert back.get(0).content == {"p50": 7}
+    assert back.latest.status is HandoffStatus.GENERATING
+    assert isinstance(back.get(0).producer_task_id, TaskId)
+    assert isinstance(back.get(0).producer_agent_id, AgentId)
+
+
+def test_agent_round_trip():
+    agent = Agent(spec="profiler", task_id=TaskId.new(), config={"model": "opus"})
+    agent.handoffs.append(HandoffRef(handoff_id=HandoffId.new(), version=2))
+
+    back = round_trip(agent)
+    assert back == agent
+    assert isinstance(back.handoffs[0].handoff_id, HandoffId)
+
+
+def test_a_restored_model_is_still_guarded():
+    """Validation is not a one-off at construction — the state machine survives."""
+    handoff = round_trip(make_handoff())
+    handoff.open_next(TaskId.new(), AgentId.new())
+    with pytest.raises(HandoffStateError):
+        handoff.open_next(TaskId.new(), AgentId.new())

--- a/agent_sys/tests/task_graph/test_policy.py
+++ b/agent_sys/tests/task_graph/test_policy.py
@@ -1,0 +1,84 @@
+"""Ordering — criterion 10.
+
+Expedite's whole effect on ordering lives here rather than in the scheduler, so
+a replacement policy is free to ignore it.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from task_graph.ids import TaskId
+from task_graph.models import Task
+from task_graph.policy import FifoPolicy, SchedulePolicy
+
+BASE = datetime(2026, 8, 20, 10, 0, tzinfo=timezone.utc)
+
+
+def task(seconds: int, *, expedited: bool = False) -> Task:
+    return Task(
+        agent_spec="profiler",
+        created_at=BASE + timedelta(seconds=seconds),
+        expedited=expedited,
+    )
+
+
+def test_fifo_orders_by_submission_time():
+    third, first, second = task(30), task(10), task(20)
+    assert FifoPolicy().select([third, first, second], {}) == [first.id, second.id, third.id]
+
+
+def test_expedited_goes_ahead_of_earlier_tasks():
+    early, late_but_expedited = task(10), task(90, expedited=True)
+    order = FifoPolicy().select([early, late_but_expedited], {})
+    assert order == [late_but_expedited.id, early.id]
+
+
+def test_expedited_tasks_are_fifo_among_themselves():
+    second, first = task(90, expedited=True), task(50, expedited=True)
+    plain = task(10)
+    order = FifoPolicy().select([plain, second, first], {})
+    assert order == [first.id, second.id, plain.id]
+
+
+def test_an_empty_set_is_empty():
+    assert FifoPolicy().select([], {}) == []
+
+
+def test_the_snapshot_is_accepted_and_ignored():
+    """In the signature for a future cost-aware policy; FIFO does not read it."""
+    a, b = task(10), task(20)
+    assert FifoPolicy().select([a, b], {"gpu": 0.0}) == FifoPolicy().select([a, b], {"gpu": 8.0})
+
+
+def test_the_input_list_is_not_reordered_in_place():
+    tasks = [task(30), task(10)]
+    original = list(tasks)
+    FifoPolicy().select(tasks, {})
+    assert tasks == original
+
+
+def test_a_replacement_policy_changes_only_the_order():
+    """The seam the mission asks for: the algorithm is decoupled."""
+
+    class LifoPolicy:
+        def select(self, eligible, snapshot):
+            return [t.id for t in sorted(eligible, key=lambda t: t.created_at, reverse=True)]
+
+    tasks = [task(10), task(20), task(30)]
+    assert LifoPolicy().select(tasks, {}) == list(reversed(FifoPolicy().select(tasks, {})))
+
+
+def test_the_protocol_is_structural_and_not_runtime_checkable():
+    """Unlike `Resumable`, nothing does an isinstance against this one, so it
+    stays a plain Protocol — a policy is supplied, never discovered."""
+    import pytest
+
+    with pytest.raises(TypeError):
+        isinstance(FifoPolicy(), SchedulePolicy)
+    assert callable(SchedulePolicy.select)
+
+
+def test_select_returns_ids_not_tasks():
+    """The scheduler re-reads each task and re-checks its status; handing back
+    objects would invite dispatching from a stale one."""
+    result = FifoPolicy().select([task(10)], {})
+    assert all(isinstance(x, TaskId) for x in result)

--- a/agent_sys/tests/task_graph/test_recovery.py
+++ b/agent_sys/tests/task_graph/test_recovery.py
@@ -1,0 +1,471 @@
+"""Recovery — criteria 8, 19, 24, 25 and 34.
+
+A restart is not a fresh start and it is not a replay: state is reloaded,
+verdicts are never re-derived, and eligibility is recomputed by asking the
+handoffs again.
+"""
+
+import pytest
+
+from task_graph.bootstrap import build_registry
+from task_graph.models import HandoffStateError, HandoffStatus, TaskStatus
+from task_graph.registry import RESUME_ORDER, Registry, resume_all
+from task_graph.store import JsonFileStoreMgr
+
+from .conftest import make_task, new_handoffs, rebuild
+
+# ------------------------------------------------------------- resume_all
+
+
+def test_resume_all_visits_every_manager_in_order(registry):
+    log = []
+
+    class Spy:
+        def __init__(self, name):
+            self.name = name
+
+        def resume_system(self):
+            log.append(self.name)
+
+    for name in ["scheduler", "task_mgr", "handoff_mgr", "agent_mgr", "resource:gpu"]:
+        registry.register(name, Spy(name))
+    resume_all(registry)
+
+    assert log == RESUME_ORDER[:3] + ["resource:gpu", "scheduler"]
+
+
+def test_a_system_with_no_state_resumes_to_nothing(store):
+    fresh = rebuild(store)
+    resume_all(fresh)
+    assert fresh.get("task_mgr").all() == []
+    assert all(not pool for pool in fresh.get("scheduler").pools.values())
+
+
+# -------------------------------------------------------------- demotion
+
+
+def test_a_running_task_is_demoted_and_its_lease_is_not_double_booked(scheduler, store):
+    """Criterion 8. The lease is gone, so recovery neither keeps it nor charges
+    for it twice when the demoted task is dispatched again."""
+    task = make_task(resources={"gpu": 3})
+    scheduler.submit(task)
+
+    fresh = rebuild(store)
+    resume_all(fresh)
+
+    restored = fresh.get("task_mgr").get(task.id)
+    assert restored.history[0].outcome is TaskStatus.SUSPENDED  # the cut-short attempt
+    assert [e.attempt for e in restored.history] == [0, 1]
+    assert fresh.get("resource:gpu").available == 5  # one reservation, not two
+
+
+def test_a_running_task_whose_inputs_went_stale_lands_back_in_waiting(
+    scheduler, runner, store, registry
+):
+    producer = make_task(outputs=new_handoffs(1))
+    scheduler.submit(producer)
+    runner.produce(registry, producer.id)
+    runner.finish(producer.id)
+
+    consumer = make_task(inputs=producer.outputs, resources={"gpu": 3})
+    scheduler.submit(consumer)
+    assert registry.get("task_mgr").get(consumer.id).status is TaskStatus.RUNNING
+
+    # a second producer reopens the slot and never seals it
+    refresher = make_task(outputs=producer.outputs)
+    scheduler.submit(refresher)
+    registry.get("handoff_mgr").get(producer.outputs[0]).open_next(
+        refresher.id, registry.get("task_mgr").get(refresher.id).current.agent_id
+    )
+    registry.get("handoff_mgr").persist(producer.outputs[0])
+
+    fresh = rebuild(store)
+    resume_all(fresh)
+
+    restored = fresh.get("task_mgr").get(consumer.id)
+    assert restored.status is TaskStatus.WAITING_HANDOFF
+    assert not restored.is_running
+    assert restored.history[-1].outcome is TaskStatus.SUSPENDED
+    assert fresh.get("resource:gpu").available == 8  # nothing is held
+
+
+def test_a_demoted_task_that_is_ready_is_dispatched_again(scheduler, store):
+    task = make_task(resources={"gpu": 3})
+    scheduler.submit(task)
+
+    fresh = rebuild(store)
+    resume_all(fresh)
+
+    assert fresh.get("task_mgr").get(task.id).status is TaskStatus.RUNNING
+    assert [e.attempt for e in fresh.get("task_mgr").get(task.id).history] == [0, 1]
+    assert fresh.get("runner").started == [task.id]
+
+
+def test_a_stopping_task_becomes_suspended_because_the_runner_is_gone(scheduler, store):
+    task = make_task()
+    scheduler.submit(task)
+    scheduler.stop(task.id)  # never acknowledged
+
+    fresh = rebuild(store)
+    resume_all(fresh)
+
+    assert fresh.get("task_mgr").get(task.id).status is TaskStatus.SUSPENDED
+
+
+@pytest.mark.parametrize(
+    "reach, expected",
+    [
+        ("succeeded", TaskStatus.SUCCEEDED),
+        ("failed", TaskStatus.FAILED),
+        ("cancelled", TaskStatus.CANCELLED),
+    ],
+)
+def test_a_settled_task_keeps_its_status(scheduler, runner, store, reach, expected):
+    task = make_task(inputs=new_handoffs(1) if reach == "cancelled" else [])
+    scheduler.submit(task)
+    if reach == "cancelled":
+        scheduler.remove_queued(task.id)
+    else:
+        runner.finish(task.id, TaskStatus[reach.upper()])
+
+    fresh = rebuild(store)
+    resume_all(fresh)
+    assert fresh.get("task_mgr").get(task.id).status is expected
+
+
+def test_a_suspended_task_is_not_restarted_by_recovery(scheduler, runner, store):
+    """Resuming it is an operator decision, not something a restart makes."""
+    task = make_task()
+    scheduler.submit(task)
+    scheduler.stop(task.id)
+    runner.ack_stop(task.id)
+
+    fresh = rebuild(store)
+    resume_all(fresh)
+
+    assert fresh.get("task_mgr").get(task.id).status is TaskStatus.SUSPENDED
+    assert fresh.get("runner").started == []
+
+
+# ----------------------------------------------------- verdicts are not redone
+
+
+def test_handoff_verdicts_are_reloaded_not_re_derived(scheduler, runner, store, registry):
+    """Criterion 19."""
+    valid_task = make_task(outputs=new_handoffs(1))
+    invalid_task = make_task(outputs=new_handoffs(1))
+    for task, ok in ((valid_task, True), (invalid_task, False)):
+        scheduler.submit(task)
+        runner.produce(registry, task.id, valid=ok, content=f"content-{ok}")
+        runner.finish(task.id)
+
+    fresh = rebuild(store)
+    resume_all(fresh)
+    hm = fresh.get("handoff_mgr")
+
+    assert hm.check_if_latest_valid(valid_task.outputs[0])
+    assert not hm.check_if_latest_valid(invalid_task.outputs[0])
+    assert hm.get(valid_task.outputs[0]).latest.content == "content-True"
+    assert hm.get(invalid_task.outputs[0]).latest.status is HandoffStatus.INVALID
+
+
+def test_a_consumer_of_a_valid_handoff_runs_after_a_restart(scheduler, runner, store, registry):
+    producer = make_task(outputs=new_handoffs(1))
+    scheduler.submit(producer)
+    runner.produce(registry, producer.id)
+    runner.finish(producer.id)
+
+    consumer = make_task(inputs=producer.outputs, resources={"gpu": 8})
+    scheduler.submit(consumer)
+
+    fresh = rebuild(store)
+    resume_all(fresh)
+    assert fresh.get("task_mgr").get(consumer.id).status is TaskStatus.RUNNING
+
+
+def test_a_consumer_of_an_invalid_handoff_still_waits_after_a_restart(
+    scheduler, runner, store, registry
+):
+    producer = make_task(outputs=new_handoffs(1))
+    scheduler.submit(producer)
+    runner.produce(registry, producer.id, valid=False)
+    runner.finish(producer.id)
+
+    consumer = make_task(inputs=producer.outputs)
+    scheduler.submit(consumer)
+
+    fresh = rebuild(store)
+    resume_all(fresh)
+    assert fresh.get("task_mgr").get(consumer.id).status is TaskStatus.WAITING_HANDOFF
+
+
+# --------------------------------------------------------------- the ordering
+
+
+def test_resuming_the_scheduler_first_leaves_every_task_blocked(scheduler, runner, store, registry):
+    """Criterion 25, which asserts a *failure*. Without this the ordering in
+    RESUME_ORDER is a comment."""
+    producer = make_task(outputs=new_handoffs(1))
+    scheduler.submit(producer)
+    runner.produce(registry, producer.id)
+    runner.finish(producer.id)
+
+    consumer = make_task(inputs=producer.outputs)
+    scheduler.submit(consumer)
+
+    fresh = rebuild(store)
+    fresh.get("task_mgr").resume_system()
+    fresh.get("scheduler").resume_system()  # HandoffMgr deliberately not resumed
+
+    # Every handoff looks unknown, so nothing is eligible — and no later event
+    # will unblock it.
+    assert fresh.get("task_mgr").get(consumer.id).status is TaskStatus.WAITING_HANDOFF
+    assert fresh.get("runner").started == []
+
+    # In the right order it works.
+    right = rebuild(store)
+    resume_all(right)
+    assert right.get("task_mgr").get(consumer.id).status is TaskStatus.RUNNING
+
+
+def test_resume_order_puts_the_scheduler_last():
+    assert RESUME_ORDER[-1] == "scheduler"
+    assert "handoff_mgr" in RESUME_ORDER[:-1]
+
+
+# ------------------------------------------------------------------- agents
+
+
+def test_the_audit_trail_resolves_after_a_restart(scheduler, runner, store, registry):
+    """Criterion 34."""
+    task = make_task(outputs=new_handoffs(1))
+    scheduler.submit(task)
+    runner.produce(registry, task.id)
+    runner.finish(task.id)
+    agent_id = registry.get("task_mgr").get(task.id).current.agent_id
+
+    fresh = rebuild(store)
+    resume_all(fresh)
+
+    restored = fresh.get("task_mgr").get(task.id)
+    agent = fresh.get("agent_mgr").get(restored.current.agent_id)
+    assert agent.id == agent_id
+    assert agent.task_id == task.id
+    assert [ref.handoff_id for ref in agent.handoffs] == task.outputs
+
+
+# -------------------------------------------------------------- consumables
+
+
+def test_a_consumable_balance_survives_but_a_renewable_lease_does_not(scheduler, runner, store):
+    """Criterion 32, end to end."""
+    spent = make_task(resources={"token": 500})
+    scheduler.submit(spent)
+    runner.finish(spent.id, usage={"token": 300})
+
+    holding = make_task(resources={"gpu": 5, "token": 400})
+    scheduler.submit(holding)  # still running when the process dies
+
+    fresh = rebuild(store)
+    # The pools alone, before the scheduler recomputes anything: this is purely
+    # what recovery restored.
+    fresh.get("resource:gpu").resume_system()
+    fresh.get("resource:token").resume_system()
+
+    assert fresh.get("resource:token").available == 1_000_000 - 300  # spend is durable
+    assert fresh.get("resource:gpu").available == 8  # the lease is not
+
+    # And the reservation that was never settled is not charged: after the full
+    # resume the demoted task takes it again from the restored balance.
+    resume_all(fresh)
+    assert fresh.get("resource:token").available == 1_000_000 - 300 - 400
+    assert fresh.get("resource:gpu").available == 3
+
+
+# ------------------------------------------------- end to end, on real files
+
+
+def test_a_full_cycle_survives_a_restart_through_the_json_store(tmp_path):
+    """Criterion 24, against the filesystem rather than the memory store."""
+    store = JsonFileStoreMgr(tmp_path / "state")
+    registry = rebuild(store)
+    scheduler, runner = registry.get("scheduler"), registry.get("runner")
+
+    (mid,) = new_handoffs(1)
+    producer = make_task(outputs=[mid], resources={"token": 200})
+    consumer = make_task(inputs=[mid], depends_on=[producer.id], resources={"gpu": 2})
+    scheduler.submit(producer)
+    scheduler.submit(consumer)
+    runner.produce(registry, producer.id, content={"p50": 7.5})
+    runner.finish(producer.id, usage={"token": 150})
+
+    # consumer is now running; the process dies here
+    assert registry.get("task_mgr").get(consumer.id).status is TaskStatus.RUNNING
+
+    fresh = rebuild(JsonFileStoreMgr(tmp_path / "state"))
+    resume_all(fresh)
+
+    assert fresh.get("task_mgr").get(producer.id).status is TaskStatus.SUCCEEDED
+    assert fresh.get("handoff_mgr").get(mid).latest.content == {"p50": 7.5}
+    assert fresh.get("resource:token").available == 1_000_000 - 150
+
+    restored_consumer = fresh.get("task_mgr").get(consumer.id)
+    assert restored_consumer.status is TaskStatus.RUNNING  # demoted, then redispatched
+    assert [e.outcome for e in restored_consumer.history] == [TaskStatus.SUSPENDED, None]
+    assert restored_consumer.depends_on == [producer.id]
+
+    # and it can still finish
+    fresh.get("runner").finish(consumer.id)
+    assert fresh.get("task_mgr").get(consumer.id).status is TaskStatus.SUCCEEDED
+
+
+def test_a_second_restart_is_idempotent(scheduler, runner, store, registry):
+    task = make_task(outputs=new_handoffs(1))
+    scheduler.submit(task)
+    runner.produce(registry, task.id)
+    runner.finish(task.id)
+
+    first = rebuild(store)
+    resume_all(first)
+    second = rebuild(store)
+    resume_all(second)
+
+    for name, expected in (("task", 1), ("handoff", 1), ("agent", 1)):
+        assert len(store.read_all(name)) == expected, name
+    assert second.get("task_mgr").get(task.id).status is TaskStatus.SUCCEEDED
+    assert len(second.get("task_mgr").get(task.id).history) == 1
+
+
+def test_recovery_does_not_need_the_registry_that_wrote_the_state(store, scheduler):
+    """Nothing is process-global; the store is the whole of the durable state."""
+    scheduler.submit(make_task(outputs=new_handoffs(1)))
+
+    other = Registry()
+    del other  # explicitly not reused
+    fresh = build_registry(store=store)
+    fresh.get("agent_mgr").register("profiler")
+    resume_all(fresh)
+
+    assert len(fresh.get("task_mgr").all()) == 1
+
+
+def test_a_generating_version_is_still_generating_after_a_restart(
+    scheduler, runner, store, registry, handoff_mgr, task_mgr
+):
+    """Criterion 19's other half. A restart must not decide that an abandoned
+    version failed — that verdict is the agent's and it was never given."""
+    task = make_task(outputs=new_handoffs(1))
+    scheduler.submit(task)
+    handoff_mgr.get(task.outputs[0]).open_next(task.id, task_mgr.get(task.id).current.agent_id)
+    handoff_mgr.persist(task.outputs[0])
+    runner.finish(task.id, TaskStatus.FAILED)
+
+    fresh = rebuild(store)
+    resume_all(fresh)
+
+    version = fresh.get("handoff_mgr").get(task.outputs[0]).latest
+    assert version.status is HandoffStatus.GENERATING
+    assert not fresh.get("handoff_mgr").check_if_latest_valid(task.outputs[0])
+
+
+def test_a_spec_removed_before_a_restart_does_not_take_recovery_down_with_it(scheduler, store):
+    """The spec table is deliberately not restored, so a task naming a spec the
+    operator has since removed cannot be dispatched. Recovery must fail that
+    one task, not abort — otherwise every healthy task behind it stays parked
+    with no later event to release it."""
+    for spec in ("profiler", "tuner", "profiler"):
+        scheduler.submit(make_task(spec=spec, resources={"gpu": 1}))
+
+    fresh = build_registry(store=store)
+    fresh.get("agent_mgr").register("tuner")  # "profiler" is gone
+    resume_all(fresh)
+
+    statuses = [t.status for t in fresh.get("task_mgr").all()]
+    assert statuses.count(TaskStatus.FAILED) == 2
+    assert statuses.count(TaskStatus.RUNNING) == 1
+    assert len(fresh.get("runner").started) == 1  # the healthy one still ran
+    assert fresh.get("resource:gpu").available == 7  # only its lease is held
+
+
+def test_a_version_left_generating_by_a_crash_deadlocks_its_own_retry(
+    scheduler, runner, store, registry, handoff_mgr, task_mgr
+):
+    """Design open question O10 — a real gap, asserted as it currently behaves.
+
+    Spec §6.4 requires that a GENERATING version is not re-derived by recovery,
+    and it is not. But `open_next` refuses a slot that is already open, and
+    nothing seals the abandoned one: the agent that opened it is dead, and the
+    scheduler is forbidden from writing handoff state. So the task is demoted,
+    re-dispatched, and its new agent cannot write its own output.
+
+    This is asserted rather than fixed because the fix changes the state
+    machine — `open_next` would need an "adopt an abandoned version" path, and
+    that decision belongs in the spec.
+    """
+    task = make_task(outputs=new_handoffs(1))
+    scheduler.submit(task)
+    handoff_mgr.get(task.outputs[0]).open_next(task.id, task_mgr.get(task.id).current.agent_id)
+    handoff_mgr.persist(task.outputs[0])  # ...and the process dies here
+
+    fresh = rebuild(store)
+    resume_all(fresh)
+
+    assert fresh.get("handoff_mgr").get(task.outputs[0]).latest.status is (HandoffStatus.GENERATING)
+    assert fresh.get("task_mgr").get(task.id).status is TaskStatus.RUNNING
+
+    with pytest.raises(HandoffStateError):
+        fresh.get("runner").produce(fresh, task.id)
+
+
+def test_a_pool_removed_before_a_restart_does_not_take_recovery_down_with_it(store):
+    """The sibling of the removed-spec case. Resolving the pool sits inside the
+    dispatch guard, so a pool an operator deleted between restarts fails only
+    the tasks that name it — recovery still reaches every healthy task."""
+    from task_graph.resource import GpuMgr
+
+    registry = Registry()
+    first = build_registry(store=store, resources=[GpuMgr(registry, capacity=8)])
+    first.get("agent_mgr").register("profiler")
+    hungry = [make_task(resources={"gpu": 4}) for _ in range(2)]
+    healthy = make_task()
+    for task in (*hungry, healthy):
+        first.get("scheduler").submit(task)
+
+    fresh = build_registry(store=store, resources=[])  # the pool is gone
+    fresh.get("agent_mgr").register("profiler")
+    resume_all(fresh)
+
+    task_mgr = fresh.get("task_mgr")
+    assert [task_mgr.get(t.id).status for t in hungry] == [TaskStatus.FAILED] * 2
+    assert task_mgr.get(healthy.id).status is TaskStatus.RUNNING
+    assert fresh.get("runner").started == [healthy.id]
+
+
+def test_a_failure_inside_the_abort_handler_still_parks_the_task(store):
+    """`_abort_launch` is the handler; an exception escaping it has nowhere to
+    go. It would propagate out of `submit`, leaving the task RUNNING with a
+    half-open attempt that only a restart can clear."""
+    from task_graph.resource import GpuMgr
+    from task_graph.runner import FakeRunner
+
+    class WedgedGpu(GpuMgr):
+        def give_back(self, amount, actual=None):
+            raise RuntimeError("the pool is wedged")
+
+    class DeadRunner(FakeRunner):
+        def start(self, task, agent, on_done):
+            raise RuntimeError("harness unreachable")
+
+    registry = Registry()
+    fresh = build_registry(
+        store=store, runner=DeadRunner(), resources=[WedgedGpu(registry, capacity=8)]
+    )
+    fresh.get("agent_mgr").register("profiler")
+    task = make_task(resources={"gpu": 2})
+
+    fresh.get("scheduler").submit(task)  # must not raise
+
+    stored = fresh.get("task_mgr").get(task.id)
+    assert stored.status is TaskStatus.FAILED
+    assert not stored.is_running  # the attempt was closed
+    fresh.get("scheduler").resume_task(task.id)  # and it is recoverable

--- a/agent_sys/tests/task_graph/test_registry.py
+++ b/agent_sys/tests/task_graph/test_registry.py
@@ -1,0 +1,135 @@
+"""Registry and the resume protocol — criterion 15.
+
+Resolve at use time, not construction time: a test must be able to swap an
+implementation after the system is wired.
+"""
+
+import pytest
+
+from task_graph.registry import RESUME_ORDER, Registry, Resumable, resume_all
+
+
+class Spy:
+    def __init__(self, log: list, name: str) -> None:
+        self.log, self.name = log, name
+
+    def resume_system(self) -> None:
+        self.log.append(self.name)
+
+
+class NotResumable:
+    """Has a `resume`, but not the one the protocol names."""
+
+    def __init__(self, log: list) -> None:
+        self.log = log
+
+    def resume(self) -> None:
+        self.log.append("wrong-method")
+
+
+def test_register_and_get():
+    r = Registry()
+    r.register("policy", "a-policy")
+    assert r.get("policy") == "a-policy"
+
+
+def test_get_fails_loudly_and_names_the_key():
+    r = Registry()
+    with pytest.raises(KeyError, match="policy"):
+        r.get("policy")
+
+
+def test_registration_replaces_deliberately():
+    """The swap mechanism. Rejecting a duplicate would forbid exactly this."""
+    r = Registry()
+    r.register("runner", "real")
+    r.register("runner", "fake")
+    assert r.get("runner") == "fake"
+
+
+def test_two_registries_are_isolated():
+    a, b = Registry(), Registry()
+    a.register("runner", "a")
+    assert a.get("runner") == "a"
+    with pytest.raises(KeyError):
+        b.get("runner")
+
+
+def test_resolve_a_plain_name_returns_one():
+    r = Registry()
+    r.register("scheduler", "s")
+    assert r.resolve("scheduler") == ["s"]
+
+
+def test_resolve_a_plain_name_that_is_missing_raises():
+    with pytest.raises(KeyError):
+        Registry().resolve("scheduler")
+
+
+def test_resolve_a_wildcard_returns_the_prefix_group_in_registration_order():
+    r = Registry()
+    r.register("resource:gpu", "gpu")
+    r.register("task_mgr", "tasks")
+    r.register("resource:token", "token")
+    assert r.resolve("resource:*") == ["gpu", "token"]
+
+
+def test_a_wildcard_that_matches_nothing_is_empty_not_an_error():
+    assert Registry().resolve("resource:*") == []
+
+
+def test_a_wildcard_does_not_match_the_bare_prefix():
+    r = Registry()
+    r.register("resource", "not-a-pool")
+    assert r.resolve("resource:*") == []
+
+
+# ------------------------------------------------------------- resume_all
+
+
+def test_resume_order_is_the_documented_one():
+    assert RESUME_ORDER == [
+        "handoff_mgr",
+        "agent_mgr",
+        "task_mgr",
+        "resource:*",
+        "scheduler",
+    ]
+
+
+def test_resume_all_follows_resume_order_not_registration_order():
+    log = []
+    r = Registry()
+    for name in ["scheduler", "task_mgr", "handoff_mgr", "agent_mgr"]:
+        r.register(name, Spy(log, name))
+    r.register("resource:gpu", Spy(log, "resource:gpu"))
+
+    resume_all(r)
+
+    assert log == ["handoff_mgr", "agent_mgr", "task_mgr", "resource:gpu", "scheduler"]
+
+
+def test_resume_all_skips_a_component_that_is_not_resumable():
+    log = []
+    r = Registry()
+    r.register("handoff_mgr", NotResumable(log))
+    r.register("task_mgr", Spy(log, "task_mgr"))
+
+    resume_all(r)
+
+    assert log == ["task_mgr"]
+    assert "wrong-method" not in log
+
+
+def test_resume_all_tolerates_a_missing_component():
+    log = []
+    r = Registry()
+    r.register("task_mgr", Spy(log, "task_mgr"))
+    resume_all(r)
+    assert log == ["task_mgr"]
+
+
+def test_resumable_matches_on_the_method_name_alone():
+    """Why the scheduler's per-task resume must not be called `resume_system`."""
+    assert isinstance(Spy([], "x"), Resumable)
+    assert not isinstance(NotResumable([]), Resumable)

--- a/agent_sys/tests/task_graph/test_resource.py
+++ b/agent_sys/tests/task_graph/test_resource.py
@@ -1,0 +1,286 @@
+"""Resource pools — criteria 4, 32, 33.
+
+Renewable and consumable differ in three behaviours — release, persistence,
+recovery — which is why the split is at the abstract-base level rather than a
+boolean flag.
+"""
+
+import pytest
+
+from task_graph.registry import Registry
+from task_graph.resource import ConsumableMgr, GpuMgr, RenewableMgr, ResourceMgr, TokenMgr
+from task_graph.store import MemoryStoreMgr
+
+
+def pool(cls, capacity: float, *, store=None, **kw):
+    registry = Registry()
+    registry.register("store_mgr", store or MemoryStoreMgr())
+    return cls(registry=registry, capacity=capacity, **kw)
+
+
+# ------------------------------------------------------------------- shared
+
+
+@pytest.fixture(params=[RenewableMgr, ConsumableMgr])
+def kind(request):
+    return request.param
+
+
+def test_a_fresh_pool_is_full(kind):
+    p = pool(kind, 8, name="thing")
+    assert p.name == "thing"
+    assert p.capacity == 8
+    assert p.available == 8
+
+
+def test_can_afford_is_inclusive_of_the_whole_pool(kind):
+    p = pool(kind, 8, name="thing")
+    assert p.can_afford(8)
+    assert not p.can_afford(8.5)
+
+
+def test_take_reduces_availability(kind):
+    p = pool(kind, 8, name="thing")
+    p.take(3)
+    assert p.available == 5
+    assert p.can_afford(5)
+    assert not p.can_afford(6)
+
+
+def test_take_more_than_available_raises(kind):
+    p = pool(kind, 8, name="thing")
+    p.take(6)
+    with pytest.raises(ValueError):
+        p.take(3)
+    assert p.available == 2  # and nothing was taken
+
+
+def test_a_negative_amount_is_rejected(kind):
+    p = pool(kind, 8, name="thing")
+    with pytest.raises(ValueError):
+        p.take(-1)
+
+
+def test_a_negative_amount_is_not_affordable(kind):
+    """Answering True would let a caller past its own guard and into `take`,
+    which then raises after earlier pools in the same acquisition were taken."""
+    p = pool(kind, 8, name="thing")
+    assert not p.can_afford(-1)
+    assert p.can_afford(0)
+
+
+def test_resource_mgr_cannot_be_instantiated():
+    with pytest.raises(TypeError):
+        ResourceMgr(registry=Registry(), name="x", capacity=1)
+
+
+# --------------------------------------------------------------- renewable
+
+
+def test_a_renewable_returns_the_full_amount():
+    p = pool(RenewableMgr, 8, name="gpu")
+    p.take(3)
+    p.give_back(3)
+    assert p.available == 8
+
+
+def test_a_renewable_ignores_actual():
+    """`actual` is meaningless for a GPU: you held it or you did not."""
+    p = pool(RenewableMgr, 8, name="gpu")
+    p.take(3)
+    p.give_back(3, actual=1)
+    assert p.available == 8
+
+
+def test_a_renewable_persists_nothing():
+    store = MemoryStoreMgr()
+    p = pool(RenewableMgr, 8, name="gpu", store=store)
+    p.take(3)
+    p.give_back(3)
+    assert store.read_all("resource") == []
+
+
+def test_a_renewable_recovers_to_full():
+    """No lease survives a restart, so nothing is held — criterion 32."""
+    store = MemoryStoreMgr()
+    p = pool(RenewableMgr, 8, name="gpu", store=store)
+    p.take(5)
+
+    fresh = pool(RenewableMgr, 8, name="gpu", store=store)
+    fresh.resume_system()
+    assert fresh.available == 8
+
+
+# -------------------------------------------------------------- consumable
+
+
+def test_a_consumable_settles_at_actual():
+    p = pool(ConsumableMgr, 1000, name="token")
+    p.take(400)
+    p.give_back(400, actual=250)
+    assert p.available == 750
+
+
+def test_a_consumable_with_no_figure_charges_the_whole_reservation():
+    """The conservative reading for a budget; `on_stopped` relies on it."""
+    p = pool(ConsumableMgr, 1000, name="token")
+    p.take(400)
+    p.give_back(400)
+    assert p.available == 600
+
+
+def test_a_consumable_clamps_actual_to_the_reservation():
+    p = pool(ConsumableMgr, 1000, name="token")
+    p.take(400)
+    p.give_back(400, actual=900)
+    assert p.available == 600
+
+
+def test_a_consumable_treats_a_negative_actual_as_zero():
+    p = pool(ConsumableMgr, 1000, name="token")
+    p.take(400)
+    p.give_back(400, actual=-5)
+    assert p.available == 1000
+
+
+def test_a_consumable_persists_only_on_settlement():
+    """A reservation is a lease; a settlement is spend. Only spend is durable."""
+    store = MemoryStoreMgr()
+    p = pool(ConsumableMgr, 1000, name="token", store=store)
+
+    p.take(400)
+    assert store.read("resource", "token") is None
+
+    p.give_back(400, actual=300)
+    record = store.read("resource", "token")
+    assert record["name"] == "token"
+    assert record["spent"] == 300.0  # `spent` is the record; `available` is a comment
+
+
+def test_a_consumable_balance_survives_a_rebuild():
+    """Criterion 32."""
+    store = MemoryStoreMgr()
+    p = pool(ConsumableMgr, 1000, name="token", store=store)
+    p.take(400)
+    p.give_back(400, actual=300)
+
+    fresh = pool(ConsumableMgr, 1000, name="token", store=store)
+    fresh.resume_system()
+    assert fresh.available == 700
+
+
+def test_an_unsettled_reservation_is_not_charged():
+    """Criterion 33: a crash mid-run costs the reservation, which is correct —
+    the task holding it is not running any more."""
+    store = MemoryStoreMgr()
+    p = pool(ConsumableMgr, 1000, name="token", store=store)
+    p.take(400)  # and then the process dies
+
+    fresh = pool(ConsumableMgr, 1000, name="token", store=store)
+    fresh.resume_system()
+    assert fresh.available == 1000
+
+
+def test_a_consumable_with_no_record_recovers_to_capacity():
+    p = pool(ConsumableMgr, 1000, name="token")
+    p.resume_system()
+    assert p.available == 1000
+
+
+def test_repeated_settlement_accumulates_durably():
+    store = MemoryStoreMgr()
+    p = pool(ConsumableMgr, 1000, name="token", store=store)
+    for _ in range(3):
+        p.take(100)
+        p.give_back(100, actual=100)
+
+    fresh = pool(ConsumableMgr, 1000, name="token", store=store)
+    fresh.resume_system()
+    assert fresh.available == 700
+
+
+# ------------------------------------------------------------ the two named
+
+
+def test_gpu_is_renewable_and_token_is_consumable():
+    """The task definition names both; they add a default name and nothing else yet."""
+    gpu = pool(GpuMgr, 8)
+    token = pool(TokenMgr, 1_000_000)
+
+    assert (gpu.name, token.name) == ("gpu", "token")
+    assert isinstance(gpu, RenewableMgr)
+    assert isinstance(token, ConsumableMgr)
+
+    gpu.take(2)
+    gpu.give_back(2, actual=1)
+    assert gpu.available == 8
+
+    token.take(100)
+    token.give_back(100, actual=40)
+    assert token.available == 1_000_000 - 40
+
+
+def test_an_outstanding_reservation_is_not_baked_into_the_record():
+    """Criterion 33, the case that matters. `available` at settlement time is
+    net of every *other* live reservation, so persisting it would make those
+    leases durable — and they are supposed to die with the process."""
+    store = MemoryStoreMgr()
+    p = pool(ConsumableMgr, 1000, name="token", store=store)
+
+    p.take(400)  # A: still running, never settles
+    p.take(500)  # B: settles at 300
+    p.give_back(500, actual=300)
+
+    assert p.available == 300  # live: 1000 - 400 (A's lease) - 300 (B's spend)
+    assert store.read("resource", "token")["spent"] == 300.0
+
+    fresh = pool(ConsumableMgr, 1000, name="token", store=store)
+    fresh.resume_system()
+    assert fresh.available == 700  # only B's spend survived, not A's lease
+    assert fresh.spent == 300
+
+
+def test_the_overcharge_does_not_compound_across_restarts():
+    """Each restart must charge for spend only. If a lease leaked into the
+    record, the same reservation would be paid for twice — once as a phantom
+    and once for real when the demoted task re-runs."""
+    store = MemoryStoreMgr()
+    for _ in range(3):
+        p = pool(ConsumableMgr, 10_000, name="token", store=store)
+        p.resume_system()
+        p.take(400)  # interrupted every time, never settled
+        p.take(100)
+        p.give_back(100, actual=100)
+
+    fresh = pool(ConsumableMgr, 10_000, name="token", store=store)
+    fresh.resume_system()
+    assert fresh.spent == 300  # three settled hundreds
+    assert fresh.available == 9_700  # and not a token less
+
+
+def test_spent_and_available_are_complements_after_a_resume():
+    store = MemoryStoreMgr()
+    p = pool(ConsumableMgr, 1000, name="token", store=store)
+    p.take(250)
+    p.give_back(250, actual=250)
+
+    fresh = pool(ConsumableMgr, 1000, name="token", store=store)
+    fresh.resume_system()
+    assert fresh.spent + fresh.available == fresh.capacity
+
+
+def test_a_capacity_lowered_below_what_is_spent_does_not_go_negative():
+    """An operator may cut a budget after some of it is gone. Unclamped,
+    `available` goes negative and `can_afford(0)` is then False — every task
+    naming the pool queues forever with no diagnostic. Sibling of O7."""
+    store = MemoryStoreMgr()
+    p = pool(ConsumableMgr, 1000, name="token", store=store)
+    p.take(300)
+    p.give_back(300, actual=300)
+
+    shrunk = pool(ConsumableMgr, 100, name="token", store=store)
+    shrunk.resume_system()
+
+    assert shrunk.available == 0.0
+    assert shrunk.can_afford(0)  # a task asking for nothing still fits
+    assert not shrunk.can_afford(1)

--- a/agent_sys/tests/task_graph/test_store.py
+++ b/agent_sys/tests/task_graph/test_store.py
@@ -1,0 +1,145 @@
+"""Persistence — criterion 29.
+
+`create` and `update` are separate because their preconditions differ and both
+are worth enforcing: `add` means *new*, `persist` means *existing*. An upsert
+would accept both mistakes silently.
+
+Both implementations are held to the same contract, so the JSON store is not a
+second-class citizen tested only once.
+"""
+
+import json
+
+import pytest
+
+from task_graph.store import JsonFileStoreMgr, MemoryStoreMgr, StoreMgr
+
+RECORD = {"id": "abc", "status": "running", "nested": {"n": [1, 2]}}
+
+
+@pytest.fixture(params=["memory", "json"])
+def store(request, tmp_path) -> StoreMgr:
+    if request.param == "memory":
+        return MemoryStoreMgr()
+    return JsonFileStoreMgr(tmp_path / "state")
+
+
+# --------------------------------------------------------------- the contract
+
+
+def test_create_then_read(store):
+    store.create("task", "abc", RECORD)
+    assert store.read("task", "abc") == RECORD
+
+
+def test_read_a_missing_record_is_none_not_an_error(store):
+    assert store.read("task", "nope") is None
+
+
+def test_create_rejects_an_existing_key(store):
+    store.create("task", "abc", RECORD)
+    with pytest.raises(KeyError, match="abc"):
+        store.create("task", "abc", RECORD)
+
+
+def test_update_replaces(store):
+    store.create("task", "abc", RECORD)
+    store.update("task", "abc", {**RECORD, "status": "succeeded"})
+    assert store.read("task", "abc")["status"] == "succeeded"
+
+
+def test_update_rejects_a_missing_key(store):
+    with pytest.raises(KeyError, match="abc"):
+        store.update("task", "abc", RECORD)
+
+
+def test_delete(store):
+    store.create("task", "abc", RECORD)
+    store.delete("task", "abc")
+    assert store.read("task", "abc") is None
+    assert not store.exists("task", "abc")
+
+
+def test_delete_rejects_a_missing_key(store):
+    with pytest.raises(KeyError, match="abc"):
+        store.delete("task", "abc")
+
+
+def test_exists(store):
+    assert not store.exists("task", "abc")
+    store.create("task", "abc", RECORD)
+    assert store.exists("task", "abc")
+
+
+def test_read_all(store):
+    store.create("task", "a", {"id": "a"})
+    store.create("task", "b", {"id": "b"})
+    assert sorted(r["id"] for r in store.read_all("task")) == ["a", "b"]
+
+
+def test_read_all_of_an_unknown_kind_is_empty(store):
+    assert store.read_all("nothing-here") == []
+
+
+def test_kinds_are_separate_namespaces(store):
+    store.create("task", "same", {"which": "task"})
+    store.create("handoff", "same", {"which": "handoff"})
+    assert store.read("task", "same") == {"which": "task"}
+    assert store.read("handoff", "same") == {"which": "handoff"}
+    assert len(store.read_all("task")) == 1
+
+
+def test_a_key_with_path_characters_survives(store):
+    """Callers pass opaque strings and should not have to know they are paths."""
+    key = "a/b:c d?e"
+    store.create("task", key, RECORD)
+    assert store.read("task", key) == RECORD
+    assert store.exists("task", key)
+    store.delete("task", key)
+    assert not store.exists("task", key)
+
+
+def test_a_stored_record_is_not_a_live_reference(store):
+    """Otherwise 'reload from persistence' returns objects nobody ever wrote,
+    and every recovery test passes vacuously."""
+    record = {"id": "abc", "nested": {"n": [1]}}
+    store.create("task", "abc", record)
+
+    record["id"] = "mutated-after-write"
+    record["nested"]["n"].append(2)
+    assert store.read("task", "abc") == {"id": "abc", "nested": {"n": [1]}}
+
+    first = store.read("task", "abc")
+    first["nested"]["n"].append(3)
+    assert store.read("task", "abc") == {"id": "abc", "nested": {"n": [1]}}
+
+
+# ------------------------------------------------------- JSON store specifics
+
+
+def test_json_store_writes_one_readable_file_per_record(tmp_path):
+    store = JsonFileStoreMgr(tmp_path / "state")
+    store.create("task", "abc", RECORD)
+
+    path = tmp_path / "state" / "task" / "abc.json"
+    assert json.loads(path.read_text()) == RECORD
+
+
+def test_json_store_leaves_no_temporary_file_behind(tmp_path):
+    """The write is <name>.json.tmp + Path.replace, which is atomic on POSIX."""
+    store = JsonFileStoreMgr(tmp_path / "state")
+    store.create("task", "abc", RECORD)
+    store.update("task", "abc", RECORD)
+    assert list((tmp_path / "state" / "task").glob("*.tmp")) == []
+
+
+def test_json_store_survives_a_fresh_instance_over_the_same_root(tmp_path):
+    JsonFileStoreMgr(tmp_path / "state").create("task", "abc", RECORD)
+    assert JsonFileStoreMgr(tmp_path / "state").read("task", "abc") == RECORD
+
+
+def test_json_store_ignores_a_non_json_file_in_a_kind_directory(tmp_path):
+    store = JsonFileStoreMgr(tmp_path / "state")
+    store.create("task", "abc", RECORD)
+    (tmp_path / "state" / "task" / "README").write_text("not a record")
+    assert store.read_all("task") == [RECORD]

--- a/agent_sys/tests/task_graph/test_submit.py
+++ b/agent_sys/tests/task_graph/test_submit.py
@@ -1,0 +1,253 @@
+"""Submission — criteria 1, 2 and 35.
+
+Where a task lands is decided by asking the handoffs, not by counting
+dependencies: a task with no inputs is immediately eligible.
+"""
+
+import logging
+
+import pytest
+
+from task_graph.models import HandoffStatus, Task, TaskStatus
+from task_graph.registry import Registry
+from task_graph.resource import GpuMgr
+
+from .conftest import make_task, new_handoffs
+
+
+def test_a_task_with_no_inputs_is_immediately_eligible(scheduler, task_mgr):
+    """Criterion 1. The pool is saturated first so the landing state is
+    observable — otherwise submit dispatches it straight through to RUNNING."""
+    scheduler.submit(make_task(resources={"gpu": 8}))
+
+    task = make_task(resources={"gpu": 1})
+    scheduler.submit(task)
+    assert task_mgr.get(task.id).status is TaskStatus.WAITING_RESOURCE
+
+
+def test_an_eligible_task_with_nothing_blocking_runs_at_once(scheduler, task_mgr):
+    task = make_task()
+    scheduler.submit(task)
+    assert task_mgr.get(task.id).status is TaskStatus.RUNNING
+
+
+def test_a_task_with_an_unmet_input_waits_for_handoffs(scheduler, task_mgr):
+    """Criterion 2."""
+    task = make_task(inputs=new_handoffs(1))
+    scheduler.submit(task)
+    assert task_mgr.get(task.id).status is TaskStatus.WAITING_HANDOFF
+
+
+def test_a_task_whose_inputs_are_already_valid_is_eligible(
+    scheduler, handoff_mgr, task_mgr, runner, registry
+):
+    producer = make_task(outputs=new_handoffs(1))
+    scheduler.submit(producer)
+    runner.produce(registry, producer.id)
+    runner.finish(producer.id)
+
+    consumer = make_task(inputs=producer.outputs)
+    scheduler.submit(consumer)
+    assert task_mgr.get(consumer.id).status is TaskStatus.RUNNING
+
+
+def test_all_inputs_must_be_valid_not_just_one(scheduler, task_mgr, runner, registry):
+    first, second = new_handoffs(2)
+    producer = make_task(outputs=[first])
+    scheduler.submit(producer)
+    runner.produce(registry, producer.id)
+    runner.finish(producer.id)
+
+    consumer = make_task(inputs=[first, second])
+    scheduler.submit(consumer)
+    assert task_mgr.get(consumer.id).status is TaskStatus.WAITING_HANDOFF
+
+
+def test_an_invalid_input_does_not_count(scheduler, task_mgr, runner, registry):
+    producer = make_task(outputs=new_handoffs(1))
+    scheduler.submit(producer)
+    runner.produce(registry, producer.id, valid=False)
+    runner.finish(producer.id, TaskStatus.FAILED)
+
+    consumer = make_task(inputs=producer.outputs)
+    scheduler.submit(consumer)
+    assert task_mgr.get(consumer.id).status is TaskStatus.WAITING_HANDOFF
+
+
+# ------------------------------------------------------------------ outputs
+
+
+def test_submit_declares_the_outputs(scheduler, handoff_mgr):
+    task = make_task(outputs=new_handoffs(2))
+    scheduler.submit(task)
+
+    for hid in task.outputs:
+        handoff = handoff_mgr.get(hid)
+        assert handoff.latest.status is HandoffStatus.CREATED
+        assert handoff.latest.producer_task_id == task.id
+
+
+def test_declaring_an_output_does_not_make_it_valid(scheduler, handoff_mgr):
+    task = make_task(outputs=new_handoffs(1))
+    scheduler.submit(task)
+    assert not handoff_mgr.check_if_latest_valid(task.outputs[0])
+
+
+def test_a_task_that_consumes_its_own_declared_output_waits(scheduler, task_mgr):
+    """Declaration is not production."""
+    (hid,) = new_handoffs(1)
+    task = make_task(inputs=[hid], outputs=[hid])
+    scheduler.submit(task)
+    assert task_mgr.get(task.id).status is TaskStatus.WAITING_HANDOFF
+
+
+# --------------------------------------------------------------- rejections
+
+
+def test_a_duplicate_id_is_rejected(scheduler):
+    task = make_task()
+    scheduler.submit(task)
+    with pytest.raises(KeyError):
+        scheduler.submit(Task(id=task.id, agent_spec="tuner"))
+
+
+def test_an_unregistered_resource_is_rejected(scheduler, task_mgr):
+    task = make_task(resources={"tpu": 1})
+    with pytest.raises(ValueError, match="tpu"):
+        scheduler.submit(task)
+    assert task_mgr.all() == []
+
+
+@pytest.mark.parametrize("amount", [-1, float("nan"), float("inf")])
+def test_a_malformed_resource_amount_is_rejected(scheduler, task_mgr, registry, amount):
+    """It would pass `can_afford` for other pools and then raise inside `take`,
+    leaving the partial reservation all-or-nothing exists to prevent."""
+    task = make_task(resources={"gpu": 1, "token": amount})
+    with pytest.raises(ValueError, match="token"):
+        scheduler.submit(task)
+
+    assert task_mgr.all() == []
+    assert registry.get("resource:gpu").available == 8  # nothing was taken
+
+
+def test_zero_is_a_legitimate_amount(scheduler, task_mgr):
+    task = make_task(resources={"gpu": 0})
+    scheduler.submit(task)
+    assert task_mgr.get(task.id).status is TaskStatus.RUNNING
+
+
+def test_a_registered_resource_is_accepted(scheduler, task_mgr):
+    task = make_task(resources={"gpu": 2, "token": 500})
+    scheduler.submit(task)
+    assert task_mgr.get(task.id).resources == {"gpu": 2, "token": 500}
+
+
+def test_an_unregistered_agent_spec_is_rejected(scheduler, task_mgr):
+    with pytest.raises(KeyError, match="nope"):
+        scheduler.submit(make_task(spec="nope"))
+    assert task_mgr.all() == []
+
+
+def test_a_rejected_task_leaves_no_trace(scheduler, task_mgr, handoff_mgr):
+    """Rejection happens before anything is written."""
+    task = make_task(resources={"tpu": 1}, outputs=new_handoffs(1))
+    with pytest.raises(ValueError):
+        scheduler.submit(task)
+
+    assert task_mgr.all() == []
+    assert handoff_mgr.all_ids() == []
+    assert all(not pool for pool in scheduler.pools.values())
+
+
+# ----------------------------------------------------- the depends_on check
+
+
+def test_a_missing_depends_on_edge_warns_and_does_not_reject(
+    scheduler, task_mgr, runner, registry, caplog
+):
+    """Criterion 35. Rejecting would make declaration order matter; repairing
+    would make depends_on derived and unable to express an edge that shares no
+    handoff."""
+    producer = make_task(outputs=new_handoffs(1))
+    scheduler.submit(producer)
+    runner.produce(registry, producer.id)
+    runner.finish(producer.id)
+
+    consumer = make_task(inputs=producer.outputs)  # depends_on left empty
+    with caplog.at_level(logging.WARNING):
+        scheduler.submit(consumer)
+
+    assert str(producer.id) in caplog.text
+    assert "depends_on" in caplog.text
+    assert task_mgr.get(consumer.id).status is TaskStatus.RUNNING  # accepted
+
+
+def test_a_correct_depends_on_edge_is_silent(scheduler, runner, registry, caplog):
+    producer = make_task(outputs=new_handoffs(1))
+    scheduler.submit(producer)
+    runner.produce(registry, producer.id)
+    runner.finish(producer.id)
+
+    consumer = make_task(inputs=producer.outputs, depends_on=[producer.id])
+    with caplog.at_level(logging.WARNING):
+        scheduler.submit(consumer)
+
+    assert caplog.text == ""
+
+
+def test_the_check_passes_vacuously_when_the_producer_is_not_yet_known(scheduler, caplog):
+    """Open question O8, asserted so the limitation is visible rather than
+    discovered later."""
+    consumer = make_task(inputs=new_handoffs(1))
+    with caplog.at_level(logging.WARNING):
+        scheduler.submit(consumer)
+    assert caplog.text == ""
+
+
+# ---------------------------------------------------------------- the index
+
+
+def test_the_pool_index_agrees_with_the_stored_status(scheduler, task_mgr):
+    hog = make_task(resources={"gpu": 8})
+    eligible = make_task(resources={"gpu": 1})
+    waiting = make_task(inputs=new_handoffs(1))
+    for task in (hog, eligible, waiting):
+        scheduler.submit(task)
+
+    assert scheduler.pools[TaskStatus.RUNNING] == {hog.id}
+    assert scheduler.pools[TaskStatus.WAITING_RESOURCE] == {eligible.id}
+    assert scheduler.pools[TaskStatus.WAITING_HANDOFF] == {waiting.id}
+    for task in (hog, eligible, waiting):
+        assert task.id in scheduler.pools[task_mgr.get(task.id).status]
+
+
+def test_submit_persists_the_task(scheduler, store):
+    task = make_task(inputs=new_handoffs(1))
+    scheduler.submit(task)
+    assert store.read("task", str(task.id))["status"] == "waiting_handoff"
+
+
+def test_a_pool_with_no_registered_resources_still_works(store):
+    """A system may declare no pools at all; a task requesting none still runs."""
+    from task_graph.bootstrap import build_registry
+
+    registry = build_registry(store=store, resources=[])
+    registry.get("agent_mgr").register("profiler")
+    scheduler = registry.get("scheduler")
+
+    task = make_task()
+    scheduler.submit(task)
+    assert registry.get("task_mgr").get(task.id).status is TaskStatus.RUNNING
+
+
+def test_resource_names_come_from_the_registry_not_a_fixed_list(store):
+    from task_graph.bootstrap import build_registry
+
+    registry = Registry()
+    pools = [GpuMgr(registry, capacity=4, name="mi300")]
+    registry = build_registry(store=store, resources=pools)
+    registry.get("agent_mgr").register("profiler")
+
+    task = make_task(resources={"mi300": 2})
+    registry.get("scheduler").submit(task)
+    assert registry.get("task_mgr").get(task.id).status is TaskStatus.RUNNING

--- a/agent_sys/tests/task_graph/test_task.py
+++ b/agent_sys/tests/task_graph/test_task.py
@@ -1,0 +1,246 @@
+"""TaskMgr — the collection, plus one recovery decision.
+
+There is no `set_status` and no `push_execution` here: those are the `Task`'s
+own transitions, with its own guards. The mgr does durability and lookup.
+"""
+
+import pytest
+
+from task_graph.ids import AgentId, HandoffId, TaskId
+from task_graph.models import Task, TaskStatus
+from task_graph.registry import Registry
+from task_graph.store import MemoryStoreMgr
+from task_graph.task import TaskMgr
+
+
+@pytest.fixture
+def store():
+    return MemoryStoreMgr()
+
+
+@pytest.fixture
+def mgr(store):
+    registry = Registry()
+    registry.register("store_mgr", store)
+    manager = TaskMgr(registry)
+    registry.register("task_mgr", manager)
+    return manager
+
+
+def rebuild(store) -> TaskMgr:
+    """A restart: fresh managers over the same store."""
+    registry = Registry()
+    registry.register("store_mgr", store)
+    fresh = TaskMgr(registry)
+    fresh.resume_system()
+    return fresh
+
+
+# --------------------------------------------------------------- collection
+
+
+def test_add_then_get(mgr):
+    task = Task(agent_spec="profiler")
+    mgr.add(task)
+    assert mgr.get(task.id) is task
+
+
+def test_add_persists(mgr, store):
+    task = Task(agent_spec="profiler")
+    mgr.add(task)
+    assert store.read("task", str(task.id))["agent_spec"] == "profiler"
+
+
+def test_get_an_unknown_id_raises(mgr):
+    with pytest.raises(KeyError):
+        mgr.get(TaskId.new())
+
+
+def test_add_rejects_a_duplicate_id(mgr):
+    task = Task(agent_spec="profiler")
+    mgr.add(task)
+    with pytest.raises(KeyError):
+        mgr.add(Task(id=task.id, agent_spec="tuner"))
+
+
+def test_add_revives_a_cancelled_id_with_fresh_history(mgr):
+    """Forced by `update_task` = remove_queued + submit under the same id."""
+    task = Task(agent_spec="profiler")
+    mgr.add(task)
+    task.push_execution(agent_id=AgentId.new())
+    task.close_execution({}, TaskStatus.FAILED)
+    task.status = TaskStatus.CANCELLED
+    mgr.persist(task.id)
+
+    replacement = Task(id=task.id, agent_spec="tuner")
+    mgr.add(replacement)
+
+    assert mgr.get(task.id) is replacement
+    assert mgr.get(task.id).history == []
+    assert mgr.get(task.id).agent_spec == "tuner"
+
+
+def test_all(mgr):
+    tasks = [Task(agent_spec="profiler") for _ in range(3)]
+    for task in tasks:
+        mgr.add(task)
+    assert sorted(t.id for t in mgr.all()) == sorted(t.id for t in tasks)
+
+
+def test_by_status(mgr):
+    running, waiting = Task(agent_spec="a"), Task(agent_spec="b")
+    running.status = TaskStatus.RUNNING
+    for task in (running, waiting):
+        mgr.add(task)
+
+    assert [t.id for t in mgr.by_status(TaskStatus.RUNNING)] == [running.id]
+    assert [t.id for t in mgr.by_status(TaskStatus.WAITING_HANDOFF)] == [waiting.id]
+    assert mgr.by_status(TaskStatus.SUCCEEDED) == []
+
+
+def test_remove(mgr, store):
+    task = Task(agent_spec="profiler")
+    mgr.add(task)
+    mgr.remove(task.id)
+
+    assert mgr.all() == []
+    assert not store.exists("task", str(task.id))
+    with pytest.raises(KeyError):
+        mgr.get(task.id)
+
+
+def test_remove_an_unknown_id_raises(mgr):
+    with pytest.raises(KeyError):
+        mgr.remove(TaskId.new())
+
+
+# -------------------------------------------------------------- persistence
+
+
+def test_persist_writes_back_a_mutation_made_through_the_task(mgr, store):
+    task = Task(agent_spec="profiler")
+    mgr.add(task)
+
+    task.status = TaskStatus.RUNNING
+    assert store.read("task", str(task.id))["status"] == "waiting_handoff"
+
+    mgr.persist(task.id)
+    assert store.read("task", str(task.id))["status"] == "running"
+
+
+def test_persist_an_unknown_id_raises(mgr):
+    with pytest.raises(KeyError):
+        mgr.persist(TaskId.new())
+
+
+def test_history_survives_a_restart_with_attempt_numbering_intact(mgr, store):
+    hid = HandoffId.new()
+    task = Task(agent_spec="profiler", inputs=[hid])
+    mgr.add(task)
+    for outcome in (TaskStatus.FAILED, TaskStatus.SUCCEEDED):
+        task.push_execution(agent_id=AgentId.new(), input_versions={hid: 0})
+        task.close_execution({hid: 1}, outcome)
+    mgr.persist(task.id)
+
+    restored = rebuild(store).get(task.id)
+
+    assert [e.attempt for e in restored.history] == [0, 1]
+    assert [e.outcome for e in restored.history] == [TaskStatus.FAILED, TaskStatus.SUCCEEDED]
+    assert restored.history[0].input_versions == {hid: 0}
+    assert restored.created_at == task.created_at
+
+
+# ------------------------------------------------------------------ resume
+
+
+def test_resume_closes_a_dangling_stack_top_as_suspended(mgr, store):
+    """The restart cut the attempt short; it was not judged."""
+    task = Task(agent_spec="profiler")
+    mgr.add(task)
+    task.push_execution(agent_id=AgentId.new())
+    task.status = TaskStatus.RUNNING
+    mgr.persist(task.id)
+
+    restored = rebuild(store).get(task.id)
+
+    top = restored.history[-1]
+    assert not top.is_open
+    assert top.outcome is TaskStatus.SUSPENDED
+    assert top.ended_at is not None
+
+
+def test_resume_leaves_the_task_status_alone(mgr, store):
+    """Where the task lands is the scheduler's decision, a moment later."""
+    task = Task(agent_spec="profiler")
+    mgr.add(task)
+    task.push_execution(agent_id=AgentId.new())
+    task.status = TaskStatus.RUNNING
+    mgr.persist(task.id)
+
+    assert rebuild(store).get(task.id).status is TaskStatus.RUNNING
+
+
+def test_a_closed_stack_top_is_not_touched(mgr, store):
+    task = Task(agent_spec="profiler")
+    mgr.add(task)
+    task.push_execution(agent_id=AgentId.new())
+    task.close_execution({}, TaskStatus.SUCCEEDED, detail="fine")
+    mgr.persist(task.id)
+
+    top = rebuild(store).get(task.id).history[-1]
+    assert top.outcome is TaskStatus.SUCCEEDED
+    assert top.detail == "fine"
+
+
+def test_closing_the_dangling_top_is_what_lets_the_next_attempt_start(mgr, store):
+    """`push_execution` refuses to stack on an open attempt, so leaving it open
+    would make the first resume_task after a restart raise."""
+    task = Task(agent_spec="profiler")
+    mgr.add(task)
+    task.push_execution(agent_id=AgentId.new())
+    mgr.persist(task.id)
+
+    restored_mgr = rebuild(store)
+    restored = restored_mgr.get(task.id)
+    restored.push_execution(agent_id=AgentId.new())  # must not raise
+    assert [e.attempt for e in restored.history] == [0, 1]
+
+
+def test_resume_replaces_the_collection_rather_than_merging(mgr, store):
+    task = Task(agent_spec="profiler")
+    mgr.add(task)
+    store.delete("task", str(task.id))
+
+    mgr.resume_system()
+    assert mgr.all() == []
+
+
+def test_resume_is_durable_for_the_close_it_performs(mgr, store):
+    """A second restart must not find the same dangling attempt again."""
+    task = Task(agent_spec="profiler")
+    mgr.add(task)
+    task.push_execution(agent_id=AgentId.new())
+    mgr.persist(task.id)
+
+    rebuild(store)
+    assert store.read("task", str(task.id))["history"][-1]["outcome"] == "suspended"
+
+
+def test_remove_refuses_a_task_the_scheduler_still_indexes(registry):
+    """`remove` is the hard delete, not cancellation. Removing an indexed task
+    leaves an id in a pool with no task behind it, and every subsequent
+    dispatch pass then raises at the eligibility re-check — permanently."""
+    scheduler, mgr = registry.get("scheduler"), registry.get("task_mgr")
+    task = Task(agent_spec="profiler", inputs=[HandoffId.new()])
+    scheduler.submit(task)
+
+    with pytest.raises(ValueError, match="still indexes it"):
+        mgr.remove(task.id)
+
+    scheduler.remove_queued(task.id)  # cancelled, but still indexed
+    with pytest.raises(ValueError, match="still indexes it"):
+        mgr.remove(task.id)
+
+    scheduler.pools[TaskStatus.CANCELLED].discard(task.id)  # an operator forgets it
+    mgr.remove(task.id)
+    assert mgr.all() == []

--- a/agent_sys/tests/task_graph/test_versioning.py
+++ b/agent_sys/tests/task_graph/test_versioning.py
@@ -1,0 +1,204 @@
+"""Versioning — criteria 16, 17 and 20.
+
+A re-run appends; it never overwrites. Nothing invalidates a downstream handoff,
+because a consumer that has already run has already recorded which version it
+saw, and one that has not will ask again.
+"""
+
+from task_graph.models import HandoffStatus, TaskStatus
+
+from .conftest import make_task, new_handoffs
+
+
+def test_a_second_producer_appends_rather_than_overwriting(
+    scheduler, handoff_mgr, runner, registry
+):
+    """Criterion 16."""
+    (hid,) = new_handoffs(1)
+    first = make_task(outputs=[hid])
+    scheduler.submit(first)
+    runner.produce(registry, first.id, content="first")
+    runner.finish(first.id)
+
+    second = make_task(outputs=[hid])
+    scheduler.submit(second)
+    runner.produce(registry, second.id, content="second")
+    runner.finish(second.id)
+
+    handoff = handoff_mgr.get(hid)
+    assert [v.version for v in handoff.versions] == [0, 1]
+    assert handoff.get(0).content == "first"
+    assert handoff.get(1).content == "second"
+
+
+def test_the_earlier_version_is_untouched(scheduler, handoff_mgr, runner, registry):
+    """Criterion 17."""
+    (hid,) = new_handoffs(1)
+    first = make_task(outputs=[hid])
+    scheduler.submit(first)
+    runner.produce(registry, first.id, content="first")
+    runner.finish(first.id)
+    before = handoff_mgr.get(hid).get(0).model_copy(deep=True)
+
+    second = make_task(outputs=[hid])
+    scheduler.submit(second)
+    runner.produce(registry, second.id, valid=False, content="second")
+    runner.finish(second.id)
+
+    assert handoff_mgr.get(hid).get(0) == before
+
+
+def test_a_version_records_which_task_and_which_agent_wrote_it(
+    scheduler, handoff_mgr, task_mgr, runner, registry
+):
+    (hid,) = new_handoffs(1)
+    first, second = make_task(outputs=[hid]), make_task(outputs=[hid])
+    for task in (first, second):
+        scheduler.submit(task)
+        runner.produce(registry, task.id)
+        runner.finish(task.id)
+
+    handoff = handoff_mgr.get(hid)
+    assert handoff.get(0).producer_task_id == first.id
+    assert handoff.get(1).producer_task_id == second.id
+    assert handoff.get(0).producer_agent_id == task_mgr.get(first.id).current.agent_id
+    assert handoff.get(1).producer_agent_id == task_mgr.get(second.id).current.agent_id
+    assert handoff.get(0).producer_agent_id != handoff.get(1).producer_agent_id
+
+
+def test_a_re_run_makes_the_slot_temporarily_not_valid(scheduler, handoff_mgr, runner, registry):
+    """Which is what blocks a consumer that has not started yet."""
+    (hid,) = new_handoffs(1)
+    first = make_task(outputs=[hid])
+    scheduler.submit(first)
+    runner.produce(registry, first.id)
+    runner.finish(first.id)
+    assert handoff_mgr.check_if_latest_valid(hid)
+
+    second = make_task(outputs=[hid])
+    scheduler.submit(second)  # dispatched, agent has not written yet
+    consumer = make_task(inputs=[hid])
+    scheduler.submit(consumer)
+    assert handoff_mgr.check_if_latest_valid(hid)  # v0 is still the latest
+
+    runner.produce(registry, second.id)  # now v1 exists and is valid
+    assert handoff_mgr.latest(hid).version == 1
+
+
+def test_a_consumer_submitted_after_a_re_run_sees_the_new_version(
+    scheduler, task_mgr, runner, registry
+):
+    """Criterion 20."""
+    (hid,) = new_handoffs(1)
+    for content in ("first", "second"):
+        producer = make_task(outputs=[hid])
+        scheduler.submit(producer)
+        runner.produce(registry, producer.id, content=content)
+        runner.finish(producer.id)
+
+    consumer = make_task(inputs=[hid])
+    scheduler.submit(consumer)
+    assert task_mgr.get(consumer.id).current.input_versions == {hid: 1}
+
+
+def test_nothing_invalidates_a_downstream_handoff(
+    scheduler, handoff_mgr, task_mgr, runner, registry
+):
+    """A consumer that already ran keeps its recorded version and its own
+    output stays VALID: cascade invalidation is deliberately absent."""
+    (upstream,) = new_handoffs(1)
+    (downstream,) = new_handoffs(1)
+
+    producer = make_task(outputs=[upstream])
+    scheduler.submit(producer)
+    runner.produce(registry, producer.id, content="v0")
+    runner.finish(producer.id)
+
+    consumer = make_task(inputs=[upstream], outputs=[downstream])
+    scheduler.submit(consumer)
+    runner.produce(registry, consumer.id)
+    runner.finish(consumer.id)
+
+    refresher = make_task(outputs=[upstream])
+    scheduler.submit(refresher)
+    runner.produce(registry, refresher.id, content="v1")
+    runner.finish(refresher.id)
+
+    assert handoff_mgr.check_if_latest_valid(downstream)
+    assert handoff_mgr.get(downstream).latest.status is HandoffStatus.VALID
+    assert task_mgr.get(consumer.id).status is TaskStatus.SUCCEEDED
+    assert task_mgr.get(consumer.id).history[0].input_versions == {upstream: 0}
+
+
+def test_a_resumed_task_writes_a_new_version_not_over_its_old_one(
+    scheduler, handoff_mgr, runner, registry
+):
+    (hid,) = new_handoffs(1)
+    task = make_task(outputs=[hid])
+    scheduler.submit(task)
+    runner.produce(registry, task.id, content="attempt 0")
+    runner.finish(task.id, TaskStatus.FAILED)
+
+    scheduler.resume_task(task.id)
+    runner.produce(registry, task.id, content="attempt 1")
+    runner.finish(task.id)
+
+    handoff = handoff_mgr.get(hid)
+    assert [v.content for v in handoff.versions] == ["attempt 0", "attempt 1"]
+    assert handoff.get(0).producer_task_id == handoff.get(1).producer_task_id == task.id
+    assert handoff.get(0).producer_agent_id != handoff.get(1).producer_agent_id
+
+
+def test_versions_survive_a_restart(scheduler, runner, registry, store):
+    from .conftest import rebuild
+
+    (hid,) = new_handoffs(1)
+    for content in ("first", "second"):
+        producer = make_task(outputs=[hid])
+        scheduler.submit(producer)
+        runner.produce(registry, producer.id, content=content)
+        runner.finish(producer.id)
+
+    fresh = rebuild(store)
+    fresh.get("handoff_mgr").resume_system()
+
+    handoff = fresh.get("handoff_mgr").get(hid)
+    assert [v.content for v in handoff.versions] == ["first", "second"]
+    assert fresh.get("handoff_mgr").check_if_latest_valid(hid)
+
+
+def test_resuming_over_an_abandoned_generating_version_appends(
+    scheduler, handoff_mgr, task_mgr, runner, registry
+):
+    """Criterion 20's other half: the abandoned version is not reused, so the
+    record still shows that an attempt was made and left unfinished.
+
+    NOTE the seal below. This test drives the case where *something* closes the
+    abandoned version off; it does NOT cover a crash, where nobody is alive to
+    make that call — see `test_recovery.py`'s deadlock test and design §14 O10."""
+    (hid,) = new_handoffs(1)
+    task = make_task(outputs=[hid])
+    scheduler.submit(task)
+
+    # the agent opened the slot and died without sealing
+    first_agent = task_mgr.get(task.id).current.agent_id
+    handoff_mgr.get(hid).open_next(task.id, first_agent)
+    handoff_mgr.persist(hid)
+    runner.finish(task.id, TaskStatus.FAILED)
+    assert handoff_mgr.get(hid).latest.status is HandoffStatus.GENERATING
+
+    scheduler.resume_task(task.id)
+    second_agent = task_mgr.get(task.id).current.agent_id
+    # `open_next` refuses a slot someone else has open — an abandoned version
+    # must be sealed off before the retry can take the slot.
+    handoff_mgr.get(hid).latest.seal(HandoffStatus.INVALID)
+    runner.produce(registry, task.id, content="retry")
+    runner.finish(task.id)
+
+    handoff = handoff_mgr.get(hid)
+    assert [v.status for v in handoff.versions] == [
+        HandoffStatus.INVALID,
+        HandoffStatus.VALID,
+    ]
+    assert handoff.get(0).producer_agent_id == first_agent
+    assert handoff.get(1).producer_agent_id == second_agent


### PR DESCRIPTION
Adds **`task_graph`**, the component that decides *which task runs when* for Infera's agent-driven performance-optimization loop, alongside the existing `env_mgr` under `agent_sys/`.

An AI agent is treated as a function that is not very procedural. A handoff is that function's input or output. The scheduler decides **when** a task runs and nothing else — it never inspects what a task does and never writes handoff state.

Delivered in three reviewed stages: **specification → design → tests & code.**

| | |
|---|---|
| [`docs/spec.md`](../blob/dev.yihou.aiopt.task.graph/agent_sys/task_graph/docs/spec.md) rev. 7 | What the system must do. 35 acceptance criteria |
| [`docs/design.md`](../blob/dev.yihou.aiopt.task.graph/agent_sys/task_graph/docs/design.md) rev. 10 | Files, classes, interfaces, test plan. §13 records every place implementing the spec literally did not work; §14 the questions left open on purpose |

## Design decisions worth naming

- **Eligibility is a query, not a counter.** `check_if_latest_valid(hid)` is re-asked at each decision point, so nothing has to be invalidated when a producer re-runs.
- **Handoffs are versioned append-only lists.** The list index *is* the version, so contiguity is structural and no validator enforces it.
- **Acquisition is atomic and all-or-nothing.** The full declared set is verified before any pool is touched, which makes hold-and-wait deadlock structurally impossible.
- **Renewable and consumable pools differ in three behaviours** — release, persistence, recovery — which is why the split is at the abstract-base level rather than a boolean flag. A reservation is a lease that dies with its process; a settlement is spend and must not be un-spent.
- **One writer per invariant.** `Scheduler._move` is the only thing that assigns `task.status` or mutates a pool.
- **Composition over inheritance, resolved at use time.** No manager imports another manager; `bootstrap.build_registry()` is the sole composition root.

## Layout

`agent_sys/` is a container for two independent components; neither imports the other.

```
agent_sys/
├── pyproject.toml       declares both packages
├── env_mgr/             (unchanged, from main)
├── task_graph/
│   ├── docs/            spec.md, design.md
│   └── *.py
└── tests/{env_mgr,task_graph}/
```

## Testing

```bash
pip install -e agent_sys
pytest agent_sys
```

**423 tests pass** (358 `task_graph` + 65 `env_mgr`), covering all 35 acceptance criteria. Design §11 maps every criterion to a named test.

Two rounds of adversarial review found **eleven real bugs**, all fixed and recorded as deviations D9–D18. They share one shape — a value or a lease that is correct in the live object but wrong the moment something fails or is made durable:

- a consumable persisted `available`, which nets out in-flight reservations, so every interrupted run permanently shrank the budget and compounded across restarts;
- a dispatch that failed after taking its lease leaked it *and* aborted the pass for every other queued task;
- the abort handler was itself unprotected, so a wedged pool left the task `RUNNING` with a half-open attempt that only a restart could clear;
- a rejected `update_task` destroyed the task it was asked to change.

Resource conservation and the authority boundary are both mutation-tested — the checks were verified to fail against a deliberately sabotaged implementation, so they are known to bite rather than assumed to.

## Notes for the reviewer

- The 11 review threads on the earlier draft are addressed; each is resolved with a note saying where. `HandoffVersion` came back with `Handoff` owning the list, `produced_by` became `producer_task_id` / `producer_agent_id`, `Task` gained `depends_on`, `agent` became `agent_spec`, `Agent` gained `task_id` + `handoffs`, and the design doc now specifies interfaces rather than bodies (§1).
- Open questions are deliberately **not** closed by implementation — they are spec-level decisions and are listed in spec §10 and design §14.
- Only runtime dependency is **pydantic v2**, already installed via `fastapi`. Everything else is the standard library. Python ≥ 3.10.
- The repository's own `pyproject.toml` is untouched.
