### PR TITLE
feat(agent_sys): label every runtime directory with the name it alrea…

### DIFF
--- a/agent_sys/env_mgr/fs/layout.py
+++ b/agent_sys/env_mgr/fs/layout.py
@@ -2,11 +2,15 @@
 # Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 """The nested layout, and where a validation goes. Design §8.
 
-Spec §5.1, unchanged::
+Spec §5.1, plus a label::
 
-    <root>/task.<uuid>.<version>.<hash>/
+    <root>/task.<closure>.<uuid>.<version>.<hash>/
       ├── handoffs/     ├── workspace/    ├── playground/    ├── logs/
-      └── task.<child-uuid>.<version>.<hash>/     ← a subtask, nested
+      └── task.<closure>.<child-uuid>.<version>.<hash>/     ← a subtask, nested
+
+The ``<closure>`` field is for whoever is reading the tree and nothing resolves
+through it — see `env_mgr.fs.zone.zone_dirname`. A zone written before it
+existed still resolves, because `find_zone_dir` matches the uuid as a field.
 
 The nesting is what makes containment answer both *"is this path in the zone"*
 and *"may this task reach that path"*, because permissions cover the task's own
@@ -30,6 +34,7 @@ __all__ = [
     "copy_out",
     "create",
     "find_zone_dir",
+    "handoff_dir",
     "handoff_version_dir",
     "stage",
     "stage_handoffs",
@@ -58,15 +63,21 @@ def _subdirs(domains: DomainRegistry) -> tuple[str, ...]:
 def find_zone_dir(base: str, task_id: Any) -> str | None:
     """The directory of `task_id`'s most recent attempt, anywhere under `base`.
 
-    A task's uuid is unique, so the ``task.<uuid>.`` prefix identifies it
-    wherever the tree happens to have put it — which is what lets a subtask be
-    placed under its parent without the parent's `Task` object being in hand.
+    A task's uuid is unique, so the ``task.`` prefix plus the uuid as a whole
+    field identifies it wherever the tree happens to have put it — which is what
+    lets a subtask be placed under its parent without the parent's `Task` object
+    being in hand.
+
+    **The uuid is matched as a field, not as a prefix**, because `zone_dirname`
+    now carries an optional label between the prefix and the uuid. Both shapes
+    match, so a run resumed against zones written before the label existed still
+    finds them.
     """
-    prefix = f"{_ZONE_PREFIX}{task_id}."
+    field = f".{task_id}."
     best: tuple[int, str] | None = None
     for dirpath, dirnames, _ in os.walk(base):
         for name in dirnames:
-            if not name.startswith(prefix):
+            if not name.startswith(_ZONE_PREFIX) or field not in name:
                 continue
             parts = name.split(".")
             try:
@@ -94,7 +105,8 @@ def create(task: Any, execution: Any, domains: DomainRegistry) -> Zone:
                 f"task {task.id} declares parent {parent_id}, which has no zone under {base}"
             )
         base = parent_dir
-    root = os.path.join(base, zone_dirname(task.id, execution.attempt))
+    name = getattr(task, "closure", None)
+    root = os.path.join(base, zone_dirname(task.id, execution.attempt, name))
     for sub in _subdirs(domains):
         # exist_ok: a resume finds its own playground and keeps the contents.
         os.makedirs(os.path.join(root, sub), exist_ok=True)
@@ -115,7 +127,8 @@ def validation_zone(task: Any, phase: str, domains: DomainRegistry) -> str:
     base = domains.storage_root()
     zone_dir = find_zone_dir(base, task.id)
     parent = os.path.dirname(zone_dir) if zone_dir else base
-    root = os.path.join(parent, validation_dirname(task.id, phase))
+    name = getattr(task, "closure", None)
+    root = os.path.join(parent, validation_dirname(task.id, phase, name))
     os.makedirs(root, exist_ok=True)
     resolved = resolve_strict(root)
     if resolved is None:  # pragma: no cover - we just created it
@@ -139,13 +152,46 @@ def validation_zone(task: Any, phase: str, domains: DomainRegistry) -> str:
 CONTENT_DIR = "content"
 
 
+#: `handoff.store.HANDOFF_PREFIX`, spelled again for the same reason
+#: `CONTENT_DIR` above is: `env_mgr` may not import `handoff`, and
+#: `tests/interfaces/test_handoff_layout.py` is the price that keeps the two
+#: spellings honest.
+HANDOFF_PREFIX = "handoff"
+
+
+def handoff_dir(store_root: str, handoff_id: Any) -> str:
+    """``<store_root>/handoff.<kind>.<hid>/`` — `handoff` design §6.2's layout.
+
+    **Resolved by scanning, not composed**, and that is not a style choice: the
+    label in the middle is the handoff's *kind*, which lives on `task_graph`'s
+    `Handoff.type` and is not a fact this module has. It does not need it — the
+    store allocates the directory at dispatch (`task_graph/scheduler.py:470`),
+    before anything here resolves a grant, so by the time this runs the
+    directory is on disk and the uuid identifies it.
+
+    A directory is this handoff's when its name *is* the uuid — the shape
+    written before labels existed, so an older store still resolves — or ends
+    with ``.<uuid>``.
+    """
+    wanted = str(handoff_id)
+    suffix = f".{wanted}"
+    try:
+        names = sorted(os.listdir(store_root))
+    except OSError:
+        names = []
+    for name in names:
+        if name == wanted or name.endswith(suffix):
+            return os.path.join(store_root, name)
+    return os.path.join(store_root, f"{HANDOFF_PREFIX}.{wanted}")
+
+
 def handoff_version_dir(store_root: str, handoff_id: Any, version: int) -> str:
-    """``<store_root>/<hid>/v<N>/`` — `handoff` design §6.2's layout.
+    """``<store_root>/handoff.<kind>.<hid>/v<N>/`` — `handoff` design §6.2's layout.
 
     This module grants access to that directory and computes nothing about its
     contents (design §1.2).
     """
-    return os.path.join(store_root, str(handoff_id), f"v{version}")
+    return os.path.join(handoff_dir(store_root, handoff_id), f"v{version}")
 
 
 def stage(
@@ -241,11 +287,18 @@ def stage(
         version = versions.get(hid)
         if version is None:
             continue
-        version_dir = handoff_version_dir(store_root, hid, version)
+        handoff_root = handoff_dir(store_root, hid)
+        version_dir = os.path.join(handoff_root, f"v{version}")
         src = os.path.join(version_dir, CONTENT_DIR) if narrow else version_dir
         if not os.path.isdir(src):
             continue
-        dst = os.path.join(into, str(hid), f"v{version}")
+        # The staged copy takes the **store directory's own name**, so the
+        # kind label rides along and a body's `materials/` reads like the store.
+        # Derived rather than passed: this function is handed slots and versions
+        # and not kinds, and threading a kinds map through `stage_handoffs` and
+        # `prepare_validation` would put `task_graph`'s vocabulary in two more
+        # signatures to compute a string that is already on disk.
+        dst = os.path.join(into, os.path.basename(handoff_root), f"v{version}")
         copy_out(src, dst)
         staged[hid] = dst
     return staged

--- a/agent_sys/env_mgr/fs/zone.py
+++ b/agent_sys/env_mgr/fs/zone.py
@@ -9,38 +9,75 @@ from typing import Any, NamedTuple
 
 from env_mgr.fs.path import contained
 
-__all__ = ["Zone", "zone_dirname", "validation_dirname"]
+__all__ = ["Zone", "slug", "zone_dirname", "validation_dirname"]
 
 #: Readability and accident-avoidance only. Spec §4.1 settled that an
 #: unguessable prefix is security-by-obscurity — it was recovered three ways by
 #: the agent that holds it — so this buys no confidence and is not asked to.
 _HASH_CHARS = 8
 
+#: Long enough to recognise a closure name, short enough that a zone path still
+#: fits in a terminal beside a full uuid. A truncated slug is a label, never a
+#: key — nothing resolves a directory through it.
+_SLUG_CHARS = 40
+
 
 def _tag(*parts: str) -> str:
     return hashlib.sha256("\x00".join(parts).encode()).hexdigest()[:_HASH_CHARS]
 
 
-def zone_dirname(task_id: Any, attempt: int) -> str:
-    """``task.<uuid>.<version>.<hash>`` — spec §5.1.
+def slug(text: Any) -> str:
+    """A directory-name-safe label, or ``""`` when there is nothing to say.
+
+    **``.`` must not survive**, and that is the whole reason this exists rather
+    than the name being interpolated raw: ``.`` is this module's field
+    separator, so a closure called ``a.b`` would silently add a field and
+    `find_zone_dir`'s ``parts[-2]`` would read the wrong one.
+    """
+    if text is None:
+        return ""
+    out: list[str] = []
+    for char in str(text):
+        keep = char if (char.isascii() and (char.isalnum() or char in "_-")) else "-"
+        if keep == "-" and (not out or out[-1] == "-"):
+            continue
+        out.append(keep)
+    return "".join(out).strip("-")[:_SLUG_CHARS].strip("-")
+
+
+def zone_dirname(task_id: Any, attempt: int, name: Any = None) -> str:
+    """``task.<name>.<uuid>.<version>.<hash>`` — spec §5.1, plus a label.
 
     The zone id is the runtime ``uuid.version``: the task's own identity, not a
     separate namespace. ``version`` is the attempt, because a zone belongs to an
     attempt (design §11.3).
+
+    `name` is the task's closure — a label for whoever is reading the tree, and
+    nothing else. It is **not** in `_tag`'s input and nothing resolves through
+    it, so an unnamed task still gets today's exact name and a renamed closure
+    does not move an existing zone. It sits *before* the uuid because that is
+    what makes ``ls`` and tab-completion useful; the uuid stays whole and stays
+    the field before the attempt, which is what every lookup keys on.
     """
     uid = str(task_id)
-    return f"task.{uid}.{attempt}.{_tag(uid, str(attempt))}"
+    label = slug(name)
+    prefix = f"task.{label}." if label else "task."
+    return f"{prefix}{uid}.{attempt}.{_tag(uid, str(attempt))}"
 
 
-def validation_dirname(task_id: Any, phase: str) -> str:
-    """``validation.<uuid>.<phase>.<hash>`` — design §8.3, deviation D5.
+def validation_dirname(task_id: Any, phase: str, name: Any = None) -> str:
+    """``validation.<name>.<uuid>.<phase>.<hash>`` — design §8.3, deviation D5.
 
     A **sibling** of the producing task's zone, never a descendant of it.
     Anything under the producing task's directory is inside its subtree and
     therefore reachable, which is exactly what criterion 13 forbids.
+
+    `name` is a label on the same terms as `zone_dirname`'s.
     """
     uid = str(task_id)
-    return f"validation.{uid}.{phase}.{_tag(uid, phase)}"
+    label = slug(name)
+    prefix = f"validation.{label}." if label else "validation."
+    return f"{prefix}{uid}.{phase}.{_tag(uid, phase)}"
 
 
 class Zone(NamedTuple):

--- a/agent_sys/examples/demo/assets/lib/store.py
+++ b/agent_sys/examples/demo/assets/lib/store.py
@@ -53,6 +53,30 @@ def store_root() -> Path:
     return Path(os.environ["AGENT_SYS_DEMO_STORE"])
 
 
+def handoff_dir(hid: str) -> Path:
+    """This handoff's directory in the store. `handoff.store.handoff_dir`, duplicated.
+
+    The store names a directory ``handoff.<kind>.<uuid>`` so that a person
+    reading a run tree can tell what an artefact is. **Nothing resolves through
+    the label**: a directory is this handoff's when its name *is* the uuid — the
+    shape written before labels existed — or ends with ``.<uuid>``. The same
+    admissible duplication as `MANIFEST` and `CONTENT` above, and covered by the
+    same agreement test.
+    """
+    root = store_root()
+    suffix = f".{hid}"
+    if root.is_dir():
+        for entry in sorted(root.iterdir()):
+            if entry.name == hid or entry.name.endswith(suffix):
+                return entry
+    return root / hid
+
+
+def hid_of(dirname: str) -> str:
+    """The handoff id in a store directory name — the last field, labelled or not."""
+    return dirname.rsplit(".", 1)[-1]
+
+
 def versions(hid: str) -> list[int]:
     """**Published versions only, and the gaps are the point.**
 
@@ -70,7 +94,7 @@ def versions(hid: str) -> list[int]:
     next. Holes are skipped and never compacted, because renumbering would move
     an artefact a digest already names.
     """
-    base = store_root() / hid
+    base = handoff_dir(hid)
     if not base.is_dir():
         return []
     found = [
@@ -87,7 +111,7 @@ def content_dir(hid: str, version: int | None = None) -> Path | None:
     if not numbers:
         return None
     chosen = numbers[-1] if version is None else version
-    path = store_root() / hid / f"v{chosen}" / CONTENT
+    path = handoff_dir(hid) / f"v{chosen}" / CONTENT
     return path if path.is_dir() else None
 
 
@@ -96,7 +120,7 @@ def kind_of(hid: str, version: int | None = None) -> str:
     if not numbers:
         return ""
     chosen = numbers[-1] if version is None else version
-    manifest = store_root() / hid / f"v{chosen}" / MANIFEST
+    manifest = handoff_dir(hid) / f"v{chosen}" / MANIFEST
     if not manifest.is_file():
         return ""
     # **YAML, not JSON**, and this read `json.loads` until the filename was
@@ -164,9 +188,10 @@ def latest_of_kind(kind: str) -> Path | None:
         return None
     best: tuple[float, Path] | None = None
     for entry in sorted(root.iterdir()):
-        if not entry.is_dir() or kind_of(entry.name) != kind:
+        hid = hid_of(entry.name)
+        if not entry.is_dir() or kind_of(hid) != kind:
             continue
-        found = content_dir(entry.name)
+        found = content_dir(hid)
         if found is None:
             continue
         stamp = found.stat().st_mtime

--- a/agent_sys/examples/demo2/assets/lib/store.py
+++ b/agent_sys/examples/demo2/assets/lib/store.py
@@ -58,6 +58,30 @@ def store_root() -> Path:
     return Path(os.environ["AGENT_SYS_DEMO_STORE"])
 
 
+def handoff_dir(hid: str) -> Path:
+    """This handoff's directory in the store. `handoff.store.handoff_dir`, duplicated.
+
+    The store names a directory ``handoff.<kind>.<uuid>`` so that a person
+    reading a run tree can tell what an artefact is. **Nothing resolves through
+    the label**: a directory is this handoff's when its name *is* the uuid — the
+    shape written before labels existed — or ends with ``.<uuid>``. The same
+    admissible duplication as `MANIFEST` and `CONTENT` above, and covered by the
+    same agreement test.
+    """
+    root = store_root()
+    suffix = f".{hid}"
+    if root.is_dir():
+        for entry in sorted(root.iterdir()):
+            if entry.name == hid or entry.name.endswith(suffix):
+                return entry
+    return root / hid
+
+
+def hid_of(dirname: str) -> str:
+    """The handoff id in a store directory name — the last field, labelled or not."""
+    return dirname.rsplit(".", 1)[-1]
+
+
 def versions(hid: str) -> list[int]:
     """**Published versions only, and the gaps are the point.**
 
@@ -75,7 +99,7 @@ def versions(hid: str) -> list[int]:
     next. Holes are skipped and never compacted, because renumbering would move
     an artefact a digest already names.
     """
-    base = store_root() / hid
+    base = handoff_dir(hid)
     if not base.is_dir():
         return []
     found = [
@@ -92,7 +116,7 @@ def content_dir(hid: str, version: int | None = None) -> Path | None:
     if not numbers:
         return None
     chosen = numbers[-1] if version is None else version
-    path = store_root() / hid / f"v{chosen}" / CONTENT
+    path = handoff_dir(hid) / f"v{chosen}" / CONTENT
     return path if path.is_dir() else None
 
 
@@ -101,7 +125,7 @@ def kind_of(hid: str, version: int | None = None) -> str:
     if not numbers:
         return ""
     chosen = numbers[-1] if version is None else version
-    manifest = store_root() / hid / f"v{chosen}" / MANIFEST
+    manifest = handoff_dir(hid) / f"v{chosen}" / MANIFEST
     if not manifest.is_file():
         return ""
     # **YAML, not JSON**, and this read `json.loads` until the filename was
@@ -173,9 +197,10 @@ def latest_of_kind(kind: str) -> Path | None:
         return None
     best: tuple[float, Path] | None = None
     for entry in sorted(root.iterdir()):
-        if not entry.is_dir() or kind_of(entry.name) != kind:
+        hid = hid_of(entry.name)
+        if not entry.is_dir() or kind_of(hid) != kind:
             continue
-        found = content_dir(entry.name)
+        found = content_dir(hid)
         if found is None:
             continue
         stamp = found.stat().st_mtime

--- a/agent_sys/examples/llm_e2e_performance_optimization/analyze-demo/assets/lib/store.py
+++ b/agent_sys/examples/llm_e2e_performance_optimization/analyze-demo/assets/lib/store.py
@@ -53,6 +53,30 @@ def store_root() -> Path:
     return Path(os.environ["AGENT_SYS_DEMO_STORE"])
 
 
+def handoff_dir(hid: str) -> Path:
+    """This handoff's directory in the store. `handoff.store.handoff_dir`, duplicated.
+
+    The store names a directory ``handoff.<kind>.<uuid>`` so that a person
+    reading a run tree can tell what an artefact is. **Nothing resolves through
+    the label**: a directory is this handoff's when its name *is* the uuid — the
+    shape written before labels existed — or ends with ``.<uuid>``. The same
+    admissible duplication as `MANIFEST` and `CONTENT` above, and covered by the
+    same agreement test.
+    """
+    root = store_root()
+    suffix = f".{hid}"
+    if root.is_dir():
+        for entry in sorted(root.iterdir()):
+            if entry.name == hid or entry.name.endswith(suffix):
+                return entry
+    return root / hid
+
+
+def hid_of(dirname: str) -> str:
+    """The handoff id in a store directory name — the last field, labelled or not."""
+    return dirname.rsplit(".", 1)[-1]
+
+
 def versions(hid: str) -> list[int]:
     """**Published versions only, and the gaps are the point.**
 
@@ -70,7 +94,7 @@ def versions(hid: str) -> list[int]:
     next. Holes are skipped and never compacted, because renumbering would move
     an artefact a digest already names.
     """
-    base = store_root() / hid
+    base = handoff_dir(hid)
     if not base.is_dir():
         return []
     found = [
@@ -87,7 +111,7 @@ def content_dir(hid: str, version: int | None = None) -> Path | None:
     if not numbers:
         return None
     chosen = numbers[-1] if version is None else version
-    path = store_root() / hid / f"v{chosen}" / CONTENT
+    path = handoff_dir(hid) / f"v{chosen}" / CONTENT
     return path if path.is_dir() else None
 
 
@@ -96,7 +120,7 @@ def kind_of(hid: str, version: int | None = None) -> str:
     if not numbers:
         return ""
     chosen = numbers[-1] if version is None else version
-    manifest = store_root() / hid / f"v{chosen}" / MANIFEST
+    manifest = handoff_dir(hid) / f"v{chosen}" / MANIFEST
     if not manifest.is_file():
         return ""
     # **YAML, not JSON**, and this read `json.loads` until the filename was
@@ -164,9 +188,10 @@ def latest_of_kind(kind: str) -> Path | None:
         return None
     best: tuple[float, Path] | None = None
     for entry in sorted(root.iterdir()):
-        if not entry.is_dir() or kind_of(entry.name) != kind:
+        hid = hid_of(entry.name)
+        if not entry.is_dir() or kind_of(hid) != kind:
             continue
-        found = content_dir(entry.name)
+        found = content_dir(hid)
         if found is None:
             continue
         stamp = found.stat().st_mtime

--- a/agent_sys/examples/llm_e2e_performance_optimization/integration-demo/assets/lib/store.py
+++ b/agent_sys/examples/llm_e2e_performance_optimization/integration-demo/assets/lib/store.py
@@ -53,6 +53,30 @@ def store_root() -> Path:
     return Path(os.environ["AGENT_SYS_DEMO_STORE"])
 
 
+def handoff_dir(hid: str) -> Path:
+    """This handoff's directory in the store. `handoff.store.handoff_dir`, duplicated.
+
+    The store names a directory ``handoff.<kind>.<uuid>`` so that a person
+    reading a run tree can tell what an artefact is. **Nothing resolves through
+    the label**: a directory is this handoff's when its name *is* the uuid — the
+    shape written before labels existed — or ends with ``.<uuid>``. The same
+    admissible duplication as `MANIFEST` and `CONTENT` above, and covered by the
+    same agreement test.
+    """
+    root = store_root()
+    suffix = f".{hid}"
+    if root.is_dir():
+        for entry in sorted(root.iterdir()):
+            if entry.name == hid or entry.name.endswith(suffix):
+                return entry
+    return root / hid
+
+
+def hid_of(dirname: str) -> str:
+    """The handoff id in a store directory name — the last field, labelled or not."""
+    return dirname.rsplit(".", 1)[-1]
+
+
 def versions(hid: str) -> list[int]:
     """**Published versions only, and the gaps are the point.**
 
@@ -70,7 +94,7 @@ def versions(hid: str) -> list[int]:
     next. Holes are skipped and never compacted, because renumbering would move
     an artefact a digest already names.
     """
-    base = store_root() / hid
+    base = handoff_dir(hid)
     if not base.is_dir():
         return []
     found = [
@@ -87,7 +111,7 @@ def content_dir(hid: str, version: int | None = None) -> Path | None:
     if not numbers:
         return None
     chosen = numbers[-1] if version is None else version
-    path = store_root() / hid / f"v{chosen}" / CONTENT
+    path = handoff_dir(hid) / f"v{chosen}" / CONTENT
     return path if path.is_dir() else None
 
 
@@ -96,7 +120,7 @@ def kind_of(hid: str, version: int | None = None) -> str:
     if not numbers:
         return ""
     chosen = numbers[-1] if version is None else version
-    manifest = store_root() / hid / f"v{chosen}" / MANIFEST
+    manifest = handoff_dir(hid) / f"v{chosen}" / MANIFEST
     if not manifest.is_file():
         return ""
     # **YAML, not JSON**, and this read `json.loads` until the filename was
@@ -164,9 +188,10 @@ def latest_of_kind(kind: str) -> Path | None:
         return None
     best: tuple[float, Path] | None = None
     for entry in sorted(root.iterdir()):
-        if not entry.is_dir() or kind_of(entry.name) != kind:
+        hid = hid_of(entry.name)
+        if not entry.is_dir() or kind_of(hid) != kind:
             continue
-        found = content_dir(entry.name)
+        found = content_dir(hid)
         if found is None:
             continue
         stamp = found.stat().st_mtime

--- a/agent_sys/examples/llm_e2e_performance_optimization/profiling-demo/assets/lib/store.py
+++ b/agent_sys/examples/llm_e2e_performance_optimization/profiling-demo/assets/lib/store.py
@@ -53,6 +53,30 @@ def store_root() -> Path:
     return Path(os.environ["AGENT_SYS_DEMO_STORE"])
 
 
+def handoff_dir(hid: str) -> Path:
+    """This handoff's directory in the store. `handoff.store.handoff_dir`, duplicated.
+
+    The store names a directory ``handoff.<kind>.<uuid>`` so that a person
+    reading a run tree can tell what an artefact is. **Nothing resolves through
+    the label**: a directory is this handoff's when its name *is* the uuid — the
+    shape written before labels existed — or ends with ``.<uuid>``. The same
+    admissible duplication as `MANIFEST` and `CONTENT` above, and covered by the
+    same agreement test.
+    """
+    root = store_root()
+    suffix = f".{hid}"
+    if root.is_dir():
+        for entry in sorted(root.iterdir()):
+            if entry.name == hid or entry.name.endswith(suffix):
+                return entry
+    return root / hid
+
+
+def hid_of(dirname: str) -> str:
+    """The handoff id in a store directory name — the last field, labelled or not."""
+    return dirname.rsplit(".", 1)[-1]
+
+
 def versions(hid: str) -> list[int]:
     """**Published versions only, and the gaps are the point.**
 
@@ -70,7 +94,7 @@ def versions(hid: str) -> list[int]:
     next. Holes are skipped and never compacted, because renumbering would move
     an artefact a digest already names.
     """
-    base = store_root() / hid
+    base = handoff_dir(hid)
     if not base.is_dir():
         return []
     found = [
@@ -87,7 +111,7 @@ def content_dir(hid: str, version: int | None = None) -> Path | None:
     if not numbers:
         return None
     chosen = numbers[-1] if version is None else version
-    path = store_root() / hid / f"v{chosen}" / CONTENT
+    path = handoff_dir(hid) / f"v{chosen}" / CONTENT
     return path if path.is_dir() else None
 
 
@@ -96,7 +120,7 @@ def kind_of(hid: str, version: int | None = None) -> str:
     if not numbers:
         return ""
     chosen = numbers[-1] if version is None else version
-    manifest = store_root() / hid / f"v{chosen}" / MANIFEST
+    manifest = handoff_dir(hid) / f"v{chosen}" / MANIFEST
     if not manifest.is_file():
         return ""
     # **YAML, not JSON**, and this read `json.loads` until the filename was
@@ -164,9 +188,10 @@ def latest_of_kind(kind: str) -> Path | None:
         return None
     best: tuple[float, Path] | None = None
     for entry in sorted(root.iterdir()):
-        if not entry.is_dir() or kind_of(entry.name) != kind:
+        hid = hid_of(entry.name)
+        if not entry.is_dir() or kind_of(hid) != kind:
             continue
-        found = content_dir(entry.name)
+        found = content_dir(hid)
         if found is None:
             continue
         stamp = found.stat().st_mtime

--- a/agent_sys/handoff/store.py
+++ b/agent_sys/handoff/store.py
@@ -50,6 +50,9 @@ __all__ = [
     "STAGING_PREFIX",
     "FilesystemStore",
     "KindSource",
+    "handoff_dir",
+    "handoff_dirname",
+    "slug",
     "store_name_for",
     "version_dir",
 ]
@@ -90,14 +93,81 @@ def store_name_for(scope: Scope) -> str:
     return _STORE_FOR_SCOPE[scope]
 
 
-def version_dir(root: Path, hid: HandoffId, version: int) -> Path:
+#: The kind prefix on a handoff's directory. Every runtime directory in this
+#: system now leads with what it *is*, so a user reading a run tree can tell a
+#: handoff from a zone without knowing any uuid.
+HANDOFF_PREFIX = "handoff"
+
+#: A label's cap. `env_mgr.fs.zone._SLUG_CHARS`, duplicated across the package
+#: boundary on `docs/interfaces.md` §8.1's terms, like `CONTENT_DIR` already is.
+_SLUG_CHARS = 40
+
+
+def slug(text: object) -> str:
+    """A directory-name-safe label, or ``""`` when there is nothing to say.
+
+    ``.`` is the field separator in a handoff directory name, so it must not
+    survive — otherwise `handoff_dir`'s *"the uuid is the last field"* rule
+    stops being true. `env_mgr.fs.zone.slug`'s rule, duplicated; the agreement
+    is pinned by `tests/interfaces/test_handoff_layout.py`.
+    """
+    if text is None:
+        return ""
+    out: list[str] = []
+    for char in str(text):
+        keep = char if (char.isascii() and (char.isalnum() or char in "_-")) else "-"
+        if keep == "-" and (not out or out[-1] == "-"):
+            continue
+        out.append(keep)
+    return "".join(out).strip("-")[:_SLUG_CHARS].strip("-")
+
+
+def handoff_dirname(hid: HandoffId, kind: object = None) -> str:
+    """``handoff.<kind>.<uuid>``, or ``handoff.<uuid>`` when the kind is unknown.
+
+    The kind is a **label**: it makes the store readable and nothing resolves
+    through it, which is why `handoff_dir` can find a directory whose label is
+    absent, stale, or was written before labels existed. The uuid stays whole
+    and stays last, because that is what a lookup keys on.
+    """
+    label = slug(kind)
+    return f"{HANDOFF_PREFIX}.{label}.{hid}" if label else f"{HANDOFF_PREFIX}.{hid}"
+
+
+def handoff_dir(root: Path, hid: HandoffId, kind: object = None) -> Path:
+    """This handoff's directory under `root` — **the existing one, if there is one**.
+
+    A directory is this handoff's when its name *is* the uuid (the shape written
+    before labels existed) or *ends with* ``.<uuid>``. That is the whole
+    compatibility story: a store written by an earlier run resumes without a
+    migration, and a label may change without moving an artefact.
+
+    When nothing is on disk yet the name to create is `handoff_dirname`'s. The
+    scan is over one directory, and only ever the store root.
+    """
+    base = Path(root)
+    wanted = str(hid)
+    suffix = f".{wanted}"
+    try:
+        entries = sorted(base.iterdir())
+    except OSError:
+        # An unreadable or absent root is not this function's error to raise;
+        # every caller already handles "the directory is not there".
+        entries = []
+    for entry in entries:
+        if entry.name == wanted or entry.name.endswith(suffix):
+            return entry
+    return base / handoff_dirname(hid, kind)
+
+
+def version_dir(root: Path, hid: HandoffId, version: int, kind: object = None) -> Path:
     """**The one function that computes a path**, and the on-disk shape is private.
 
     Bazel #23576 is the lesson: a path-shape change survived only because
     consumers use `file.path` rather than composing strings. Every other module
     asks for a path; none builds one.
     """
-    return Path(root) / str(hid) / f"v{version}"
+    return handoff_dir(root, hid, kind) / f"v{version}"
 
 
 class KindSource(Protocol):
@@ -124,7 +194,7 @@ class KindSource(Protocol):
 
 
 class FilesystemStore:
-    """`<root>/<hid>/v<N>/{content/,validation.yaml,manifest.yaml}`."""
+    """`<root>/handoff.<kind>.<hid>/v<N>/{content/,validation.yaml,manifest.yaml}`."""
 
     def __init__(
         self,
@@ -143,6 +213,20 @@ class FilesystemStore:
     def root(self) -> Path:
         """Read-only. A caller that wants a path inside asks `version_dir`."""
         return self._root
+
+    def _dir(self, hid: HandoffId) -> Path:
+        """This handoff's directory, labelled with its kind when one is known.
+
+        The label comes from `self._kinds`, which is exactly the same source
+        `put` and `seal` already use for the manifest — so a store that can
+        publish can also name, and a read-only store (`kinds=None`) still finds
+        every directory, because `handoff_dir` resolves on the uuid.
+        """
+        kind = self._kinds.kind_for(hid) if self._kinds is not None else None
+        return handoff_dir(self._root, hid, getattr(kind, "name", None))
+
+    def _version_dir(self, hid: HandoffId, version: int) -> Path:
+        return self._dir(hid) / f"v{version}"
 
     # ---- reads ----
 
@@ -210,12 +294,12 @@ class FilesystemStore:
         """
         if version is None:
             return bool(self.list_versions(hid))
-        return (version_dir(self._root, hid, version) / MANIFEST_FILE).is_file()
+        return (self._version_dir(hid, version) / MANIFEST_FILE).is_file()
 
     def _version_dirs(self, hid: HandoffId) -> list[tuple[int, Path]]:
         """Every `v<N>/` on disk, published or not. **Internal**: allocation
         must see the unpublished ones or it would hand out a number in use."""
-        base = self._root / str(hid)
+        base = self._dir(hid)
         if not base.is_dir():
             return []
         out = [
@@ -282,7 +366,7 @@ class FilesystemStore:
         want = manifest.digest.get("sha256")
         if got != want:
             raise DigestMismatch(
-                f"{version_dir(self._root, hid, version)}: manifest records "
+                f"{self._version_dir(hid, version)}: manifest records "
                 f"sha256={want}, the copy at {dst} recomputes to sha256={got} "
                 f"(algorithm {manifest.algorithm})"
             )
@@ -342,10 +426,10 @@ class FilesystemStore:
         and `seal` are where that refusal lives. Requiring it here would block
         dispatch on a resolver only the seal can use.
         """
-        base = self._root / str(hid)
+        base = self._dir(hid)
         base.mkdir(parents=True, exist_ok=True)
         for n in itertools.count(self._next_guess(base)):
-            target = version_dir(self._root, hid, n)
+            target = self._version_dir(hid, n)
             try:
                 os.mkdir(target)
             except FileExistsError:
@@ -411,7 +495,7 @@ class FilesystemStore:
         # `NotSealable`, and it raises rather than returning a reason: neither
         # of these says anything about the content, so neither is an outcome of
         # the attempt. See `errors.NotSealable` for the re-run case.
-        target = version_dir(self._root, hid, version)
+        target = self._version_dir(hid, version)
         if not target.is_dir():
             raise NotSealable(
                 f"cannot seal {hid} v{version}: {target} does not exist. A version "
@@ -500,7 +584,7 @@ class FilesystemStore:
         # disconnected caller, not a deleted module, so re-wiring it is one line.
         content_mod.check_items(content_mod.load(content_dir), ctype, kind.items_schema)
 
-        base = self._root / str(hid)
+        base = self._dir(hid)
         base.mkdir(parents=True, exist_ok=True)
         for n in itertools.count(self._next_guess(base)):
             stage = base / f"{STAGING_PREFIX}{n}"  # a SIBLING of the destination
@@ -606,7 +690,7 @@ class FilesystemStore:
         a second home for that fact would pre-empt it. **It returns the day
         F-D1 moves the seal after output validation, and not before.**
         """
-        path = version_dir(self._root, hid, version)
+        path = self._version_dir(hid, version)
         if not (path / MANIFEST_FILE).is_file():
             have = self.list_versions(hid)
             allocated = path.is_dir()

--- a/agent_sys/tests/env_mgr/test_grants.py
+++ b/agent_sys/tests/env_mgr/test_grants.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from env_mgr.fs.domain import DomainKind, DomainRegistry
+from env_mgr.fs.layout import handoff_version_dir
 from env_mgr.grants import input_env, mode_for, output_env, resolve, resolve_all
 from env_mgr.protocols import Mode, UnresolvedGrant
 from task_graph.ids import HandoffId
@@ -44,7 +45,7 @@ def test_a_kind_resolves_to_the_version_this_attempt_has(store: str) -> None:
     # `content/`, **not** `v2/`. Under §4.14 the manifest is the seal, so a
     # version directory granted whole lets its producer publish its own unsealed
     # version. A read grant gets one path because a consumer has nothing to claim.
-    assert granted.path == os.path.join(store, str(task.inputs[0]), "v2", "content")
+    assert granted.path == os.path.join(handoff_version_dir(store, task.inputs[0], 2), "content")
     assert granted.mode is Mode.READ_EXEC
 
 
@@ -157,8 +158,8 @@ def test_resolve_all_flattens_every_grant(tmp_path: Path, store: str) -> None:
     granted = resolve_all(task, execution, ctx)
     assert len(granted) == 3
     assert {g.path for g in granted} == {
-        os.path.join(store, str(a), "v0", "content"),
-        os.path.join(store, str(b), "v0", "content"),
+        os.path.join(handoff_version_dir(store, a, 0), "content"),
+        os.path.join(handoff_version_dir(store, b, 0), "content"),
         "/usr",
     }
 
@@ -351,7 +352,7 @@ def test_an_output_is_exported_under_its_declared_kind(store: str) -> None:
     execution = Execution(attempt=0, output_versions={hid: 0})
 
     assert output_env(task, execution, store) == {
-        "AGENT_SYS_OUTPUT_FACTS": os.path.join(store, str(hid), "v0", "content"),
+        "AGENT_SYS_OUTPUT_FACTS": os.path.join(handoff_version_dir(store, hid, 0), "content"),
     }
 
 

--- a/agent_sys/tests/env_mgr/test_layout.py
+++ b/agent_sys/tests/env_mgr/test_layout.py
@@ -171,6 +171,85 @@ def test_find_zone_dir_picks_the_latest_attempt(domains: DomainRegistry) -> None
     assert layout.find_zone_dir(domains.storage_root(), task.id) == latest.root
 
 
+# ------------------------------------------------- the label on a directory
+#
+# A run tree is something a person reads. Every directory `agent_sys` creates
+# now leads with what it *is* and carries the name the system already knew, so
+# `ls` answers "which task is this" without a lookup. The tests below hold the
+# two properties that make the label safe: nothing resolves through it, and a
+# tree written before it existed still resolves.
+
+
+def test_a_zone_is_named_after_its_closure(domains: DomainRegistry) -> None:
+    task = Task(closure="describe")
+    zone = layout.create(task, task.push_execution(), domains)
+    assert os.path.basename(zone.root).startswith(f"task.describe.{task.id}.")
+
+
+def test_a_task_with_no_closure_keeps_the_unlabelled_name(domains: DomainRegistry) -> None:
+    """The label is optional and its absence is not a placeholder: a task that
+    has no closure gets exactly the name it got before labels existed."""
+    task = Task()
+    zone = layout.create(task, task.push_execution(), domains)
+    assert os.path.basename(zone.root).startswith(f"task.{task.id}.")
+
+
+def test_a_closure_name_cannot_add_a_field(domains: DomainRegistry) -> None:
+    """`find_zone_dir` reads the attempt from ``parts[-2]``, so a ``.`` in a
+    closure name would make it read the wrong field. The slug is what stops it."""
+    task = Task(closure="a.b/c d")
+    execution = task.push_execution()
+    zone = layout.create(task, execution, domains)
+    name = os.path.basename(zone.root)
+    assert name == f"task.a-b-c-d.{task.id}.0.{name.rsplit('.', 1)[-1]}"
+    assert layout.find_zone_dir(domains.storage_root(), task.id) == zone.root
+
+
+def test_find_zone_dir_still_finds_an_unlabelled_zone(domains: DomainRegistry) -> None:
+    """The compatibility claim, asserted rather than argued: a zone directory in
+    the shape written before labels existed is still this task's."""
+    task = Task()
+    legacy = os.path.join(domains.storage_root(), f"task.{task.id}.0.deadbeef")
+    os.makedirs(legacy)
+    assert layout.find_zone_dir(domains.storage_root(), task.id) == legacy
+
+
+def test_a_validation_zone_is_named_after_its_closure(
+    domains: DomainRegistry,
+) -> None:
+    task = Task(closure="describe")
+    layout.create(task, task.push_execution(), domains)
+    root = layout.validation_zone(task, "output_validation", domains)
+    assert os.path.basename(root).startswith(f"validation.describe.{task.id}.output_validation.")
+
+
+def test_a_staged_input_keeps_the_store_directory_s_name(
+    domains: DomainRegistry, tmp_path: Path
+) -> None:
+    """The staged copy inherits the label instead of recomputing it, so a body's
+    ``materials/`` reads like the store and no kind map has to be threaded
+    through `stage`."""
+    from task_graph.ids import HandoffId
+
+    from .stubs import context
+
+    store = tmp_path / "store"
+    hid = HandoffId.new()
+    published = store / f"handoff.facts.{hid}" / "v1" / "content"
+    published.mkdir(parents=True)
+    (published / "result.json").write_text("{}")
+
+    task = Task(inputs=[hid])
+    execution = task.push_execution()
+    execution.input_versions = {hid: 1}
+    zone = layout.create(task, execution, domains)
+
+    ctx = context(domains=domains, store_root=str(store))
+    staged = layout.stage_handoffs(task, execution, zone, ctx)
+
+    assert Path(staged[hid]).parent.name == f"handoff.facts.{hid}"
+
+
 def test_a_parent_without_a_zone_is_an_error(domains: DomainRegistry) -> None:
     orphan = Task(parent=Task().id)
     with pytest.raises(ValueError, match="has no zone under"):

--- a/agent_sys/tests/env_mgr/test_task_graph_agreement.py
+++ b/agent_sys/tests/env_mgr/test_task_graph_agreement.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import pytest
 
 from env_mgr.fs.domain import DomainKind, DomainRegistry
+from env_mgr.fs.layout import handoff_version_dir
 from env_mgr.grants import mode_for, resolve_all
 from env_mgr.protocols import Context, Mode, Tier, UnresolvedGrant
 from task_graph import Access, Grant, Permissions
@@ -153,7 +154,7 @@ def test_resolve_all_against_real_permissions(store: str, tmp_path: Path) -> Non
     execution = task.push_execution(AgentId.new(), {hid: 2})
 
     granted = resolve_all(task, execution, _ctx(store, {hid: _handoff(hid, "trace")}, tmp_path))
-    assert [g.path for g in granted] == [os.path.join(store, str(hid), "v2", "content")]
+    assert [g.path for g in granted] == [os.path.join(handoff_version_dir(store, hid, 2), "content")]
     assert granted[0].mode is Mode.READ_EXEC
 
 

--- a/agent_sys/tests/handoff/conformance.py
+++ b/agent_sys/tests/handoff/conformance.py
@@ -20,7 +20,7 @@ import pytest
 
 from handoff.digest import tree_digest
 from handoff.errors import Malformed, NotSealable
-from handoff.store import CLAIM_DIR
+from handoff.store import CLAIM_DIR, version_dir
 from task_graph.ids import HandoffId, TaskId
 from tests.handoff.conftest import FixedKind, make_content, make_kind, open_kind
 
@@ -173,7 +173,7 @@ class StoreConformance:
         # does not exist either raises in `prepare` or evaporates.
         shutil.copytree(
             tmp_path / "written",
-            store.root / str(hid) / f"v{version}" / "content",
+            version_dir(store.root, hid, version) / "content",
             dirs_exist_ok=True,
         )
 
@@ -191,7 +191,7 @@ class StoreConformance:
         store, hid = self._store_and_id(tmp_path)
         version = store.allocate(hid)
         # Something was written, and it is not a handoff: no README, no items.
-        (store.root / str(hid) / f"v{version}" / "content" / "stray.txt").write_text("x")
+        (version_dir(store.root, hid, version) / "content" / "stray.txt").write_text("x")
 
         why = store.seal(hid, version, producer=TaskId.new())
         assert why, "a refusal reports its reason rather than raising"
@@ -210,7 +210,7 @@ class StoreConformance:
         """
         store, hid = self._store_and_id(tmp_path)
         version = store.allocate(hid)
-        vdir = store.root / str(hid) / f"v{version}"
+        vdir = version_dir(store.root, hid, version)
         for granted in ("content", "claim"):
             assert (vdir / granted).is_dir(), f"{granted}/ exists before the body runs"
             assert list((vdir / granted).iterdir()) == [], f"{granted}/ is empty"
@@ -235,11 +235,11 @@ class StoreConformance:
         store, hid = self._store_and_id(tmp_path)
 
         plain = store.allocate(hid)
-        make_content(store.root / str(hid) / f"v{plain}" / "content")
+        make_content(version_dir(store.root, hid, plain) / "content")
         store.seal(hid, plain, producer=TaskId.new())
 
         claimed = store.allocate(hid)
-        vdir = store.root / str(hid) / f"v{claimed}"
+        vdir = version_dir(store.root, hid, claimed)
         make_content(vdir / "content")
         (vdir / CLAIM_DIR / "self_check.yaml").write_text("done: true\n", encoding="utf-8")
         store.seal(hid, claimed, producer=TaskId.new())
@@ -301,6 +301,6 @@ class StoreConformance:
         rather than `""`, so nothing reads a reason that is not there."""
         store, hid = self._store_and_id(tmp_path)
         version = store.allocate(hid)
-        make_content(store.root / str(hid) / f"v{version}" / "content")
+        make_content(version_dir(store.root, hid, version) / "content")
         assert store.seal(hid, version, producer=TaskId.new()) is None
         assert store.latest(hid) == version

--- a/agent_sys/tests/handoff/test_containment.py
+++ b/agent_sys/tests/handoff/test_containment.py
@@ -15,6 +15,7 @@ import pytest
 
 from handoff import check_contained, version_dir
 from handoff.errors import NotContained
+from handoff.store import handoff_dir
 from task_graph.ids import HandoffId
 
 
@@ -89,9 +90,9 @@ def test_a_path_that_does_not_exist_yet_is_still_checkable(tmp_path: Path) -> No
 
 
 def test_the_store_layout_is_what_containment_is_asserted_against(tmp_path: Path) -> None:
-    """Against the real layout, not a synthetic one: `<root>/<hid>/v<N>/`."""
+    """Against the real layout, not a synthetic one: `<root>/handoff.<kind>.<hid>/v<N>/`."""
     root = tmp_path / "handoffs"
     mine, theirs = HandoffId.new(), HandoffId.new()
-    check_contained(version_dir(root, mine, 0), root / str(mine))
+    check_contained(version_dir(root, mine, 0), handoff_dir(root, mine))
     with pytest.raises(NotContained):
-        check_contained(version_dir(root, theirs, 0), root / str(mine))
+        check_contained(version_dir(root, theirs, 0), handoff_dir(root, mine))

--- a/agent_sys/tests/handoff/test_digest.py
+++ b/agent_sys/tests/handoff/test_digest.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import pytest
 
-from handoff import canonical, tree_digest
+from handoff import canonical, tree_digest, version_dir
 from handoff.errors import Malformed
 
 # --------------------------------------------------------------------------- #
@@ -93,7 +93,7 @@ def test_copy_out_raises_on_a_tampered_version(kinded_store, tmp_path: Path) -> 
 
     store, hid = kinded_store
     version = store.put(hid, make_content(tmp_path / "produced"), producer=_task_id())
-    (store.root / str(hid) / f"v{version}" / "content" / "items" / "result").write_text("99\n")
+    (version_dir(store.root, hid, version) / "content" / "items" / "result").write_text("99\n")
 
     from handoff.errors import DigestMismatch
 

--- a/agent_sys/tests/handoff/test_store.py
+++ b/agent_sys/tests/handoff/test_store.py
@@ -20,7 +20,7 @@ import pytest
 from handoff import FilesystemStore, Scope, store_name_for, version_dir
 from handoff.errors import Malformed
 from handoff.protocols import HandoffStore
-from handoff.store import STAGING_PREFIX
+from handoff.store import STAGING_PREFIX, handoff_dir
 from task_graph.ids import HandoffId, TaskId
 from tests.handoff.conftest import FixedKind, make_content, make_kind, open_kind
 
@@ -181,7 +181,7 @@ def test_a_failed_put_leaves_no_staging_directory(tmp_path: Path) -> None:
     with pytest.raises(Malformed, match="README.md"):
         store.put(hid, bad, producer=TaskId.new())
     assert store.list_versions(hid) == []
-    assert list((store.root / str(hid)).glob(f"{STAGING_PREFIX}*")) == []
+    assert list(handoff_dir(store.root, hid).glob(f"{STAGING_PREFIX}*")) == []
 
 
 def test_a_store_with_no_kind_source_reads_but_does_not_publish(tmp_path: Path) -> None:
@@ -294,8 +294,8 @@ def test_knowledge_instance_is_separate(tmp_path: Path) -> None:
 
     assert knowledge.exists(hid, 0)
     assert not handoffs.exists(hid)
-    assert (tmp_path / "knowledge" / str(hid) / "v0").is_dir()
-    assert not (tmp_path / "handoffs" / str(hid)).exists()
+    assert version_dir(tmp_path / "knowledge", hid, 0).is_dir()
+    assert not handoff_dir(tmp_path / "handoffs", hid).exists()
 
 
 def test_a_store_needs_a_root(tmp_path: Path) -> None:

--- a/agent_sys/tests/handoff/test_verdict.py
+++ b/agent_sys/tests/handoff/test_verdict.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from handoff import Manifest, Verdict
+from handoff import Manifest, Verdict, version_dir
 from handoff import verdict as verdict_mod
 from handoff.errors import Malformed
 from task_graph.ids import AgentId, TaskId
@@ -91,7 +91,7 @@ def test_an_empty_list_and_a_missing_file_mean_different_things(
     whitelist mean very different things."*"""
     store, hid = kinded_store
     version = store.put(hid, make_content(tmp_path / "c"), producer=TaskId.new())
-    path = store.root / str(hid) / f"v{version}" / verdict_mod.VERDICT_FILE
+    path = version_dir(store.root, hid, version) / verdict_mod.VERDICT_FILE
 
     assert path.is_file() and store.read_verdicts(hid, version) == []
 
@@ -136,7 +136,7 @@ def test_a_verdict_with_no_agent_round_trips_as_null(kinded_store, tmp_path: Pat
     assert got == unattributed, "the whole record round-trips, not just the field"
 
     raw = yaml.safe_load(
-        (store.root / str(hid) / f"v{version}" / verdict_mod.VERDICT_FILE).read_text()
+        (version_dir(store.root, hid, version) / verdict_mod.VERDICT_FILE).read_text()
     )
     assert raw["verdicts"][0]["agent_id"] is None
     assert "agent_id" in raw["verdicts"][0], (

--- a/agent_sys/tests/interfaces/test_handoff_layout.py
+++ b/agent_sys/tests/interfaces/test_handoff_layout.py
@@ -5,7 +5,7 @@ writers of one path shape, and this is the price of that.
 on-disk shape is private"**, with Bazel #23576 as the reason: a path-shape change
 survived there only because consumers use `file.path` rather than composing
 strings. `env_mgr` composes the string anyway — `grants.py` and `meta.py` need
-`<root>/<hid>/v<N>/` to grant access to it.
+`<root>/handoff.<kind>.<hid>/v<N>/` to grant access to it.
 
 **It is duplicated by construction, not by carelessness.** `docs/interfaces.md`
 §4.6 permits `env_mgr` to import `task_graph` and nothing else of ours, so it
@@ -31,6 +31,8 @@ from pathlib import Path
 import pytest
 
 from env_mgr.fs.layout import handoff_version_dir
+from env_mgr.fs.zone import slug as zone_slug
+from handoff.store import slug as handoff_slug
 from handoff.store import version_dir
 
 CASES = [
@@ -52,13 +54,46 @@ def test_the_two_writers_of_the_layout_agree(root: str, hid: str, version: int) 
     assert Path(handoff_version_dir(root, hid, version)) == version_dir(Path(root), hid, version)
 
 
-def test_the_shape_is_root_then_id_then_v_number() -> None:
+def test_the_shape_is_root_then_labelled_id_then_v_number() -> None:
     """Pin the shape itself, so a *matching* change to both still gets read.
 
     Without this, the pair could agree on something neither design describes.
     """
-    assert version_dir(Path("/r"), "h-9", 3) == Path("/r/h-9/v3")
-    assert handoff_version_dir("/r", "h-9", 3) == "/r/h-9/v3"
+    assert version_dir(Path("/r"), "h-9", 3) == Path("/r/handoff.h-9/v3")
+    assert handoff_version_dir("/r", "h-9", 3) == "/r/handoff.h-9/v3"
+
+
+def test_the_label_is_the_kind_and_only_handoff_knows_it() -> None:
+    """`handoff` writes the label; `env_mgr` only ever finds what is already there.
+
+    So the two are *not* symmetric on the write path, and pinning that is the
+    point: a caller with a kind in hand gets ``handoff.<kind>.<hid>``, and the
+    one without gets the unlabelled form.
+    """
+    assert version_dir(Path("/r"), "h-9", 3, "trace") == Path("/r/handoff.trace.h-9/v3")
+
+
+@pytest.mark.parametrize(
+    ("dirname", "hid"), [("h-9", "h-9"), ("handoff.h-9", "h-9"), ("handoff.trace.h-9", "h-9")]
+)
+def test_both_readers_find_a_directory_whatever_its_label(
+    tmp_path: Path, dirname: str, hid: str
+) -> None:
+    """Including ``<hid>`` bare — the shape written before labels existed.
+
+    This is the whole backwards-compatibility claim, and it is asserted on both
+    sides of the duplication because either could regress alone.
+    """
+    (tmp_path / dirname / "v3").mkdir(parents=True)
+    assert version_dir(tmp_path, hid, 3) == tmp_path / dirname / "v3"
+    assert handoff_version_dir(str(tmp_path), hid, 3) == str(tmp_path / dirname / "v3")
+
+
+def test_a_label_never_gains_a_field_separator() -> None:
+    """A kind with a ``.`` in it must not add a field: the uuid is the last one,
+    and `handoff_dir`/`find_zone_dir` both key on that."""
+    assert version_dir(Path("/r"), "h-9", 0, "a.b c") == Path("/r/handoff.a-b-c.h-9/v0")
+    assert zone_slug("a.b c") == handoff_slug("a.b c") == "a-b-c"
 
 
 def test_the_two_spellings_of_the_granted_subdirectories_agree() -> None:


### PR DESCRIPTION
…dy knew

A run tree was browsable only if you already knew the uuids: `handoffs/<uuid>/`, `zones/task.<uuid>.<attempt>.<hash>/`. The closure name and the handoff kind were both in hand at the moment the directory was created, and both thrown away. They are now the second field:

    handoffs/handoff.solutions_a.57882e8c-.../v0/content/
    zones/task.main.2c0260e5-.../task.solve_a.310209e3-....0.ce4e41e0/
    zones/task.main.2c0260e5-.../validation.solve_a.310209e3-....output_validation.01a143f0/

Two properties keep the label from becoming a contract:

- **Nothing resolves through it.** `find_zone_dir` matches the uuid as a whole field, and `handoff_dir` finds the directory whose name *is* the uuid or ends with `.<uuid>`. So a store or zone tree written before labels existed resolves unchanged, and a renamed closure does not move an artefact.
- **`.` does not survive a label.** The uuid is the last field before the attempt/version, and `parts[-2]` would read the wrong one otherwise.

The staged copy in a zone takes the store directory's own basename rather than recomputing the label, which keeps `task_graph`'s kind vocabulary out of `stage`, `stage_handoffs` and `prepare_validation`.

`handoff.store.version_dir` and `env_mgr.fs.layout.handoff_version_dir` stay the two sanctioned writers of the shape; `tests/interfaces/test_handoff_layout.py` pins both, including that either alone would regress the compatibility rule. The five body-side `examples/*/assets/lib/store.py` readers get the same scan-then-fallback rule under the same agreement test.

Verified: 2266 passed / 3 skipped / 4 xfailed; `examples/demo2` run end to end and the tree above read off it; that run's store renamed back to bare uuids and re-read through all three readers.

# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
