### PR TITLE
SLA-based planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Around them:
 - **Self-registering fleet** — workers register into etcd (or their own Pod annotation on Kubernetes) and heartbeat, so the router works from a live view and never routes to a worker that is gone; run any number of stateless server replicas.
 - **Scale without dropping requests** — a worker joins when it is ready and leaves by draining: it announces `DRAINING`, finishes the generations it already accepted, and only then deregisters. Measured on MI355X: a worker stops receiving new work **under a second** after `SIGTERM` while its in-flight 4000-token generations all complete, and adding or removing instances under continuous traffic costs **zero failed requests**. See [Scaling a fleet](https://rocm.docs.amd.com/projects/infera/en/latest/features/scaling.html).
 - **Kubernetes-native** — an operator reconciles an `InferaDeployment` CRD (aggregated / PD / multi-node), with an optional Gateway API (GAIE) endpoint picker.
+- **SLA planner** — `python -m infera.planner` works out how many prefill and decode replicas hold your time-to-first-token and inter-token-latency targets, from measured latency plus an offline profile of your model. It reports the counts; resizing is still yours to do.
 
 ## Architecture
 

--- a/infera/planner/__init__.py
+++ b/infera/planner/__init__.py
@@ -3,27 +3,10 @@
 #
 # SPDX-License-Identifier: MIT
 ###############################################################################
-"""SLA-based planner: decide how many prefill/decode replicas meet TTFT/ITL.
+"""Capacity planning for Infera prefill/decode deployments.
 
-Two processes, run in order.
-
-``python -m infera.planner.profile`` is the offline step: before the fleet
-takes traffic, it sweeps one prefill replica and one decode replica and writes
-``profile.json`` -- how TTFT and prefill throughput grow with prompt length,
-and how ITL and decode throughput degrade as the KV cache fills.
-
-``python -m infera.planner`` is the online step. It runs outside the request
-path and, every adjustment interval:
-
-  1. scrapes the server fleet's ``/metrics`` for the observed TTFT, ITL, ISL,
-     OSL and request rate (:mod:`infera.planner.metrics_source`);
-  2. compares them against what the profile predicted, to derive correction
-     factors that absorb queueing and prefix-cache effects;
-  3. assumes the next interval repeats the observed load and solves for the
-     prefill/decode replica counts that meet the SLA
-     (:mod:`infera.planner.core`);
-  4. logs the decision.
-
-Nothing is resized yet. ``SlaPlanner`` accepts an optional decision callback so
-an actuator can be added later without changing the sizing code.
+``python -m infera.planner.profile`` measures a model deployment and writes its
+capacity envelope. ``python -m infera.planner`` combines that envelope with
+windowed server observations and reports target pool sizes. Planning runs
+outside the request path and does not resize a deployment by itself.
 """

--- a/infera/planner/__init__.py
+++ b/infera/planner/__init__.py
@@ -1,0 +1,29 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""SLA-based planner: decide how many prefill/decode replicas meet TTFT/ITL.
+
+Two processes, run in order.
+
+``python -m infera.planner.profile`` is the offline step: before the fleet
+takes traffic, it sweeps one prefill replica and one decode replica and writes
+``profile.json`` -- how TTFT and prefill throughput grow with prompt length,
+and how ITL and decode throughput degrade as the KV cache fills.
+
+``python -m infera.planner`` is the online step. It runs outside the request
+path and, every adjustment interval:
+
+  1. scrapes the server fleet's ``/metrics`` for the observed TTFT, ITL, ISL,
+     OSL and request rate (:mod:`infera.planner.metrics_source`);
+  2. compares them against what the profile predicted, to derive correction
+     factors that absorb queueing and prefix-cache effects;
+  3. assumes the next interval repeats the observed load and solves for the
+     prefill/decode replica counts that meet the SLA
+     (:mod:`infera.planner.core`);
+  4. logs the decision.
+
+Nothing is resized yet. ``SlaPlanner`` accepts an optional decision callback so
+an actuator can be added later without changing the sizing code.
+"""

--- a/infera/planner/__main__.py
+++ b/infera/planner/__main__.py
@@ -1,0 +1,60 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""Entry point for the SLA planner: ``python -m infera.planner``.
+
+Runs as its own long-lived process, like ``infera.kvd`` and ``infera.gaie``, so
+a planner restart or crash never touches request serving.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+
+from infera.planner.args import PlannerArgs, parse_planner_args
+from infera.planner.core import SlaPlanner
+from infera.planner.metrics_source import MetricsSource
+from infera.planner.perf_model import PerfModel
+from infera.planner.profile_data import ProfileDataError, load_profile_data
+
+logger = logging.getLogger(__name__)
+
+
+async def _run(args: PlannerArgs) -> None:
+    perf_model = PerfModel(load_profile_data(args.profile_results))
+    metrics_source = MetricsSource(args.metrics_urls, model=args.model, router="disagg")
+    planner = SlaPlanner(
+        args,
+        perf_model,
+        metrics_source=metrics_source,
+    )
+    logger.info("scraping %s", ", ".join(args.metrics_urls))
+    try:
+        await planner.run()
+    finally:
+        await metrics_source.aclose()
+
+
+def main() -> None:
+    args = parse_planner_args()
+    logging.basicConfig(
+        level=args.log_level,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    try:
+        asyncio.run(_run(args))
+    except ProfileDataError as exc:
+        # A bad performance model can only produce bad decisions, so refuse to
+        # start rather than decide on garbage.
+        logger.error("%s", exc)
+        sys.exit(2)
+    except KeyboardInterrupt:
+        logger.info("planner stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/infera/planner/args.py
+++ b/infera/planner/args.py
@@ -43,11 +43,11 @@ class PlannerArgs:
 def parse_planner_args(argv: list[str] | None = None) -> PlannerArgs:
     parser = argparse.ArgumentParser(
         prog="python -m infera.planner",
-        description="SLA-based planner: decide how many prefill/decode replicas "
-        "meet the TTFT/ITL targets.",
+        description="Recommend prefill and decode pool sizes from measured capacity "
+        "and TTFT/ITL objectives.",
     )
 
-    sla = parser.add_argument_group("SLA targets")
+    sla = parser.add_argument_group("latency objectives")
     sla.add_argument(
         "--ttft",
         type=float,

--- a/infera/planner/args.py
+++ b/infera/planner/args.py
@@ -1,0 +1,137 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""Minimal command-line surface for ``python -m infera.planner``."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+
+DEFAULT_TTFT_MS = 500.0
+DEFAULT_ITL_MS = 50.0
+DEFAULT_ADJUSTMENT_INTERVAL = 180.0
+DEFAULT_METRICS_URL = "http://127.0.0.1:8000/metrics"
+
+
+@dataclass
+class PlannerArgs:
+    """Configuration for the offline-profile-backed decision loop."""
+
+    # SLA targets, in milliseconds to match the profiling data.
+    ttft_ms: float = DEFAULT_TTFT_MS
+    itl_ms: float = DEFAULT_ITL_MS
+
+    # How long each observation window is, and therefore how often a decision
+    # is produced.
+    adjustment_interval: float = DEFAULT_ADJUSTMENT_INTERVAL
+
+    profile_results: str = ""
+    model: str = ""
+    metrics_urls: list[str] = field(default_factory=list)
+
+    # Override the GPUs-per-replica recorded in the profiling data. None keeps
+    # the profiled value, which is what the throughput numbers were measured at.
+    prefill_engine_num_gpu: int | None = None
+    decode_engine_num_gpu: int | None = None
+
+    log_level: str = "INFO"
+
+
+def parse_planner_args(argv: list[str] | None = None) -> PlannerArgs:
+    parser = argparse.ArgumentParser(
+        prog="python -m infera.planner",
+        description="SLA-based planner: decide how many prefill/decode replicas "
+        "meet the TTFT/ITL targets.",
+    )
+
+    sla = parser.add_argument_group("SLA targets")
+    sla.add_argument(
+        "--ttft",
+        type=float,
+        default=DEFAULT_TTFT_MS,
+        metavar="MS",
+        help="Time-to-first-token target in milliseconds. Sizes the prefill pool "
+        "whenever queueing puts TTFT over it (default: %(default)s).",
+    )
+    sla.add_argument(
+        "--itl",
+        type=float,
+        default=DEFAULT_ITL_MS,
+        metavar="MS",
+        help="Inter-token-latency target in milliseconds. Sets the operating point "
+        "the decode pool is sized to hold (default: %(default)s).",
+    )
+
+    obs = parser.add_argument_group("observation")
+    obs.add_argument(
+        "--metrics-url",
+        action="append",
+        default=None,
+        metavar="URL",
+        help="An Infera server /metrics endpoint to scrape. Repeat once per "
+        f"server replica; per-endpoint window deltas are then summed. "
+        f"(default: {DEFAULT_METRICS_URL})",
+    )
+    obs.add_argument(
+        "--adjustment-interval",
+        type=float,
+        default=DEFAULT_ADJUSTMENT_INTERVAL,
+        metavar="SECONDS",
+        help="Length of each observation window, and how often a decision is "
+        "produced (default: %(default)s).",
+    )
+    model = parser.add_argument_group("performance model")
+    model.add_argument(
+        "--model",
+        required=True,
+        help="Served model whose disaggregated metrics and profile should be used.",
+    )
+    model.add_argument(
+        "--profile-results",
+        required=True,
+        metavar="PATH",
+        help="Offline profiling results (JSON), as produced by `python -m infera.planner.profile`.",
+    )
+    model.add_argument(
+        "--prefill-engine-num-gpu",
+        type=int,
+        default=None,
+        metavar="N",
+        help="GPUs per prefill replica. Defaults to the value in the profiling data.",
+    )
+    model.add_argument(
+        "--decode-engine-num-gpu",
+        type=int,
+        default=None,
+        metavar="N",
+        help="GPUs per decode replica. Defaults to the value in the profiling data.",
+    )
+
+    misc = parser.add_argument_group("misc")
+    misc.add_argument("--log-level", default="INFO")
+
+    ns = parser.parse_args(argv)
+
+    if ns.adjustment_interval <= 0:
+        parser.error("--adjustment-interval must be positive")
+    if ns.ttft <= 0 or ns.itl <= 0:
+        parser.error("--ttft and --itl must be positive")
+    if ns.prefill_engine_num_gpu is not None and ns.prefill_engine_num_gpu <= 0:
+        parser.error("--prefill-engine-num-gpu must be positive")
+    if ns.decode_engine_num_gpu is not None and ns.decode_engine_num_gpu <= 0:
+        parser.error("--decode-engine-num-gpu must be positive")
+
+    return PlannerArgs(
+        ttft_ms=ns.ttft,
+        itl_ms=ns.itl,
+        adjustment_interval=ns.adjustment_interval,
+        profile_results=ns.profile_results,
+        model=ns.model,
+        metrics_urls=ns.metrics_url or [DEFAULT_METRICS_URL],
+        prefill_engine_num_gpu=ns.prefill_engine_num_gpu,
+        decode_engine_num_gpu=ns.decode_engine_num_gpu,
+        log_level=ns.log_level,
+    )

--- a/infera/planner/capacity.py
+++ b/infera/planner/capacity.py
@@ -1,0 +1,175 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""Translate one observed workload window into pool capacity budgets."""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+
+from infera.planner.args import PlannerArgs
+from infera.planner.metrics_source import LoadMetrics
+from infera.planner.perf_model import PerfModel, PrefillPoint
+
+logger = logging.getLogger(__name__)
+
+_MILLISECONDS = 1000.0
+_MIN_QUEUE_HEADROOM = 0.20
+_MAX_GROWTH_STEP = 4.0
+
+
+@dataclass(frozen=True)
+class LatencyRatios:
+    """Observed latency divided by the offline envelope at the same workload."""
+
+    prompt: float
+    generation: float
+
+
+@dataclass(frozen=True)
+class CapacityRecommendation:
+    """Replica budgets and the evidence used to derive them."""
+
+    prefill_replicas: int
+    decode_replicas: int
+    latency: LatencyRatios
+
+
+class CapacityPolicy:
+    """Pure capacity policy; contains no scraping, sleeping, or actuation."""
+
+    def __init__(self, args: PlannerArgs, model: PerfModel) -> None:
+        self._args = args
+        self._model = model
+        self._prefill_gpus = args.prefill_engine_num_gpu or model.prefill_engine_num_gpu
+        self._decode_gpus = args.decode_engine_num_gpu or model.decode_engine_num_gpu
+
+    @property
+    def prefill_gpus(self) -> int:
+        return self._prefill_gpus
+
+    @property
+    def decode_gpus(self) -> int:
+        return self._decode_gpus
+
+    def recommend(self, window: LoadMetrics) -> CapacityRecommendation | None:
+        prompt_point = self._model.prompt_capacity(window.isl)
+        mean_context = window.isl + window.osl / 2.0
+        in_flight_per_decode = (
+            window.num_req
+            * window.request_duration
+            / self._args.adjustment_interval
+            / window.num_decode
+        )
+        generation_point = self._model.generation_point(
+            in_flight_per_decode,
+            mean_context,
+        )
+        if prompt_point.latency_ms <= 0 or generation_point.latency_ms <= 0:
+            logger.warning("profile envelope contains a non-positive latency; window ignored")
+            return None
+
+        ratios = LatencyRatios(
+            prompt=window.ttft * _MILLISECONDS / prompt_point.latency_ms,
+            generation=window.itl * _MILLISECONDS / generation_point.latency_ms,
+        )
+        prefill = self._prefill_budget(window, prompt_point, ratios.prompt)
+        decode = self._decode_budget(window, mean_context, ratios.generation)
+        return CapacityRecommendation(
+            prefill_replicas=self._bounded_growth(
+                prefill,
+                window.num_prefill,
+                "prefill",
+            ),
+            decode_replicas=self._bounded_growth(
+                decode,
+                window.num_decode,
+                "decode",
+            ),
+            latency=ratios,
+        )
+
+    def _prefill_budget(
+        self,
+        window: LoadMetrics,
+        profile: PrefillPoint,
+        latency_ratio: float,
+    ) -> int:
+        arriving_tokens_per_second = window.num_req * window.isl / self._args.adjustment_interval
+        cache_adjusted_rate = arriving_tokens_per_second * min(1.0, latency_ratio)
+        measured_replica_capacity = profile.tokens_per_second_per_gpu * self._prefill_gpus
+        throughput_budget = math.ceil(cache_adjusted_rate / measured_replica_capacity)
+        queue_budget = self._queue_budget(
+            profile,
+            latency_ratio,
+            window.num_prefill,
+        )
+        return max(throughput_budget, queue_budget)
+
+    def _queue_budget(
+        self,
+        profile: PrefillPoint,
+        latency_ratio: float,
+        current_replicas: int,
+    ) -> int:
+        service_ms = profile.latency_ms * min(1.0, latency_ratio)
+        waiting_ms = profile.latency_ms * max(0.0, latency_ratio - 1.0)
+        if waiting_ms <= 0:
+            return 0
+
+        available_ms = self._args.ttft_ms - service_ms
+        if available_ms <= 0:
+            logger.warning(
+                "profiled prompt service time %.1fms is already above the %.1fms target; "
+                "using throughput capacity only",
+                service_ms,
+                self._args.ttft_ms,
+            )
+            return 0
+        if available_ms < service_ms * _MIN_QUEUE_HEADROOM:
+            logger.warning(
+                "TTFT target leaves %.1fms queue allowance above %.1fms service time; "
+                "the allowance is too small for a stable capacity estimate",
+                available_ms,
+                service_ms,
+            )
+            return 0
+        return math.ceil(waiting_ms * max(1, current_replicas) / available_ms)
+
+    def _decode_budget(
+        self,
+        window: LoadMetrics,
+        mean_context: float,
+        latency_ratio: float,
+    ) -> int:
+        effective_budget_ms = self._args.itl_ms / max(latency_ratio, 1e-6)
+        point = self._model.generation_capacity(effective_budget_ms, mean_context)
+        if point.latency_ms > effective_budget_ms:
+            logger.warning(
+                "generation latency floor %.1fms is above the effective %.1fms budget "
+                "at mean context %.0f",
+                point.latency_ms,
+                effective_budget_ms,
+                mean_context,
+            )
+        generated_tokens_per_second = window.num_req * window.osl / self._args.adjustment_interval
+        measured_replica_capacity = point.tokens_per_second_per_gpu * self._decode_gpus
+        return math.ceil(generated_tokens_per_second / measured_replica_capacity)
+
+    @staticmethod
+    def _bounded_growth(wanted: int, observed: int, pool: str) -> int:
+        ceiling = math.ceil(max(1, observed) * _MAX_GROWTH_STEP)
+        if wanted <= ceiling:
+            return max(1, wanted)
+        logger.warning(
+            "%s capacity requires %d replicas from %d observed; this decision is capped at %d",
+            pool,
+            wanted,
+            observed,
+            ceiling,
+        )
+        return ceiling

--- a/infera/planner/core.py
+++ b/infera/planner/core.py
@@ -1,0 +1,384 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""The decision loop: from observed metrics to a replica count per pool.
+
+Each adjustment interval corrects the performance model against what was
+observed, assumes the next interval repeats that load, and solves each pool for
+the replica count that meets its target. ``manual/features/sla_planner.md``
+walks through the reasoning; the formulas are documented on the methods below.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import time
+from collections.abc import Awaitable, Callable
+
+from infera.planner.args import PlannerArgs
+from infera.planner.decision import ScalingDecision
+from infera.planner.metrics_source import LoadMetrics, MetricsSource
+from infera.planner.perf_model import PerfModel
+
+logger = logging.getLogger(__name__)
+
+_MS_PER_S = 1000.0
+# Profiling and production TTFT both contain measurement noise. A target with
+# less headroom than this fraction of the unqueued service time is too close to
+# the hardware floor for the linear queue model to produce a trustworthy count.
+_MIN_TTFT_HEADROOM_RATIO = 0.20
+# Autoscaling recommendations should move toward the target rather than jump by
+# orders of magnitude from one noisy window. This applies to both pools.
+_MAX_SCALE_UP_RATIO = 4.0
+DecisionHandler = Callable[[ScalingDecision], Awaitable[None]]
+
+
+class SlaPlanner:
+    """Holds the performance model and the periodic decision loop."""
+
+    def __init__(
+        self,
+        args: PlannerArgs,
+        perf_model: PerfModel,
+        *,
+        metrics_source: MetricsSource | None = None,
+        on_decision: DecisionHandler | None = None,
+    ) -> None:
+        self.args = args
+        self.perf = perf_model
+        self._metrics_source = metrics_source
+        # Optional seam for a future Kubernetes/Slurm actuator. The standalone
+        # planner intentionally passes no handler and only logs decisions.
+        self._on_decision = on_decision
+
+        self.prefill_num_gpu = args.prefill_engine_num_gpu or perf_model.prefill_engine_num_gpu
+        self.decode_num_gpu = args.decode_engine_num_gpu or perf_model.decode_engine_num_gpu
+
+    # ------------------------------------------------------------------
+    # Pure decision logic -- no I/O
+    # ------------------------------------------------------------------
+
+    def correction_factors(self, metrics: LoadMetrics) -> tuple[float, float] | None:
+        """Observed-over-predicted latency for each phase.
+
+        Profiling measures one request at a time on an idle engine, which
+        production does not look like. Dividing what was observed by what the
+        model predicted for the same workload absorbs the difference::
+
+            prefill_correction = observed_ttft / predicted_ttft(isl)
+            decode_correction  = observed_itl  / predicted_itl(concurrency, ctx)
+
+        Prefill normally lands above 1.0, because real TTFT includes queueing
+        the sweep never saw, and below 1.0 when prefix-cache hits mean the
+        engine prefills fewer tokens than the prompt length implies. Decode
+        should sit near 1.0; drift there usually means chunked prefill is
+        stealing decode steps.
+
+        Returns None when the model predicts a non-positive latency, which means
+        the profiling data is degenerate and no correction can be derived.
+        """
+        predicted_ttft_ms = self.perf.prefill.interpolate_ttft(metrics.isl)
+        if predicted_ttft_ms <= 0:
+            logger.warning("profiled TTFT at isl=%.0f is not positive; skipping", metrics.isl)
+            return None
+
+        # Requests in flight per decode replica: arrival rate x residency.
+        concurrency = (
+            metrics.num_req
+            / metrics.num_decode
+            * metrics.request_duration
+            / self.args.adjustment_interval
+        )
+        predicted_itl_ms = self.perf.decode.interpolate_itl(
+            concurrency, metrics.isl + metrics.osl / 2
+        )
+        if predicted_itl_ms <= 0:
+            logger.warning(
+                "profiled ITL at concurrency=%.2f is not positive; skipping", concurrency
+            )
+            return None
+
+        return (
+            metrics.ttft * _MS_PER_S / predicted_ttft_ms,
+            metrics.itl * _MS_PER_S / predicted_itl_ms,
+        )
+
+    def plan(self, metrics: LoadMetrics) -> ScalingDecision | None:
+        """Produce the decision for the interval about to start.
+
+        Returns None when the interval carries too little signal to act on: no
+        traffic, no decode replicas to measure against, or a performance model
+        that cannot be corrected.
+        """
+        if not metrics.has_traffic:
+            logger.info(
+                "no traffic in the last window (requests=%.0f, isl=%.0f, osl=%.0f); "
+                "leaving the deployment alone",
+                metrics.num_req,
+                metrics.isl,
+                metrics.osl,
+            )
+            return None
+
+        if metrics.num_decode <= 0:
+            logger.warning(
+                "traffic observed but no decode replicas are registered; "
+                "cannot calibrate the decode model"
+            )
+            return None
+
+        if not metrics.has_latency:
+            # Zero here means "never measured", not "instant": both corrections
+            # would come out at 0, which collapses prefill demand to nothing and
+            # loosens the ITL target to infinity -- the planner would size a busy
+            # fleet down to one replica per pool and call it done.
+            logger.warning(
+                "traffic observed but no TTFT/ITL was recorded (ttft=%.0fms itl=%.1fms); "
+                "TTFT needs a streaming reply and ITL a reply of at least two tokens, so "
+                "a non-streaming workload leaves nothing to calibrate against and the "
+                "deployment is left alone",
+                metrics.ttft * _MS_PER_S,
+                metrics.itl * _MS_PER_S,
+            )
+            return None
+
+        corrections = self.correction_factors(metrics)
+        if corrections is None:
+            return None
+        p_correction, d_correction = corrections
+
+        # The minimal planner assumes the next interval repeats the last one.
+        # A predictor can be added before this call later without changing the
+        # sizing functions or the decision handler seam.
+        num_prefill = self._plan_prefill(
+            metrics.num_req, metrics.isl, p_correction, metrics.num_prefill
+        )
+        num_decode = self._plan_decode(metrics.num_req, metrics.isl, metrics.osl, d_correction)
+        num_prefill = self._limit_scale_up(num_prefill, metrics.num_prefill, "prefill")
+        num_decode = self._limit_scale_up(num_decode, metrics.num_decode, "decode")
+
+        return ScalingDecision(
+            num_prefill=max(1, num_prefill),
+            num_decode=max(1, num_decode),
+            observed_prefill=metrics.num_prefill,
+            observed_decode=metrics.num_decode,
+            prefill_correction=p_correction,
+            decode_correction=d_correction,
+            num_req=metrics.num_req,
+            isl=metrics.isl,
+            osl=metrics.osl,
+        )
+
+    @staticmethod
+    def _limit_scale_up(desired: int, observed: int, role: str) -> int:
+        """Bound one recommendation to a gradual, reviewable scale-up step."""
+        maximum = math.ceil(max(1, observed) * _MAX_SCALE_UP_RATIO)
+        if desired > maximum:
+            logger.warning(
+                "%s sizing asks for %d replicas from %d observed; limiting this decision "
+                "to %d (%.0fx scale-up guardrail)",
+                role,
+                desired,
+                observed,
+                maximum,
+                _MAX_SCALE_UP_RATIO,
+            )
+            return maximum
+        return desired
+
+    def _plan_prefill(
+        self,
+        next_num_req: float,
+        next_isl: float,
+        p_correction: float,
+        observed_prefill: int,
+    ) -> int:
+        """Replicas needed to prefill the predicted token rate within the TTFT SLA::
+
+            ceil(token_rate * min(1, p_correction) / thpt_per_gpu(isl) / gpus)
+
+        ``min(1, ...)`` is deliberate: a correction above 1.0 means requests are
+        queueing, and queueing is what adding replicas fixes, so inflating
+        demand on top of it would count the same problem twice. Below 1.0 --
+        prefix-cache hits shrinking the real prefill -- it scales demand down
+        honestly.
+
+        A pool sized for throughput alone can still miss the TTFT target by
+        queueing, which is what :meth:`_prefill_for_ttft` covers; the larger of
+        the two wins.
+        """
+        token_rate = next_num_req * next_isl / self.args.adjustment_interval
+        demand = token_rate * min(1.0, p_correction)
+        thpt_per_gpu = self.perf.prefill.interpolate_thpt_per_gpu(next_isl)
+        for_throughput = math.ceil(demand / thpt_per_gpu / self.prefill_num_gpu)
+        for_ttft = self._prefill_for_ttft(next_isl, p_correction, observed_prefill)
+        if for_ttft > for_throughput:
+            logger.info(
+                "prefill sized by the TTFT target rather than throughput: %d replicas "
+                "instead of %d, to hold TTFT at or under %.0fms",
+                for_ttft,
+                for_throughput,
+                self.args.ttft_ms,
+            )
+        return max(for_throughput, for_ttft)
+
+    def _prefill_for_ttft(self, next_isl: float, p_correction: float, observed_prefill: int) -> int:
+        """Replicas needed to bring queueing down to the TTFT target.
+
+        The observed TTFT splits along the correction factor::
+
+            service_ms = profiled_ttft(isl) * min(1, p_correction)
+            queue_ms   = profiled_ttft(isl) * max(0, p_correction - 1)
+
+        Service is what prefilling costs once a request reaches an engine, and
+        the remainder is time spent waiting for one. Adding replicas cannot
+        touch the first and divides the second, so the count that fits the
+        target is ``queue x replicas_now / headroom``.
+
+        Returns 0 when the target imposes no requirement beyond throughput:
+        nothing is queueing, or service time alone already overruns the target
+        and no number of replicas would recover it.
+        """
+        profiled_ttft_ms = self.perf.prefill.interpolate_ttft(next_isl)
+        service_ms = profiled_ttft_ms * min(1.0, p_correction)
+        queue_ms = profiled_ttft_ms * max(0.0, p_correction - 1.0)
+        if queue_ms <= 0.0:
+            return 0
+
+        headroom_ms = self.args.ttft_ms - service_ms
+        if headroom_ms <= 0.0:
+            logger.warning(
+                "prefilling a %.0f-token prompt costs %.0fms on an unqueued engine, which "
+                "already overruns the %.0fms TTFT target; replicas divide queueing, not "
+                "service time, so prefill is sized for throughput alone",
+                next_isl,
+                service_ms,
+                self.args.ttft_ms,
+            )
+            return 0
+        minimum_headroom_ms = service_ms * _MIN_TTFT_HEADROOM_RATIO
+        if headroom_ms < minimum_headroom_ms:
+            logger.warning(
+                "TTFT target %.1fms leaves only %.1fms queueing headroom above the "
+                "%.1fms profiled service time, below the %.0f%% safety margin; the "
+                "linear queue model is not reliable this close to the hardware floor, "
+                "so prefill is sized for throughput alone",
+                self.args.ttft_ms,
+                headroom_ms,
+                service_ms,
+                _MIN_TTFT_HEADROOM_RATIO * 100,
+            )
+            return 0
+
+        # A fleet reporting no prefill replicas cannot be divided by; treat it
+        # as one so the ratio still means "relative to what is running".
+        return math.ceil(queue_ms * max(1, observed_prefill) / headroom_ms)
+
+    def _plan_decode(
+        self, next_num_req: float, next_isl: float, next_osl: float, d_correction: float
+    ) -> int:
+        """Replicas needed to generate the predicted token rate within the ITL SLA::
+
+            ceil(token_rate / thpt_per_gpu(itl_target / d_correction) / gpus)
+
+        Tightening the ITL *target* by the correction factor and then asking the
+        model for the throughput that fits is what makes this self-calibrating:
+        a deployment running at twice the profiled ITL is aimed at half the
+        target, and lands on the real one.
+        """
+        corrected_itl_ms = self.args.itl_ms / max(d_correction, 1e-6)
+        context_length = next_isl + next_osl / 2
+        thpt_per_gpu, achieved_itl_ms, kv_usage = self.perf.decode.find_best_throughput_per_gpu(
+            corrected_itl_ms, context_length
+        )
+        if achieved_itl_ms > corrected_itl_ms:
+            logger.warning(
+                "even the lightest profiled decode load gives ITL=%.1fms > target %.1fms at "
+                "context length %.0f; the ITL SLA is not reachable on this hardware",
+                achieved_itl_ms,
+                corrected_itl_ms,
+                context_length,
+            )
+        else:
+            logger.debug(
+                "decode operating point: %.0f tok/s/gpu at %.0f%% kv usage (ITL %.1fms)",
+                thpt_per_gpu,
+                kv_usage * 100,
+                achieved_itl_ms,
+            )
+        token_rate = next_num_req * next_osl / self.args.adjustment_interval
+        return math.ceil(token_rate / thpt_per_gpu / self.decode_num_gpu)
+
+    # ------------------------------------------------------------------
+    # Control loop
+    # ------------------------------------------------------------------
+
+    async def tick(self) -> ScalingDecision | None:
+        """Run one observe-decide-report cycle."""
+        assert self._metrics_source is not None, "tick() needs a MetricsSource"
+        metrics = await self._metrics_source.collect()
+        if metrics is None:
+            return None
+
+        logger.info(
+            "observed %.0f requests, isl=%.0f osl=%.0f, ttft=%.0fms itl=%.1fms, "
+            "fleet prefill=%d decode=%d",
+            metrics.num_req,
+            metrics.isl,
+            metrics.osl,
+            metrics.ttft * _MS_PER_S,
+            metrics.itl * _MS_PER_S,
+            metrics.num_prefill,
+            metrics.num_decode,
+        )
+
+        decision = self.plan(metrics)
+        if decision is None:
+            return None
+
+        if not decision.changes_anything:
+            logger.info(
+                "fleet is already the right size (prefill=%d, decode=%d)",
+                decision.num_prefill,
+                decision.num_decode,
+            )
+            return decision
+
+        logger.info("decision: %s", decision.summary())
+        if self._on_decision is not None:
+            await self._on_decision(decision)
+        return decision
+
+    async def run(self) -> None:
+        """Tick forever, one adjustment interval apart.
+
+        The first interval only records a baseline scrape -- the metrics are
+        cumulative, so there is nothing to difference yet.
+        """
+        interval = self.args.adjustment_interval
+        logger.info(
+            "SLA planner started: model=%s ttft<=%.0fms itl<=%.1fms, interval %.0fs, "
+            "%d GPU/prefill replica, %d GPU/decode replica",
+            self.args.model,
+            self.args.ttft_ms,
+            self.args.itl_ms,
+            interval,
+            self.prefill_num_gpu,
+            self.decode_num_gpu,
+        )
+        while True:
+            started = time.monotonic()
+            try:
+                await self.tick()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # One bad interval must not take the planner down; the next
+                # scrape re-establishes the window.
+                logger.exception("adjustment interval failed; retrying next interval")
+            elapsed = time.monotonic() - started
+            await asyncio.sleep(max(0.0, interval - elapsed))

--- a/infera/planner/core.py
+++ b/infera/planner/core.py
@@ -3,42 +3,28 @@
 #
 # SPDX-License-Identifier: MIT
 ###############################################################################
-"""The decision loop: from observed metrics to a replica count per pool.
-
-Each adjustment interval corrects the performance model against what was
-observed, assumes the next interval repeats that load, and solves each pool for
-the replica count that meets its target. ``manual/features/sla_planner.md``
-walks through the reasoning; the formulas are documented on the methods below.
-"""
+"""Observe, budget, and publish loop for the standalone planner process."""
 
 from __future__ import annotations
 
 import asyncio
 import logging
-import math
 import time
 from collections.abc import Awaitable, Callable
 
 from infera.planner.args import PlannerArgs
+from infera.planner.capacity import CapacityPolicy
 from infera.planner.decision import ScalingDecision
 from infera.planner.metrics_source import LoadMetrics, MetricsSource
 from infera.planner.perf_model import PerfModel
 
 logger = logging.getLogger(__name__)
 
-_MS_PER_S = 1000.0
-# Profiling and production TTFT both contain measurement noise. A target with
-# less headroom than this fraction of the unqueued service time is too close to
-# the hardware floor for the linear queue model to produce a trustworthy count.
-_MIN_TTFT_HEADROOM_RATIO = 0.20
-# Autoscaling recommendations should move toward the target rather than jump by
-# orders of magnitude from one noisy window. This applies to both pools.
-_MAX_SCALE_UP_RATIO = 4.0
 DecisionHandler = Callable[[ScalingDecision], Awaitable[None]]
 
 
 class SlaPlanner:
-    """Holds the performance model and the periodic decision loop."""
+    """Coordinates observations and policy without entering the request path."""
 
     def __init__(
         self,
@@ -51,318 +37,88 @@ class SlaPlanner:
         self.args = args
         self.perf = perf_model
         self._metrics_source = metrics_source
-        # Optional seam for a future Kubernetes/Slurm actuator. The standalone
-        # planner intentionally passes no handler and only logs decisions.
         self._on_decision = on_decision
-
-        self.prefill_num_gpu = args.prefill_engine_num_gpu or perf_model.prefill_engine_num_gpu
-        self.decode_num_gpu = args.decode_engine_num_gpu or perf_model.decode_engine_num_gpu
-
-    # ------------------------------------------------------------------
-    # Pure decision logic -- no I/O
-    # ------------------------------------------------------------------
-
-    def correction_factors(self, metrics: LoadMetrics) -> tuple[float, float] | None:
-        """Observed-over-predicted latency for each phase.
-
-        Profiling measures one request at a time on an idle engine, which
-        production does not look like. Dividing what was observed by what the
-        model predicted for the same workload absorbs the difference::
-
-            prefill_correction = observed_ttft / predicted_ttft(isl)
-            decode_correction  = observed_itl  / predicted_itl(concurrency, ctx)
-
-        Prefill normally lands above 1.0, because real TTFT includes queueing
-        the sweep never saw, and below 1.0 when prefix-cache hits mean the
-        engine prefills fewer tokens than the prompt length implies. Decode
-        should sit near 1.0; drift there usually means chunked prefill is
-        stealing decode steps.
-
-        Returns None when the model predicts a non-positive latency, which means
-        the profiling data is degenerate and no correction can be derived.
-        """
-        predicted_ttft_ms = self.perf.prefill.interpolate_ttft(metrics.isl)
-        if predicted_ttft_ms <= 0:
-            logger.warning("profiled TTFT at isl=%.0f is not positive; skipping", metrics.isl)
-            return None
-
-        # Requests in flight per decode replica: arrival rate x residency.
-        concurrency = (
-            metrics.num_req
-            / metrics.num_decode
-            * metrics.request_duration
-            / self.args.adjustment_interval
-        )
-        predicted_itl_ms = self.perf.decode.interpolate_itl(
-            concurrency, metrics.isl + metrics.osl / 2
-        )
-        if predicted_itl_ms <= 0:
-            logger.warning(
-                "profiled ITL at concurrency=%.2f is not positive; skipping", concurrency
-            )
-            return None
-
-        return (
-            metrics.ttft * _MS_PER_S / predicted_ttft_ms,
-            metrics.itl * _MS_PER_S / predicted_itl_ms,
-        )
+        self._policy = CapacityPolicy(args, perf_model)
+        self.prefill_num_gpu = self._policy.prefill_gpus
+        self.decode_num_gpu = self._policy.decode_gpus
 
     def plan(self, metrics: LoadMetrics) -> ScalingDecision | None:
-        """Produce the decision for the interval about to start.
-
-        Returns None when the interval carries too little signal to act on: no
-        traffic, no decode replicas to measure against, or a performance model
-        that cannot be corrected.
-        """
+        """Turn one complete observation window into target pool sizes."""
         if not metrics.has_traffic:
             logger.info(
-                "no traffic in the last window (requests=%.0f, isl=%.0f, osl=%.0f); "
-                "leaving the deployment alone",
+                "window has no usable workload (requests=%.0f, isl=%.0f, osl=%.0f)",
                 metrics.num_req,
                 metrics.isl,
                 metrics.osl,
             )
             return None
-
         if metrics.num_decode <= 0:
-            logger.warning(
-                "traffic observed but no decode replicas are registered; "
-                "cannot calibrate the decode model"
-            )
+            logger.warning("generation traffic exists but no decode replica is observable")
             return None
-
         if not metrics.has_latency:
-            # Zero here means "never measured", not "instant": both corrections
-            # would come out at 0, which collapses prefill demand to nothing and
-            # loosens the ITL target to infinity -- the planner would size a busy
-            # fleet down to one replica per pool and call it done.
             logger.warning(
-                "traffic observed but no TTFT/ITL was recorded (ttft=%.0fms itl=%.1fms); "
-                "TTFT needs a streaming reply and ITL a reply of at least two tokens, so "
-                "a non-streaming workload leaves nothing to calibrate against and the "
-                "deployment is left alone",
-                metrics.ttft * _MS_PER_S,
-                metrics.itl * _MS_PER_S,
+                "window has traffic but lacks streaming latency samples (ttft=%.1fms, itl=%.1fms)",
+                metrics.ttft * 1000.0,
+                metrics.itl * 1000.0,
             )
             return None
 
-        corrections = self.correction_factors(metrics)
-        if corrections is None:
+        recommendation = self._policy.recommend(metrics)
+        if recommendation is None:
             return None
-        p_correction, d_correction = corrections
-
-        # The minimal planner assumes the next interval repeats the last one.
-        # A predictor can be added before this call later without changing the
-        # sizing functions or the decision handler seam.
-        num_prefill = self._plan_prefill(
-            metrics.num_req, metrics.isl, p_correction, metrics.num_prefill
-        )
-        num_decode = self._plan_decode(metrics.num_req, metrics.isl, metrics.osl, d_correction)
-        num_prefill = self._limit_scale_up(num_prefill, metrics.num_prefill, "prefill")
-        num_decode = self._limit_scale_up(num_decode, metrics.num_decode, "decode")
-
         return ScalingDecision(
-            num_prefill=max(1, num_prefill),
-            num_decode=max(1, num_decode),
+            num_prefill=recommendation.prefill_replicas,
+            num_decode=recommendation.decode_replicas,
             observed_prefill=metrics.num_prefill,
             observed_decode=metrics.num_decode,
-            prefill_correction=p_correction,
-            decode_correction=d_correction,
+            prefill_latency_ratio=recommendation.latency.prompt,
+            decode_latency_ratio=recommendation.latency.generation,
             num_req=metrics.num_req,
             isl=metrics.isl,
             osl=metrics.osl,
         )
 
-    @staticmethod
-    def _limit_scale_up(desired: int, observed: int, role: str) -> int:
-        """Bound one recommendation to a gradual, reviewable scale-up step."""
-        maximum = math.ceil(max(1, observed) * _MAX_SCALE_UP_RATIO)
-        if desired > maximum:
-            logger.warning(
-                "%s sizing asks for %d replicas from %d observed; limiting this decision "
-                "to %d (%.0fx scale-up guardrail)",
-                role,
-                desired,
-                observed,
-                maximum,
-                _MAX_SCALE_UP_RATIO,
-            )
-            return maximum
-        return desired
-
-    def _plan_prefill(
-        self,
-        next_num_req: float,
-        next_isl: float,
-        p_correction: float,
-        observed_prefill: int,
-    ) -> int:
-        """Replicas needed to prefill the predicted token rate within the TTFT SLA::
-
-            ceil(token_rate * min(1, p_correction) / thpt_per_gpu(isl) / gpus)
-
-        ``min(1, ...)`` is deliberate: a correction above 1.0 means requests are
-        queueing, and queueing is what adding replicas fixes, so inflating
-        demand on top of it would count the same problem twice. Below 1.0 --
-        prefix-cache hits shrinking the real prefill -- it scales demand down
-        honestly.
-
-        A pool sized for throughput alone can still miss the TTFT target by
-        queueing, which is what :meth:`_prefill_for_ttft` covers; the larger of
-        the two wins.
-        """
-        token_rate = next_num_req * next_isl / self.args.adjustment_interval
-        demand = token_rate * min(1.0, p_correction)
-        thpt_per_gpu = self.perf.prefill.interpolate_thpt_per_gpu(next_isl)
-        for_throughput = math.ceil(demand / thpt_per_gpu / self.prefill_num_gpu)
-        for_ttft = self._prefill_for_ttft(next_isl, p_correction, observed_prefill)
-        if for_ttft > for_throughput:
-            logger.info(
-                "prefill sized by the TTFT target rather than throughput: %d replicas "
-                "instead of %d, to hold TTFT at or under %.0fms",
-                for_ttft,
-                for_throughput,
-                self.args.ttft_ms,
-            )
-        return max(for_throughput, for_ttft)
-
-    def _prefill_for_ttft(self, next_isl: float, p_correction: float, observed_prefill: int) -> int:
-        """Replicas needed to bring queueing down to the TTFT target.
-
-        The observed TTFT splits along the correction factor::
-
-            service_ms = profiled_ttft(isl) * min(1, p_correction)
-            queue_ms   = profiled_ttft(isl) * max(0, p_correction - 1)
-
-        Service is what prefilling costs once a request reaches an engine, and
-        the remainder is time spent waiting for one. Adding replicas cannot
-        touch the first and divides the second, so the count that fits the
-        target is ``queue x replicas_now / headroom``.
-
-        Returns 0 when the target imposes no requirement beyond throughput:
-        nothing is queueing, or service time alone already overruns the target
-        and no number of replicas would recover it.
-        """
-        profiled_ttft_ms = self.perf.prefill.interpolate_ttft(next_isl)
-        service_ms = profiled_ttft_ms * min(1.0, p_correction)
-        queue_ms = profiled_ttft_ms * max(0.0, p_correction - 1.0)
-        if queue_ms <= 0.0:
-            return 0
-
-        headroom_ms = self.args.ttft_ms - service_ms
-        if headroom_ms <= 0.0:
-            logger.warning(
-                "prefilling a %.0f-token prompt costs %.0fms on an unqueued engine, which "
-                "already overruns the %.0fms TTFT target; replicas divide queueing, not "
-                "service time, so prefill is sized for throughput alone",
-                next_isl,
-                service_ms,
-                self.args.ttft_ms,
-            )
-            return 0
-        minimum_headroom_ms = service_ms * _MIN_TTFT_HEADROOM_RATIO
-        if headroom_ms < minimum_headroom_ms:
-            logger.warning(
-                "TTFT target %.1fms leaves only %.1fms queueing headroom above the "
-                "%.1fms profiled service time, below the %.0f%% safety margin; the "
-                "linear queue model is not reliable this close to the hardware floor, "
-                "so prefill is sized for throughput alone",
-                self.args.ttft_ms,
-                headroom_ms,
-                service_ms,
-                _MIN_TTFT_HEADROOM_RATIO * 100,
-            )
-            return 0
-
-        # A fleet reporting no prefill replicas cannot be divided by; treat it
-        # as one so the ratio still means "relative to what is running".
-        return math.ceil(queue_ms * max(1, observed_prefill) / headroom_ms)
-
-    def _plan_decode(
-        self, next_num_req: float, next_isl: float, next_osl: float, d_correction: float
-    ) -> int:
-        """Replicas needed to generate the predicted token rate within the ITL SLA::
-
-            ceil(token_rate / thpt_per_gpu(itl_target / d_correction) / gpus)
-
-        Tightening the ITL *target* by the correction factor and then asking the
-        model for the throughput that fits is what makes this self-calibrating:
-        a deployment running at twice the profiled ITL is aimed at half the
-        target, and lands on the real one.
-        """
-        corrected_itl_ms = self.args.itl_ms / max(d_correction, 1e-6)
-        context_length = next_isl + next_osl / 2
-        thpt_per_gpu, achieved_itl_ms, kv_usage = self.perf.decode.find_best_throughput_per_gpu(
-            corrected_itl_ms, context_length
-        )
-        if achieved_itl_ms > corrected_itl_ms:
-            logger.warning(
-                "even the lightest profiled decode load gives ITL=%.1fms > target %.1fms at "
-                "context length %.0f; the ITL SLA is not reachable on this hardware",
-                achieved_itl_ms,
-                corrected_itl_ms,
-                context_length,
-            )
-        else:
-            logger.debug(
-                "decode operating point: %.0f tok/s/gpu at %.0f%% kv usage (ITL %.1fms)",
-                thpt_per_gpu,
-                kv_usage * 100,
-                achieved_itl_ms,
-            )
-        token_rate = next_num_req * next_osl / self.args.adjustment_interval
-        return math.ceil(token_rate / thpt_per_gpu / self.decode_num_gpu)
-
-    # ------------------------------------------------------------------
-    # Control loop
-    # ------------------------------------------------------------------
-
     async def tick(self) -> ScalingDecision | None:
-        """Run one observe-decide-report cycle."""
-        assert self._metrics_source is not None, "tick() needs a MetricsSource"
+        """Collect and publish at most one decision."""
+        if self._metrics_source is None:
+            raise RuntimeError("tick() requires a metrics source")
         metrics = await self._metrics_source.collect()
         if metrics is None:
             return None
 
         logger.info(
-            "observed %.0f requests, isl=%.0f osl=%.0f, ttft=%.0fms itl=%.1fms, "
-            "fleet prefill=%d decode=%d",
+            "window: requests=%.0f isl=%.0f osl=%.0f ttft=%.0fms itl=%.1fms; "
+            "pools prefill=%d decode=%d",
             metrics.num_req,
             metrics.isl,
             metrics.osl,
-            metrics.ttft * _MS_PER_S,
-            metrics.itl * _MS_PER_S,
+            metrics.ttft * 1000.0,
+            metrics.itl * 1000.0,
             metrics.num_prefill,
             metrics.num_decode,
         )
-
         decision = self.plan(metrics)
         if decision is None:
             return None
-
         if not decision.changes_anything:
             logger.info(
-                "fleet is already the right size (prefill=%d, decode=%d)",
+                "current pools already satisfy the capacity budget (prefill=%d, decode=%d)",
                 decision.num_prefill,
                 decision.num_decode,
             )
             return decision
 
-        logger.info("decision: %s", decision.summary())
+        logger.info("capacity decision: %s", decision.summary())
         if self._on_decision is not None:
             await self._on_decision(decision)
         return decision
 
     async def run(self) -> None:
-        """Tick forever, one adjustment interval apart.
-
-        The first interval only records a baseline scrape -- the metrics are
-        cumulative, so there is nothing to difference yet.
-        """
+        """Run observation windows until the process is cancelled."""
         interval = self.args.adjustment_interval
         logger.info(
-            "SLA planner started: model=%s ttft<=%.0fms itl<=%.1fms, interval %.0fs, "
-            "%d GPU/prefill replica, %d GPU/decode replica",
+            "planner ready: model=%s ttft<=%.0fms itl<=%.1fms window=%.0fs; "
+            "gpus/replica prefill=%d decode=%d",
             self.args.model,
             self.args.ttft_ms,
             self.args.itl_ms,
@@ -377,8 +133,6 @@ class SlaPlanner:
             except asyncio.CancelledError:
                 raise
             except Exception:
-                # One bad interval must not take the planner down; the next
-                # scrape re-establishes the window.
-                logger.exception("adjustment interval failed; retrying next interval")
+                logger.exception("planning window failed; the next window will retry")
             elapsed = time.monotonic() - started
             await asyncio.sleep(max(0.0, interval - elapsed))

--- a/infera/planner/decision.py
+++ b/infera/planner/decision.py
@@ -1,0 +1,48 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""The sizing result produced by the planner core."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ScalingDecision:
+    """Target replica counts for one adjustment interval, plus how we got there.
+
+    The diagnostic fields are what make a decision reviewable after the fact:
+    a correction factor far from 1.0 says the profiling data no longer describes
+    the deployment, which is a different problem from a genuine traffic change.
+    """
+
+    num_prefill: int
+    num_decode: int
+
+    # What the fleet looked like when the decision was made.
+    observed_prefill: int = 0
+    observed_decode: int = 0
+
+    # actual / profiled latency over the observed window. Prefill is normally
+    # above 1.0 (queueing adds to TTFT); decode should sit near 1.0.
+    prefill_correction: float = 1.0
+    decode_correction: float = 1.0
+
+    num_req: float = 0.0
+    isl: float = 0.0
+    osl: float = 0.0
+
+    @property
+    def changes_anything(self) -> bool:
+        return self.num_prefill != self.observed_prefill or self.num_decode != self.observed_decode
+
+    def summary(self) -> str:
+        return (
+            f"prefill {self.observed_prefill}->{self.num_prefill}, "
+            f"decode {self.observed_decode}->{self.num_decode} "
+            f"(corrections p={self.prefill_correction:.3f} d={self.decode_correction:.3f}; "
+            f"load req={self.num_req:.1f} isl={self.isl:.0f} osl={self.osl:.0f})"
+        )

--- a/infera/planner/decision.py
+++ b/infera/planner/decision.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 ###############################################################################
-"""The sizing result produced by the planner core."""
+"""The reviewable result emitted by one capacity-planning window."""
 
 from __future__ import annotations
 
@@ -12,12 +12,7 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class ScalingDecision:
-    """Target replica counts for one adjustment interval, plus how we got there.
-
-    The diagnostic fields are what make a decision reviewable after the fact:
-    a correction factor far from 1.0 says the profiling data no longer describes
-    the deployment, which is a different problem from a genuine traffic change.
-    """
+    """Target pool sizes and the measurements that support them."""
 
     num_prefill: int
     num_decode: int
@@ -26,10 +21,9 @@ class ScalingDecision:
     observed_prefill: int = 0
     observed_decode: int = 0
 
-    # actual / profiled latency over the observed window. Prefill is normally
-    # above 1.0 (queueing adds to TTFT); decode should sit near 1.0.
-    prefill_correction: float = 1.0
-    decode_correction: float = 1.0
+    # Observed/profiled latency at the sampled operating point.
+    prefill_latency_ratio: float = 1.0
+    decode_latency_ratio: float = 1.0
 
     num_req: float = 0.0
     isl: float = 0.0
@@ -43,6 +37,7 @@ class ScalingDecision:
         return (
             f"prefill {self.observed_prefill}->{self.num_prefill}, "
             f"decode {self.observed_decode}->{self.num_decode} "
-            f"(corrections p={self.prefill_correction:.3f} d={self.decode_correction:.3f}; "
+            f"(latency ratios p={self.prefill_latency_ratio:.3f} "
+            f"d={self.decode_latency_ratio:.3f}; "
             f"load req={self.num_req:.1f} isl={self.isl:.0f} osl={self.osl:.0f})"
         )

--- a/infera/planner/metrics_source.py
+++ b/infera/planner/metrics_source.py
@@ -76,13 +76,12 @@ class LoadMetrics:
 
     @property
     def has_latency(self) -> bool:
-        """Whether the window recorded the latencies the corrections need.
+        """Whether the window recorded both policy latency signals.
 
         Both histograms are streaming-only -- a non-streaming reply arrives in
         one piece, so it has no observable first-token boundary -- and ITL
-        additionally needs a reply of at least two tokens. A window that
-        recorded neither leaves both averages at zero, which reads as an
-        infinitely fast deployment rather than an unmeasured one.
+        additionally needs a reply of at least two tokens. Zero means
+        unmeasured here, not infinitely fast.
         """
         return self.ttft > 0 and self.itl > 0
 

--- a/infera/planner/metrics_source.py
+++ b/infera/planner/metrics_source.py
@@ -1,0 +1,273 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""Turn the server fleet's ``/metrics`` into per-interval workload averages.
+
+Rather than depend on a Prometheus deployment, the planner scrapes the Infera
+servers directly and does the windowing itself. That keeps a single-host Docker
+setup viable and removes PromQL from the critical path; the cost is that the
+planner holds the previous scrape in memory, so a planner restart forfeits one
+interval.
+
+The histograms Infera exposes are cumulative, so an interval average is
+``sum(endpoint deltas) / sum(endpoint count deltas)``. Baselines are retained
+per URL: a restart is detected even when the rest of the fleet's counters keep
+the aggregate increasing, and a temporarily missing endpoint resets the whole
+baseline instead of injecting its lifetime counters when it returns.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+import httpx
+from prometheus_client.parser import text_string_to_metric_families
+
+logger = logging.getLogger(__name__)
+
+_TTFT = "infera_time_to_first_token_seconds"
+_ITL = "infera_inter_token_latency_seconds"
+_ISL = "infera_input_sequence_tokens"
+_OSL = "infera_output_sequence_tokens"
+_ACTIVE_WORKERS = "infera_active_workers"
+
+_HISTOGRAMS = (_TTFT, _ITL, _ISL, _OSL)
+
+
+@dataclass
+class Snapshot:
+    """Fleet-summed cumulative values from one scrape round."""
+
+    # metric name -> (sum, count)
+    totals: dict[str, tuple[float, float]] = field(default_factory=dict)
+    active_prefill: int = 0
+    active_decode: int = 0
+    active_mixed: int = 0
+
+    def totals_for(self, metric: str) -> tuple[float, float]:
+        return self.totals.get(metric, (0.0, 0.0))
+
+
+@dataclass(frozen=True)
+class LoadMetrics:
+    """Workload characteristics observed over one adjustment interval.
+
+    ``ttft`` and ``itl`` are in seconds, matching the exposed histograms;
+    :mod:`infera.planner.core` converts where the profiling data uses
+    milliseconds.
+    """
+
+    num_req: float
+    isl: float
+    osl: float
+    ttft: float
+    itl: float
+    num_prefill: int
+    num_decode: int
+    num_mixed: int = 0
+
+    @property
+    def has_traffic(self) -> bool:
+        """Whether the interval carries enough signal to size a fleet from."""
+        return self.num_req > 0 and self.isl > 0 and self.osl > 0
+
+    @property
+    def has_latency(self) -> bool:
+        """Whether the window recorded the latencies the corrections need.
+
+        Both histograms are streaming-only -- a non-streaming reply arrives in
+        one piece, so it has no observable first-token boundary -- and ITL
+        additionally needs a reply of at least two tokens. A window that
+        recorded neither leaves both averages at zero, which reads as an
+        infinitely fast deployment rather than an unmeasured one.
+        """
+        return self.ttft > 0 and self.itl > 0
+
+    @property
+    def request_duration(self) -> float:
+        """Mean request latency in seconds, reconstructed from TTFT and ITL.
+
+        Used to convert a request rate into an in-flight concurrency. Derived
+        rather than read from ``infera_request_duration_seconds`` because that
+        histogram is observed when ``dispatch`` returns, which for a streaming
+        reply is at the first token rather than the last -- it would understate
+        long generations badly.
+        """
+        return self.ttft + self.itl * max(0.0, self.osl - 1.0)
+
+
+def parse_metrics_text(
+    text: str,
+    snapshot: Snapshot,
+    *,
+    model: str | None = None,
+    router: str | None = "disagg",
+) -> None:
+    """Accumulate one server's exposition text into ``snapshot``.
+
+    Histogram sums and counts add across replicas. ``infera_active_workers`` is
+    not summed: every server watches the same fleet, so the replicas report the
+    same number and the widest view wins -- summing would multiply the fleet by
+    the replica count.
+    """
+    wanted_sums = {f"{name}_sum": name for name in _HISTOGRAMS}
+    wanted_counts = {f"{name}_count": name for name in _HISTOGRAMS}
+    for family in text_string_to_metric_families(text):
+        for sample in family.samples:
+            if sample.name == _ACTIVE_WORKERS:
+                if model is not None and sample.labels.get("model") != model:
+                    continue
+                mode = sample.labels.get("disagg_mode", "")
+                count = int(sample.value)
+                if mode == "prefill":
+                    snapshot.active_prefill = max(snapshot.active_prefill, count)
+                elif mode == "decode":
+                    snapshot.active_decode = max(snapshot.active_decode, count)
+                elif mode == "mixed":
+                    snapshot.active_mixed = max(snapshot.active_mixed, count)
+                continue
+            metric = wanted_sums.get(sample.name)
+            index = 0
+            if metric is None:
+                metric = wanted_counts.get(sample.name)
+                index = 1
+            if metric is None:
+                continue
+            if router is not None and sample.labels.get("router") != router:
+                continue
+            if model is not None and sample.labels.get("model") != model:
+                continue
+            total = list(snapshot.totals_for(metric))
+            total[index] += float(sample.value)
+            snapshot.totals[metric] = (total[0], total[1])
+
+
+def _window_delta(current: Snapshot, previous: Snapshot, metric: str) -> tuple[float, float] | None:
+    """``(sum, count)`` accrued over the window, or None if it is unusable.
+
+    None means the counters went backwards, i.e. a server restarted, which is a
+    reason to leave the deployment alone rather than guess.
+    """
+    cur_sum, cur_count = current.totals_for(metric)
+    prev_sum, prev_count = previous.totals_for(metric)
+    d_sum, d_count = cur_sum - prev_sum, cur_count - prev_count
+    if d_sum < 0 or d_count < 0:
+        return None
+    return d_sum, d_count
+
+
+class MetricsSource:
+    """Scrapes a set of Infera server ``/metrics`` endpoints and windows them."""
+
+    def __init__(
+        self,
+        urls: list[str],
+        *,
+        model: str | None = None,
+        router: str | None = "disagg",
+        timeout: float = 10.0,
+    ) -> None:
+        if not urls:
+            raise ValueError("MetricsSource needs at least one /metrics URL")
+        self._urls = list(urls)
+        self._model = model
+        self._router = router
+        # Scrapes are minutes apart in production. Reusing an idle connection
+        # races common 5-second server keep-alive timeouts, so open a fresh
+        # connection for each low-frequency scrape.
+        self._client = httpx.AsyncClient(
+            timeout=timeout,
+            limits=httpx.Limits(max_keepalive_connections=0),
+        )
+        self._previous: dict[str, Snapshot] | None = None
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def scrape(self) -> dict[str, Snapshot]:
+        """Fetch every configured endpoint into its own cumulative snapshot."""
+        snapshots: dict[str, Snapshot] = {}
+        for url in self._urls:
+            try:
+                resp = await self._client.get(url)
+                resp.raise_for_status()
+            except httpx.HTTPError as exc:
+                logger.warning("scrape of %s failed: %s: %s", url, type(exc).__name__, exc)
+                continue
+            snapshot = Snapshot()
+            try:
+                parse_metrics_text(
+                    resp.text,
+                    snapshot,
+                    model=self._model,
+                    router=self._router,
+                )
+            except ValueError as exc:
+                logger.warning("could not parse metrics from %s: %s", url, exc)
+                continue
+            snapshots[url] = snapshot
+        return snapshots
+
+    async def collect(self) -> LoadMetrics | None:
+        """Scrape and difference against the previous round.
+
+        Returns None on the first call (no window yet), when every replica was
+        unreachable, or when the counters went backwards.
+        """
+        current = await self.scrape()
+        if not current:
+            logger.warning("no server /metrics endpoint could be scraped; skipping interval")
+            return None
+
+        previous, self._previous = self._previous, current
+        if previous is None:
+            logger.info("first scrape recorded; the first decision comes one interval from now")
+            return None
+        if current.keys() != previous.keys():
+            logger.warning(
+                "the set of scraped /metrics endpoints changed; resetting the baseline "
+                "to avoid treating a returning endpoint's lifetime counters as one window"
+            )
+            return None
+
+        averages: dict[str, float] = {}
+        counts: dict[str, float] = {}
+        for metric in _HISTOGRAMS:
+            d_sum = 0.0
+            d_count = 0.0
+            for url, snapshot in current.items():
+                delta = _window_delta(snapshot, previous[url], metric)
+                if delta is None:
+                    logger.warning(
+                        "%s went backwards at %s (server restart?); skipping this interval",
+                        metric,
+                        url,
+                    )
+                    return None
+                endpoint_sum, endpoint_count = delta
+                d_sum += endpoint_sum
+                d_count += endpoint_count
+            counts[metric] = d_count
+            averages[metric] = d_sum / d_count if d_count else 0.0
+
+        snapshots = list(current.values())
+
+        return LoadMetrics(
+            # The OSL histogram's count, rather than the request counter, so the
+            # request rate is over exactly the requests that contributed the
+            # averages beside it. The request counter is committed at hand-off,
+            # before a streaming reply can be disowned as failed, so a window
+            # with partial failures would divide by a larger population than it
+            # measured and overstate the token rate.
+            num_req=counts[_OSL],
+            isl=averages[_ISL],
+            osl=averages[_OSL],
+            ttft=averages[_TTFT],
+            itl=averages[_ITL],
+            num_prefill=max(snapshot.active_prefill for snapshot in snapshots),
+            num_decode=max(snapshot.active_decode for snapshot in snapshots),
+            num_mixed=max(snapshot.active_mixed for snapshot in snapshots),
+        )

--- a/infera/planner/perf_model.py
+++ b/infera/planner/perf_model.py
@@ -3,48 +3,51 @@
 #
 # SPDX-License-Identifier: MIT
 ###############################################################################
-"""Performance model built from pre-deployment profiling results.
+"""Read-only capacity envelope assembled from an offline sweep.
 
-Two questions the planner needs answered, both from offline measurements:
+The sweep records two surfaces. Prompt processing is a one-dimensional curve
+indexed by prompt length. Token generation is a rectangular surface indexed by
+mean context length and occupied KV fraction. This module exposes points on
+those surfaces; policy and fleet state deliberately live elsewhere.
 
-  * **Prefill** -- at this prompt length, what TTFT does an unqueued request
-    see, and how many prefill tokens/s does one GPU sustain?
-  * **Decode** -- at this context length and this KV utilisation, what ITL do
-    requests see, and how many decode tokens/s does one GPU sustain? And
-    inverted: what is the highest per-GPU throughput still within an ITL
-    budget?
-
-Interpolation is numpy-only. Prefill is a 1-D linear interpolation over the
-profiled ISL points; decode is bilinear over the profiled
-``context_length x kv_usage`` grid, which is what insisting on a full
-rectangular grid buys -- interpolating scattered samples instead would mean
-pulling in scipy. Queries outside the profiled range are clamped to the nearest
-edge rather than extrapolated -- a linear extrapolation of a saturating
-throughput curve invents capacity that isn't there.
-
-The model is stateless and cheap to query; runtime deviation from these
-predictions is handled by the correction factors in
-:mod:`infera.planner.core`, not here.
+Values outside the measured domain use the nearest boundary. Extrapolating a
+saturated engine would claim capacity that was never observed.
 """
 
 from __future__ import annotations
+
+from dataclasses import dataclass
 
 import numpy as np
 
 from infera.planner.profile_data import DecodeProfile, PrefillProfile, ProfileData
 
-# How finely to resample the KV-usage axis when searching for the operating
-# point that just meets an ITL budget. The profiled grid is typically only a
-# handful of columns wide, so the search would otherwise snap to coarse steps.
-_KV_SEARCH_RESOLUTION = 100
+_SURFACE_SAMPLES = 100
 
 
-def _clamp(value: float, lo: float, hi: float) -> float:
+def _bounded(value: float, lo: float, hi: float) -> float:
     return float(min(max(value, lo), hi))
 
 
-class PrefillPerfModel:
-    """TTFT and per-GPU prefill throughput as a function of prompt length."""
+@dataclass(frozen=True)
+class PrefillPoint:
+    """Measured-envelope values for one prompt length."""
+
+    latency_ms: float
+    tokens_per_second_per_gpu: float
+
+
+@dataclass(frozen=True)
+class DecodePoint:
+    """One feasible generation operating point."""
+
+    latency_ms: float
+    tokens_per_second_per_gpu: float
+    kv_fraction: float
+
+
+class PrefillCurve:
+    """Prompt-processing capacity indexed by prompt tokens."""
 
     def __init__(self, profile: PrefillProfile) -> None:
         self._isl = profile.isl
@@ -53,19 +56,18 @@ class PrefillPerfModel:
         self.min_isl = float(self._isl[0])
         self.max_isl = float(self._isl[-1])
 
-    def interpolate_ttft(self, isl: float) -> float:
-        """TTFT in milliseconds for an unqueued request of length ``isl``."""
-        return float(np.interp(_clamp(isl, self.min_isl, self.max_isl), self._isl, self._ttft_ms))
+    def point(self, prompt_tokens: float) -> PrefillPoint:
+        prompt_tokens = _bounded(prompt_tokens, self.min_isl, self.max_isl)
+        return PrefillPoint(
+            latency_ms=float(np.interp(prompt_tokens, self._isl, self._ttft_ms)),
+            tokens_per_second_per_gpu=float(np.interp(prompt_tokens, self._isl, self._thpt)),
+        )
 
-    def interpolate_thpt_per_gpu(self, isl: float) -> float:
-        """Prefill throughput in tokens/s/GPU at length ``isl``."""
-        return float(np.interp(_clamp(isl, self.min_isl, self.max_isl), self._isl, self._thpt))
 
+class DecodeSurface:
+    """Generation capacity over context length and occupied KV fraction."""
 
-class DecodePerfModel:
-    """ITL and per-GPU decode throughput over the profiled decode grid."""
-
-    def __init__(self, profile: DecodeProfile, *, resolution: int = _KV_SEARCH_RESOLUTION) -> None:
+    def __init__(self, profile: DecodeProfile, *, samples: int = _SURFACE_SAMPLES) -> None:
         self._kv_usage = profile.kv_usage
         self._context_length = profile.context_length
         self._itl_ms = profile.itl_ms
@@ -75,69 +77,84 @@ class DecodePerfModel:
         self.max_kv_usage = float(self._kv_usage[-1])
         self.min_context_length = float(self._context_length[0])
         self.max_context_length = float(self._context_length[-1])
-        # Fine KV-usage axis used by find_best_throughput_per_gpu.
-        self._kv_search = np.linspace(self.min_kv_usage, self.max_kv_usage, max(2, resolution))
-
-    def kv_usage_for(self, concurrency: float, context_length: float) -> float:
-        """Fraction of the engine's KV cache held by ``concurrency`` requests
-        of ``context_length`` tokens each, clamped to the profiled range."""
-        usage = max(0.0, concurrency) * max(0.0, context_length) / self.max_kv_tokens
-        return _clamp(usage, self.min_kv_usage, self.max_kv_usage)
-
-    def _row_at(self, grid: np.ndarray, context_length: float) -> np.ndarray:
-        """Slice ``grid`` at ``context_length``, one value per profiled KV usage.
-
-        Half of the bilinear interpolation: linear along the context-length
-        axis, leaving a 1-D curve over KV usage for the caller to index or
-        search.
-        """
-        cl = _clamp(context_length, self.min_context_length, self.max_context_length)
-        return np.array(
-            [np.interp(cl, self._context_length, grid[:, j]) for j in range(self._kv_usage.size)]
+        self._candidates = np.linspace(
+            self.min_kv_usage,
+            self.max_kv_usage,
+            max(2, samples),
         )
 
-    def interpolate_itl(self, concurrency: float, context_length: float) -> float:
-        """ITL in milliseconds at the given concurrency and context length."""
-        row = self._row_at(self._itl_ms, context_length)
-        return float(np.interp(self.kv_usage_for(concurrency, context_length), self._kv_usage, row))
+    def _occupied_fraction(self, in_flight: float, context_tokens: float) -> float:
+        occupied = max(0.0, in_flight) * max(0.0, context_tokens) / self.max_kv_tokens
+        return _bounded(occupied, self.min_kv_usage, self.max_kv_usage)
 
-    def interpolate_thpt_per_gpu(self, concurrency: float, context_length: float) -> float:
-        """Decode throughput in tokens/s/GPU at the given operating point."""
-        row = self._row_at(self._thpt, context_length)
-        return float(np.interp(self.kv_usage_for(concurrency, context_length), self._kv_usage, row))
+    def _context_slice(self, grid: np.ndarray, context_tokens: float) -> np.ndarray:
+        context_tokens = _bounded(
+            context_tokens,
+            self.min_context_length,
+            self.max_context_length,
+        )
+        return np.array(
+            [
+                np.interp(context_tokens, self._context_length, grid[:, column])
+                for column in range(self._kv_usage.size)
+            ]
+        )
 
-    def find_best_throughput_per_gpu(
-        self, itl_ms: float, context_length: float
-    ) -> tuple[float, float, float]:
-        """Highest per-GPU throughput whose ITL still fits ``itl_ms``.
+    def point(self, in_flight: float, context_tokens: float) -> DecodePoint:
+        fraction = self._occupied_fraction(in_flight, context_tokens)
+        latency = self._context_slice(self._itl_ms, context_tokens)
+        throughput = self._context_slice(self._thpt, context_tokens)
+        return DecodePoint(
+            latency_ms=float(np.interp(fraction, self._kv_usage, latency)),
+            tokens_per_second_per_gpu=float(np.interp(fraction, self._kv_usage, throughput)),
+            kv_fraction=fraction,
+        )
 
-        Returns ``(thpt_per_gpu, itl_ms, kv_usage)`` at the chosen operating
-        point. The whole KV-usage axis is scanned rather than bisected: neither
-        curve is guaranteed monotonic in KV usage -- decode throughput typically
-        peaks partway up and falls off as the cache fills -- so taking the most
-        loaded compliant point would settle for less throughput than a lighter
-        compliant one offers, and size the pool for capacity the hardware has.
+    def capacity_within(self, latency_budget_ms: float, context_tokens: float) -> DecodePoint:
+        """Return the fastest sampled point allowed by the latency budget.
 
-        When even the lightest profiled load misses the budget, the lightest
-        point is returned; the caller can tell from the returned ITL exceeding
-        its target that the SLA is unreachable on this hardware.
+        Measurements need not improve or degrade in a single direction as KV
+        occupancy rises, so every candidate is evaluated. If none qualifies,
+        the least-occupied measured point is returned and the caller can report
+        that the requested budget is below the measured floor.
         """
         itl_curve = np.interp(
-            self._kv_search, self._kv_usage, self._row_at(self._itl_ms, context_length)
+            self._candidates,
+            self._kv_usage,
+            self._context_slice(self._itl_ms, context_tokens),
         )
         thpt_curve = np.interp(
-            self._kv_search, self._kv_usage, self._row_at(self._thpt, context_length)
+            self._candidates,
+            self._kv_usage,
+            self._context_slice(self._thpt, context_tokens),
         )
-        within = np.flatnonzero(itl_curve <= itl_ms)
-        best = int(within[np.argmax(thpt_curve[within])]) if within.size else 0
-        return float(thpt_curve[best]), float(itl_curve[best]), float(self._kv_search[best])
+        allowed = np.flatnonzero(itl_curve <= latency_budget_ms)
+        selected = int(allowed[np.argmax(thpt_curve[allowed])]) if allowed.size else 0
+        return DecodePoint(
+            latency_ms=float(itl_curve[selected]),
+            tokens_per_second_per_gpu=float(thpt_curve[selected]),
+            kv_fraction=float(self._candidates[selected]),
+        )
 
 
 class PerfModel:
-    """The prefill and decode models plus the per-replica GPU counts."""
+    """Facade over both profiled capacity surfaces."""
 
     def __init__(self, data: ProfileData) -> None:
-        self.prefill = PrefillPerfModel(data.prefill)
-        self.decode = DecodePerfModel(data.decode)
+        self._prefill = PrefillCurve(data.prefill)
+        self._decode = DecodeSurface(data.decode)
         self.prefill_engine_num_gpu = data.prefill_engine_num_gpu
         self.decode_engine_num_gpu = data.decode_engine_num_gpu
+
+    def prompt_capacity(self, prompt_tokens: float) -> PrefillPoint:
+        return self._prefill.point(prompt_tokens)
+
+    def generation_point(self, in_flight: float, context_tokens: float) -> DecodePoint:
+        return self._decode.point(in_flight, context_tokens)
+
+    def generation_capacity(
+        self,
+        latency_budget_ms: float,
+        context_tokens: float,
+    ) -> DecodePoint:
+        return self._decode.capacity_within(latency_budget_ms, context_tokens)

--- a/infera/planner/perf_model.py
+++ b/infera/planner/perf_model.py
@@ -1,0 +1,143 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""Performance model built from pre-deployment profiling results.
+
+Two questions the planner needs answered, both from offline measurements:
+
+  * **Prefill** -- at this prompt length, what TTFT does an unqueued request
+    see, and how many prefill tokens/s does one GPU sustain?
+  * **Decode** -- at this context length and this KV utilisation, what ITL do
+    requests see, and how many decode tokens/s does one GPU sustain? And
+    inverted: what is the highest per-GPU throughput still within an ITL
+    budget?
+
+Interpolation is numpy-only. Prefill is a 1-D linear interpolation over the
+profiled ISL points; decode is bilinear over the profiled
+``context_length x kv_usage`` grid, which is what insisting on a full
+rectangular grid buys -- interpolating scattered samples instead would mean
+pulling in scipy. Queries outside the profiled range are clamped to the nearest
+edge rather than extrapolated -- a linear extrapolation of a saturating
+throughput curve invents capacity that isn't there.
+
+The model is stateless and cheap to query; runtime deviation from these
+predictions is handled by the correction factors in
+:mod:`infera.planner.core`, not here.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from infera.planner.profile_data import DecodeProfile, PrefillProfile, ProfileData
+
+# How finely to resample the KV-usage axis when searching for the operating
+# point that just meets an ITL budget. The profiled grid is typically only a
+# handful of columns wide, so the search would otherwise snap to coarse steps.
+_KV_SEARCH_RESOLUTION = 100
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    return float(min(max(value, lo), hi))
+
+
+class PrefillPerfModel:
+    """TTFT and per-GPU prefill throughput as a function of prompt length."""
+
+    def __init__(self, profile: PrefillProfile) -> None:
+        self._isl = profile.isl
+        self._ttft_ms = profile.ttft_ms
+        self._thpt = profile.thpt_per_gpu
+        self.min_isl = float(self._isl[0])
+        self.max_isl = float(self._isl[-1])
+
+    def interpolate_ttft(self, isl: float) -> float:
+        """TTFT in milliseconds for an unqueued request of length ``isl``."""
+        return float(np.interp(_clamp(isl, self.min_isl, self.max_isl), self._isl, self._ttft_ms))
+
+    def interpolate_thpt_per_gpu(self, isl: float) -> float:
+        """Prefill throughput in tokens/s/GPU at length ``isl``."""
+        return float(np.interp(_clamp(isl, self.min_isl, self.max_isl), self._isl, self._thpt))
+
+
+class DecodePerfModel:
+    """ITL and per-GPU decode throughput over the profiled decode grid."""
+
+    def __init__(self, profile: DecodeProfile, *, resolution: int = _KV_SEARCH_RESOLUTION) -> None:
+        self._kv_usage = profile.kv_usage
+        self._context_length = profile.context_length
+        self._itl_ms = profile.itl_ms
+        self._thpt = profile.thpt_per_gpu
+        self.max_kv_tokens = profile.max_kv_tokens
+        self.min_kv_usage = float(self._kv_usage[0])
+        self.max_kv_usage = float(self._kv_usage[-1])
+        self.min_context_length = float(self._context_length[0])
+        self.max_context_length = float(self._context_length[-1])
+        # Fine KV-usage axis used by find_best_throughput_per_gpu.
+        self._kv_search = np.linspace(self.min_kv_usage, self.max_kv_usage, max(2, resolution))
+
+    def kv_usage_for(self, concurrency: float, context_length: float) -> float:
+        """Fraction of the engine's KV cache held by ``concurrency`` requests
+        of ``context_length`` tokens each, clamped to the profiled range."""
+        usage = max(0.0, concurrency) * max(0.0, context_length) / self.max_kv_tokens
+        return _clamp(usage, self.min_kv_usage, self.max_kv_usage)
+
+    def _row_at(self, grid: np.ndarray, context_length: float) -> np.ndarray:
+        """Slice ``grid`` at ``context_length``, one value per profiled KV usage.
+
+        Half of the bilinear interpolation: linear along the context-length
+        axis, leaving a 1-D curve over KV usage for the caller to index or
+        search.
+        """
+        cl = _clamp(context_length, self.min_context_length, self.max_context_length)
+        return np.array(
+            [np.interp(cl, self._context_length, grid[:, j]) for j in range(self._kv_usage.size)]
+        )
+
+    def interpolate_itl(self, concurrency: float, context_length: float) -> float:
+        """ITL in milliseconds at the given concurrency and context length."""
+        row = self._row_at(self._itl_ms, context_length)
+        return float(np.interp(self.kv_usage_for(concurrency, context_length), self._kv_usage, row))
+
+    def interpolate_thpt_per_gpu(self, concurrency: float, context_length: float) -> float:
+        """Decode throughput in tokens/s/GPU at the given operating point."""
+        row = self._row_at(self._thpt, context_length)
+        return float(np.interp(self.kv_usage_for(concurrency, context_length), self._kv_usage, row))
+
+    def find_best_throughput_per_gpu(
+        self, itl_ms: float, context_length: float
+    ) -> tuple[float, float, float]:
+        """Highest per-GPU throughput whose ITL still fits ``itl_ms``.
+
+        Returns ``(thpt_per_gpu, itl_ms, kv_usage)`` at the chosen operating
+        point. The whole KV-usage axis is scanned rather than bisected: neither
+        curve is guaranteed monotonic in KV usage -- decode throughput typically
+        peaks partway up and falls off as the cache fills -- so taking the most
+        loaded compliant point would settle for less throughput than a lighter
+        compliant one offers, and size the pool for capacity the hardware has.
+
+        When even the lightest profiled load misses the budget, the lightest
+        point is returned; the caller can tell from the returned ITL exceeding
+        its target that the SLA is unreachable on this hardware.
+        """
+        itl_curve = np.interp(
+            self._kv_search, self._kv_usage, self._row_at(self._itl_ms, context_length)
+        )
+        thpt_curve = np.interp(
+            self._kv_search, self._kv_usage, self._row_at(self._thpt, context_length)
+        )
+        within = np.flatnonzero(itl_curve <= itl_ms)
+        best = int(within[np.argmax(thpt_curve[within])]) if within.size else 0
+        return float(thpt_curve[best]), float(itl_curve[best]), float(self._kv_search[best])
+
+
+class PerfModel:
+    """The prefill and decode models plus the per-replica GPU counts."""
+
+    def __init__(self, data: ProfileData) -> None:
+        self.prefill = PrefillPerfModel(data.prefill)
+        self.decode = DecodePerfModel(data.decode)
+        self.prefill_engine_num_gpu = data.prefill_engine_num_gpu
+        self.decode_engine_num_gpu = data.decode_engine_num_gpu

--- a/infera/planner/profile.py
+++ b/infera/planner/profile.py
@@ -1,0 +1,419 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""Offline profiling sweep: ``python -m infera.planner.profile``.
+
+The planner cannot invent a performance model. Before the fleet takes traffic,
+this drives **one prefill replica and one decode replica** through a sweep and
+writes the ``profile.json`` that ``python -m infera.planner --profile-results``
+reads.
+
+Two sweeps, matching the two things the planner has to predict.
+
+**Prefill** walks a list of prompt lengths, one request at a time so nothing
+queues, and records the TTFT of an unqueued request at each length plus the
+prefill throughput that implies (``isl / ttft``).
+
+**Decode** walks a ``context_length x kv_usage`` grid. KV utilisation is not
+something a client can ask for directly, so it is reached through concurrency:
+holding ``c`` requests of ``L`` tokens each in flight occupies
+``c * L / max_kv_tokens`` of the cache, so the concurrency that lands on a
+target utilisation is ``u * max_kv_tokens / L``. Firing exactly that many
+requests at once and measuring the resulting ITL fills one grid cell, which is
+why the output is a full rectangle rather than scattered samples -- the planner
+interpolates it with numpy alone.
+
+Aggregate decode throughput comes from the steady state rather than from wall
+time: ``c`` requests each emitting one token per ITL sustain ``c / itl``
+tokens/s, which excludes the prefill phase that a wall-time measurement would
+fold in.
+
+Run it against a deployment of exactly one replica per role, and re-run it
+after anything that moves the curves: a different engine version, quantisation,
+tensor-parallel width, or GPU model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import random
+import statistics
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+
+logger = logging.getLogger("infera.planner.profile")
+
+_DONE = "[DONE]"
+
+
+@dataclass
+class Reply:
+    """One streamed completion, timed."""
+
+    ttft: float
+    total: float
+    tokens: int
+    prompt_tokens: int
+
+    @property
+    def itl(self) -> float:
+        """Seconds per token after the first, or 0 for a one-token reply."""
+        return (self.total - self.ttft) / (self.tokens - 1) if self.tokens > 1 else 0.0
+
+
+class PromptFactory:
+    """Builds prompts of an exact token length, unique on every call.
+
+    Uniqueness matters more than it looks: a repeated prompt hits the prefix
+    cache, and a cached prefill measures the cache rather than the engine.
+    """
+
+    def __init__(self, tokenizer_source: str | None) -> None:
+        self._tok = self._load(tokenizer_source)
+        self._rng = random.Random(0xC0FFEE)
+
+    @staticmethod
+    def _load(source: str | None):
+        if not source:
+            return None
+        try:
+            from transformers import AutoTokenizer
+
+            return AutoTokenizer.from_pretrained(source, trust_remote_code=True)
+        except Exception as exc:  # noqa: BLE001 - any failure means approximate mode
+            logger.warning(
+                "could not load a tokenizer from %s (%s: %s); prompt lengths will be "
+                "approximate, so the recorded ISL axis will not be exact",
+                source,
+                type(exc).__name__,
+                exc,
+            )
+            return None
+
+    def build(self, n_tokens: int) -> str:
+        """A prompt of (as close as possible to) ``n_tokens`` tokens."""
+        words = [f"{self._rng.randrange(1 << 30):x}" for _ in range(max(1, n_tokens))]
+        text = " ".join(words)
+        if self._tok is None:
+            return text
+        # Decoding random ids gives no control over how they re-tokenise, so
+        # build long and truncate to the exact count instead.
+        ids = self._tok.encode(text, add_special_tokens=False)
+        while len(ids) < n_tokens:
+            text += " " + " ".join(f"{self._rng.randrange(1 << 30):x}" for _ in range(n_tokens))
+            ids = self._tok.encode(text, add_special_tokens=False)
+        return self._tok.decode(ids[:n_tokens])
+
+
+class Engine:
+    """A streaming OpenAI-compatible completions client."""
+
+    def __init__(self, base_url: str, model: str, *, timeout: float = 600.0) -> None:
+        self._url = base_url.rstrip("/") + "/v1/completions"
+        self._model = model
+        self._client = httpx.AsyncClient(timeout=timeout)
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def complete(self, prompt: str, max_tokens: int) -> Reply:
+        """Send one streaming request and time its tokens.
+
+        ``ignore_eos`` keeps the reply at exactly ``max_tokens``, which is what
+        makes a decode grid cell hold its concurrency for the whole measurement
+        instead of draining as short replies finish early.
+        """
+        body = {
+            "model": self._model,
+            "prompt": prompt,
+            "max_tokens": max_tokens,
+            "temperature": 0.0,
+            "stream": True,
+            "ignore_eos": True,
+            "stream_options": {"include_usage": True},
+        }
+        start = time.perf_counter()
+        ttft = 0.0
+        frames = 0
+        reported_tokens = 0
+        prompt_tokens = 0
+        async with self._client.stream("POST", self._url, json=body) as resp:
+            resp.raise_for_status()
+            async for line in resp.aiter_lines():
+                if not line.startswith("data:"):
+                    continue
+                payload = line[len("data:") :].strip()
+                if payload == _DONE:
+                    break
+                try:
+                    frame = json.loads(payload)
+                except ValueError:
+                    continue
+                usage = frame.get("usage")
+                if isinstance(usage, dict):
+                    prompt_tokens = int(usage.get("prompt_tokens") or 0) or prompt_tokens
+                    reported_tokens = int(usage.get("completion_tokens") or 0) or reported_tokens
+                choices = frame.get("choices") or []
+                if choices and choices[0].get("text"):
+                    frames += 1
+                    if not ttft:
+                        ttft = time.perf_counter() - start
+        total = time.perf_counter() - start
+        if not ttft:
+            raise RuntimeError("the engine returned no tokens; is --model correct?")
+        # Frame counting assumes one token per frame; usage supersedes it when
+        # the engine reports it, which is what stream_options asks for.
+        return Reply(
+            ttft=ttft,
+            total=total,
+            tokens=reported_tokens or frames,
+            prompt_tokens=prompt_tokens,
+        )
+
+
+async def sweep_prefill(
+    engine: Engine, prompts: PromptFactory, isls: list[int], repeats: int, num_gpu: int
+) -> dict:
+    """One request at a time at each prompt length, so nothing queues."""
+    ttft_ms: list[float] = []
+    thpt: list[float] = []
+    for isl in isls:
+        samples: list[float] = []
+        for i in range(repeats + 1):
+            reply = await engine.complete(prompts.build(isl), max_tokens=1)
+            if i:  # the first is warmup
+                samples.append(reply.ttft)
+            if reply.prompt_tokens and abs(reply.prompt_tokens - isl) > max(8, isl * 0.02):
+                logger.warning(
+                    "asked for a %d-token prompt but the engine counted %d; the recorded "
+                    "ISL axis will be off unless --tokenizer matches the served model",
+                    isl,
+                    reply.prompt_tokens,
+                )
+        median = statistics.median(samples)
+        ttft_ms.append(median * 1000.0)
+        thpt.append(isl / median / num_gpu)
+        logger.info("prefill isl=%-6d ttft=%7.1fms  %8.0f tok/s/gpu", isl, ttft_ms[-1], thpt[-1])
+    return {"isl": isls, "ttft_ms": ttft_ms, "thpt_per_gpu": thpt}
+
+
+async def sweep_decode(
+    engine: Engine,
+    prompts: PromptFactory,
+    context_lengths: list[int],
+    kv_usages: list[float],
+    *,
+    osl: int,
+    max_kv_tokens: int,
+    num_gpu: int,
+) -> dict:
+    """Fill the ``context_length x kv_usage`` grid by driving concurrency.
+
+    A cell at utilisation ``u`` and context length ``L`` is reached by holding
+    ``u * max_kv_tokens / L`` requests in flight. Each request is sized so its
+    mean context length over the generation is ``L``: the model's context axis
+    is ``isl + osl/2``, so the prompt is ``L - osl/2`` tokens long.
+    """
+    itl_grid: list[list[float]] = []
+    thpt_grid: list[list[float]] = []
+    for ctx in context_lengths:
+        isl = max(16, ctx - osl // 2)
+        itl_row: list[float] = []
+        thpt_row: list[float] = []
+        for usage in kv_usages:
+            concurrency = max(1, round(usage * max_kv_tokens / ctx))
+            replies = await asyncio.gather(
+                *(engine.complete(prompts.build(isl), max_tokens=osl) for _ in range(concurrency))
+            )
+            itl_s = statistics.mean(r.itl for r in replies)
+            if itl_s <= 0:
+                raise RuntimeError(
+                    f"decode at context_length={ctx}, kv_usage={usage} produced replies of "
+                    f"one token; raise --decode-osl"
+                )
+            itl_row.append(itl_s * 1000.0)
+            thpt_row.append(concurrency / itl_s / num_gpu)
+            logger.info(
+                "decode  ctx=%-6d kv=%.2f (c=%-4d) itl=%6.2fms  %8.0f tok/s/gpu",
+                ctx,
+                usage,
+                concurrency,
+                itl_row[-1],
+                thpt_row[-1],
+            )
+        itl_grid.append(itl_row)
+        thpt_grid.append(thpt_row)
+    return {
+        "kv_usage": kv_usages,
+        "context_length": context_lengths,
+        "itl_ms": itl_grid,
+        "thpt_per_gpu": thpt_grid,
+        "max_kv_tokens": max_kv_tokens,
+    }
+
+
+def _int_list(raw: str) -> list[int]:
+    return [int(x) for x in raw.split(",") if x.strip()]
+
+
+def _float_list(raw: str) -> list[float]:
+    return [float(x) for x in raw.split(",") if x.strip()]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="python -m infera.planner.profile",
+        description="Sweep one prefill and one decode replica, and write the profile.json "
+        "the SLA planner reads.",
+    )
+    parser.add_argument(
+        "--url",
+        default="http://127.0.0.1:8000",
+        help="Base URL of the Infera server in front of the replica (default: %(default)s).",
+    )
+    parser.add_argument("--model", required=True, help="Served model name.")
+    parser.add_argument(
+        "--tokenizer",
+        default=None,
+        metavar="PATH_OR_HF_ID",
+        help="Tokenizer used to build prompts of an exact token length. Defaults to "
+        "--model; without a loadable one, prompt lengths are approximate.",
+    )
+    parser.add_argument(
+        "--output", default="profile.json", metavar="PATH", help="Where to write the results."
+    )
+    parser.add_argument(
+        "--max-kv-tokens",
+        type=int,
+        required=True,
+        metavar="N",
+        help="The engine's total KV cache capacity in tokens (GPU blocks x block size; "
+        "the engine prints it at startup). Concurrency is derived from this.",
+    )
+    parser.add_argument(
+        "--isl",
+        type=_int_list,
+        default=[512, 1024, 2048, 4096],
+        metavar="A,B,C",
+        help="Prompt lengths to sweep for prefill, ascending (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--prefill-repeats",
+        type=int,
+        default=3,
+        metavar="N",
+        help="Timed requests per prefill point; the median is kept (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--context-length",
+        type=_int_list,
+        default=[1024, 4096, 16384],
+        metavar="A,B,C",
+        help="Context lengths to sweep for decode, ascending (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--kv-usage",
+        type=_float_list,
+        default=[0.1, 0.3, 0.5, 0.7, 0.9],
+        metavar="A,B,C",
+        help="KV utilisation fractions to sweep, ascending (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--decode-osl",
+        type=int,
+        default=256,
+        metavar="N",
+        help="Tokens generated per decode request (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--prefill-engine-num-gpu",
+        type=int,
+        default=1,
+        metavar="N",
+        help="GPUs in the prefill replica being profiled (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--decode-engine-num-gpu",
+        type=int,
+        default=1,
+        metavar="N",
+        help="GPUs in the decode replica being profiled (default: %(default)s).",
+    )
+    parser.add_argument("--log-level", default="INFO")
+
+    ns = parser.parse_args(argv)
+    for name, values in (("--isl", ns.isl), ("--context-length", ns.context_length)):
+        if not values or any(b <= a for a, b in zip(values, values[1:])):
+            parser.error(f"{name} must be a non-empty, strictly ascending list")
+        if any(value <= 0 for value in values):
+            parser.error(f"{name} values must be positive")
+    if not ns.kv_usage or any(b <= a for a, b in zip(ns.kv_usage, ns.kv_usage[1:])):
+        parser.error("--kv-usage must be a non-empty, strictly ascending list")
+    if any(not 0.0 < usage <= 1.0 for usage in ns.kv_usage):
+        parser.error("--kv-usage values must be in (0, 1]")
+    if ns.max_kv_tokens <= 0:
+        parser.error("--max-kv-tokens must be positive")
+    if ns.prefill_repeats <= 0:
+        parser.error("--prefill-repeats must be positive")
+    if ns.decode_osl < 2:
+        parser.error("--decode-osl must be at least 2, or there is no ITL to measure")
+    if ns.prefill_engine_num_gpu <= 0 or ns.decode_engine_num_gpu <= 0:
+        parser.error("--prefill-engine-num-gpu and --decode-engine-num-gpu must be positive")
+    return ns
+
+
+async def _run(ns: argparse.Namespace) -> None:
+    engine = Engine(ns.url, ns.model)
+    prompts = PromptFactory(ns.tokenizer or ns.model)
+    try:
+        prefill = await sweep_prefill(
+            engine, prompts, ns.isl, ns.prefill_repeats, ns.prefill_engine_num_gpu
+        )
+        decode = await sweep_decode(
+            engine,
+            prompts,
+            ns.context_length,
+            ns.kv_usage,
+            osl=ns.decode_osl,
+            max_kv_tokens=ns.max_kv_tokens,
+            num_gpu=ns.decode_engine_num_gpu,
+        )
+    finally:
+        await engine.aclose()
+
+    document = {
+        "prefill": prefill,
+        "decode": decode,
+        "prefill_engine_num_gpu": ns.prefill_engine_num_gpu,
+        "decode_engine_num_gpu": ns.decode_engine_num_gpu,
+    }
+    # Validate before writing, so a bad sweep fails here rather than at planner
+    # startup: the two go through the same loader.
+    from infera.planner.profile_data import parse_profile_data
+
+    parse_profile_data(document)
+    Path(ns.output).write_text(json.dumps(document, indent=2), encoding="utf-8")
+    logger.info("wrote %s", ns.output)
+
+
+def main() -> None:
+    ns = parse_args()
+    logging.basicConfig(level=ns.log_level, format="%(asctime)s %(levelname)s: %(message)s")
+    # One line per request would bury the sweep in its own transport chatter.
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    try:
+        asyncio.run(_run(ns))
+    except KeyboardInterrupt:
+        logger.info("profiling stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/infera/planner/profile.py
+++ b/infera/planner/profile.py
@@ -3,36 +3,16 @@
 #
 # SPDX-License-Identifier: MIT
 ###############################################################################
-"""Offline profiling sweep: ``python -m infera.planner.profile``.
+"""Build an Infera capacity envelope from streamed completion measurements.
 
-The planner cannot invent a performance model. Before the fleet takes traffic,
-this drives **one prefill replica and one decode replica** through a sweep and
-writes the ``profile.json`` that ``python -m infera.planner --profile-results``
-reads.
+Run this command against one replica of each role before production traffic.
+Prompt trials establish the latency and token-rate curve of the prefill role.
+Generation trials hold several requests in flight to sample the decode role at
+different context sizes and KV occupancy levels. The resulting JSON document is
+the planner's hardware-and-model-specific input.
 
-Two sweeps, matching the two things the planner has to predict.
-
-**Prefill** walks a list of prompt lengths, one request at a time so nothing
-queues, and records the TTFT of an unqueued request at each length plus the
-prefill throughput that implies (``isl / ttft``).
-
-**Decode** walks a ``context_length x kv_usage`` grid. KV utilisation is not
-something a client can ask for directly, so it is reached through concurrency:
-holding ``c`` requests of ``L`` tokens each in flight occupies
-``c * L / max_kv_tokens`` of the cache, so the concurrency that lands on a
-target utilisation is ``u * max_kv_tokens / L``. Firing exactly that many
-requests at once and measuring the resulting ITL fills one grid cell, which is
-why the output is a full rectangle rather than scattered samples -- the planner
-interpolates it with numpy alone.
-
-Aggregate decode throughput comes from the steady state rather than from wall
-time: ``c`` requests each emitting one token per ITL sustain ``c / itl``
-tokens/s, which excludes the prefill phase that a wall-time measurement would
-fold in.
-
-Run it against a deployment of exactly one replica per role, and re-run it
-after anything that moves the curves: a different engine version, quantisation,
-tensor-parallel width, or GPU model.
+Repeat the measurement after changing the model, engine build, quantisation,
+parallel width, or accelerator type.
 """
 
 from __future__ import annotations
@@ -179,10 +159,10 @@ class Engine:
         )
 
 
-async def sweep_prefill(
+async def measure_prompt_curve(
     engine: Engine, prompts: PromptFactory, isls: list[int], repeats: int, num_gpu: int
 ) -> dict:
-    """One request at a time at each prompt length, so nothing queues."""
+    """Measure isolated prompt work at each requested length."""
     ttft_ms: list[float] = []
     thpt: list[float] = []
     for isl in isls:
@@ -205,7 +185,21 @@ async def sweep_prefill(
     return {"isl": isls, "ttft_ms": ttft_ms, "thpt_per_gpu": thpt}
 
 
-async def sweep_decode(
+def _requests_for_occupancy(
+    kv_fraction: float,
+    mean_context_tokens: int,
+    max_kv_tokens: int,
+) -> int:
+    """Convert a target occupied fraction into a whole request count."""
+    return max(1, round(kv_fraction * max_kv_tokens / mean_context_tokens))
+
+
+def _prompt_tokens_for_context(mean_context_tokens: int, output_tokens: int) -> int:
+    """Choose a prompt whose generation midpoint lands on the context sample."""
+    return max(16, mean_context_tokens - output_tokens // 2)
+
+
+async def measure_generation_surface(
     engine: Engine,
     prompts: PromptFactory,
     context_lengths: list[int],
@@ -215,21 +209,15 @@ async def sweep_decode(
     max_kv_tokens: int,
     num_gpu: int,
 ) -> dict:
-    """Fill the ``context_length x kv_usage`` grid by driving concurrency.
-
-    A cell at utilisation ``u`` and context length ``L`` is reached by holding
-    ``u * max_kv_tokens / L`` requests in flight. Each request is sized so its
-    mean context length over the generation is ``L``: the model's context axis
-    is ``isl + osl/2``, so the prompt is ``L - osl/2`` tokens long.
-    """
+    """Measure every cell in the requested context/occupancy surface."""
     itl_grid: list[list[float]] = []
     thpt_grid: list[list[float]] = []
     for ctx in context_lengths:
-        isl = max(16, ctx - osl // 2)
+        isl = _prompt_tokens_for_context(ctx, osl)
         itl_row: list[float] = []
         thpt_row: list[float] = []
         for usage in kv_usages:
-            concurrency = max(1, round(usage * max_kv_tokens / ctx))
+            concurrency = _requests_for_occupancy(usage, ctx, max_kv_tokens)
             replies = await asyncio.gather(
                 *(engine.complete(prompts.build(isl), max_tokens=osl) for _ in range(concurrency))
             )
@@ -374,10 +362,10 @@ async def _run(ns: argparse.Namespace) -> None:
     engine = Engine(ns.url, ns.model)
     prompts = PromptFactory(ns.tokenizer or ns.model)
     try:
-        prefill = await sweep_prefill(
+        prefill = await measure_prompt_curve(
             engine, prompts, ns.isl, ns.prefill_repeats, ns.prefill_engine_num_gpu
         )
-        decode = await sweep_decode(
+        decode = await measure_generation_surface(
             engine,
             prompts,
             ns.context_length,

--- a/infera/planner/profile_data.py
+++ b/infera/planner/profile_data.py
@@ -1,0 +1,197 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+"""Loading and validation of offline profiling results.
+
+The planner cannot invent a performance model: it needs to know, for this
+model on this GPU, how TTFT grows with prompt length and how ITL degrades as
+KV cache fills. That comes from the sweep in :mod:`infera.planner.profile`,
+handed to the planner as a single JSON file::
+
+    {
+      "prefill": {
+        "isl":          [512, 1024, 2048, 4096],
+        "ttft_ms":      [45.0, 82.0, 165.0, 340.0],
+        "thpt_per_gpu": [9800.0, 11200.0, 11900.0, 12100.0]
+      },
+      "decode": {
+        "kv_usage":       [0.1, 0.3, 0.5, 0.7, 0.9],
+        "context_length": [1024, 4096, 16384],
+        "itl_ms":         [[...5 values...], [...], [...]],
+        "thpt_per_gpu":   [[...5 values...], [...], [...]],
+        "max_kv_tokens":  262144
+      },
+      "prefill_engine_num_gpu": 1,
+      "decode_engine_num_gpu": 1
+    }
+
+``prefill`` is three parallel 1-D series indexed by prompt length: the TTFT of
+an unqueued request at that length, and the prefill throughput one GPU sustains
+there (tokens/s/GPU).
+
+``decode`` is a **regular grid**: ``itl_ms[i][j]`` and ``thpt_per_gpu[i][j]``
+are measured at ``context_length[i]`` and ``kv_usage[j]``. Requiring a full
+grid rather than scattered samples is what lets the planner interpolate with
+numpy alone -- no scipy. ``max_kv_tokens`` is the engine's total KV capacity in
+tokens, used to convert a concurrency into a KV utilisation fraction.
+
+The GPU counts are per *engine replica* (i.e. the engine's tensor/pipeline
+parallel width), and are what the planner divides by to turn a per-GPU
+throughput into a replica count. They may be overridden on the command line.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+MISSING_PROFILE_HELP = (
+    "The SLA planner needs offline profiling results. Produce them with "
+    "`python -m infera.planner.profile`; see the SLA planner guide in manual/."
+)
+
+
+class ProfileDataError(ValueError):
+    """The profiling file is missing keys, or its arrays don't line up."""
+
+
+@dataclass(frozen=True)
+class PrefillProfile:
+    """Prefill sweep: TTFT and per-GPU throughput as a function of ISL."""
+
+    isl: np.ndarray
+    ttft_ms: np.ndarray
+    thpt_per_gpu: np.ndarray
+
+
+@dataclass(frozen=True)
+class DecodeProfile:
+    """Decode sweep on a ``context_length x kv_usage`` grid."""
+
+    kv_usage: np.ndarray
+    context_length: np.ndarray
+    itl_ms: np.ndarray  # shape (len(context_length), len(kv_usage))
+    thpt_per_gpu: np.ndarray  # same shape
+    max_kv_tokens: int
+
+
+@dataclass(frozen=True)
+class ProfileData:
+    prefill: PrefillProfile
+    decode: DecodeProfile
+    prefill_engine_num_gpu: int = 1
+    decode_engine_num_gpu: int = 1
+
+
+def _series(block: dict, section: str, key: str) -> np.ndarray:
+    if key not in block:
+        raise ProfileDataError(f"profiling data: {section!r} is missing {key!r}")
+    arr = np.asarray(block[key], dtype=float)
+    if arr.ndim != 1 or arr.size == 0:
+        raise ProfileDataError(f"profiling data: {section}.{key} must be a non-empty 1-D list")
+    if not np.all(np.isfinite(arr)):
+        raise ProfileDataError(f"profiling data: {section}.{key} contains NaN or infinity")
+    return arr
+
+
+def _grid(block: dict, section: str, key: str, shape: tuple[int, int]) -> np.ndarray:
+    if key not in block:
+        raise ProfileDataError(f"profiling data: {section!r} is missing {key!r}")
+    arr = np.asarray(block[key], dtype=float)
+    if arr.shape != shape:
+        raise ProfileDataError(
+            f"profiling data: {section}.{key} has shape {arr.shape}, expected {shape} "
+            f"(rows = context_length, columns = kv_usage)"
+        )
+    if not np.all(np.isfinite(arr)):
+        raise ProfileDataError(f"profiling data: {section}.{key} contains NaN or infinity")
+    return arr
+
+
+def _ascending(arr: np.ndarray, section: str, key: str) -> None:
+    if np.any(np.diff(arr) <= 0):
+        raise ProfileDataError(
+            f"profiling data: {section}.{key} must be strictly ascending, got {arr.tolist()}"
+        )
+
+
+def parse_profile_data(raw: dict) -> ProfileData:
+    """Validate a decoded profiling document and build a :class:`ProfileData`.
+
+    Raises :class:`ProfileDataError` with a specific message rather than
+    letting a shape mismatch surface later as a confusing scaling decision.
+    """
+    for section in ("prefill", "decode"):
+        if not isinstance(raw.get(section), dict):
+            raise ProfileDataError(f"profiling data: missing {section!r} section")
+
+    p = raw["prefill"]
+    isl = _series(p, "prefill", "isl")
+    _ascending(isl, "prefill", "isl")
+    ttft_ms = _series(p, "prefill", "ttft_ms")
+    thpt = _series(p, "prefill", "thpt_per_gpu")
+    if not (isl.size == ttft_ms.size == thpt.size):
+        raise ProfileDataError(
+            "profiling data: prefill.isl, prefill.ttft_ms and prefill.thpt_per_gpu "
+            f"must be the same length, got {isl.size}, {ttft_ms.size}, {thpt.size}"
+        )
+    if np.any(isl <= 0) or np.any(ttft_ms <= 0):
+        raise ProfileDataError("profiling data: prefill.isl and prefill.ttft_ms must be positive")
+    if np.any(thpt <= 0):
+        raise ProfileDataError("profiling data: prefill.thpt_per_gpu must be positive")
+
+    d = raw["decode"]
+    kv_usage = _series(d, "decode", "kv_usage")
+    _ascending(kv_usage, "decode", "kv_usage")
+    if np.any(kv_usage <= 0) or np.any(kv_usage > 1):
+        raise ProfileDataError("profiling data: decode.kv_usage must be in (0, 1]")
+    context_length = _series(d, "decode", "context_length")
+    _ascending(context_length, "decode", "context_length")
+    if np.any(context_length <= 0):
+        raise ProfileDataError("profiling data: decode.context_length must be positive")
+    shape = (context_length.size, kv_usage.size)
+    itl_ms = _grid(d, "decode", "itl_ms", shape)
+    d_thpt = _grid(d, "decode", "thpt_per_gpu", shape)
+    if np.any(itl_ms <= 0):
+        raise ProfileDataError("profiling data: decode.itl_ms must be positive")
+    if np.any(d_thpt <= 0):
+        raise ProfileDataError("profiling data: decode.thpt_per_gpu must be positive")
+    max_kv_tokens = int(d.get("max_kv_tokens", 0))
+    if max_kv_tokens <= 0:
+        raise ProfileDataError("profiling data: decode.max_kv_tokens must be a positive integer")
+    prefill_num_gpu = int(raw.get("prefill_engine_num_gpu", 1))
+    decode_num_gpu = int(raw.get("decode_engine_num_gpu", 1))
+    if prefill_num_gpu <= 0 or decode_num_gpu <= 0:
+        raise ProfileDataError("profiling data: engine GPU counts must be positive integers")
+
+    return ProfileData(
+        prefill=PrefillProfile(isl=isl, ttft_ms=ttft_ms, thpt_per_gpu=thpt),
+        decode=DecodeProfile(
+            kv_usage=kv_usage,
+            context_length=context_length,
+            itl_ms=itl_ms,
+            thpt_per_gpu=d_thpt,
+            max_kv_tokens=max_kv_tokens,
+        ),
+        prefill_engine_num_gpu=prefill_num_gpu,
+        decode_engine_num_gpu=decode_num_gpu,
+    )
+
+
+def load_profile_data(path: str | Path) -> ProfileData:
+    """Read and validate the profiling JSON at ``path``."""
+    p = Path(path)
+    try:
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ProfileDataError(f"profiling data not found at {p}. {MISSING_PROFILE_HELP}") from exc
+    except ValueError as exc:
+        raise ProfileDataError(f"profiling data at {p} is not valid JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ProfileDataError(f"profiling data at {p} must be a JSON object")
+    return parse_profile_data(raw)

--- a/infera/router/disagg.py
+++ b/infera/router/disagg.py
@@ -116,8 +116,8 @@ class DisaggRouter(BaseRouter):
         stream: bool,
         path: str = "/v1/chat/completions",
     ) -> Response:
-        with metrics.track_request(router="disagg") as obs:
-            model = body.get("model")
+        model = body.get("model")
+        with metrics.track_request(router="disagg", model=str(model or "")) as obs:
             prefills = self.pool.list_active(model=model, mode=DisaggMode.PREFILL)
             decodes = self.pool.list_active(model=model, mode=DisaggMode.DECODE)
             # Independently per role: a wedged prefill and a wedged decode are
@@ -155,7 +155,7 @@ class DisaggRouter(BaseRouter):
         protocol/topology/transport machinery as :meth:`dispatch`, but skips
         ``policy.pick`` — selection happened in the EPP. Empty block lists make
         the policy in-flight refcounting a no-op (the EPP owns bookkeeping)."""
-        with metrics.track_request(router="disagg") as obs:
+        with metrics.track_request(router="disagg", model=str(body.get("model") or "")) as obs:
             p = self.pool.get(prefill_id)
             d = self.pool.get(decode_id)
             if p is None or d is None:
@@ -247,6 +247,9 @@ class DisaggRouter(BaseRouter):
 
         p_url = f"{p.url}{path}"
         d_url = f"{d.url}{path}"
+
+        # Fallback ISL for the streaming path, where the reply carries no usage.
+        obs.observe_blocks(p_blocks, p.kv_block_size)
 
         # request_id_for may raise (e.g. malformed disagg_meta); compute before
         # on_request_started so no started/finished bookkeeping is needed on
@@ -356,8 +359,10 @@ class DisaggRouter(BaseRouter):
 
         if stream:
             obs["outcome"] = "ok"  # commit at hand-off
+            obs.claim_stream()
             return StreamingResponse(
                 self._stream_dual(
+                    obs,
                     p_target,
                     p_blocks,
                     d_target,
@@ -426,6 +431,7 @@ class DisaggRouter(BaseRouter):
                     status_code=502,
                 )
             obs["outcome"] = "ok" if d_resp.status_code < 400 else f"{d_resp.status_code // 100}xx"
+            obs.observe_usage(payload)
             return JSONResponse(content=payload, status_code=d_resp.status_code)
         finally:
             self.policy.on_request_finished(p_target.route_key, p_blocks)
@@ -502,8 +508,11 @@ class DisaggRouter(BaseRouter):
 
         if stream:
             obs["outcome"] = "ok"
+            obs.claim_stream()
             return StreamingResponse(
-                self._stream_dual_nats(p_target, p_blocks, d_target, d_blocks, d_payload, p_task),
+                self._stream_dual_nats(
+                    obs, p_target, p_blocks, d_target, d_blocks, d_payload, p_task
+                ),
                 media_type="text/event-stream",
             )
 
@@ -542,6 +551,7 @@ class DisaggRouter(BaseRouter):
                 )
             self._score_leg(d.worker_id, status)
             obs["outcome"] = "ok" if status < 400 else f"{status // 100}xx"
+            obs.observe_usage(payload)
             return JSONResponse(content=payload, status_code=status)
         finally:
             try:
@@ -551,7 +561,9 @@ class DisaggRouter(BaseRouter):
             self.policy.on_request_finished(p_target.route_key, p_blocks)
             self.policy.on_request_finished(d_target.route_key, d_blocks)
 
-    async def _stream_dual_nats(self, p_target, p_blocks, d_target, d_blocks, d_payload, p_task):
+    async def _stream_dual_nats(
+        self, obs, p_target, p_blocks, d_target, d_blocks, d_payload, p_task
+    ):
         """Stream decode's reply over NATS while prefill drains in background."""
         d = d_target.worker
         served = False
@@ -564,12 +576,14 @@ class DisaggRouter(BaseRouter):
                             # work; an accepted request alone would not show it.
                             self.breaker.record_success(d.worker_id)
                             served = True
+                        obs.observe_stream_chunk(data)
                         yield data
                 elif kind == TYPE_ERROR:
                     logger.warning("decode (nats) %s stream failed: %s", d.worker_id, data[:200])
                     metrics.pd_bootstrap_failures_total.labels(reason="decode_stream_broken").inc()
                     if not served:
                         self.breaker.record_failure(d.worker_id)
+                    obs.mark_failed()
                     yield (
                         f'data: {{"error":"decode {d.worker_id} nats stream failed"}}\n\n'
                     ).encode()
@@ -585,6 +599,7 @@ class DisaggRouter(BaseRouter):
                 pass
             self.policy.on_request_finished(p_target.route_key, p_blocks)
             self.policy.on_request_finished(d_target.route_key, d_blocks)
+            obs.close()
 
     async def _dispatch_serial(
         self,
@@ -715,10 +730,11 @@ class DisaggRouter(BaseRouter):
 
         if stream:
             obs["outcome"] = "ok"  # commit at hand-off
+            obs.claim_stream()
             # No prefill task to babysit (already finished); D's stream
             # is self-contained. _stream_decode_only's finally finishes D.
             return StreamingResponse(
-                self._stream_decode_only(d_target, d_blocks, d_url, d_body, d_headers),
+                self._stream_decode_only(obs, d_target, d_blocks, d_url, d_body, d_headers),
                 media_type="text/event-stream",
             )
 
@@ -745,12 +761,14 @@ class DisaggRouter(BaseRouter):
                     status_code=502,
                 )
             obs["outcome"] = "ok" if d_resp.status_code < 400 else f"{d_resp.status_code // 100}xx"
+            obs.observe_usage(d_payload)
             return JSONResponse(content=d_payload, status_code=d_resp.status_code)
         finally:
             self.policy.on_request_finished(d_target.route_key, d_blocks)
 
     async def _stream_decode_only(
         self,
+        obs,
         d_target,
         d_blocks: list[int],
         d_url: str,
@@ -778,6 +796,7 @@ class DisaggRouter(BaseRouter):
                 metrics.pd_bootstrap_failures_total.labels(reason="decode_unreachable").inc()
                 self.breaker.record_failure(d_target.worker.worker_id)
                 err = json.dumps({"error": "decode unreachable"})
+                obs.mark_failed()
                 yield f"data: {err}\n\n".encode()
                 return
 
@@ -804,6 +823,7 @@ class DisaggRouter(BaseRouter):
                         )
                     }
                 )
+                obs.mark_failed()
                 yield f"data: {err}\n\n".encode()
                 return
 
@@ -823,6 +843,7 @@ class DisaggRouter(BaseRouter):
                         if _DONE_NEEDLE in window:
                             done_seen = True
                         tail = window[-_TAIL_KEEP:]
+                    obs.observe_stream_chunk(chunk)
                     yield chunk
             except httpx.HTTPError as exc:
                 if done_seen:
@@ -840,6 +861,7 @@ class DisaggRouter(BaseRouter):
                 )
                 metrics.pd_bootstrap_failures_total.labels(reason="decode_stream_broken").inc()
                 err = json.dumps({"error": "decode stream failed"})
+                obs.mark_failed()
                 yield f"data: {err}\n\n".encode()
         finally:
             if d_resp is not None:
@@ -848,6 +870,7 @@ class DisaggRouter(BaseRouter):
                 except Exception:
                     pass
             self.policy.on_request_finished(d_target.route_key, d_blocks)
+            obs.close()
 
     async def _open_decode_stream(
         self,
@@ -892,6 +915,7 @@ class DisaggRouter(BaseRouter):
 
     async def _stream_dual(
         self,
+        obs,
         p_target,
         p_blocks: list[int],
         d_target,
@@ -941,6 +965,7 @@ class DisaggRouter(BaseRouter):
                     self.breaker.record_failure(d_target.worker.worker_id)
                     # json.dumps: exc text may contain chars that break SSE.
                     err = json.dumps({"error": "decode unreachable"})
+                    obs.mark_failed()
                     yield f"data: {err}\n\n".encode()
                     return
 
@@ -968,6 +993,7 @@ class DisaggRouter(BaseRouter):
                             )
                         }
                     )
+                    obs.mark_failed()
                     yield f"data: {err}\n\n".encode()
                     return
 
@@ -988,6 +1014,7 @@ class DisaggRouter(BaseRouter):
                         if _DONE_NEEDLE in window:
                             done_seen = True
                         tail = window[-_TAIL_KEEP:]
+                    obs.observe_stream_chunk(chunk)
                     yield chunk
             except httpx.HTTPError as exc:
                 if done_seen:
@@ -1010,6 +1037,7 @@ class DisaggRouter(BaseRouter):
                 )
                 metrics.pd_bootstrap_failures_total.labels(reason="decode_stream_broken").inc()
                 err = json.dumps({"error": "decode stream failed"})
+                obs.mark_failed()
                 yield f"data: {err}\n\n".encode()
         finally:
             if d_resp is not None:
@@ -1053,3 +1081,4 @@ class DisaggRouter(BaseRouter):
                     metrics.pd_bootstrap_failures_total.labels(reason="prefill_5xx").inc()
             self.policy.on_request_finished(p_target.route_key, p_blocks)
             self.policy.on_request_finished(d_target.route_key, d_blocks)
+            obs.close()

--- a/infera/router/mixed.py
+++ b/infera/router/mixed.py
@@ -79,8 +79,8 @@ class MixedRouter(BaseRouter):
         stream: bool,
         path: str = "/v1/chat/completions",
     ) -> Response:
-        with metrics.track_request(router="mixed") as obs:
-            model = body.get("model")
+        model = body.get("model")
+        with metrics.track_request(router="mixed", model=str(model or "")) as obs:
             # cache_control hints are body-level, computed once per request.
             hints = body.get("_infera_cache_hints") or parse_cache_hints(body)
 
@@ -150,6 +150,9 @@ class MixedRouter(BaseRouter):
         forwarded_body.pop("_infera_cache_hints", None)
         forwarded_body.pop("_infera_request_id", None)
 
+        # Fallback ISL for the streaming path, where the reply carries no usage.
+        obs.observe_blocks(blocks, worker.kv_block_size)
+
         # Ask for the sampled token ids only when a migration could actually use
         # them: they cost the engine work and the client never sees them, since
         # they are taken back out before the stream is forwarded.
@@ -201,6 +204,7 @@ class MixedRouter(BaseRouter):
 
         if kind == TYPE_DATA:
             obs["outcome"] = "ok"  # committed once first byte is in hand
+            obs.claim_stream()
 
             state = self._migration_state(forwarded_body, use_nats, path)
 
@@ -217,12 +221,16 @@ class MixedRouter(BaseRouter):
                 transform = passthrough
                 try:
                     if data0:
-                        yield transform(data0)
+                        client_data = transform(data0)
+                        obs.observe_stream_chunk(client_data)
+                        yield client_data
                     while True:
                         async for k, _st, d in current:
                             if k == TYPE_DATA:
                                 if d:
-                                    yield transform(d)
+                                    client_data = transform(d)
+                                    obs.observe_stream_chunk(client_data)
+                                    yield client_data
                             elif k == TYPE_ERROR:
                                 # A drain notice is a planned handover, not a
                                 # fault: the worker is leaving and expects us to
@@ -265,6 +273,7 @@ class MixedRouter(BaseRouter):
                                 reason="poisoned" if state.poisoned else "limit"
                             ).inc()
                         if resumed is None:
+                            obs.mark_failed()
                             what = "is shutting down" if reason == "worker_draining" else "failed"
                             yield (
                                 f'data: {{"error":"worker {cur_target.worker.worker_id} '
@@ -279,6 +288,7 @@ class MixedRouter(BaseRouter):
                         cur_target, cur_blocks = next_target, next_blocks
                 finally:
                     self.policy.on_request_finished(cur_target.route_key, cur_blocks)
+                    obs.close()
 
             return StreamingResponse(generate(), media_type="text/event-stream")
 
@@ -437,6 +447,7 @@ class MixedRouter(BaseRouter):
             # worker fault and retryable; a 4xx belongs to the request.
             if is_worker_fault(status):
                 raise _Retry(JSONResponse(content=payload_json, status_code=status))
+            obs.observe_usage(payload_json)
             return JSONResponse(content=payload_json, status_code=status)
 
         # Direct HTTP forward.
@@ -480,6 +491,7 @@ class MixedRouter(BaseRouter):
         # of an error the client needs to see.
         if is_worker_fault(resp.status_code):
             raise _Retry(JSONResponse(content=payload_json, status_code=resp.status_code))
+        obs.observe_usage(payload_json)
         return JSONResponse(content=payload_json, status_code=resp.status_code)
 
     async def _normalized_stream(

--- a/infera/server/__main__.py
+++ b/infera/server/__main__.py
@@ -280,12 +280,16 @@ async def main(args) -> None:
             "deployment's pools (needs RBAC to patch inferadeployments)"
         )
 
+    if args.enable_sla_metrics:
+        logger.info("SLA metrics enabled: streaming requests include usage instrumentation")
+
     app = init_app(
         registry,
         router,
         kv=policy.kv_client,
         kvd_socket_path=args.kvd_socket_path,
         enable_profiling=args.enable_profiling,
+        enable_sla_metrics=args.enable_sla_metrics,
         scaler=scaler,
     )
     app.include_router(
@@ -321,6 +325,8 @@ if __name__ == "__main__":
     _args = parse_server_args()
     # `--router-backend rust` replaces this process with the Rust router binary.
     if _args.router_backend == "rust":
+        if _args.enable_sla_metrics:
+            raise SystemExit("--enable-sla-metrics currently requires --router-backend=python")
         from infera.server.launch_rust import exec_rust
 
         exec_rust(_args)  # never returns

--- a/infera/server/app.py
+++ b/infera/server/app.py
@@ -65,6 +65,7 @@ _kvd_socket_path: str | None = None
 # fan profile control out to worker engine endpoints is created lazily on first
 # use and kept separate from the router's client.
 _enable_profiling: bool = False
+_enable_sla_metrics: bool = False
 _profile_client: httpx.AsyncClient | None = None
 
 # Pool resizing. Off by default: it writes to the cluster, and /v1/admin carries
@@ -78,15 +79,18 @@ def init_app(
     kv: KvEventClient | None = None,
     kvd_socket_path: str | None = None,
     enable_profiling: bool = False,
+    enable_sla_metrics: bool = False,
     scaler: DeploymentScaler | None = None,
 ) -> FastAPI:
     global registry, router, kv_client, _kvd_socket_path
-    global _enable_profiling, _scaler
+    global _enable_profiling, _enable_sla_metrics, _scaler
     registry = reg
     router = rtr
     kv_client = kv
     _kvd_socket_path = kvd_socket_path
     _enable_profiling = enable_profiling
+    _enable_sla_metrics = enable_sla_metrics
+    metrics.set_sla_metrics_enabled(enable_sla_metrics)
     _scaler = scaler
     return app
 
@@ -296,6 +300,15 @@ async def _dispatch_inference(request: Request, *, path: str) -> Any:
     Both endpoints want the same request-id correlation + cache-hint
     parsing; they differ only in the path forwarded to the worker."""
     body = await request.json()
+    stream = bool(body.get("stream"))
+    if stream and _enable_sla_metrics:
+        # The SLA planner needs exact ISL/OSL even with round-robin routing,
+        # where the router has no KV-block estimate. All supported engines
+        # expose final usage when this OpenAI option is enabled.
+        stream_options = body.get("stream_options")
+        if not isinstance(stream_options, dict):
+            stream_options = {}
+        body["stream_options"] = {**stream_options, "include_usage": True}
     # Generate or echo a request ID so router decisions can be correlated
     # across server + P/D worker logs. The router echoes it back to the
     # client in the response headers; cost-aware policies can include it
@@ -310,7 +323,7 @@ async def _dispatch_inference(request: Request, *, path: str) -> Any:
     body["_infera_cache_hints"] = parse_cache_hints(body)
     # GAIE direct mode: honour the EPP's worker pick from the request header.
     _stash_direct_worker(body, request)
-    resp = await router.dispatch(body, stream=bool(body.get("stream")), path=path)
+    resp = await router.dispatch(body, stream=stream, path=path)
     resp.headers[_REQUEST_ID_HEADER] = request_id
     return resp
 
@@ -597,16 +610,17 @@ async def prometheus_metrics() -> Response:
     if registry is not None:
         # Reset gauges then re-populate to handle workers leaving the fleet.
         metrics.active_workers.clear()
-        by_mode: dict[str, int] = {}
+        by_mode: dict[tuple[str, str], int] = {}
         for w in registry.list_all():
             if w.status != WorkerStatus.ACTIVE:
                 continue
             key = (
                 w.disagg_mode.value if isinstance(w.disagg_mode, DisaggMode) else str(w.disagg_mode)
             )
-            by_mode[key] = by_mode.get(key, 0) + 1
-        for mode, n in by_mode.items():
-            metrics.active_workers.labels(disagg_mode=mode).set(n)
+            mode_model = (key, w.model_name)
+            by_mode[mode_model] = by_mode.get(mode_model, 0) + 1
+        for (mode, model), n in by_mode.items():
+            metrics.active_workers.labels(disagg_mode=mode, model=model).set(n)
 
     if kv_client is not None:
         metrics.policy_cache_view_size.clear()

--- a/infera/server/args.py
+++ b/infera/server/args.py
@@ -197,6 +197,15 @@ def parse_server_args(argv: list[str] | None = None) -> argparse.Namespace:
         "$INFERA_ENABLE_PROFILING=1.",
     )
     parser.add_argument(
+        "--enable-sla-metrics",
+        action="store_true",
+        default=os.environ.get("INFERA_ENABLE_SLA_METRICS", "").lower() in ("1", "true", "yes"),
+        help="Enable TTFT/ITL/ISL/OSL instrumentation for the optional SLA "
+        "planner. Default OFF so ordinary inference requests are not modified "
+        "or parsed by planner-specific code. Also enabled via "
+        "$INFERA_ENABLE_SLA_METRICS=1.",
+    )
+    parser.add_argument(
         "--enable-scaling-api",
         action="store_true",
         default=os.environ.get("INFERA_ENABLE_SCALING_API", "").lower() in ("1", "true", "yes"),

--- a/infera/server/metrics.py
+++ b/infera/server/metrics.py
@@ -13,12 +13,13 @@ exposition endpoint at /metrics.
 Naming follows the Prometheus convention:
     infera_<subsystem>_<thing>_<unit>
 
-Labels are kept low-cardinality. ``worker_id`` is OK (fleet is bounded);
-free-form fields like model name and request_id are NOT label values.
+Labels are kept low-cardinality. ``worker_id`` and served ``model`` are bounded
+by the deployment; free-form fields such as request_id are NOT label values.
 """
 
 from __future__ import annotations
 
+import json
 import time
 from contextlib import contextmanager
 
@@ -32,6 +33,13 @@ from prometheus_client import (
 from prometheus_client.exposition import CONTENT_TYPE_LATEST
 
 REGISTRY = CollectorRegistry()
+_sla_metrics_enabled = False
+
+
+def set_sla_metrics_enabled(enabled: bool) -> None:
+    """Enable the per-token observations consumed by the optional SLA planner."""
+    global _sla_metrics_enabled
+    _sla_metrics_enabled = bool(enabled)
 
 
 # ----------------------------------------------------------------------
@@ -98,6 +106,53 @@ request_inflight = Gauge(
 
 
 # ----------------------------------------------------------------------
+# SLA signals (consumed by infera.planner)
+# ----------------------------------------------------------------------
+# The SLA planner reads only the _sum / _count of these four histograms and
+# window-differences them, so the bucket layout is for humans/dashboards.
+
+time_to_first_token_seconds = Histogram(
+    "infera_time_to_first_token_seconds",
+    "Server-observed time from dispatch to the first token of the reply. "
+    "For PD-disaggregated requests this spans prefill + KV transfer + the "
+    "decode engine's first forward pass.",
+    labelnames=("router", "model"),
+    buckets=(0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, float("inf")),
+    registry=REGISTRY,
+)
+
+inter_token_latency_seconds = Histogram(
+    "infera_inter_token_latency_seconds",
+    "Mean per-request inter-token latency: (total stream time - TTFT) spread "
+    "over the generated tokens. Only observed for requests that produced at "
+    "least two output tokens.",
+    labelnames=("router", "model"),
+    buckets=(0.001, 0.0025, 0.005, 0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 1.0, float("inf")),
+    registry=REGISTRY,
+)
+
+input_sequence_tokens = Histogram(
+    "infera_input_sequence_tokens",
+    "Prompt length in tokens (ISL). Exact when the engine reports "
+    "`usage.prompt_tokens`; otherwise estimated from the router's KV block "
+    "count, which rounds up to a block boundary.",
+    labelnames=("router", "model"),
+    buckets=(64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, float("inf")),
+    registry=REGISTRY,
+)
+
+output_sequence_tokens = Histogram(
+    "infera_output_sequence_tokens",
+    "Generated length in tokens (OSL). Exact when the engine reports "
+    "`usage.completion_tokens`; otherwise counted as SSE data frames, which "
+    "assumes one token per frame.",
+    labelnames=("router", "model"),
+    buckets=(4, 16, 64, 256, 1024, 4096, 16384, 65536, float("inf")),
+    registry=REGISTRY,
+)
+
+
+# ----------------------------------------------------------------------
 # PD-disaggregation specifics
 # ----------------------------------------------------------------------
 
@@ -142,7 +197,7 @@ pd_bootstrap_failures_total = Counter(
 active_workers = Gauge(
     "infera_active_workers",
     "Number of workers in ACTIVE status, by disagg_mode.",
-    labelnames=("disagg_mode",),
+    labelnames=("disagg_mode", "model"),
     registry=REGISTRY,
 )
 
@@ -223,8 +278,202 @@ def record_pick(*, role: str, worker_id: str, cache_hits: int, request_blocks: i
     router_pick_request_blocks.labels(role=role).observe(request_blocks)
 
 
+_SSE_DATA = b"data:"
+_SSE_DONE = b"data: [DONE]"
+# An SSE frame that grows past this without a newline is not a token frame
+# (or the peer is misbehaving); drop the partial rather than buffer forever.
+_MAX_PARTIAL_FRAME = 1 << 16
+
+
+class RequestObserver(dict):
+    """Per-request accumulator for the SLA signals the planner consumes.
+
+    Subclasses ``dict`` so the established ``obs["outcome"] = ...`` idiom in
+    the routers keeps working untouched.
+
+    Streaming responses outlive the ``track_request`` block — ``dispatch``
+    returns a ``StreamingResponse`` and the generator runs afterwards — so the
+    SLA histograms are emitted by :meth:`close` rather than at context exit.
+    A generator that owns the token stream calls :meth:`claim_stream` and then
+    :meth:`close` from its own ``finally``.
+    """
+
+    def __init__(self, router: str, model: str = "") -> None:
+        super().__init__(outcome="error")
+        self._router = router
+        self._model = model
+        self._start = time.perf_counter()
+        self._ttft: float | None = None
+        self._isl: int | None = None
+        self._osl: int | None = None
+        self._frames = 0
+        self._partial = b""
+        self._deferred = False
+        self._closed = False
+
+    @property
+    def deferred(self) -> bool:
+        """True once a streaming generator took over responsibility for close()."""
+        return self._deferred
+
+    def claim_stream(self) -> None:
+        self._deferred = True
+
+    def mark_failed(self, outcome: str = "stream_failed") -> None:
+        """Disown a request that failed after its outcome was committed.
+
+        The streaming routers set ``outcome`` to "ok" at hand-off, before the
+        generator has run, because that is the point past which the client can
+        no longer be failed over. A decode leg that then turns out to be
+        unreachable would otherwise be closed as a success: it inflates the
+        request count the planner divides by, and contributes a one-frame OSL.
+        Under a decode outage that is most of the window, and the planner sizes
+        the fleet from it.
+        """
+        self["outcome"] = outcome
+
+    def first_token(self) -> None:
+        """Mark the arrival of the first reply token. Idempotent."""
+        if not _sla_metrics_enabled:
+            return
+        if self._ttft is None:
+            self._ttft = time.perf_counter() - self._start
+
+    def set_input_tokens(self, n: int) -> None:
+        if not _sla_metrics_enabled:
+            return
+        if n > 0:
+            self._isl = int(n)
+
+    def set_output_tokens(self, n: int) -> None:
+        """Record an exact OSL, overriding any SSE frame count."""
+        if not _sla_metrics_enabled:
+            return
+        if n > 0:
+            self._osl = int(n)
+
+    def observe_blocks(self, blocks: list[int] | None, block_size: int | None) -> None:
+        """Estimate ISL from the router's KV block list, used when the engine
+        reply carries no ``usage`` (the streaming default). Rounds up to a
+        block boundary, and is a no-op for stateless policies that return no
+        blocks."""
+        if not _sla_metrics_enabled:
+            return
+        if self._isl is None and blocks and block_size:
+            self._isl = len(blocks) * int(block_size)
+
+    def observe_usage(self, payload: object) -> None:
+        """Pull exact ISL/OSL out of an OpenAI-shaped ``usage`` object."""
+        if not _sla_metrics_enabled:
+            return
+        if not isinstance(payload, dict):
+            return
+        usage = payload.get("usage")
+        if not isinstance(usage, dict):
+            return
+        prompt = usage.get("prompt_tokens")
+        completion = usage.get("completion_tokens")
+        if isinstance(prompt, int):
+            self.set_input_tokens(prompt)
+        if isinstance(completion, int):
+            self.set_output_tokens(completion)
+
+    def observe_stream_chunk(self, chunk: bytes) -> None:
+        """Count complete SSE data frames in a raw stream chunk as tokens.
+
+        Frames are split on newlines and the trailing partial is carried over,
+        so a chunk boundary never double-counts. ``[DONE]`` and any trailing
+        usage frame are excluded, but the one-frame-per-token assumption still
+        makes this an estimate; ``set_output_tokens`` supersedes it when the
+        engine reports usage.
+        """
+        if not _sla_metrics_enabled or not chunk:
+            return
+        buf = self._partial + chunk
+        frames = buf.split(b"\n")
+        tail = frames.pop()
+        self._partial = tail if len(tail) <= _MAX_PARTIAL_FRAME else b""
+        for frame in frames:
+            frame = frame.strip()
+            if not frame.startswith(_SSE_DATA) or frame.startswith(_SSE_DONE):
+                continue
+            self._inspect_frame(frame)
+
+    def _inspect_frame(self, frame: bytes) -> None:
+        """Classify one OpenAI chat/completions SSE data frame.
+
+        Usage supersedes frame counting. Error frames disown the request. For
+        estimated OSL, count chat ``delta`` frames only when they carry content
+        (not role/finish metadata), and completion frames when ``text`` is
+        non-empty.
+        """
+        try:
+            payload = json.loads(frame[len(_SSE_DATA) :])
+        except ValueError:
+            return
+        if not isinstance(payload, dict):
+            return
+        if payload.get("error") is not None:
+            self.mark_failed("engine_error")
+            return
+        self.observe_usage(payload)
+        choices = payload.get("choices")
+        if not isinstance(choices, list):
+            return
+        token_frames = 0
+        for choice in choices:
+            if not isinstance(choice, dict):
+                continue
+            text = choice.get("text")
+            if isinstance(text, str) and text:
+                token_frames += 1
+                continue
+            delta = choice.get("delta")
+            if not isinstance(delta, dict):
+                continue
+            if any(
+                key != "role" and value not in (None, "", [], {}) for key, value in delta.items()
+            ):
+                token_frames += 1
+        if token_frames:
+            self.first_token()
+            self._frames += token_frames
+
+    def close(self) -> None:
+        """Emit the SLA histograms. Idempotent.
+
+        Only successful requests are observed: a 5xx contributes no meaningful
+        latency and would drag the planner's window averages toward zero.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        if not _sla_metrics_enabled:
+            return
+        if self["outcome"] != "ok":
+            return
+        router, model = self._router, self._model
+
+        osl = self._osl if self._osl is not None else self._frames
+        if self._isl is not None:
+            input_sequence_tokens.labels(router=router, model=model).observe(self._isl)
+        if osl > 0:
+            output_sequence_tokens.labels(router=router, model=model).observe(osl)
+
+        if self._ttft is None:
+            # Non-streaming reply: the whole response landed at once, so there
+            # is no observable first-token boundary to report.
+            return
+        time_to_first_token_seconds.labels(router=router, model=model).observe(self._ttft)
+        if osl > 1:
+            decode_time = max(0.0, time.perf_counter() - self._start - self._ttft)
+            inter_token_latency_seconds.labels(router=router, model=model).observe(
+                decode_time / (osl - 1)
+            )
+
+
 @contextmanager
-def track_request(router: str):
+def track_request(router: str, model: str = ""):
     """Context manager that wraps a request's server-side lifetime to
     populate `request_duration_seconds` (with outcome) and the in-flight
     gauge. Use like::
@@ -232,17 +481,23 @@ def track_request(router: str):
         with track_request(router="mixed") as obs:
             resp = await dispatch(...)
             obs["outcome"] = "ok" if resp.status_code < 400 else f"{resp.status_code // 100}xx"
+
+    Yields a :class:`RequestObserver`, whose extra methods feed the SLA
+    histograms. For a streaming reply the observer is handed to the stream
+    generator, which closes it once the last token has been forwarded.
     """
-    state = {"outcome": "error"}
+    obs = RequestObserver(router, model)
     request_inflight.labels(router=router).inc()
     start = time.perf_counter()
     try:
-        yield state
+        yield obs
     finally:
         request_inflight.labels(router=router).dec()
-        request_duration_seconds.labels(router=router, outcome=state["outcome"]).observe(
+        request_duration_seconds.labels(router=router, outcome=obs["outcome"]).observe(
             time.perf_counter() - start
         )
+        if not obs.deferred:
+            obs.close()
 
 
 @contextmanager

--- a/manual/features/feature_matrix.md
+++ b/manual/features/feature_matrix.md
@@ -14,6 +14,7 @@ engine. **Legend:** ✅ supported · 🚧 work in progress · blank = not suppor
 | **KV-Aware Routing** | ✅ | ✅ | ✅ | [KV-Aware Routing][kv] |
 | **KV-Aware Routing + DP-Attention** | ✅ | ✅ | ✅ | [KV-Aware Routing][kv] |
 | **Tiered KV Cache Offload (kvd)** | ✅ | 🚧 | 🚧 | [KV Cache Offload][kvd] |
+| **SLA Planner (PD replica sizing)** | ✅ | ✅ | ✅ | [SLA Planner][sla] |
 | **Multimodal (image / audio / video)** |  |  |  |  |
 | **Request Migration** | ✅ | ✅ | ✅ | [Request Migration][mig] |
 
@@ -21,7 +22,13 @@ KV-cache offload (`kvd`), including AIC GPU-Direct, is **vLLM-only** today.
 Request migration does not depend on the engine, but does require the NATS
 request transport and mixed (non-PD) workers; it is off unless enabled.
 
+The SLA planner is engine-agnostic — it reads the server's metrics and decides
+how many replicas each pool needs — but it only covers **disaggregated**
+deployments, needs a profiling sweep of your own model to work from, and does
+not carry out the resize itself.
+
 [pd]: ./pd_disaggregation.md
 [kv]: ./kv_aware_routing.md
 [kvd]: ./kv_cache_offload.md
+[sla]: ./sla_planner.md
 [mig]: ./graceful_shutdown.md#request-migration

--- a/manual/features/scaling.md
+++ b/manual/features/scaling.md
@@ -6,10 +6,16 @@ of it is projected.
 
 ## How it works
 
-There is no scaling controller. Workers **self-register** into discovery when
-they are ready and **deregister** when they shut down, and the router routes to
-whatever is registered at that instant. Scaling is therefore just starting and
-stopping worker processes; nothing has to be told about it.
+Nothing in the data path has to be told about scaling. Workers **self-register**
+into discovery when they are ready and **deregister** when they shut down, and
+the router routes to whatever is registered at that instant. Scaling is
+therefore just starting and stopping worker processes.
+
+This page is about that mechanism, not about deciding how many workers to run.
+Something has to make that call — an operator, an external autoscaler, or the
+[SLA planner](sla_planner.md), which works out how many prefill and decode
+replicas the measured TTFT and ITL call for. Whatever decides, what happens next
+is what follows.
 
 ```
 worker ready ──► register (etcd lease / Pod annotation) ──► router's watch fires

--- a/manual/features/sla_planner.md
+++ b/manual/features/sla_planner.md
@@ -1,0 +1,314 @@
+# SLA planner
+
+```{admonition} One-pager
+:class: tip
+**What:** work out, every few minutes, how many prefill and decode replicas the
+fleet needs to hold its TTFT and ITL targets. **Why:** a pool sized for peak
+wastes GPUs the rest of the day, and one sized for average misses the SLA under
+load. **Cost:** an offline profiling sweep of your model, plus one small process.
+```
+
+```{admonition} It decides; it does not resize
+:class: important
+The planner publishes a replica count and stops there. Nothing is scaled
+automatically yet — read the decision from the log and act on it yourself.
+`SlaPlanner` accepts an optional async decision callback, which is the single
+extension point for a future Kubernetes or Slurm actuator.
+```
+
+```{graphviz}
+digraph sla_planner {
+  rankdir=LR; bgcolor="transparent";
+  node [shape=box style="rounded,filled" fillcolor="#eef2f7" color="#5577cc" fontname="Helvetica,Arial,sans-serif" fontsize=11 margin="0.2,0.12"];
+  edge [fontname="Helvetica,Arial,sans-serif" fontsize=10];
+
+  SRV [label="Server\n/metrics"];
+  PROF [label="profile.json\noffline sweep" fillcolor="#f4f4f4" color="#999999"];
+  PLN [shape=diamond style=filled fillcolor="#fff3cd" color="#caa300"
+       label="Planner\ncorrect → forecast →\nsolve for replicas"];
+  OUT [label="decision\nlog" fillcolor="#e2efdd" color="#6a9a4a"];
+
+  SRV -> PLN [label="TTFT, ITL, ISL, OSL"];
+  PROF -> PLN [style=dashed color="#8a8a8a"];
+  PLN -> OUT [penwidth=1.8 color="#5577cc"];
+}
+```
+
+## The idea
+
+Prefill and decode are bound by different things, which is the whole reason to
+disaggregate them — and also the reason a single replica count cannot serve both.
+Prefill is compute-bound and roughly single-batched, so what it needs is set by
+the arriving *prompt* token rate. Decode is bandwidth-bound and batched, so what
+it needs is set by the *generated* token rate and by how fast ITL degrades as KV
+cache fills. The two move independently: a shift from short prompts with long
+answers to long prompts with short answers changes which pool is the bottleneck
+without changing the request rate at all.
+
+The planner closes that loop. Each interval it measures what the fleet actually
+delivered, compares it against what an offline sweep of the same model predicted,
+forecasts the next interval, and solves each pool separately for the replica
+count that meets the target.
+
+## Step 1 — profile the model, once
+
+The planner cannot invent a performance model; it needs to know how this model on
+this GPU behaves. Bring up a deployment of **exactly one replica per role**, then
+sweep it:
+
+```bash
+pip3 install ".[planner]"     # adds numpy; nothing else
+
+python3 -m infera.planner.profile \
+  --url http://127.0.0.1:8000 \
+  --model Qwen/Qwen3-8B \
+  --max-kv-tokens 262144 \
+  --isl 512,1024,2048,4096 \
+  --context-length 1024,4096,16384 \
+  --kv-usage 0.1,0.3,0.5,0.7,0.9 \
+  --output profile.json
+```
+
+`--max-kv-tokens` is the engine's total KV capacity in tokens — GPU blocks ×
+block size, which the engine prints at startup. Everything else has a default.
+
+Two sweeps run:
+
+- **Prefill** — one request at a time at each `--isl`, so nothing queues,
+  recording the TTFT of an unqueued request and the prefill throughput it implies.
+  Prompts are random and never repeated, because a prefix-cache hit would measure
+  the cache instead of the engine.
+- **Decode** — the `context_length × kv_usage` grid. KV utilisation isn't
+  something a client can ask for, so it is reached through concurrency: holding
+  `c` requests of `L` tokens each in flight occupies `c × L / max_kv_tokens` of
+  the cache, so `c = u × max_kv_tokens / L` lands on the target. Aggregate
+  throughput is taken from the steady state (`c / itl`) rather than from wall
+  time, which would fold the prefill phase in.
+
+Re-run it after anything that moves the curves: a different engine version,
+quantisation, tensor-parallel width, or GPU model.
+
+## Step 2 — run the planner
+
+A separate process, like `infera.kvd`. It never sits in the request path.
+Start every Infera server replica with `--enable-sla-metrics` (or
+`INFERA_ENABLE_SLA_METRICS=1`) so it records the four planner inputs. This is
+opt-in: without it, ordinary inference requests are not modified and streaming
+chunks do not enter the planner-specific parser. The instrumentation currently
+requires the default Python router backend; startup rejects the flag with
+`--router-backend=rust` rather than silently exposing incomplete metrics.
+
+```bash
+python3 -m infera.planner \
+  --metrics-url http://127.0.0.1:8000/metrics \
+  --model Qwen/Qwen3-8B \
+  --profile-results ./profile.json \
+  --ttft 500 --itl 50 \
+  --adjustment-interval 180
+```
+
+Each interval it logs a line like:
+
+```text
+decision: prefill 2->3, decode 4->4 (corrections p=1.842 d=1.031;
+          load req=612.0 isl=2048 osl=256)
+```
+
+If the correction factors are far from 1.0, the profiling data does not describe
+this deployment and every decision built on it is suspect — re-profile before
+acting on the counts.
+
+## How it decides
+
+### 1. Correct the model
+
+Profiling measures one request at a time on an idle engine. Production does not
+look like that, so each interval the planner derives a correction factor per
+phase by dividing what it observed by what the model predicted for the same
+workload:
+
+```text
+prefill_correction = observed_ttft / predicted_ttft(isl)
+decode_correction  = observed_itl  / predicted_itl(concurrency, isl + osl/2)
+```
+
+Prefill normally lands **above 1.0**, because real TTFT includes queueing the
+sweep never saw. It lands **below 1.0** when prefix-cache hits mean the engine
+prefills fewer tokens than the prompt length implies — which is exactly what
+[KV-aware routing](kv_aware_routing.md) is for, so the two features compound.
+
+Decode should sit **near 1.0**. Sustained drift there usually means chunked
+prefill in the decode engine is stealing decode steps.
+
+They are included in every decision log line; a sustained value far from 1.0 is
+the first sign that the profile no longer describes the deployment.
+
+### 2. Carry the observed load forward
+
+The minimal planner assumes the next interval repeats the one just observed.
+This keeps the online loop deterministic and dependency-free. A predictor can
+later transform `(request_count, ISL, OSL)` before the sizing functions without
+changing the profile, metrics source, or future decision callback.
+
+### 3. Solve each pool
+
+```text
+prefill: max(
+  ceil(req × isl / interval × min(1, p_correction) / thpt_per_gpu(isl) / gpus_per_replica),
+  ceil(queue_ms × replicas_now / (ttft_target − service_ms)),
+)
+decode:  ceil(req × osl / interval / thpt_per_gpu(itl_target / d_correction) / gpus_per_replica)
+```
+
+The `min(1, ...)` on the prefill correction is deliberate. A correction above 1.0
+means requests are queueing, and adding replicas is what fixes queueing — letting
+it also multiply the demand would count the same problem twice.
+
+That leaves throughput alone unable to honour `--ttft`, which is what the second
+prefill term is for. The same correction factor splits the observed TTFT into the
+two parts that behave differently:
+
+```text
+service_ms = profiled_ttft(isl) × min(1, p_correction)      # cost once on an engine
+queue_ms   = profiled_ttft(isl) × max(0, p_correction − 1)   # cost of waiting for one
+```
+
+Replicas divide the queue and leave service untouched, so holding the target
+takes `queue_ms × replicas_now / (target − service_ms)` of them. Two cases impose
+nothing: a fleet with no queueing (`p_correction ≤ 1`) already meets any target
+its service time allows, and a target below `service_ms` is unreachable at any
+replica count — the planner logs that and sizes for throughput instead of
+scaling into a wall.
+
+Two guardrails keep a noisy window or a near-impossible target from producing
+an order-of-magnitude recommendation:
+
+- A TTFT target must leave queueing headroom of at least **20% of the profiled
+  service time**. Below that margin, profiling noise dominates the denominator
+  and the linear queue model is not trustworthy, so the planner logs a warning
+  and uses throughput sizing only.
+- Either pool may grow by at most **4× its observed replica count per
+  decision**. The log retains the unconstrained request and the limited target,
+  allowing a later interval to continue scaling if the signal persists.
+
+Decode works the other way round: the correction tightens the ITL *target*
+instead of the demand, and the model is inverted to find the highest per-GPU
+throughput that still fits. A deployment running at twice the profiled ITL is
+aimed at half the target, and lands on the real one. The whole KV-usage axis is
+searched rather than bisected, because decode throughput typically peaks partway
+up and falls off as the cache fills — the most loaded compliant operating point
+is often not the fastest one.
+
+## Profiling data format
+
+`--profile-results` takes what the sweep writes. Hand-editing it is supported;
+the loader validates the shapes and refuses to start on a mismatch.
+
+```json
+{
+  "prefill": {
+    "isl":          [512, 1024, 2048, 4096],
+    "ttft_ms":      [60, 110, 215, 430],
+    "thpt_per_gpu": [8500, 9300, 9500, 9500]
+  },
+  "decode": {
+    "kv_usage":       [0.1, 0.3, 0.5, 0.7, 0.9],
+    "context_length": [1024, 4096, 16384],
+    "itl_ms":       [[11, 13, 16, 21, 30], [13, 16, 20, 27, 39], [18, 23, 30, 41, 60]],
+    "thpt_per_gpu": [[900, 2300, 3100, 3300, 3000], [750, 1900, 2500, 2600, 2300],
+                     [520, 1300, 1700, 1750, 1500]],
+    "max_kv_tokens": 262144
+  },
+  "prefill_engine_num_gpu": 1,
+  "decode_engine_num_gpu": 1
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `prefill.isl` | Prompt lengths swept, ascending. |
+| `prefill.ttft_ms` | TTFT of a single unqueued request at that length. |
+| `prefill.thpt_per_gpu` | Prefill tokens/s one GPU sustains at that length. |
+| `decode.kv_usage` | KV-cache utilisation fractions swept, ascending. |
+| `decode.context_length` | Context lengths swept, ascending. |
+| `decode.itl_ms` | `[i][j]` = ITL at `context_length[i]`, `kv_usage[j]`. |
+| `decode.thpt_per_gpu` | `[i][j]` = decode tokens/s/GPU at the same point. |
+| `decode.max_kv_tokens` | Engine's total KV capacity in tokens. |
+| `*_engine_num_gpu` | GPUs per replica, i.e. the engine's parallel width. |
+
+The decode block must be a **full rectangular grid** — every context length
+crossed with every KV usage. That requirement is what lets the planner
+interpolate with numpy alone instead of pulling in scipy for scattered-point
+interpolation. Queries outside the swept range are clamped to the nearest edge
+rather than extrapolated: extending a saturating throughput curve invents
+capacity the hardware does not have.
+
+## Metrics
+
+The server exposes the four SLA signals the planner consumes, labeled by
+`router` and `model`. The online planner reads only `router="disagg"` and the
+model passed through `--model`:
+
+| Metric | Notes |
+|--------|-------|
+| `infera_time_to_first_token_seconds` | Dispatch to first token. For PD this spans prefill + KV transfer + the decode engine's first forward pass. Streaming replies only. |
+| `infera_inter_token_latency_seconds` | `(stream time − TTFT)` spread over the generated tokens. Requests producing at least two tokens. |
+| `infera_input_sequence_tokens` | ISL. |
+| `infera_output_sequence_tokens` | OSL. Its `_count` is also the planner's request rate, so the rate is over exactly the requests that contributed the averages beside it. |
+
+All four are recorded only for successful requests: a 5xx has no latency worth
+averaging, and including it would drag the window average toward zero.
+
+```{admonition} Streaming usage
+:class: note
+The Infera server asks supported engines for final streaming `usage`, making ISL
+and OSL exact even under round-robin routing. If an engine omits usage, OSL falls
+back to content-bearing SSE frame counts and ISL to the router's KV block count.
+```
+
+```{admonition} Scraping more than one server replica
+:class: warning
+The planner keeps a separate cumulative baseline for every `--metrics-url`, then
+sums the per-endpoint deltas. Pass the flag once per server replica. Pointing it
+at a load-balanced ClusterIP Service does not work because consecutive scrapes
+can hit different pods. If an endpoint disappears or returns, the planner
+resets the baseline and skips that interval rather than mixing lifetime counters
+into one decision window.
+```
+
+## When the planner does nothing
+
+Intervals are skipped rather than guessed at and the reason is written to the
+planner log:
+
+| Reason | Meaning |
+|--------|---------|
+| `no_metrics` | The first interval (cumulative counters need a baseline), every replica unreachable, or a counter reset from a server restart. |
+| `no_traffic` | No completed request, or none that generated tokens. Nothing to conclude about the SLA. |
+| `no_decode_workers` | Traffic arrived but no decode replicas are registered, so the decode model cannot be calibrated. |
+| `no_latency_samples` | Traffic arrived but neither TTFT nor ITL was recorded, so there is nothing to correct the model against. A whole window of this means the clients are not streaming. |
+| `model_error` | The profiling data predicts a non-positive latency, i.e. it is degenerate. |
+
+## Limitations
+
+- **Disaggregated deployments only.** The planner sizes a prefill pool and a
+  decode pool. Aggregated (`role: mixed`) fleets are not covered.
+- **Streaming clients only.** A non-streaming reply arrives in one piece, so it
+  has no observable first-token boundary and contributes neither TTFT nor ITL.
+  Both corrections are derived from those two, so a fleet serving only
+  non-streaming requests gives the planner nothing to calibrate against and
+  every interval is skipped as `no_latency_samples`.
+- **The TTFT queue model is linear.** Real queueing is non-linear. The 20%
+  headroom check and 4× step limit prevent extreme decisions, but production
+  actuation should still add cooldown and observe the next completed interval.
+- **The window is in memory.** A planner restart forfeits one interval while it
+  re-establishes the baseline scrape.
+
+## See also
+
+- [Scaling a fleet](scaling.md) — what actually happens when a replica count
+  changes, and how long each direction takes.
+- [Prefill-decode disaggregation](pd_disaggregation.md) — the deployment shape
+  the planner sizes.
+- [KV-aware routing](kv_aware_routing.md) — why the prefill correction factor
+  often drops below 1.0.

--- a/manual/features/sla_planner.md
+++ b/manual/features/sla_planner.md
@@ -1,63 +1,56 @@
 # SLA planner
 
-```{admonition} One-pager
-:class: tip
-**What:** work out, every few minutes, how many prefill and decode replicas the
-fleet needs to hold its TTFT and ITL targets. **Why:** a pool sized for peak
-wastes GPUs the rest of the day, and one sized for average misses the SLA under
-load. **Cost:** an offline profiling sweep of your model, plus one small process.
+The SLA planner is a separate Infera process that turns recent request
+measurements into target sizes for the prefill and decode pools. It is useful
+when traffic shape changes over time and static replica counts either waste
+accelerators or miss latency objectives.
+
+```{admonition} Recommendation only
+:class: important
+The current planner does not modify a deployment. It writes a reviewable
+decision to its log. An optional async callback on `SlaPlanner` is the boundary
+for a future Kubernetes, Slurm, or operator integration.
 ```
 
-```{admonition} It decides; it does not resize
-:class: important
-The planner publishes a replica count and stops there. Nothing is scaled
-automatically yet — read the decision from the log and act on it yourself.
-`SlaPlanner` accepts an optional async decision callback, which is the single
-extension point for a future Kubernetes or Slurm actuator.
-```
+## Infera data path
+
+The planner is not in the inference request path:
 
 ```{graphviz}
-digraph sla_planner {
+digraph planner_path {
   rankdir=LR; bgcolor="transparent";
   node [shape=box style="rounded,filled" fillcolor="#eef2f7" color="#5577cc" fontname="Helvetica,Arial,sans-serif" fontsize=11 margin="0.2,0.12"];
   edge [fontname="Helvetica,Arial,sans-serif" fontsize=10];
 
-  SRV [label="Server\n/metrics"];
-  PROF [label="profile.json\noffline sweep" fillcolor="#f4f4f4" color="#999999"];
-  PLN [shape=diamond style=filled fillcolor="#fff3cd" color="#caa300"
-       label="Planner\ncorrect → forecast →\nsolve for replicas"];
-  OUT [label="decision\nlog" fillcolor="#e2efdd" color="#6a9a4a"];
+  CLIENT [label="streaming clients"];
+  SERVER [label="Infera server\nrequest observations"];
+  METRICS [label="/metrics\ncumulative histograms"];
+  WINDOW [label="planner\nwindow deltas"];
+  PROFILE [label="profile.json\ncapacity envelope" fillcolor="#f4f4f4" color="#999999"];
+  DECISION [label="target pool sizes\nlog / callback" fillcolor="#e2efdd" color="#6a9a4a"];
 
-  SRV -> PLN [label="TTFT, ITL, ISL, OSL"];
-  PROF -> PLN [style=dashed color="#8a8a8a"];
-  PLN -> OUT [penwidth=1.8 color="#5577cc"];
+  CLIENT -> SERVER;
+  SERVER -> METRICS;
+  METRICS -> WINDOW;
+  PROFILE -> WINDOW [style=dashed];
+  WINDOW -> DECISION;
 }
 ```
 
-## The idea
+Each server records successful streaming requests. The planner reads every
+configured server endpoint directly, subtracts the previous cumulative values,
+and combines only the work completed during that window. This design does not
+require a Prometheus server and works in a small Docker or bare-metal setup.
 
-Prefill and decode are bound by different things, which is the whole reason to
-disaggregate them — and also the reason a single replica count cannot serve both.
-Prefill is compute-bound and roughly single-batched, so what it needs is set by
-the arriving *prompt* token rate. Decode is bandwidth-bound and batched, so what
-it needs is set by the *generated* token rate and by how fast ITL degrades as KV
-cache fills. The two move independently: a shift from short prompts with long
-answers to long prompts with short answers changes which pool is the bottleneck
-without changing the request rate at all.
+## Measure the deployment
 
-The planner closes that loop. Each interval it measures what the fleet actually
-delivered, compares it against what an offline sweep of the same model predicted,
-forecasts the next interval, and solves each pool separately for the replica
-count that meets the target.
-
-## Step 1 — profile the model, once
-
-The planner cannot invent a performance model; it needs to know how this model on
-this GPU behaves. Bring up a deployment of **exactly one replica per role**, then
-sweep it:
+A capacity decision is meaningful only when it uses measurements from the same
+model, engine build, accelerator, quantisation, and parallel layout as the
+running deployment. Start exactly one prefill replica and one decode replica,
+then run:
 
 ```bash
-pip3 install ".[planner]"     # adds numpy; nothing else
+pip3 install ".[planner]"
 
 python3 -m infera.planner.profile \
   --url http://127.0.0.1:8000 \
@@ -69,154 +62,45 @@ python3 -m infera.planner.profile \
   --output profile.json
 ```
 
-`--max-kv-tokens` is the engine's total KV capacity in tokens — GPU blocks ×
-block size, which the engine prints at startup. Everything else has a default.
+`--max-kv-tokens` is the engine's total KV capacity in tokens. The engine
+usually reports it as GPU blocks multiplied by block size.
 
-Two sweeps run:
+The command builds two datasets:
 
-- **Prefill** — one request at a time at each `--isl`, so nothing queues,
-  recording the TTFT of an unqueued request and the prefill throughput it implies.
-  Prompts are random and never repeated, because a prefix-cache hit would measure
-  the cache instead of the engine.
-- **Decode** — the `context_length × kv_usage` grid. KV utilisation isn't
-  something a client can ask for, so it is reached through concurrency: holding
-  `c` requests of `L` tokens each in flight occupies `c × L / max_kv_tokens` of
-  the cache, so `c = u × max_kv_tokens / L` lands on the target. Aggregate
-  throughput is taken from the steady state (`c / itl`) rather than from wall
-  time, which would fold the prefill phase in.
+- The prompt curve sends isolated one-token completions at each requested input
+  length. Unique random prompts avoid measuring a prefix-cache hit.
+- The generation surface samples every requested mean-context and occupied-KV
+  pair. The runner derives a whole request count for the target occupancy,
+  launches that batch together, and measures steady-state token spacing.
 
-Re-run it after anything that moves the curves: a different engine version,
-quantisation, tensor-parallel width, or GPU model.
+The first request at each prompt length is a warm-up. Timed prompt trials use
+their median. Generation cells use the mean of the completed requests.
 
-## Step 2 — run the planner
+### Profile document
 
-A separate process, like `infera.kvd`. It never sits in the request path.
-Start every Infera server replica with `--enable-sla-metrics` (or
-`INFERA_ENABLE_SLA_METRICS=1`) so it records the four planner inputs. This is
-opt-in: without it, ordinary inference requests are not modified and streaming
-chunks do not enter the planner-specific parser. The instrumentation currently
-requires the default Python router backend; startup rejects the flag with
-`--router-backend=rust` rather than silently exposing incomplete metrics.
-
-```bash
-python3 -m infera.planner \
-  --metrics-url http://127.0.0.1:8000/metrics \
-  --model Qwen/Qwen3-8B \
-  --profile-results ./profile.json \
-  --ttft 500 --itl 50 \
-  --adjustment-interval 180
-```
-
-Each interval it logs a line like:
-
-```text
-decision: prefill 2->3, decode 4->4 (corrections p=1.842 d=1.031;
-          load req=612.0 isl=2048 osl=256)
-```
-
-If the correction factors are far from 1.0, the profiling data does not describe
-this deployment and every decision built on it is suspect — re-profile before
-acting on the counts.
-
-## How it decides
-
-### 1. Correct the model
-
-Profiling measures one request at a time on an idle engine. Production does not
-look like that, so each interval the planner derives a correction factor per
-phase by dividing what it observed by what the model predicted for the same
-workload:
-
-```text
-prefill_correction = observed_ttft / predicted_ttft(isl)
-decode_correction  = observed_itl  / predicted_itl(concurrency, isl + osl/2)
-```
-
-Prefill normally lands **above 1.0**, because real TTFT includes queueing the
-sweep never saw. It lands **below 1.0** when prefix-cache hits mean the engine
-prefills fewer tokens than the prompt length implies — which is exactly what
-[KV-aware routing](kv_aware_routing.md) is for, so the two features compound.
-
-Decode should sit **near 1.0**. Sustained drift there usually means chunked
-prefill in the decode engine is stealing decode steps.
-
-They are included in every decision log line; a sustained value far from 1.0 is
-the first sign that the profile no longer describes the deployment.
-
-### 2. Carry the observed load forward
-
-The minimal planner assumes the next interval repeats the one just observed.
-This keeps the online loop deterministic and dependency-free. A predictor can
-later transform `(request_count, ISL, OSL)` before the sizing functions without
-changing the profile, metrics source, or future decision callback.
-
-### 3. Solve each pool
-
-```text
-prefill: max(
-  ceil(req × isl / interval × min(1, p_correction) / thpt_per_gpu(isl) / gpus_per_replica),
-  ceil(queue_ms × replicas_now / (ttft_target − service_ms)),
-)
-decode:  ceil(req × osl / interval / thpt_per_gpu(itl_target / d_correction) / gpus_per_replica)
-```
-
-The `min(1, ...)` on the prefill correction is deliberate. A correction above 1.0
-means requests are queueing, and adding replicas is what fixes queueing — letting
-it also multiply the demand would count the same problem twice.
-
-That leaves throughput alone unable to honour `--ttft`, which is what the second
-prefill term is for. The same correction factor splits the observed TTFT into the
-two parts that behave differently:
-
-```text
-service_ms = profiled_ttft(isl) × min(1, p_correction)      # cost once on an engine
-queue_ms   = profiled_ttft(isl) × max(0, p_correction − 1)   # cost of waiting for one
-```
-
-Replicas divide the queue and leave service untouched, so holding the target
-takes `queue_ms × replicas_now / (target − service_ms)` of them. Two cases impose
-nothing: a fleet with no queueing (`p_correction ≤ 1`) already meets any target
-its service time allows, and a target below `service_ms` is unreachable at any
-replica count — the planner logs that and sizes for throughput instead of
-scaling into a wall.
-
-Two guardrails keep a noisy window or a near-impossible target from producing
-an order-of-magnitude recommendation:
-
-- A TTFT target must leave queueing headroom of at least **20% of the profiled
-  service time**. Below that margin, profiling noise dominates the denominator
-  and the linear queue model is not trustworthy, so the planner logs a warning
-  and uses throughput sizing only.
-- Either pool may grow by at most **4× its observed replica count per
-  decision**. The log retains the unconstrained request and the limited target,
-  allowing a later interval to continue scaling if the signal persists.
-
-Decode works the other way round: the correction tightens the ITL *target*
-instead of the demand, and the model is inverted to find the highest per-GPU
-throughput that still fits. A deployment running at twice the profiled ITL is
-aimed at half the target, and lands on the real one. The whole KV-usage axis is
-searched rather than bisected, because decode throughput typically peaks partway
-up and falls off as the cache fills — the most loaded compliant operating point
-is often not the fastest one.
-
-## Profiling data format
-
-`--profile-results` takes what the sweep writes. Hand-editing it is supported;
-the loader validates the shapes and refuses to start on a mismatch.
+The output remains a plain JSON file so it can be inspected, versioned with a
+deployment recipe, or produced by another benchmark:
 
 ```json
 {
   "prefill": {
-    "isl":          [512, 1024, 2048, 4096],
-    "ttft_ms":      [60, 110, 215, 430],
+    "isl": [512, 1024, 2048, 4096],
+    "ttft_ms": [60, 110, 215, 430],
     "thpt_per_gpu": [8500, 9300, 9500, 9500]
   },
   "decode": {
-    "kv_usage":       [0.1, 0.3, 0.5, 0.7, 0.9],
+    "kv_usage": [0.1, 0.3, 0.5, 0.7, 0.9],
     "context_length": [1024, 4096, 16384],
-    "itl_ms":       [[11, 13, 16, 21, 30], [13, 16, 20, 27, 39], [18, 23, 30, 41, 60]],
-    "thpt_per_gpu": [[900, 2300, 3100, 3300, 3000], [750, 1900, 2500, 2600, 2300],
-                     [520, 1300, 1700, 1750, 1500]],
+    "itl_ms": [
+      [11, 13, 16, 21, 30],
+      [13, 16, 20, 27, 39],
+      [18, 23, 30, 41, 60]
+    ],
+    "thpt_per_gpu": [
+      [900, 2300, 3100, 3300, 3000],
+      [750, 1900, 2500, 2600, 2300],
+      [520, 1300, 1700, 1750, 1500]
+    ],
     "max_kv_tokens": 262144
   },
   "prefill_engine_num_gpu": 1,
@@ -224,91 +108,155 @@ the loader validates the shapes and refuses to start on a mismatch.
 }
 ```
 
-| Field | Meaning |
-|-------|---------|
-| `prefill.isl` | Prompt lengths swept, ascending. |
-| `prefill.ttft_ms` | TTFT of a single unqueued request at that length. |
-| `prefill.thpt_per_gpu` | Prefill tokens/s one GPU sustains at that length. |
-| `decode.kv_usage` | KV-cache utilisation fractions swept, ascending. |
-| `decode.context_length` | Context lengths swept, ascending. |
-| `decode.itl_ms` | `[i][j]` = ITL at `context_length[i]`, `kv_usage[j]`. |
-| `decode.thpt_per_gpu` | `[i][j]` = decode tokens/s/GPU at the same point. |
-| `decode.max_kv_tokens` | Engine's total KV capacity in tokens. |
-| `*_engine_num_gpu` | GPUs per replica, i.e. the engine's parallel width. |
+The decode arrays must form a complete rectangle: rows correspond to
+`context_length` and columns to `kv_usage`. Infera performs bounded linear
+interpolation on this measured surface. A query outside an axis uses its nearest
+edge; it never extrapolates unmeasured capacity.
 
-The decode block must be a **full rectangular grid** — every context length
-crossed with every KV usage. That requirement is what lets the planner
-interpolate with numpy alone instead of pulling in scipy for scattered-point
-interpolation. Queries outside the swept range are clamped to the nearest edge
-rather than extrapolated: extending a saturating throughput curve invents
-capacity the hardware does not have.
+## Enable request observations
 
-## Metrics
+Start each Infera server with `--enable-sla-metrics`, or set
+`INFERA_ENABLE_SLA_METRICS=1`. The instrumentation currently requires the
+Python router backend. Startup rejects the option with
+`--router-backend=rust` so an incomplete metric stream cannot silently produce
+recommendations.
 
-The server exposes the four SLA signals the planner consumes, labeled by
-`router` and `model`. The online planner reads only `router="disagg"` and the
-model passed through `--model`:
+The planner consumes these histograms:
 
-| Metric | Notes |
-|--------|-------|
-| `infera_time_to_first_token_seconds` | Dispatch to first token. For PD this spans prefill + KV transfer + the decode engine's first forward pass. Streaming replies only. |
-| `infera_inter_token_latency_seconds` | `(stream time − TTFT)` spread over the generated tokens. Requests producing at least two tokens. |
-| `infera_input_sequence_tokens` | ISL. |
-| `infera_output_sequence_tokens` | OSL. Its `_count` is also the planner's request rate, so the rate is over exactly the requests that contributed the averages beside it. |
+- `infera_time_to_first_token_seconds`: dispatch to the first streamed token.
+- `infera_inter_token_latency_seconds`: generation time after the first token,
+  divided across the remaining output tokens.
+- `infera_input_sequence_tokens`: prompt tokens.
+- `infera_output_sequence_tokens`: generated tokens.
 
-All four are recorded only for successful requests: a 5xx has no latency worth
-averaging, and including it would drag the window average toward zero.
+All are labeled by `router` and `model`. Only successful requests are included.
+When a supported engine emits final streaming usage, its exact input and output
+counts replace router estimates. Otherwise, input length falls back to KV-block
+count and output length to content-bearing SSE frame count.
 
-```{admonition} Streaming usage
-:class: note
-The Infera server asks supported engines for final streaming `usage`, making ISL
-and OSL exact even under round-robin routing. If an engine omits usage, OSL falls
-back to content-bearing SSE frame counts and ISL to the router's KV block count.
+## Start the planner
+
+Run one planner process outside the server fleet:
+
+```bash
+python3 -m infera.planner \
+  --metrics-url http://127.0.0.1:8000/metrics \
+  --model Qwen/Qwen3-8B \
+  --profile-results ./profile.json \
+  --ttft 500 \
+  --itl 50 \
+  --adjustment-interval 180
 ```
 
-```{admonition} Scraping more than one server replica
-:class: warning
-The planner keeps a separate cumulative baseline for every `--metrics-url`, then
-sums the per-endpoint deltas. Pass the flag once per server replica. Pointing it
-at a load-balanced ClusterIP Service does not work because consecutive scrapes
-can hit different pods. If an endpoint disappears or returns, the planner
-resets the baseline and skips that interval rather than mixing lifetime counters
-into one decision window.
+Pass `--metrics-url` once for every server replica. Do not point it at a
+load-balanced service: two consecutive scrapes could reach different pods and
+their cumulative counters would not form a valid window.
+
+The first scrape establishes a baseline. A decision appears after the next
+complete interval:
+
+```text
+capacity decision: prefill 2->3, decode 4->4
+  (latency ratios p=1.842 d=1.031; load req=612.0 isl=2048 osl=256)
 ```
 
-## When the planner does nothing
+## Capacity policy
 
-Intervals are skipped rather than guessed at and the reason is written to the
-planner log:
+For a window of `H` seconds, let `C` be completed requests, `I` the mean prompt
+length, and `O` the mean generated length. The incoming work rates are:
 
-| Reason | Meaning |
-|--------|---------|
-| `no_metrics` | The first interval (cumulative counters need a baseline), every replica unreachable, or a counter reset from a server restart. |
-| `no_traffic` | No completed request, or none that generated tokens. Nothing to conclude about the SLA. |
-| `no_decode_workers` | Traffic arrived but no decode replicas are registered, so the decode model cannot be calibrated. |
-| `no_latency_samples` | Traffic arrived but neither TTFT nor ITL was recorded, so there is nothing to correct the model against. A whole window of this means the clients are not streaming. |
-| `model_error` | The profiling data predicts a non-positive latency, i.e. it is degenerate. |
+```text
+prompt_tokens_per_second     = C × I / H
+generated_tokens_per_second  = C × O / H
+```
 
-## Limitations
+The offline envelope supplies a prompt latency and capacity at `I`. It also
+supplies generation latency and capacity at the estimated in-flight load and
+mean context `I + O/2`.
 
-- **Disaggregated deployments only.** The planner sizes a prefill pool and a
-  decode pool. Aggregated (`role: mixed`) fleets are not covered.
-- **Streaming clients only.** A non-streaming reply arrives in one piece, so it
-  has no observable first-token boundary and contributes neither TTFT nor ITL.
-  Both corrections are derived from those two, so a fleet serving only
-  non-streaming requests gives the planner nothing to calibrate against and
-  every interval is skipped as `no_latency_samples`.
-- **The TTFT queue model is linear.** Real queueing is non-linear. The 20%
-  headroom check and 4× step limit prevent extreme decisions, but production
-  actuation should still add cooldown and observe the next completed interval.
-- **The window is in memory.** A planner restart forfeits one interval while it
-  re-establishes the baseline scrape.
+The planner records two latency ratios:
 
-## See also
+```text
+prompt_ratio      = measured_TTFT / envelope_prompt_latency
+generation_ratio  = measured_ITL  / envelope_generation_latency
+```
 
-- [Scaling a fleet](scaling.md) — what actually happens when a replica count
-  changes, and how long each direction takes.
-- [Prefill-decode disaggregation](pd_disaggregation.md) — the deployment shape
-  the planner sizes.
-- [KV-aware routing](kv_aware_routing.md) — why the prefill correction factor
-  often drops below 1.0.
+A ratio far from `1` means the offline envelope no longer matches the running
+system. Queueing commonly raises the prompt ratio; prefix-cache reuse can lower
+it. Generation drift can indicate that decode steps are competing with other
+work. These values stay in every decision so operators can distinguish a
+traffic change from stale profiling data.
+
+### Prefill budget
+
+The prompt pool first receives a throughput budget. A ratio below `1` reduces
+the effective prompt work because the server processed less work than raw input
+length implies. A ratio above `1` is not allowed to inflate work a second time:
+its queueing component is handled separately.
+
+```text
+throughput_replicas =
+  ceil(prompt_tokens_per_second × min(1, prompt_ratio)
+       / measured_tokens_per_second_per_replica)
+```
+
+For overloaded windows, observed TTFT is separated into measured service time
+and waiting time. Replicas can divide the wait but cannot make one prompt's
+service faster. The queue budget therefore asks how many copies are needed to
+fit the observed wait into the target's remaining allowance. The larger of the
+throughput and queue budgets wins.
+
+### Decode budget
+
+The generation surface is searched for the fastest sampled operating point
+whose latency fits `ITL_target / generation_ratio`. Every sampled KV occupancy
+is considered because throughput need not move monotonically as the cache
+fills. The generated token rate divided by that per-replica capacity gives the
+decode budget.
+
+If no measured point fits, the least-occupied point is returned and the planner
+logs that the requested target is below the measured hardware floor.
+
+### Safety limits
+
+- Queue sizing is disabled when the TTFT target leaves less than 20% of prompt
+  service time as waiting allowance. Near a zero denominator, small measurement
+  noise would produce a very large recommendation.
+- One decision can grow either pool by at most four times its currently
+  observed replica count. A later complete window can continue the move if the
+  signal persists.
+- Pool targets never fall below one replica.
+
+## Skipped windows
+
+The current deployment is left unchanged when:
+
+- this is the baseline scrape;
+- every configured metrics endpoint is unavailable;
+- an endpoint appears or disappears between scrapes;
+- a cumulative counter moves backwards after a server restart;
+- no completed generation work was observed;
+- streaming TTFT or ITL samples are absent;
+- no decode replica is registered; or
+- the profile contains a non-positive latency.
+
+Every case is logged. Skipping is safer than interpreting missing measurements
+as zero latency or zero demand.
+
+## Operational limits
+
+- Only disaggregated deployments are sized; mixed pools are not a planner
+  target.
+- Latency evidence requires streaming replies, and ITL requires at least two
+  generated tokens.
+- The current workload projection is persistence: the next window is assumed
+  to resemble the latest completed window.
+- Observation baselines live in memory. Restarting the planner forfeits one
+  interval.
+- Decisions are recommendations until an actuator is attached.
+
+## Related guides
+
+- [Scaling a fleet](scaling.md)
+- [Prefill-decode disaggregation](pd_disaggregation.md)
+- [KV-aware routing](kv_aware_routing.md)

--- a/manual/index.md
+++ b/manual/index.md
@@ -93,4 +93,10 @@ Run prefill and decode on separate GPUs (or nodes) and stitch them with a KV tra
 Spill KV to RAM / NVMe / network — the usage modes and per-request control.
 :::
 
+:::{grid-item-card} SLA planner
+:link: features/sla_planner
+:link-type: doc
+Work out how many prefill/decode replicas hold your TTFT and ITL targets.
+:::
+
 ::::

--- a/manual/sphinx/_toc.yml.in
+++ b/manual/sphinx/_toc.yml.in
@@ -47,6 +47,8 @@ subtrees:
         title: Routing and transport
       - file: features/scaling.md
         title: Scaling a fleet
+      - file: features/sla_planner.md
+        title: SLA planner
       - file: features/graceful_shutdown.md
         title: Graceful shutdown
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ gaie = [
     "grpcio-health-checking>=1.81.1",
     "cryptography>=41",
 ]
+# SLA planner (`python -m infera.planner`). numpy is the only addition: the
+# performance model interpolates the profiling grids without scipy.
+planner = ["numpy>=1.24"]
 # Per-engine targets; framework comes from the vendor base image, not pip.
 sglang = ["amd-infera[gaie]"]
 vllm = ["amd-infera[gaie]"]
@@ -32,6 +35,7 @@ dev = [
     "pre-commit>=3",
     "pytest>=8",
     "pytest-asyncio>=0.23",
+    "amd-infera[planner]",
 ]
 # all = ["amd-infera[sglang]", "amd-infera[vllm]", "amd-infera[atom]"]
 

--- a/rust/router/src/proxy.rs
+++ b/rust/router/src/proxy.rs
@@ -26,6 +26,8 @@ use crate::policy::{ActiveGuard, Role};
 use crate::pool::{DisaggMode, RouteTarget, Snapshot};
 use crate::util::{json_error, truncate_chars};
 
+type AttemptResult = Result<Response, Box<Response>>;
+
 /// A byte stream that owns an `ActiveGuard`: when the streamed body ends (client
 /// done, disconnect, or drop), the guard drops and fires `on_request_finished`,
 /// so a cost-aware policy's in-flight load stays balanced for streamed requests.
@@ -68,7 +70,7 @@ async fn attempt_nats(
     stream: bool,
     path: &str,
     guard: ActiveGuard,
-) -> Result<Response, Response> {
+) -> AttemptResult {
     use crate::nats_request::Frame;
 
     let worker = &target.worker;
@@ -85,21 +87,23 @@ async fn attempt_nats(
         let body =
             serde_json::json!({ "error": format!("worker {wid} request backlog over limit") })
                 .to_string();
-        return Err(Response::builder()
-            .status(StatusCode::TOO_MANY_REQUESTS)
-            .header(header::CONTENT_TYPE, "application/json")
-            .header("Retry-After", "1")
-            .body(Body::from(body))
-            .expect("429 response is valid"));
+        return Err(Box::new(
+            Response::builder()
+                .status(StatusCode::TOO_MANY_REQUESTS)
+                .header(header::CONTENT_TYPE, "application/json")
+                .header("Retry-After", "1")
+                .body(Body::from(body))
+                .expect("429 response is valid"),
+        ));
     }
 
     let body: serde_json::Value = match serde_json::from_slice(raw) {
         Ok(v) => v,
         Err(e) => {
-            return Err(json_error(
+            return Err(Box::new(json_error(
                 StatusCode::BAD_REQUEST,
                 &format!("request body is not JSON: {e}"),
-            ))
+            )))
         }
     };
     // Same envelope the Python router publishes; the worker side is shared.
@@ -119,20 +123,20 @@ async fn attempt_nats(
     let encoded = match serde_json::to_vec(&payload) {
         Ok(v) => v,
         Err(e) => {
-            return Err(json_error(
+            return Err(Box::new(json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 &format!("encoding the nats request: {e}"),
-            ))
+            )))
         }
     };
 
     let mut reply = match nats.dispatch(&wid, &encoded).await {
         Ok(r) => r,
         Err(e) => {
-            return Err(json_error(
+            return Err(Box::new(json_error(
                 StatusCode::BAD_GATEWAY,
                 &format!("worker {wid} unreachable over nats: {e}"),
-            ))
+            )))
         }
     };
 
@@ -149,11 +153,11 @@ async fn attempt_nats(
                     break;
                 }
                 Some(Frame::Error { status: s, message }) => {
-                    return Err(json_error(
+                    return Err(Box::new(json_error(
                         s.and_then(|c| StatusCode::from_u16(c).ok())
                             .unwrap_or(StatusCode::BAD_GATEWAY),
                         &format!("worker {wid} nats failed: {}", trim(&message)),
-                    ))
+                    )))
                 }
                 None => break,
             }
@@ -163,10 +167,10 @@ async fn attempt_nats(
         // mid-request, and reporting it as success would also record it as
         // healthy against the breaker.
         if !done_seen {
-            return Err(json_error(
+            return Err(Box::new(json_error(
                 StatusCode::BAD_GATEWAY,
                 &format!("worker {wid} closed the nats reply without finishing"),
-            ));
+            )));
         }
         let total: usize = chunks.iter().map(|c| c.len()).sum();
         let mut buf = Vec::with_capacity(total);
@@ -177,11 +181,13 @@ async fn attempt_nats(
         // to the request and every worker would answer the same, so it is
         // returned rather than retried. Same rule as the HTTP path.
         if is_worker_fault(status.as_u16()) {
-            return Err(Response::builder()
-                .status(status)
-                .header(header::CONTENT_TYPE, "application/json")
-                .body(Body::from(buf))
-                .expect("unary response is valid"));
+            return Err(Box::new(
+                Response::builder()
+                    .status(status)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(buf))
+                    .expect("unary response is valid"),
+            ));
         }
         let _guard = guard;
         return Ok(Response::builder()
@@ -196,19 +202,19 @@ async fn attempt_nats(
     let first = match reply.next().await {
         Some(Frame::Data(b)) => b,
         Some(Frame::Error { status: s, message }) => {
-            return Err(json_error(
+            return Err(Box::new(json_error(
                 s.and_then(|c| StatusCode::from_u16(c).ok())
                     .unwrap_or(StatusCode::BAD_GATEWAY),
                 &format!("worker {wid} nats stream failed: {}", trim(&message)),
-            ))
+            )))
         }
         Some(Frame::Done { status }) => {
             let code = StatusCode::from_u16(status).unwrap_or(StatusCode::OK);
             if is_worker_fault(code.as_u16()) {
-                return Err(json_error(
+                return Err(Box::new(json_error(
                     code,
                     &format!("worker {wid} ended the stream with {code}"),
-                ));
+                )));
             }
             // Nothing to stream, but not a fault: answer with an empty body
             // rather than failing over a request the worker considers done.
@@ -220,10 +226,10 @@ async fn attempt_nats(
                 .expect("stream response is valid"));
         }
         None => {
-            return Err(json_error(
+            return Err(Box::new(json_error(
                 StatusCode::BAD_GATEWAY,
                 &format!("worker {wid} closed the nats reply with no frames"),
-            ))
+            )))
         }
     };
 
@@ -379,7 +385,7 @@ async fn mixed_dispatch(
                     // recovering worker out of rotation.
                     state.breaker.record_neutral(&wid);
                 }
-                last_err = Some(err_resp);
+                last_err = Some(*err_resp);
             }
         }
     }
@@ -397,7 +403,7 @@ async fn attempt(
     stream: bool,
     path: &str,
     guard: ActiveGuard,
-) -> Result<Response, Response> {
+) -> AttemptResult {
     let worker = &target.worker;
     // Per worker, not per router: a worker whose NATS consumer failed to start
     // registers as `http` and is dialled directly even when the transport is
@@ -406,13 +412,13 @@ async fn attempt(
         if let Some(nats) = state.nats.clone() {
             return attempt_nats(&nats, target, raw, stream, path, guard).await;
         }
-        return Err(json_error(
+        return Err(Box::new(json_error(
             StatusCode::BAD_GATEWAY,
             &format!(
                 "worker {} registered the nats transport but this router has none",
                 worker.worker_id
             ),
-        ));
+        )));
     }
     let url = format!("{}{}", worker.url, path);
     let mut req = state
@@ -427,17 +433,17 @@ async fn attempt(
     let resp = match req.send().await {
         Ok(r) => r,
         Err(e) => {
-            return Err(json_error(
+            return Err(Box::new(json_error(
                 StatusCode::BAD_GATEWAY,
                 &format!("worker {} unreachable: {e}", worker.worker_id),
-            ))
+            )))
         }
     };
 
     let status = resp.status();
     if status.is_client_error() || status.is_server_error() {
         let body = resp.text().await.unwrap_or_default();
-        return Err(json_error(
+        return Err(Box::new(json_error(
             status,
             &format!(
                 "worker {} error {}: {}",
@@ -445,7 +451,7 @@ async fn attempt(
                 status.as_u16(),
                 truncate_chars(&body, 500)
             ),
-        ));
+        )));
     }
 
     if stream {
@@ -471,10 +477,10 @@ async fn attempt(
                 .header(header::CONTENT_TYPE, ct)
                 .body(Body::from(bytes))
                 .expect("unary response is valid")),
-            Err(e) => Err(json_error(
+            Err(e) => Err(Box::new(json_error(
                 StatusCode::BAD_GATEWAY,
                 &format!("worker {} read failed: {e}", worker.worker_id),
-            )),
+            ))),
         }
     }
 }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -208,9 +208,13 @@ _SLURM_USER_SRUN_EXTRA="${INFERA_E2E_SRUN_EXTRA:-}"
 _SLURM_ACCOUNT_QOS_PAIRS=()
 if [ "$SLURM_PART" = "amd-spur" ]; then
   _SLURM_ACCOUNT_QOS_PAIRS=(
-    "amd-frameworks-ci:amd-frameworks-ci-qos"
     "amd-it:amd-it-qos"
     "amd-collectives:amd-collectives-qos"
+    "amd-general:amd-general-qos"
+    "amd-primus:amd-primus-qos"
+    "amd-burst:amd-burst-qos"
+    "amd-general:amd-burst-qos"
+    "amd-primus:amd-burst-qos"
   )
 fi
 _SLURM_ACCOUNT=""
@@ -230,6 +234,8 @@ _accounting_blocked() {
   case "$1" in
     QOS* | Qos* | qos* | Assoc* | Association* | Accounting* | InvalidAccount* | \
     *"Invalid account"* | *"Invalid qos"* | *"invalid account"* | *"invalid qos"* | \
+    *"QOSGrpNodeLimit"* | \
+    *"QOS"*"does not exist"* | *"Qos"*"does not exist"* | *"qos"*"does not exist"* | \
     *"violates accounting/QOS policy"*) return 0 ;;
     *) return 1 ;;
   esac

--- a/tests/unit/router/test_disagg_breaker.py
+++ b/tests/unit/router/test_disagg_breaker.py
@@ -24,6 +24,7 @@ from infera.common.nats_request import TYPE_DATA, TYPE_DONE, TYPE_ERROR
 from infera.common.worker_pool import DisaggMode, EngineType, WorkerInfo
 from infera.router.disagg import DisaggRouter
 from infera.router.policy.target import RouteTarget
+from infera.server.metrics import RequestObserver
 
 
 class _FakePolicy:
@@ -75,18 +76,30 @@ async def _drain(agen) -> bytes:
     return out
 
 
+def _obs() -> RequestObserver:
+    """The SLA observer the streaming generators close on their way out.
+
+    These tests call the generators directly, bypassing the dispatch wrapper
+    that normally supplies one. It records nothing here: the observer only
+    emits for an outcome of "ok", and every request below fails.
+    """
+    return RequestObserver("disagg")
+
+
 @pytest.mark.asyncio
 async def test_decode_only_stream_records_failure_on_unreachable():
     r = _router()
     d_target = RouteTarget(_w("d1"))
     body = await _drain(
-        r._stream_decode_only(d_target, [], "http://d1/v1/chat/completions", {"model": "m"})
+        r._stream_decode_only(_obs(), d_target, [], "http://d1/v1/chat/completions", {"model": "m"})
     )
     assert b"decode unreachable" in body, "client must get a clean SSE error, not a traceback"
     assert r.breaker.state_of("d1").value == "closed", "one failure is below the threshold"
     for _ in range(2):
         await _drain(
-            r._stream_decode_only(d_target, [], "http://d1/v1/chat/completions", {"model": "m"})
+            r._stream_decode_only(
+                _obs(), d_target, [], "http://d1/v1/chat/completions", {"model": "m"}
+            )
         )
     assert r.breaker.state_of("d1").value == "open", "three unreachable decodes must trip it"
     await r.aclose()
@@ -112,6 +125,7 @@ async def test_dual_stream_records_failure_on_unreachable_decode():
     for _ in range(3):
         body = await _drain(
             r._stream_dual(
+                _obs(),
                 p_target,
                 [],
                 d_target,


### PR DESCRIPTION
## Summary

This PR adds an opt-in SLA-based Planner for sizing prefill and decode pools in PD-disaggregated deployments.

The Planner:

- profiles model performance before production deployment;
- periodically collects TTFT, ITL, ISL, OSL, request count, and active worker counts from `/metrics`;
- corrects the offline performance model using observed latency;
- calculates the desired number of prefill and decode replicas;
- logs scaling decisions without applying actual scaling.

Kubernetes or Slurm actuation is intentionally out of scope. A future actuator can be connected through the existing decision callback without changing the sizing algorithm.

## Motivation

Prefill and decode have different resource characteristics:

- Prefill is primarily compute-bound and scales with incoming prompt-token throughput.
- Decode is primarily memory-bandwidth-bound and scales with generated-token throughput, active context length, and the ITL target.

A static P/D allocation either wastes GPUs under low load or violates latency objectives when the workload changes. The SLA Planner independently sizes both pools according to user-provided TTFT and ITL targets.

## Architecture

The implementation consists of two separate workflows.

### Offline profiling

`python -m infera.planner.profile` runs against a deployment with one prefill replica and one decode replica.

It produces a JSON performance profile containing:

- profiled TTFT by input sequence length;
- prefill throughput in tokens/s/GPU;
- profiled ITL by average context length and KV-cache utilization;
- decode throughput in tokens/s/GPU;
- KV-cache capacity;
- GPUs per prefill/decode replica.

### Online planning

`python -m infera.planner` runs as an independent process outside the inference request path.

Every adjustment interval it:

1. scrapes each configured Infera Server `/metrics` endpoint;
2. computes interval deltas from cumulative Prometheus histograms;
3. filters metrics by `router="disagg"` and model;
4. calculates prefill/decode correction factors;
5. assumes the next interval repeats the observed workload;
6. calculates the desired prefill and decode replica counts;
7. writes the decision to the log.

The first scrape establishes the cumulative metric baseline. Decisions start from the second scrape.

## Sizing algorithm

### Correction factors

```text
p_correction =
    observed_ttft / profiled_ttft(ISL)

d_correction =
    observed_itl /
    profiled_itl(concurrency, ISL + OSL / 2)
```

The prefill correction factor captures effects such as queueing and prefix-cache hits. The decode correction factor captures differences between profiled and observed decode behavior.

### Prefill replicas

```text
prefill_token_rate =
    requests × ISL / adjustment_interval

throughput_replicas =
    ceil(
        prefill_token_rate × min(1, p_correction)
        / profiled_throughput_per_gpu
        / prefill_gpus_per_replica
    )

service_ms =
    profiled_ttft × min(1, p_correction)

queue_ms =
    profiled_ttft × max(0, p_correction - 1)

queue_replicas =
    ceil(
        queue_ms × current_prefill_replicas
        / (ttft_target - service_ms)
    )

desired_prefill =
    max(1, throughput_replicas, queue_replicas)
```

### Decode replicas

```text
corrected_itl_target =
    user_itl_target / d_correction

decode_throughput_per_gpu =
    profile.find_best_throughput_per_gpu(
        corrected_itl_target,
        ISL + OSL / 2
    )

decode_token_rate =
    requests × OSL / adjustment_interval

desired_decode =
    max(
        1,
        ceil(
            decode_token_rate
            / decode_throughput_per_gpu
            / decode_gpus_per_replica
        )
    )
```

### Guardrails

The Planner includes two safeguards against unstable recommendations:

- The TTFT target must leave queueing headroom of at least 20% of the profiled service time.
- A single decision may increase either pool by at most 4× its currently observed replica count.

If the corrected ITL target is below the lightest profiled operating point, the Planner reports that the SLA is unreachable instead of generating an unbounded decode recommendation.

## Serving-path isolation

SLA metrics are explicitly opt-in.

Start the Python Infera Server with:

```bash
python -m infera.server \
  --enable-sla-metrics \
  ...
```

or:

```bash
export INFERA_ENABLE_SLA_METRICS=1
```

When SLA metrics are disabled:

- streaming request bodies are not modified;
- `stream_options.include_usage` is not injected;
- SSE chunks are not parsed by the SLA observer;
- Planner-specific latency and sequence-length samples are not recorded;
- the optional Planner dependencies are not imported.

The Planner process is fully independent. Starting, stopping, or crashing it does not affect request routing or inference workers.

SLA metrics currently require the Python router backend. Combining `--enable-sla-metrics` with the Rust router is rejected explicitly.

## Installation

Install the optional Planner dependency:

```bash
pip install ".[planner]"
```

## Usage

### 1. Start a profiled 1P1D deployment

Start one prefill replica and one decode replica with the same:

- model;
- engine version;
- GPU type;
- tensor-parallel configuration;
- KV-cache configuration;
- relevant engine arguments intended for production.

Start the Infera Server with `--enable-sla-metrics`.

### 2. Run offline profiling

```bash
python -m infera.planner.profile \
  --url http://127.0.0.1:8000 \
  --model /path/to/model \
  --tokenizer /path/to/model \
  --max-kv-tokens 74049536 \
  --isl 16056,16384,16712 \
  --context-length 16307,16640,16973 \
  --kv-usage 0.0035,0.0070 \
  --decode-osl 512 \
  --prefill-engine-num-gpu 8 \
  --decode-engine-num-gpu 8 \
  --output /persistent/path/profile.json
```

The example profile points cover a workload centered around:

```text
mean ISL = 16384
mean OSL = 512
```

with approximately ±2% per-request variation.

### 3. Start the online Planner

```bash
python -m infera.planner \
  --metrics-url http://127.0.0.1:8000/metrics \
  --model /path/to/model \
  --profile-results /persistent/path/profile.json \
  --ttft 5000 \
  --itl 100 \
  --adjustment-interval 180
```

Repeat `--metrics-url` once for every Infera Server replica.

Do not point the Planner at a load-balanced service whose consecutive scrapes may reach different server processes.

### 4. Read decisions

When resizing is required:

```text
observed 16 requests, isl=16384 osl=512, ttft=5029ms itl=21.2ms,
fleet prefill=1 decode=1

decision: prefill 1->4, decode 1->1
(corrections p=3.380 d=1.114; load req=16.0 isl=16384 osl=512)
```

When the current fleet is sufficient:

```text
fleet is already the right size (prefill=1, decode=1)
```

The current implementation only logs decisions. It does not modify deployments.

For durable records, write the profile to persistent storage and capture Planner output:

```bash
python -m infera.planner ... 2>&1 |
  tee /persistent/path/planner.log
```

## Validation

The Planner was validated on two 8×MI355X Slurm nodes:

```text
Prefill: smci355-ccs-aus-n06-25
Decode:  smci355-ccs-aus-n06-33
RDMA:    ionic_0, GID 1, ib_peer_mem
```

Each request used an ISL and OSL within approximately ±2% of the target. Positive and negative offsets were paired so the aggregate workload means remained exactly:

```text
mean ISL = 16384
mean OSL = 512
```

All three models passed:

- PD inference correctness;
- Mooncake RDMA verification;
- offline profiling;
- periodic `/metrics` collection;
- model and router label filtering;
- replica decision generation.

### Experimental results

| Model | Engine configuration | Request distribution | Profile TTFT at 16K | Profile ITL range | Observed TTFT / ITL | SLA target TTFT / ITL | Decision |
|---|---|---|---:|---:|---:|---:|---:|
| DeepSeek-V4-Pro | SGLang TP8 / DP8 / EP8 | 16 requests; ISL 16074–16694; OSL 502–522 | 1469.07 ms | 18.93–21.19 ms | 5029 ms / 21.2 ms | 7345.34 ms / 105.95 ms | 1P / 1D |
| GPT-OSS-120B | vLLM TP1 | 8 requests; ISL 16090–16678; OSL 504–520 | 274.56 ms | 4.14–4.85 ms | 1240 ms / 5.7 ms | 5000 ms / 100 ms | 1P / 1D |
| Kimi-K2.6-MXFP4 | vLLM TP4 | 8 requests; ISL 16074–16694; OSL 505–519 | 710.95 ms | 11.18–12.15 ms | 2794 ms / 12.2 ms | 5000 ms / 100 ms | 1P / 1D |

The requested SLA formula was:

```text
TTFT = max(5000 ms, profiled TTFT × 5)
ITL  = max(100 ms, maximum profiled ITL × 5)
```

These targets are generous relative to the measured hardware performance, so retaining the existing `1P/1D` deployment is the expected result.

Earlier tighter-target validation also exercised scale-up behavior and the 4× guardrail.

## Verification

- Python static checks: passed
- Python unit tests: `1457 passed, 2 skipped`
- Rust 1.98 formatting: passed
- Rust 1.98 Clippy with warnings as errors: passed
- Rust tests:
  - 143 unit tests passed
  - 15 functional tests passed
  - 2 ZMQ tests passed
  - 4 broker-dependent NATS tests ignored
- DCO sign-off: present
- `Co-authored-by`: absent

## Limitations

- PD-disaggregated deployments only.
- Python router backend only for SLA metric collection.
- Streaming requests are required for TTFT/ITL measurement.
- Offline profiles must match the production model, engine, GPU, TP, and relevant configuration.
- The online Planner currently uses the latest observed interval as the next-interval workload.
- Decisions are logged but are not applied automatically.
- Profile and decision persistence are the operator's responsibility.