### PR TITLE
Recover PD engine crashes and NATS JetStream filestore failures

### DIFF
--- a/deploy/operator/internal/controller/nats.go
+++ b/deploy/operator/internal/controller/nats.go
@@ -28,7 +28,7 @@ func natsImage(idep *inferav1alpha1.InferaDeployment) string {
 	if idep.Spec.NATS != nil && idep.Spec.NATS.Image != "" {
 		return idep.Spec.NATS.Image
 	}
-	return "nats:latest"
+	return "nats:2.11.1"
 }
 
 func natsStorageSize(idep *inferav1alpha1.InferaDeployment) string {
@@ -55,7 +55,9 @@ func buildNATSService(idep *inferav1alpha1.InferaDeployment) *corev1.Service {
 }
 
 // buildNATSStatefulSet creates a single-replica JetStream NATS whose store_dir
-// is driven by NATS_STORE_DIR pointing at the mounted PVC (survives restarts).
+// is the mounted PVC at /data/jetstream (survives restarts). The path is a
+// literal: expanding $(NATS_STORE_DIR) in Args is CRI-dependent and an empty
+// -sd makes nats-server report 10077 "opening msg block file [\"\"]".
 // Scale to an odd replica count for RAFT quorum in production.
 func buildNATSStatefulSet(idep *inferav1alpha1.InferaDeployment) *appsv1.StatefulSet {
 	lbls := natsLabels(idep.Name)
@@ -81,9 +83,8 @@ func buildNATSStatefulSet(idep *inferav1alpha1.InferaDeployment) *appsv1.Statefu
 					Containers: []corev1.Container{{
 						Name:  "nats",
 						Image: natsImage(idep),
-						// K8s expands $(NATS_STORE_DIR) in args from the env below.
-						Args: []string{"-js", "-sd", "$(NATS_STORE_DIR)", "-m", "8222"},
-						Env:  []corev1.EnvVar{{Name: "NATS_STORE_DIR", Value: "/data/jetstream"}},
+						Args:  []string{"-js", "-sd", "/data/jetstream", "-m", "8222"},
+						Env:   []corev1.EnvVar{{Name: "NATS_STORE_DIR", Value: "/data/jetstream"}},
 						Ports: []corev1.ContainerPort{
 							{Name: "client", ContainerPort: natsClientPort},
 							{Name: "monitor", ContainerPort: natsMonitorPort},

--- a/infera/engine/atom/__main__.py
+++ b/infera/engine/atom/__main__.py
@@ -38,7 +38,7 @@ from infera.common.net import free_tcp_port
 from infera.common.registration import RegistrationClient
 from infera.engine.atom.args import parse_atom_args
 from infera.engine.atom.worker import AtomEngine
-from infera.engine.base import watch_engine_death
+from infera.engine.base import EngineDeath, watch_engine_death
 
 logging.basicConfig(level=logging.INFO)
 logging.getLogger("httpx").setLevel(logging.WARNING)  # silence etcd keepalive spam
@@ -155,7 +155,8 @@ async def main() -> None:
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, stop.set)
 
-    death_task = watch_engine_death(engine, stop)
+    death = EngineDeath()
+    death_task = watch_engine_death(engine, stop, death)
     await stop.wait()
 
     death_task.cancel()
@@ -176,6 +177,8 @@ async def main() -> None:
         # thing to inherit if one is ever added.
         logger.warning("stopping anyway")
     await engine.stop()
+    if death.exit_status is not None:
+        raise SystemExit(death.exit_status)
 
 
 if __name__ == "__main__":

--- a/infera/engine/base.py
+++ b/infera/engine/base.py
@@ -70,13 +70,39 @@ class BaseEngine(ABC):
         return proc.returncode
 
 
-def watch_engine_death(engine: BaseEngine, stop: asyncio.Event) -> asyncio.Task:
+@dataclass
+class EngineDeath:
+    """Captures an inference subprocess exit observed by the death watcher."""
+
+    observed: bool = False
+    returncode: int | None = None
+
+    @property
+    def exit_status(self) -> int | None:
+        """Return a non-zero POSIX status for an observed subprocess exit."""
+        if not self.observed:
+            return None
+        if self.returncode is None:
+            return 1
+        if self.returncode < 0:
+            return 128 - self.returncode
+        return self.returncode or 1
+
+
+def watch_engine_death(
+    engine: BaseEngine,
+    stop: asyncio.Event,
+    death: EngineDeath | None = None,
+) -> asyncio.Task:
     async def _watch() -> None:
         if engine._proc is None:
             # No subprocess to watch (e.g. engine not started yet); never trip
             # shutdown on a phantom "death".
             return
         code = await engine.wait()
+        if death is not None:
+            death.observed = True
+            death.returncode = code
         logger.error(
             "engine subprocess exited (code=%s); deregistering worker and shutting down",
             code,

--- a/infera/engine/sglang/__main__.py
+++ b/infera/engine/sglang/__main__.py
@@ -29,7 +29,7 @@ from infera.common.disagg_preflight import (
     validate_sglang_transport,
 )
 from infera.common.registration import RegistrationClient
-from infera.engine.base import watch_engine_death
+from infera.engine.base import EngineDeath, watch_engine_death
 from infera.engine.drain import drain_engine_inflight
 from infera.engine.flush import anchor_kv_chain
 from infera.engine.sglang.args import (
@@ -341,8 +341,17 @@ async def _run_after_start(args: SglangWorkerArgs, engine: SglangEngine, config)
         loop = asyncio.get_running_loop()
         for sig in (signal.SIGINT, signal.SIGTERM):
             loop.add_signal_handler(sig, stop.set)
+        death = EngineDeath()
+        death_task = watch_engine_death(engine, stop, death)
         await stop.wait()
+        death_task.cancel()
+        try:
+            await death_task
+        except asyncio.CancelledError:
+            pass
         await engine.stop()
+        if death.exit_status is not None:
+            raise SystemExit(death.exit_status)
         return
 
     # --- KV plane (best-effort under auto, fatal under on, skipped under off) ---
@@ -468,7 +477,8 @@ async def _run_after_start(args: SglangWorkerArgs, engine: SglangEngine, config)
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, stop.set)
 
-    death_task = watch_engine_death(engine, stop)
+    death = EngineDeath()
+    death_task = watch_engine_death(engine, stop, death)
 
     await stop.wait()
 
@@ -528,6 +538,8 @@ async def _run_after_start(args: SglangWorkerArgs, engine: SglangEngine, config)
         await kv_wiring.stop()
 
     await engine.stop()
+    if death.exit_status is not None:
+        raise SystemExit(death.exit_status)
 
 
 if __name__ == "__main__":

--- a/infera/engine/vllm/__main__.py
+++ b/infera/engine/vllm/__main__.py
@@ -23,7 +23,7 @@ from infera.common.disagg_preflight import (
 from infera.common.net import free_tcp_port
 from infera.common.registration import RegistrationClient
 from infera.common.worker_pool import DisaggMode, KvRegistrationMetadata
-from infera.engine.base import watch_engine_death
+from infera.engine.base import EngineDeath, watch_engine_death
 from infera.engine.drain import drain_engine_inflight
 from infera.engine.flush import anchor_kv_chain
 from infera.engine.vllm.args import VllmWorkerArgs, parse_vllm_args
@@ -301,8 +301,17 @@ async def main() -> None:
         loop = asyncio.get_running_loop()
         for sig in (signal.SIGINT, signal.SIGTERM):
             loop.add_signal_handler(sig, stop.set)
+        death = EngineDeath()
+        death_task = watch_engine_death(engine, stop, death)
         await stop.wait()
+        death_task.cancel()
+        try:
+            await death_task
+        except asyncio.CancelledError:
+            pass
         await engine.stop()
+        if death.exit_status is not None:
+            raise SystemExit(death.exit_status)
         return
 
     # Optional NATS request transport: proxy this worker's per-instance subject
@@ -360,7 +369,8 @@ async def main() -> None:
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, stop.set)
 
-    death_task = watch_engine_death(engine, stop)
+    death = EngineDeath()
+    death_task = watch_engine_death(engine, stop, death)
     await stop.wait()
 
     death_task.cancel()
@@ -413,6 +423,8 @@ async def main() -> None:
     if kv_relay is not None:
         await kv_relay.stop()
     await engine.stop()
+    if death.exit_status is not None:
+        raise SystemExit(death.exit_status)
 
 
 if __name__ == "__main__":

--- a/infera/kv/nats_bus.py
+++ b/infera/kv/nats_bus.py
@@ -84,6 +84,22 @@ def parse_kv_subject(subject: str) -> tuple[str, int] | None:
 KV_VIEW_BUCKET = "infera_kv_view"
 
 
+def js_store_failed(exc: BaseException) -> bool:
+    """True when JetStream cannot open its on-disk msg blocks.
+
+    nats-server reports this as JSStreamStoreFailedF (10077), often with an
+    empty msg-block path when store_dir is unset or the FILE stream is
+    corrupt. Live routing still works; FILE-backed KV/stream writes do not.
+    """
+    text = str(exc).lower()
+    return (
+        "10077" in text
+        or "jsstreamstorefailed" in text.replace(" ", "")
+        or "msg block file" in text
+        or "opening msg block file" in text
+    )
+
+
 def kv_key_for_worker(worker_id: str, rank: int = 0) -> str:
     """KV bucket key ``<token>.<rank>`` (NATS KV keys allow ``.``)."""
     return f"{_token(worker_id)}.{rank}"
@@ -167,32 +183,63 @@ class NatsBus:
 
         return await self._nc.subscribe(subject, cb=_handler)
 
-    async def ensure_event_stream(self) -> None:
-        """Idempotently create the JetStream stream that captures live KV-event
-        deltas (infera.kv.events.>). Bounded by bytes/msgs so it can't grow
-        unbounded; OLD messages are discarded first. Both relay (publisher) and
-        router (subscriber) call this so neither races ahead of the other."""
-        if self._nc is None:
-            return
-        from nats.js.api import DiscardPolicy, RetentionPolicy, StorageType, StreamConfig
+    def _event_stream_config(self, storage):
+        from nats.js.api import DiscardPolicy, RetentionPolicy, StreamConfig
 
-        js = self._nc.jetstream()
-        cfg = StreamConfig(
+        return StreamConfig(
             name=KV_EVENTS_STREAM,
             subjects=[f"{KV_EVENTS_SUBJECT_PREFIX}.>"],
             retention=RetentionPolicy.LIMITS,
-            storage=StorageType.FILE,
+            storage=storage,
             discard=DiscardPolicy.OLD,
             max_bytes=256 * 1024 * 1024,
             max_msgs=1_000_000,
         )
+
+    async def _install_event_stream(self, js, cfg) -> Exception | None:
         try:
             await js.add_stream(cfg)
-        except Exception:
+            return None
+        except Exception as add_exc:
             try:
                 await js.update_stream(cfg)
-            except Exception:
-                pass
+                return None
+            except Exception as update_exc:
+                return update_exc if js_store_failed(update_exc) else add_exc
+
+    async def ensure_event_stream(self) -> None:
+        """Idempotently create the JetStream stream that captures live KV-event
+        deltas (infera.kv.events.>). Bounded by bytes/msgs so it can't grow
+        unbounded; OLD messages are discarded first. Both relay (publisher) and
+        router (subscriber) call this so neither races ahead of the other.
+
+        FILE is preferred. A 10077 / empty msg-block failure means the
+        broker's filestore is unusable, so the stream is deleted and recreated
+        in MEMORY rather than leaving kv-aware with a stream that cannot
+        accept publishes.
+        """
+        if self._nc is None:
+            return
+        from nats.js.api import StorageType
+
+        js = self._nc.jetstream()
+        err = await self._install_event_stream(js, self._event_stream_config(StorageType.FILE))
+        if err is None or not js_store_failed(err):
+            return
+        logger.warning(
+            "KV event stream FILE store failed (%s); recreating %s in MEMORY",
+            err,
+            KV_EVENTS_STREAM,
+        )
+        try:
+            await js.delete_stream(KV_EVENTS_STREAM)
+        except Exception:
+            pass
+        mem_err = await self._install_event_stream(
+            js, self._event_stream_config(StorageType.MEMORY)
+        )
+        if mem_err is not None:
+            logger.warning("KV event stream MEMORY recreate failed: %s", mem_err)
 
     async def js_publish(self, subject: str, payload: bytes) -> None:
         """Persistent publish onto the JetStream stream (acked, flow-controlled,
@@ -232,6 +279,11 @@ class NatsBus:
             config=ConsumerConfig(deliver_policy=DeliverPolicy.ALL),
         )
 
+    async def _create_kv_view(self, js, storage):
+        from nats.js.api import KeyValueConfig
+
+        return await js.create_key_value(KeyValueConfig(bucket=KV_VIEW_BUCKET, storage=storage))
+
     async def kv_view_store(self):
         """Return the JetStream KV bucket holding per-worker cache views,
         creating it on first use. Returns None if NATS isn't connected."""
@@ -241,14 +293,42 @@ class NatsBus:
         try:
             return await js.key_value(KV_VIEW_BUCKET)
         except Exception:
-            # BucketNotFoundError (or first-run race) -> create it.
-            from nats.js.api import KeyValueConfig
+            return await self._create_kv_view_with_fallback(js)
 
+    async def _create_kv_view_with_fallback(self, js):
+        from nats.js.api import StorageType
+
+        try:
+            return await self._create_kv_view(js, StorageType.FILE)
+        except Exception as exc:
+            if js_store_failed(exc):
+                logger.warning(
+                    "KV view bucket FILE create failed (%s); retrying in MEMORY", exc
+                )
+                try:
+                    await js.delete_key_value(KV_VIEW_BUCKET)
+                except Exception:
+                    pass
+                return await self._create_kv_view(js, StorageType.MEMORY)
             try:
-                return await js.create_key_value(KeyValueConfig(bucket=KV_VIEW_BUCKET))
-            except Exception:
-                # Lost a create race; the bucket now exists.
                 return await js.key_value(KV_VIEW_BUCKET)
+            except Exception:
+                return await self._create_kv_view(js, StorageType.MEMORY)
+
+    async def rebuild_kv_view_store(self):
+        """Drop a filestore-broken KV bucket and recreate it.
+
+        Called after a put returns 10077. FILE is retried first; MEMORY is
+        the fallback so a cold router can still seed from live workers.
+        """
+        if self._nc is None:
+            return None
+        js = self._nc.jetstream()
+        try:
+            await js.delete_key_value(KV_VIEW_BUCKET)
+        except Exception as exc:
+            logger.warning("KV view bucket delete failed (continuing recreate): %s", exc)
+        return await self._create_kv_view_with_fallback(js)
 
     async def close(self) -> None:
         if self._nc is not None:

--- a/infera/kv/nats_bus.py
+++ b/infera/kv/nats_bus.py
@@ -302,9 +302,7 @@ class NatsBus:
             return await self._create_kv_view(js, StorageType.FILE)
         except Exception as exc:
             if js_store_failed(exc):
-                logger.warning(
-                    "KV view bucket FILE create failed (%s); retrying in MEMORY", exc
-                )
+                logger.warning("KV view bucket FILE create failed (%s); retrying in MEMORY", exc)
                 try:
                     await js.delete_key_value(KV_VIEW_BUCKET)
                 except Exception:

--- a/infera/kv/nats_relay.py
+++ b/infera/kv/nats_relay.py
@@ -69,6 +69,8 @@ class KvEventNatsRelay:
         multiplexed: bool = False,
         nats_url: str | None = None,
     ) -> None:
+        if not worker_id.strip():
+            raise ValueError("worker_id must not be empty")
         self._worker_id = worker_id
         self._base_endpoint = _local_endpoint(engine_zmq_endpoint)
         # Ranks this relay tails. Multiplexed SGLang DP publishes rank r on
@@ -91,6 +93,8 @@ class KvEventNatsRelay:
         self._dirty: dict[int, bool] = {}
         self._decode_failures = 0
         self._next_decode_warn = 1
+        self._bucket_failures = 0
+        self._next_bucket_warn = 1
         self._ctx: zmq.asyncio.Context | None = None
         self._sockets: list[zmq.asyncio.Socket] = []
         self._tasks: list[asyncio.Task] = []
@@ -217,6 +221,19 @@ class KvEventNatsRelay:
         )
         self._next_decode_warn = self._decode_failures * 10
 
+    def _note_bucket_failure(self, rank: int, exc: Exception) -> None:
+        """Report persistent JetStream storage failures geometrically."""
+        self._bucket_failures += 1
+        if self._bucket_failures < self._next_bucket_warn:
+            return
+        logger.warning(
+            "KV relay bucket put failed (r%d, %d so far), will retry: %s",
+            rank,
+            self._bucket_failures,
+            exc,
+        )
+        self._next_bucket_warn = self._bucket_failures * 10
+
     async def _maybe_write_bucket(self, rank: int) -> None:
         if self._kv is None or not self._dirty.get(rank):
             return
@@ -231,6 +248,8 @@ class KvEventNatsRelay:
         view = sorted(self._sub.view_for(rank))
         try:
             await self._kv.put(kv_key_for_worker(self._worker_id, rank), self._encoder.encode(view))
+            self._bucket_failures = 0
+            self._next_bucket_warn = 1
         except Exception as exc:
             # Nothing was written, so the bucket still holds an older view. Left
             # clean, that view would stand until the *next* event happened to
@@ -241,7 +260,7 @@ class KvEventNatsRelay:
             # `_last_write` stays stamped, so the retry is spaced like any other
             # write rather than spinning at drain-tick rate against a dead bus.
             self._dirty[rank] = True
-            logger.warning("KV relay bucket put failed (r%d), will retry: %s", rank, exc)
+            self._note_bucket_failure(rank, exc)
 
     async def stop(self) -> None:
         self._closing = True

--- a/infera/kv/nats_relay.py
+++ b/infera/kv/nats_relay.py
@@ -284,9 +284,7 @@ class KvEventNatsRelay:
                         self._dirty[rank] = False
                         self._bucket_failures = 0
                         self._next_bucket_warn = 1
-                        logger.warning(
-                            "KV view bucket rebuilt after filestore failure (r%d)", rank
-                        )
+                        logger.warning("KV view bucket rebuilt after filestore failure (r%d)", rank)
                         return
                     except Exception as retry_exc:
                         self._note_bucket_failure(rank, retry_exc)

--- a/infera/kv/nats_relay.py
+++ b/infera/kv/nats_relay.py
@@ -33,6 +33,7 @@ from msgspec.msgpack import Decoder, Encoder
 
 from infera.kv.nats_bus import (
     NatsBus,
+    js_store_failed,
     kv_key_for_worker,
     subject_for_worker,
 )
@@ -95,6 +96,8 @@ class KvEventNatsRelay:
         self._next_decode_warn = 1
         self._bucket_failures = 0
         self._next_bucket_warn = 1
+        self._kv_healed = False
+        self._stream_healed = False
         self._ctx: zmq.asyncio.Context | None = None
         self._sockets: list[zmq.asyncio.Socket] = []
         self._tasks: list[asyncio.Task] = []
@@ -154,7 +157,15 @@ class KvEventNatsRelay:
             try:
                 await self._bus.js_publish(subject, payload)
             except Exception as exc:
-                logger.warning("KV relay NATS publish failed: %s", exc)
+                if js_store_failed(exc) and not self._stream_healed:
+                    self._stream_healed = True
+                    await self._bus.ensure_event_stream()
+                    try:
+                        await self._bus.js_publish(subject, payload)
+                    except Exception as retry_exc:
+                        logger.warning("KV relay NATS publish failed: %s", retry_exc)
+                else:
+                    logger.warning("KV relay NATS publish failed: %s", exc)
             # 2. Update authoritative per-rank view + persist to KV bucket.
             try:
                 batch = self._decoder.decode(payload)
@@ -260,6 +271,26 @@ class KvEventNatsRelay:
             # `_last_write` stays stamped, so the retry is spaced like any other
             # write rather than spinning at drain-tick rate against a dead bus.
             self._dirty[rank] = True
+            if js_store_failed(exc) and not self._kv_healed:
+                self._kv_healed = True
+                store = await self._bus.rebuild_kv_view_store()
+                if store is not None:
+                    self._kv = store
+                    try:
+                        await self._kv.put(
+                            kv_key_for_worker(self._worker_id, rank),
+                            self._encoder.encode(view),
+                        )
+                        self._dirty[rank] = False
+                        self._bucket_failures = 0
+                        self._next_bucket_warn = 1
+                        logger.warning(
+                            "KV view bucket rebuilt after filestore failure (r%d)", rank
+                        )
+                        return
+                    except Exception as retry_exc:
+                        self._note_bucket_failure(rank, retry_exc)
+                        return
             self._note_bucket_failure(rank, exc)
 
     async def stop(self) -> None:

--- a/infera/router/auto.py
+++ b/infera/router/auto.py
@@ -77,15 +77,14 @@ class AutoRouter(BaseRouter):
         has_d = self.pool.list_active(model=model, mode=DisaggMode.DECODE)
         if has_p and has_d:
             return await self._disagg.dispatch(body, stream=stream, path=path)
+        has_mixed = self.pool.list_active(model=model, mode=DisaggMode.MIXED)
         # Exactly one PD pool populated: the deployment is disaggregated but
         # half of it is gone. Falling through to the mixed router would be
         # correct-but-useless -- there are no mixed workers either, so it
         # answers "no active mixed worker", which sends the reader looking for
         # something they never deployed while a decode (or prefill) pool sits
         # right there. Scaling either side to zero is the usual cause.
-        if bool(has_p) != bool(has_d) and not self.pool.list_active(
-            model=model, mode=DisaggMode.MIXED
-        ):
+        if bool(has_p) != bool(has_d) and not has_mixed:
             present, missing = ("prefill", "decode") if has_p else ("decode", "prefill")
             logger.warning(
                 "model=%r has %d %s worker(s) but no %s worker: PD dispatch needs both",
@@ -101,6 +100,11 @@ class AutoRouter(BaseRouter):
                         f"but no {missing} worker; PD dispatch requires both pools"
                     )
                 },
+                status_code=503,
+            )
+        if not has_p and not has_d and not has_mixed:
+            return JSONResponse(
+                content={"error": f"no active worker for model={model!r}"},
                 status_code=503,
             )
         return await self._mixed.dispatch(body, stream=stream, path=path)

--- a/rust/router/src/kv_event_nats.rs
+++ b/rust/router/src/kv_event_nats.rs
@@ -166,11 +166,32 @@ async fn ensure_event_stream(js: &async_nats::jetstream::Context) -> Result<()> 
     };
     // The relay may have created it first; either way the config converges.
     if js.create_stream(cfg.clone()).await.is_err() {
-        js.update_stream(&cfg)
-            .await
-            .context("creating or updating the KV event stream")?;
+        match js.update_stream(&cfg).await {
+            Ok(_) => {}
+            Err(e) if is_js_store_failed(&e) => {
+                tracing::warn!(
+                    "kv events (nats): FILE stream store failed ({e:#}); recreating {KV_EVENTS_STREAM} in MEMORY"
+                );
+                let _ = js.delete_stream(KV_EVENTS_STREAM).await;
+                let mut mem = cfg;
+                mem.storage = StorageType::Memory;
+                js.create_stream(mem)
+                    .await
+                    .context("recreating the KV event stream in MEMORY")?;
+            }
+            Err(e) => {
+                return Err(e).context("creating or updating the KV event stream");
+            }
+        }
     }
     Ok(())
+}
+
+fn is_js_store_failed(err: &impl std::fmt::Display) -> bool {
+    let text = err.to_string().to_ascii_lowercase();
+    text.contains("10077")
+        || text.contains("msg block file")
+        || text.contains("jsstreamstorefailed")
 }
 
 async fn consume_events(
@@ -217,7 +238,48 @@ async fn consume_events(
     Ok(())
 }
 
-/// A bucket value is the msgpack list of chained hashes the relay wrote.
+async fn open_kv_view(
+    js: &async_nats::jetstream::Context,
+) -> Result<async_nats::jetstream::kv::Store> {
+    use async_nats::jetstream::kv::Config;
+    use async_nats::jetstream::stream::StorageType;
+
+    match js
+        .create_key_value(Config {
+            bucket: KV_VIEW_BUCKET.to_string(),
+            storage: StorageType::File,
+            ..Default::default()
+        })
+        .await
+    {
+        Ok(store) => Ok(store),
+        Err(e) if is_js_store_failed(&e) => {
+            tracing::warn!(
+                "kv events (nats): FILE KV store failed ({e:#}); recreating {KV_VIEW_BUCKET} in MEMORY"
+            );
+            let _ = js.delete_key_value(KV_VIEW_BUCKET).await;
+            js.create_key_value(Config {
+                bucket: KV_VIEW_BUCKET.to_string(),
+                storage: StorageType::Memory,
+                ..Default::default()
+            })
+            .await
+            .context("recreating the KV view bucket in MEMORY")
+        }
+        Err(_) => match js.get_key_value(KV_VIEW_BUCKET).await {
+            Ok(store) => Ok(store),
+            Err(_) => js
+                .create_key_value(Config {
+                    bucket: KV_VIEW_BUCKET.to_string(),
+                    storage: StorageType::Memory,
+                    ..Default::default()
+                })
+                .await
+                .context("opening the KV view bucket"),
+        },
+    }
+}
+
 fn decode_view(bytes: &[u8]) -> Option<Vec<u64>> {
     let mut cur = std::io::Cursor::new(bytes);
     let value = rmpv::decode::read_value(&mut cur).ok()?;
@@ -240,22 +302,29 @@ async fn watch_bucket(
 ) -> Result<()> {
     let store = match js.get_key_value(KV_VIEW_BUCKET).await {
         Ok(s) => s,
-        Err(_) => js
-            .create_key_value(async_nats::jetstream::kv::Config {
-                bucket: KV_VIEW_BUCKET.to_string(),
-                ..Default::default()
-            })
-            .await
-            .context("opening the KV view bucket")?,
+        Err(_) => open_kv_view(&js).await.context("opening the KV view bucket")?,
     };
     // `watch_all` delivers only subsequent updates, which would leave a
     // cold-starting router waiting for the next time a relay happens to rewrite
     // a view -- the bootstrap would never arrive. Asking for history delivers
     // each key's current value first, then the updates.
-    let mut watcher = store
-        .watch_many_with_history([">"])
-        .await
-        .context("watching the KV view bucket")?;
+    let mut watcher = match store.watch_many_with_history([">"]).await {
+        Ok(w) => w,
+        Err(e) if is_js_store_failed(&e) => {
+            tracing::warn!(
+                "kv events (nats): KV watch FILE store failed ({e:#}); rebuilding {KV_VIEW_BUCKET}"
+            );
+            let _ = js.delete_key_value(KV_VIEW_BUCKET).await;
+            let healed = open_kv_view(&js)
+                .await
+                .context("reopening the KV view bucket after filestore failure")?;
+            healed
+                .watch_many_with_history([">"])
+                .await
+                .context("watching the KV view bucket")?
+        }
+        Err(e) => return Err(e).context("watching the KV view bucket"),
+    };
     while let Some(entry) = watcher.next().await {
         let entry = match entry {
             Ok(e) => e,
@@ -290,6 +359,14 @@ mod tests {
 
     fn token(s: &str) -> String {
         URL_SAFE_NO_PAD.encode(s.as_bytes())
+    }
+
+    #[test]
+    fn store_failed_detects_empty_msg_block() {
+        assert!(is_js_store_failed(
+            &r#"nats: 503 err_code=10077 error opening msg block file [""]"#
+        ));
+        assert!(!is_js_store_failed(&"timeout"));
     }
 
     #[test]

--- a/rust/router/src/kv_event_nats.rs
+++ b/rust/router/src/kv_event_nats.rs
@@ -302,7 +302,9 @@ async fn watch_bucket(
 ) -> Result<()> {
     let store = match js.get_key_value(KV_VIEW_BUCKET).await {
         Ok(s) => s,
-        Err(_) => open_kv_view(&js).await.context("opening the KV view bucket")?,
+        Err(_) => open_kv_view(&js)
+            .await
+            .context("opening the KV view bucket")?,
     };
     // `watch_all` delivers only subsequent updates, which would leave a
     // cold-starting router waiting for the next time a relay happens to rewrite

--- a/rust/router/src/proxy.rs
+++ b/rust/router/src/proxy.rs
@@ -357,11 +357,34 @@ pub(crate) async fn dispatch_routed(
     let guard = state.pool.load();
     let snap: &Snapshot = &guard;
 
-    let has_p = !snap.list_active(model, DisaggMode::Prefill).is_empty();
-    let has_d = !snap.list_active(model, DisaggMode::Decode).is_empty();
+    let prefill = snap.list_active(model, DisaggMode::Prefill);
+    let decode = snap.list_active(model, DisaggMode::Decode);
+    let mixed = snap.list_active(model, DisaggMode::Mixed);
+    let has_p = !prefill.is_empty();
+    let has_d = !decode.is_empty();
     if has_p && has_d {
         return crate::disagg::dispatch(state, snap, model, routing_request, raw, stream, path)
             .await;
+    }
+    if has_p != has_d && mixed.is_empty() {
+        let (present, missing, count) = if has_p {
+            ("prefill", "decode", prefill.len())
+        } else {
+            ("decode", "prefill", decode.len())
+        };
+        return json_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            &format!(
+                "model={model:?} has {count} {present} worker(s) but no {missing} worker; \
+                 PD dispatch requires both pools"
+            ),
+        );
+    }
+    if !has_p && !has_d && mixed.is_empty() {
+        return json_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            &format!("no active worker for model={model:?}"),
+        );
     }
     mixed_dispatch(state, snap, model, routing_request, raw, stream, path).await
 }

--- a/rust/router/tests/functional.rs
+++ b/rust/router/tests/functional.rs
@@ -367,6 +367,52 @@ async fn mixed_failover_to_healthy_worker() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn half_pd_names_the_missing_pool() {
+    for (mode, missing) in [("prefill", "decode"), ("decode", "prefill")] {
+        let state = make_state(
+            vec![worker(json!({
+                "worker_id": mode,
+                "url": "http://127.0.0.1:1",
+                "model_name": "m",
+                "disagg_mode": mode
+            }))],
+            0,
+        );
+        let router = spawn_router(state).await;
+        let resp = client()
+            .post(format!("{router}/v1/chat/completions"))
+            .json(&json!({"model": "m"}))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 503);
+        let body = resp.json::<Value>().await.unwrap();
+        let error = body["error"].as_str().unwrap();
+        assert!(error.contains(missing), "{error}");
+        assert!(error.contains("PD dispatch requires both pools"), "{error}");
+        assert!(!error.contains("mixed"), "{error}");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn empty_fleet_reports_no_active_worker() {
+    let router = spawn_router(make_state(vec![], 0)).await;
+    let resp = client()
+        .post(format!("{router}/v1/chat/completions"))
+        .json(&json!({"model": "m"}))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 503);
+    assert_eq!(
+        resp.json::<Value>().await.unwrap()["error"],
+        "no active worker for model=\"m\""
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn breaker_stops_reselecting_a_dead_worker() {
     // The regression behind issue #82, end to end through the real router
     // rather than against the breaker in isolation.

--- a/tests/unit/engine/test_engine_death_exit.py
+++ b/tests/unit/engine/test_engine_death_exit.py
@@ -1,0 +1,53 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from infera.engine.base import EngineDeath, watch_engine_death
+
+
+class _DeadEngine:
+    """Provides the process contract consumed by the death watcher."""
+
+    _proc = object()
+
+    def __init__(self, returncode: int | None) -> None:
+        self.returncode = returncode
+
+    async def wait(self) -> int | None:
+        return self.returncode
+
+
+@pytest.mark.parametrize(
+    ("returncode", "exit_status"),
+    [(-9, 137), (-15, 143), (7, 7), (0, 1), (None, 1)],
+)
+def test_engine_death_maps_subprocess_returncode(returncode, exit_status):
+    """Signal exits retain their conventional POSIX shell status."""
+    death = EngineDeath(observed=True, returncode=returncode)
+    assert death.exit_status == exit_status
+
+
+def test_unobserved_engine_death_has_no_exit_status():
+    """An operator shutdown remains a successful launcher exit."""
+    assert EngineDeath().exit_status is None
+
+
+@pytest.mark.asyncio
+async def test_watcher_records_death_before_requesting_shutdown():
+    """The launcher can distinguish engine death from an operator signal."""
+    stop = asyncio.Event()
+    death = EngineDeath()
+
+    task = watch_engine_death(_DeadEngine(-9), stop, death)
+    await task
+
+    assert stop.is_set()
+    assert death.returncode == -9
+    assert death.exit_status == 137

--- a/tests/unit/kv/test_nats_bus.py
+++ b/tests/unit/kv/test_nats_bus.py
@@ -1,0 +1,24 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+from __future__ import annotations
+
+import pytest
+
+from infera.kv.nats_bus import js_store_failed
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ('nats: 503 err_code=10077 error opening msg block file [""]', True),
+        ("JSStreamStoreFailedF", True),
+        ("error opening msg block file", True),
+        ("timeout talking to nats", False),
+    ],
+)
+def test_js_store_failed_detects_filestore_errors(text, expected):
+    """10077 is a broken JetStream FILE store, not a missing worker."""
+    assert js_store_failed(RuntimeError(text)) is expected

--- a/tests/unit/kv/test_nats_relay.py
+++ b/tests/unit/kv/test_nats_relay.py
@@ -64,6 +64,16 @@ def _relay(engine) -> KvEventNatsRelay:
     )
 
 
+def test_relay_rejects_an_empty_worker_id():
+    """Bucket keys must always identify one registered worker."""
+    with pytest.raises(ValueError, match="worker_id"):
+        KvEventNatsRelay(
+            worker_id=" ",
+            engine_zmq_endpoint="tcp://0.0.0.0:5557",
+            engine=EngineType.SGLANG,
+        )
+
+
 class _FakeSocket:
     """Hands out each payload once, then lets ``_loop`` fall out of its while."""
 
@@ -275,6 +285,24 @@ async def test_a_put_that_failed_is_retried_rather_than_dropped(monkeypatch):
 
     assert len(kv.puts) == 1, "the view the failed put carried never reached the bucket"
     assert relay._dirty[0] is False
+
+
+@pytest.mark.asyncio
+async def test_persistent_bucket_failures_are_logged_geometrically(monkeypatch, caplog):
+    """A broken JetStream store must not flood the worker log."""
+    monkeypatch.setattr(relay_mod, "_BUCKET_WRITE_INTERVAL_S", 0)
+    relay = _relay(EngineType.SGLANG)
+    relay._kv = _FakeKv(fail_first=20)
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(11):
+            relay._dirty[0] = True
+            await relay._maybe_write_bucket(0)
+
+    messages = [r.message for r in caplog.records if "bucket put failed" in r.message]
+    assert len(messages) == 2
+    assert "1 so far" in messages[0]
+    assert "10 so far" in messages[1]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/kv/test_nats_relay.py
+++ b/tests/unit/kv/test_nats_relay.py
@@ -306,6 +306,45 @@ async def test_persistent_bucket_failures_are_logged_geometrically(monkeypatch, 
 
 
 @pytest.mark.asyncio
+async def test_a_filestore_put_failure_rebuilds_the_bucket(monkeypatch):
+    """A 10077 bucket is dropped and replaced so bootstrap can resume."""
+    monkeypatch.setattr(relay_mod, "_BUCKET_WRITE_INTERVAL_S", 0)
+    relay = _relay(EngineType.SGLANG)
+
+    class _Broken:
+        async def put(self, key, value):
+            raise RuntimeError('nats: 503 err_code=10077 error opening msg block file [""]')
+
+    class _Healed:
+        def __init__(self) -> None:
+            self.puts: list[bytes] = []
+
+        async def put(self, key, value):
+            self.puts.append(value)
+
+    class _Bus:
+        def __init__(self, store) -> None:
+            self.store = store
+            self.rebuilds = 0
+
+        async def rebuild_kv_view_store(self):
+            self.rebuilds += 1
+            return self.store
+
+    healed = _Healed()
+    bus = _Bus(healed)
+    relay._kv = _Broken()
+    relay._bus = bus
+    relay._dirty[0] = True
+    await relay._maybe_write_bucket(0)
+
+    assert bus.rebuilds == 1
+    assert len(healed.puts) == 1
+    assert relay._dirty[0] is False
+    assert relay._kv is healed
+
+
+@pytest.mark.asyncio
 async def test_the_drain_writes_nothing_when_no_rank_is_dirty(monkeypatch):
     """It runs for the life of the worker, so a quiet rank must cost a dict
     lookup and not a bucket round-trip per tick."""

--- a/tests/unit/router/test_failover.py
+++ b/tests/unit/router/test_failover.py
@@ -390,6 +390,19 @@ async def test_half_a_pd_deployment_names_the_empty_pool(present, missing):
 
 
 @pytest.mark.asyncio
+async def test_empty_fleet_does_not_claim_a_mixed_worker_is_required():
+    """An empty auto-router fleet reports the actual absence of workers."""
+    from infera.router.auto import AutoRouter
+
+    r = AutoRouter(_ModePool([]), _FakePolicy())
+    resp = await r.dispatch({"model": "m"}, stream=False)
+    assert resp.status_code == 503
+    body = json.loads(bytes(resp.body))["error"]
+    assert body == "no active worker for model='m'"
+    await r.aclose()
+
+
+@pytest.mark.asyncio
 async def test_a_mixed_worker_still_absorbs_a_half_pd_fleet():
     """A mixed worker alongside half a PD pool can serve, so the 503 must not
     fire -- this is the rolling-upgrade case."""


### PR DESCRIPTION
## Summary
- Engine subprocess SIGKILL and similar crashes now exit the worker non-zero, and an empty PD pool is reported as a named prefill/decode outage rather than a missing mixed worker.
- JetStream FILE streams/KV buckets that fail with 10077 (empty or corrupt msg-block path) are recreated in MEMORY so kv-aware routing can keep publishing.
- Infera operator NATS uses `nats:2.11.1` and a literal `/data/jetstream` store dir instead of CRI-dependent `$(NATS_STORE_DIR)` expansion.

## Test plan
- [ ] `pytest -n auto tests/unit/kv/test_nats_bus.py tests/unit/kv/test_nats_relay.py tests/unit/engine/test_engine_death_exit.py`
- [ ] Confirm a 10077 bucket put rebuilds the KV view instead of flooding logs
- [ ] Confirm operator NATS args are `-js -sd /data/jetstream -m 8222`


Made with [Cursor](https://cursor.com)