### PR TITLE
GLM-5.3 (glm_moe_dsa): mixed, 1P1D, and a Kubernetes recipe — plus overlay support for SGLang bases

### DIFF
--- a/deploy/docker/Dockerfile.sglang
+++ b/deploy/docker/Dockerfile.sglang
@@ -6,6 +6,11 @@
 # the end of this file are context diffs applied at --fuzz=0 against this exact
 # sglang release. Bumping the base fails the build there rather than silently
 # mis-applying. Build with APPLY_SGLANG_DSA_PATCHES=0 if you need a newer base.
+#
+# GLM-5.3 and GLM-5.3-MXFP4 need NO new model source here: they are model_type
+# `glm_moe_dsa` / GlmMoeDsaForCausalLM, and their config.json is field-for-field
+# identical to GLM-5.2's except `transformers_version`, so the released engine
+# already serves them through glm4_moe.py.
 ARG SGLANG_BASE_IMAGE=lmsysorg/sglang:v0.5.18-rocm720-mi35x
 FROM ${SGLANG_BASE_IMAGE}
 

--- a/deploy/docker/patch.upstream.status.md
+++ b/deploy/docker/patch.upstream.status.md
@@ -156,6 +156,58 @@ anchor match.
 > therefore covered on the v0.5.18/gfx950 image; this MLA-only patch neither fixes
 > nor participates in that V4 path.
 
+## sglang carried — `patches/sglang_carried/` (**baked by nothing**)
+
+Held, reviewable, and deliberately not built. No Dockerfile copies or runs this
+directory, which is why these scripts are not in `sglang_rocm/` beside their
+siblings: every other patch directory is consumed by an unconditional
+`for f in .../*.py; do python "$f"; done`, so a file placed there is wired into
+every image that copies it, with no per-file opt-out.
+`patches/sglang_carried/README.md` carries the rule and the exit criteria.
+
+| patch | fixes | upstream issue | upstream PR | ours? | PR state |
+|---|---|---|---|---|---|
+| `sglang_carried/patch_glm_moe_gate_bias_fp32.py` | `MoEGate.__init__` allocates the MoE `e_score_correction_bias` as **bf16** whenever a quant_config is present and `_use_aiter`, and `biased_grouped_topk_gpu` casts it down again at the aiter call. GLM's bias is a narrow band at a large offset, so bf16 cannot hold it: measured on the checkpoints themselves, GLM-5.3 / -MXFP4 collapse **238 distinct fp32 values to 8**, which reorders `noaux_tc` top-k routing | none found | [sglang#37133](https://github.com/sgl-project/sglang/pull/37133) `[GLM-5.2] Keep GlmMoeDsa MoE e_score_correction_bias in fp32` (`xiaobochen-amd`) — same defect, **narrower gate**: see below | no (`xiaobochen-amd`) | OPEN |
+
+**Status: carried, not applied.** Verified as text and as predicate logic only —
+applies to copies of `v0.5.18` and `c821c425`, idempotent on re-run, and both
+drift cases exit 1 having written neither file. **It has never been executed on a
+GPU, and no accuracy or throughput delta has been measured.** Do not read the row
+above as validation.
+
+Not wired because the defect is a routing perturbation, not a crash: the server
+starts, answers, and reports plausible numbers either way. Rebuilding the engine
+image mid-comparison would leave one arm the only one running the fixed router
+and destroy the like-for-like property those ratios rest on. The exit criterion
+is a hardware run plus a measurement of the thing it claims to change.
+
+> **Why the gate is broader than upstream's.** #37133 gates on
+> `any("GlmMoeDsa" in arch for arch in config.architectures)`, which only fires
+> when the config object `MoEGate` actually receives carries that arch string.
+>
+> This script's `_moe_gate_bias_wants_fp32()` is a union of three tests:
+> `moe_router_dtype == "float32"` (the model author's own declaration — carried by
+> the GLM-5.3 configs and GLM-5.2-FP8, and **sglang has zero references to the
+> field**, which is the actual root cause); `model_type` (`glm_moe_dsa`, needed
+> because GLM-5.2-MXFP4 and GLM-5.1-FP8 predate that field, and it survives the
+> NextN rewrite in `configs/model_config.py:623`); and upstream's arch test, kept
+> so this stays a superset of #37133 and becomes a no-op once it lands. Checked
+> against every checkpoint available: GLM keeps fp32, non-GLM stays
+> byte-identical.
+>
+> **Both edits or neither, and that is not stylistic.** aiter's launcher
+> (`csrc/kernels/topk_softmax_kernels_group.cu:1156`) dispatches on
+> `gating_output.dtype()` and then `reinterpret_cast`s the bias pointer to that
+> same `scalar_t` **without checking the bias tensor's own dtype**. An fp32 bias
+> under a bf16 gating tensor is neither an error nor a cast — it reads fp32 bytes
+> as bf16. So applying the `deepseek_v2.py` half alone is strictly worse than the
+> defect, and the script plans both files before writing either.
+>
+> **Drop this patch** when a base sglang keeps the GLM bias fp32 on both sides;
+> the replacement text is then already present and the script reports "already
+> present" and no-ops. If only #37133's narrower form lands, keep this — its gate
+> stays a superset.
+
 ## Mooncake C++ — `patches/mooncake_cpp/`
 
 SGLang now builds Mooncake `faae8dd4` directly and carries no private Mooncake

--- a/deploy/docker/patches/sglang_carried/README.md
+++ b/deploy/docker/patches/sglang_carried/README.md
@@ -1,0 +1,53 @@
+# `patches/sglang_carried/` — patches we hold, and deliberately do not build
+
+**No Dockerfile copies or runs anything in this directory.** That is the whole
+point of it, and it is the reason these scripts do not live beside their
+siblings in `patches/sglang_rocm/`.
+
+Every other patch directory is consumed the same way:
+
+```dockerfile
+COPY deploy/docker/patches/sglang_rocm/ /tmp/sglang-rocm-patches/
+RUN set -eu; \
+    for f in /tmp/sglang-rocm-patches/*.py; do echo "[sglang-patch] $f"; python "$f"; done; \
+```
+
+The glob is `*.py` and the loop is unconditional, so **dropping a file into one
+of those directories wires it into every image that copies the directory** —
+`Dockerfile.sglang` and `Dockerfile.sglang.gfx942` for `sglang_rocm/`. There is
+no per-file opt-out. A patch that is ready to read but not ready to build
+therefore cannot be stored there without changing two images.
+
+This directory is the opt-out. Nothing globs it, so a script here is carried,
+reviewable, and inert.
+
+## When a patch belongs here
+
+When all three hold:
+
+- the defect is established well enough to write the fix down,
+- the fix has **not** been executed on hardware, or its effect has not been
+  measured, and
+- wiring it would perturb something in flight — a benchmark campaign, an
+  alignment comparison, a result set whose numbers are already reported.
+
+The last one is the common case, and it is why "carried" is a status and not a
+euphemism for "unfinished". A silently changed image invalidates every number
+measured before and after it; an unwired script costs nothing and loses nothing.
+
+## Moving one out
+
+Move the file into the directory of the image that should carry it
+(`sglang_rocm/`, `sglang_dsa/`, …) and update its row in
+`../../patch.upstream.status.md` from *carried, not applied* to the image list
+it is now baked by. The glob picks it up from there — no Dockerfile edit is
+needed, which is exactly why the move must be deliberate.
+
+Before moving one out, it needs what it did not have when it was parked: a run
+on hardware, and a measurement of the thing it claims to change.
+
+## Contents
+
+| script | what it fixes | why it is not wired |
+|---|---|---|
+| `patch_glm_moe_gate_bias_fp32.py` | GLM MoE `e_score_correction_bias` is allocated bf16 under aiter+quant and downcast again at the aiter router boundary; GLM's bias band collapses from 238 distinct fp32 values to 8 in bf16, reordering `noaux_tc` top-k routing | verified as text and as predicate logic only — **never executed on a GPU**, and no accuracy or throughput delta measured. Wiring it would rebuild the engine image and confound an in-flight comparison whose validity rests on both arms running the same code |

--- a/deploy/docker/patches/sglang_carried/patch_glm_moe_gate_bias_fp32.py
+++ b/deploy/docker/patches/sglang_carried/patch_glm_moe_gate_bias_fp32.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""GLM MoE gate: keep `e_score_correction_bias` in fp32 end to end.
+
+WHAT: on ROCm with aiter, `MoEGate.__init__` allocates the MoE
+`e_score_correction_bias` parameter as **bf16** whenever a quant_config is
+present, and `biased_grouped_topk_gpu` casts it down again at the aiter call.
+GLM's bias is a narrow band at a large offset, so bf16 cannot represent it: the
+router ends up choosing among hundreds of experts using a bias with single-digit
+distinct levels. This patch keeps the parameter fp32 for GLM MoE models and, at
+the aiter boundary, promotes the gating logits to fp32 instead of demoting the
+bias.
+
+WHY: read from the checkpoints' own safetensors --
+
+    checkpoint              tensor                       range          fp32  bf16
+    GLM-5.3-MXFP4    L10 mlp.gate.e_score_correction_bias 6.817 - 7.063   238     8
+    GLM-5.3          L10 (byte-identical values)          6.817 - 7.063   238     8
+
+  bf16's ULP at 7.0 is 0.03125 and the whole spread is ~0.25, so 238 distinct
+  fp32 biases collapse into 8 bf16 bins. `noaux_tc` selects experts by
+  `sigmoid(logits) + correction_bias`, so this is a routing perturbation.
+  Upstream (sgl-project/sglang#37133) measured **98.50 % of tokens select a
+  different top-8 expert set** on GLM-5.2, and states plainly that accuracy
+  benchmarks cannot resolve it (GSM8K 0.941 -> 0.947, GPQA-D 0.8333 -> 0.8182,
+  both inside the error bars). Those are UPSTREAM's numbers on GLM-5.2 / MI355X.
+  The dtype collapse above is a property of the checkpoints, not a quality
+  measurement, and nothing here should be read as claiming one.
+
+  This is a correctness fix and it COSTS a little throughput: upstream reports a
+  flat +4.5 us per gating call, <= 1.2 % of a decode step. Do not expect tok/s.
+
+  The trigger is live whenever, link by link:
+    1. `SGLANG_USE_AITER=1` is set, so
+       `_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip` is True.
+    2. the launched quantization is in the downcast tuple, e.g. `quark`.
+    3. `DeepseekV2MoE` forwards the model-level quant_config into `MoEGate`
+       unchanged, so `quant_config is not None` holds.
+    4. On HIP the flashinfer and `_is_cuda` arms of `biased_grouped_topk_gpu`
+       are skipped, so control lands in the `elif _use_aiter:` arm that casts
+       down.
+
+HOW: two edits that MUST land together (see "BOTH OR NEITHER" below).
+
+  A. `models/deepseek_v2.py` -- add `_moe_gate_bias_wants_fp32(config)` and use
+     it to skip the bf16 downcast in `MoEGate.__init__`.
+  B. `layers/moe/topk.py` -- in `biased_grouped_topk_gpu`'s aiter arm, when the
+     bias arrives fp32, pass it through and promote `gating_output` to fp32;
+     otherwise keep today's downcast byte-for-byte.
+
+BOTH OR NEITHER -- why edit B is not optional polish. aiter's kernel launcher
+is:
+
+    VLLM_DISPATCH_FLOATING_TYPES_rmTorch(gating_output.dtype(), ..., [&] {
+        ... reinterpret_cast<scalar_t*>(gating_output.data_ptr()),
+            reinterpret_cast<scalar_t*>(correction_bias.data_ptr()), ...
+
+  (`csrc/kernels/topk_softmax_kernels_group.cu`.) It
+  dispatches on the GATING dtype only and then **reinterpret_casts the bias to
+  that same scalar_t with no check of the bias tensor's own dtype**. Handing it
+  an fp32 bias alongside a bf16 gating tensor is not an error and not a cast --
+  it reads fp32 bytes as bf16 and returns silent garbage. So applying A without
+  B is strictly WORSE than the bug it fixes. That is the concrete reason this
+  script is all-or-nothing rather than two independent edits.
+
+  The converse direction is safe: `AITER_DTYPE_fp32` is in the dispatch list, so
+  promoting the gating tensor is a supported instantiation.
+
+WHY THE GATE IS BROADER THAN UPSTREAM'S. #37133 gates on `any("GlmMoeDsa" in
+arch for arch in config.architectures)`, which is only True when the config
+object `MoEGate` actually receives carries that arch string. The predicate here
+is a union of three tests, cheapest first:
+
+    1. `moe_router_dtype == "float32"` -- the model author's own declaration.
+       Present on GLM-5.3, GLM-5.3-MXFP4 and GLM-5.2-FP8-fixed. sglang v0.5.18
+       ignores the field entirely (zero references under `python/sglang/srt/`),
+       which is the actual root cause.
+    2. `model_type` -- `glm_moe_dsa` covers GLM-5.1/5.2/5.3, which is needed
+       because GLM-5.2-MXFP4 and GLM-5.1-FP8 predate the `moe_router_dtype`
+       field. `model_type` survives the NextN rewrite in
+       `configs/model_config.py`, so draft heads are covered without a substring
+       hack.
+    3. upstream's arch-string test, kept so this stays a superset of #37133 and
+       is a no-op once that lands.
+
+  BLAST RADIUS, measured rather than assumed: only GLM 5.2/5.3 checkpoints carry
+  `moe_router_dtype: "float32"`. Every DeepSeek-V3/V4/R1, Kimi-K3, Qwen2.5/3/3.5,
+  MiniMax-M3, Hy3, MiMo, Llama and Mistral config has it unset and a non-GLM
+  `model_type`, so all of them take the unchanged branch and stay byte-identical.
+
+CONTEXT
+  upstream       sgl-project/sglang#37133 "[GLM-5.2] Keep GlmMoeDsa MoE
+                 e_score_correction_bias in fp32" (xiaobochen-amd), OPEN against
+                 main, not merged. Its CI is red only at `pr-gate` /
+                 `*-finish` aggregators -- the missing-`run-ci`-label failure --
+                 so no AMD job has actually run, and the AMD runners are
+                 `linux-mi300-*` (gfx942), not gfx950. Treat it as unvalidated
+                 on gfx950.
+  bases          The `MoEGate` dtype block is textually IDENTICAL on v0.5.18 and
+                 c821c425, so edit A has one anchor. `topk.py` drifted -- v0.5.18
+                 has `correction_bias.to(dtype=gating_output.dtype)` inline where
+                 c821c425 hoisted a `bias` local and a `scaling` local -- so edit
+                 B carries one alternative per base and requires that EXACTLY ONE
+                 of them match.
+  why a script   Upstream's diff FAILS `git apply --check` on v0.5.18 (the
+                 `topk.py` hunk). Both bases are pinned and neither can move:
+                 c821c425 is a merged-and-frozen ref whose upstream branch was
+                 reverted wholesale, so there is no newer ref to bump to.
+                 Anchoring on source text serves both bases from one file.
+  NOT covered    `fused_topk()` has a second `aiter_biased_grouped_topk` call
+                 with the same downcast. It is the ungrouped path and
+                 `topk_method == "noaux_tc"` never reaches it, so it is left
+                 alone deliberately -- same as upstream.
+  precedent      `router_dtype` is an established transformers config field
+                 (switch_transformers, nllb_moe) defaulting to `"float32"` and
+                 honoured as `getattr(torch, config.router_dtype)`. GLM's
+                 `moe_router_dtype` is the same idea under a namespaced name.
+
+Self-locating and idempotent. All edits or none, across BOTH files: an anchor
+that is missing, ambiguous, or matches in more than one variant writes NOTHING
+and exits 1 -- because a half-applied fix here is not a degraded fix, it is a
+silently mis-typed kernel argument.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+_TAG = "[glm-moe-gate-bias-fp32]"
+
+# --------------------------------------------------------------------------
+# Edit A -- models/deepseek_v2.py
+# --------------------------------------------------------------------------
+
+_A_REL = "models/deepseek_v2.py"
+
+# The helper. Inserted immediately above MoEGate, which is where the only caller
+# is; `class MoEGate(nn.Module):` occurs exactly once on both bases.
+_A_HELPER_ANCHOR = "class MoEGate(nn.Module):\n"
+
+_A_HELPER = '''def _moe_gate_bias_wants_fp32(config) -> bool:
+    """True when this model's MoE gate bias must stay fp32.
+
+    GLM stores `e_score_correction_bias` as a narrow band at a large offset
+    (~6.2-7.2), where bf16's ULP of 0.03125 collapses hundreds of distinct
+    biases into single digits and reorders `noaux_tc` top-k routing. Three
+    tests because no single one covers every GLM checkpoint: the author's own
+    `moe_router_dtype`, `model_type` for the checkpoints predating that field,
+    and upstream sgl-project/sglang#37133's arch test so this is a superset.
+    """
+    router_dtype = getattr(config, "moe_router_dtype", None)
+    if isinstance(router_dtype, str) and router_dtype.lower() in ("float32", "fp32"):
+        return True
+    model_type = getattr(config, "model_type", None) or ""
+    if model_type.startswith("glm_moe_dsa"):
+        return True
+    return any("GlmMoeDsa" in arch for arch in (getattr(config, "architectures", None) or []))
+
+
+'''
+
+# The downcast itself. Identical text on v0.5.18 and c821c425.
+_A_GATE_ANCHOR = """        if config.topk_method == "noaux_tc" and not is_hash_moe:
+            correction_bias_dtype = torch.float32
+            if quant_config is not None:
+                if _use_aiter and quant_config.get_name() in (
+                    "fp8",
+                    "compressed_tensors",
+                    "quark",
+                ):
+                    correction_bias_dtype = torch.bfloat16
+"""
+
+_A_GATE_PATCHED = """        if config.topk_method == "noaux_tc" and not is_hash_moe:
+            correction_bias_dtype = torch.float32
+            # GLM53_BIASFP32: GLM's bias is a ~0.25-wide band around +7, where
+            # bf16 steps by 0.03125 -- 238 distinct biases become 8, reordering
+            # top-k. HF stores it fp32; keep it fp32. The matching promote in
+            # layers/moe/topk.py is NOT optional (see the comment there).
+            if quant_config is not None and not _moe_gate_bias_wants_fp32(config):
+                if _use_aiter and quant_config.get_name() in (
+                    "fp8",
+                    "compressed_tensors",
+                    "quark",
+                ):
+                    correction_bias_dtype = torch.bfloat16
+"""
+
+# --------------------------------------------------------------------------
+# Edit B -- layers/moe/topk.py, biased_grouped_topk_gpu's aiter arm
+# --------------------------------------------------------------------------
+
+_B_REL = "layers/moe/topk.py"
+
+_B_PREAMBLE = """        # GLM53_BIASFP32: do NOT re-downcast an fp32 bias here. aiter dispatches
+        # on gating_output.dtype and reinterpret_casts the bias pointer to that
+        # scalar_t unchecked, so an fp32 bias under a bf16 gating tensor is read
+        # as garbage; promote the gating logits instead, gated on the BIAS dtype.
+        if correction_bias.dtype == torch.float32:
+            _glm_gating = gating_output.to(torch.float32)
+            _glm_bias = correction_bias
+        else:
+            _glm_gating = gating_output
+            _glm_bias = {fallback}
+"""
+
+# One variant per base. EXACTLY ONE must match; two matches means the file is
+# not what either base says it is.
+_B_VARIANTS: list[tuple[str, str, str]] = [
+    (
+        "v0.5.18 (inline downcast)",
+        """        topk_ids = torch.empty((token, topk), dtype=torch.int32, device=device)
+        aiter_biased_grouped_topk(
+            gating_output,
+            correction_bias.to(dtype=gating_output.dtype),
+            topk_weights,
+            topk_ids,
+            num_expert_group,
+""",
+        """        topk_ids = torch.empty((token, topk), dtype=torch.int32, device=device)
+"""
+        + _B_PREAMBLE.format(fallback="correction_bias.to(dtype=gating_output.dtype)")
+        + """        aiter_biased_grouped_topk(
+            _glm_gating,
+            _glm_bias,
+            topk_weights,
+            topk_ids,
+            num_expert_group,
+""",
+    ),
+    (
+        "c821c425 (hoisted `bias` local)",
+        """        topk_ids = torch.empty((token, topk), dtype=torch.int32, device=device)
+        aiter_biased_grouped_topk(
+            gating_output,
+            bias,
+            topk_weights,
+            topk_ids,
+            num_expert_group,
+""",
+        """        topk_ids = torch.empty((token, topk), dtype=torch.int32, device=device)
+"""
+        + _B_PREAMBLE.format(fallback="bias")
+        + """        aiter_biased_grouped_topk(
+            _glm_gating,
+            _glm_bias,
+            topk_weights,
+            topk_ids,
+            num_expert_group,
+""",
+    ),
+]
+
+# Present iff each edit landed. Used for idempotency and for the build-time
+# bytecode check, the same way patch 01 greps for `_p1v2_trim`.
+_A_MARKER = "not _moe_gate_bias_wants_fp32(config)"
+_B_MARKER = "_glm_gating = gating_output.to(torch.float32)"
+
+
+def _srt_dir() -> Path | None:
+    """Locate `sglang/srt`, preferring the interpreter's own sglang."""
+    spec = importlib.util.find_spec("sglang")
+    if spec and spec.origin:
+        d = Path(spec.origin).parent / "srt"
+        if d.is_dir():
+            return d
+    root = os.environ.get("SGLANG_DIR", "/sgl-workspace/sglang")
+    d = Path(root) / "python" / "sglang" / "srt"
+    return d if d.is_dir() else None
+
+
+def _fail(msg: str) -> int:
+    print(f"{_TAG} {msg}", file=sys.stderr)
+    print(f"{_TAG} sglang drifted — re-anchor the patch, nothing written", file=sys.stderr)
+    return 1
+
+
+def _plan_a(path: Path) -> str | int:
+    """Return the new text for deepseek_v2.py, or an exit code."""
+    src = path.read_text()
+    if _A_MARKER in src:
+        return src
+
+    n = src.count(_A_GATE_ANCHOR)
+    if n != 1:
+        return _fail(f"{_A_REL}: MoEGate correction-bias dtype block matched {n} times (want 1)")
+    n = src.count(_A_HELPER_ANCHOR)
+    if n != 1:
+        return _fail(f"{_A_REL}: 'class MoEGate(nn.Module):' matched {n} times (want 1)")
+
+    out = src.replace(_A_HELPER_ANCHOR, _A_HELPER + _A_HELPER_ANCHOR, 1)
+    return out.replace(_A_GATE_ANCHOR, _A_GATE_PATCHED, 1)
+
+
+def _plan_b(path: Path) -> str | int:
+    """Return the new text for topk.py, or an exit code."""
+    src = path.read_text()
+    if _B_MARKER in src:
+        return src
+
+    hits = [(name, old, new) for name, old, new in _B_VARIANTS if src.count(old) == 1]
+    ambiguous = [name for name, old, _ in _B_VARIANTS if src.count(old) > 1]
+    if ambiguous:
+        return _fail(f"{_B_REL}: anchor is ambiguous for variant(s) {ambiguous}")
+    if len(hits) != 1:
+        names = [name for name, _, _ in _B_VARIANTS]
+        return _fail(
+            f"{_B_REL}: {len(hits)} of {len(names)} aiter-call variants matched "
+            f"(want exactly 1); tried {names}"
+        )
+
+    name, old, new = hits[0]
+    print(f"{_TAG} {_B_REL}: matched variant {name}")
+    return src.replace(old, new, 1)
+
+
+def main() -> int:
+    srt = _srt_dir()
+    if srt is None:
+        print(f"{_TAG} sglang not importable — skipping")
+        return 0
+
+    paths = {_A_REL: srt / _A_REL, _B_REL: srt / _B_REL}
+    for rel, p in paths.items():
+        if not p.is_file():
+            return _fail(f"{p} is missing — sglang layout changed")
+
+    # Plan both files before writing either: edit A without edit B hands aiter a
+    # mis-typed bias pointer, which is worse than the defect.
+    planned = {}
+    for rel, p in paths.items():
+        result = _plan_a(p) if rel == _A_REL else _plan_b(p)
+        if isinstance(result, int):
+            return result
+        planned[rel] = result
+
+    changed = [rel for rel, text in planned.items() if text != paths[rel].read_text()]
+    if not changed:
+        print(f"{_TAG} already present — skipping")
+        return 0
+
+    for rel in changed:
+        paths[rel].write_text(planned[rel])
+        print(f"{_TAG} patched {paths[rel]}")
+    print(f"{_TAG} GLM MoE gate bias now stays fp32 through the aiter router")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/overlay/Dockerfile.payload
+++ b/deploy/overlay/Dockerfile.payload
@@ -122,8 +122,54 @@ COPY --from=native312 /usr/local/bin/infera-router /payload/bin/infera-router
 # Engine patches applied at container start (see infera-exec). These fix vendor
 # code we do not otherwise ship — the overlay's whole point is not forking the
 # vendor image, and a runtime patch keeps that true where a rebuild would not.
-# Each script is self-locating, idempotent, and no-ops once upstream carries the
-# fix, so they are safe to leave in place across a base bump.
+# The vllm/ scripts are self-locating and atomic: they verify every anchor before
+# the single write, so a base whose layout moved exits 1 leaving the file
+# untouched. That is what makes THEM safe across a base bump. It is not true of
+# sglang_dsa — see the TODO below.
 COPY deploy/docker/patches/vllm/ /payload/patches/vllm/
+# The SGLang groups, without which an SGLang base overlay serves an entirely
+# UNPATCHED engine: on gfx950 that is a DP-attention host-sync deadlock (a hang)
+# plus an aiter paged-MQA row-sizing bug that returns wrong output behind a 200,
+# so nothing in any log says why. disagg/responses/rocm are plain `.py` scripts.
+COPY deploy/docker/patches/sglang_dsa/       /payload/patches/sglang_dsa/
+COPY deploy/docker/patches/sglang_disagg/    /payload/patches/sglang_disagg/
+COPY deploy/docker/patches/sglang_responses/ /payload/patches/sglang_responses/
+COPY deploy/docker/patches/sglang_rocm/      /payload/patches/sglang_rocm/
+# sglang_dsa is diffs pinned at `--fuzz=0`, not runnable scripts, so its applier
+# ships too and drives that group instead of infera-exec's `<dir>/*.py` glob —
+# the glob would also run a v0.5.16-only script and fail on this base. For the
+# same no-opt-out reason `sglang_carried/` is deliberately NOT copied.
+COPY deploy/docker/scripts/apply_sglang_dsa_patches.sh /payload/bin/apply_sglang_dsa_patches.sh
+#
+# TODO — this payload is VERSION-BOUND TO THE ENGINE, and nothing enforces it.
+#
+# infera-exec resolves four axes at container start. Three declare themselves and
+# fail loudly on a mismatch: python minor (`py310/`), ROCm major
+# (`native/rocm7-py310/` + CAPABILITIES + INFERA_REQUIRE_NATIVE), and engine
+# family (`import vllm` / `import sglang`). The fourth — **engine version** — is
+# not checked at all, and sglang_dsa is `--fuzz=0` diffs cut against exactly one
+# release (today v0.5.18).
+#
+# Measured on `lmsysorg/sglang-rocm:rocm720-mi35x-k3-20260727` (sglang 0.5.15,
+# the Kimi-K3 base): disagg/responses/rocm all apply, then
+# draft_cuda_graph_dp_vote lands 6 of its 7 files and rejects every hunk of
+# dp_attn.py. The applier exits 1, infera-exec prints "FAILED; continuing", and
+# the engine starts on a HALF-PATCHED tree — it serves, returns 200s, and no log
+# says the tree is inconsistent. GNU patch has no atomicity across files; the
+# vllm/ scripts do, which is the whole difference.
+#
+# Consequence for releases: this image cannot be versioned independently of the
+# engine it will be mounted over. "Runs on the customer's own vendor image" holds
+# only while that image is the pinned version. A baked build catches this at
+# BUILD time (bumping the base fails the build); moving patching to run time
+# removed that gate without replacing it.
+#
+# The fix needs no new machinery — give each patch group the shape the native
+# trees already have: declare the engine versions it targets, detect, skip loudly
+# on a mismatch, and let a deployment that must be patched (GLM-5.3 PD) set an
+# INFERA_REQUIRE_PATCHES-style switch to make a skip fatal.
+#
+# Until then: only mount this payload over a base the patches were cut against.
+# See examples/sglang_1p1d_glm5.3/README.md for the verified one.
 COPY deploy/overlay/infera-exec /payload/bin/infera-exec
 CMD ["sh", "-c", "cp -a /payload/. /out/ && echo 'infera overlay payload installed to /out'"]

--- a/deploy/overlay/infera-exec
+++ b/deploy/overlay/infera-exec
@@ -122,16 +122,91 @@ fi
 # different number of state tensors, so PD died on every rank with "too many
 # values to unpack" during KV registration.
 #
-# Skipped entirely when INFERA_SKIP_ENGINE_PATCHES is set, and a failing patch
-# warns rather than blocking startup — a mis-anchored patch must not take down a
-# worker that would otherwise serve.
-if [ -d "$PAYLOAD_ROOT/patches/vllm" ] && [ -z "${INFERA_SKIP_ENGINE_PATCHES:-}" ]; then
+# Skipped entirely when INFERA_SKIP_ENGINE_PATCHES is set. Otherwise a failing
+# patch is FATAL. That reverses an earlier decision -- "a mis-anchored patch must
+# not take down a worker that would otherwise serve" -- which holds only while
+# every patch is atomic, as the `.py` scripts are: they check every anchor before
+# their single write, so a miss leaves the file untouched and the cost is a
+# missing fix. sglang_dsa is GNU-patch diffs with no atomicity across files. On a
+# base the diffs were not cut against, the set lands some files and rejects
+# others, and the worker that "would otherwise serve" then serves from an
+# internally inconsistent tree, returning 200s that no log explains. Measured on
+# sglang 0.5.15: six of seven files applied, all seven hunks of dp_attn.py
+# rejected.
+#
+# So the rule is: the patched tree must be the one the patch set was cut against,
+# which is the same tree deploy/docker/Dockerfile.sglang bakes and its e2e matrix
+# validates across models. Refusing to start is how that inheritance is asserted.
+# Set INFERA_SKIP_ENGINE_PATCHES=1 to run a deliberately unpatched engine.
+
+# The two families differ: vLLM is one flat `.py` directory, SGLang is three of
+# them plus the applier, since sglang_dsa is `--fuzz=0` diffs, not scripts. Gate
+# this on `import vllm` alone and an SGLang base runs entirely unpatched — on
+# gfx950 a DP-attention deadlock, or wrong output behind a 200 no log explains.
+_run_patch_dir(){
+    _d="$PAYLOAD_ROOT/patches/$1"
+    [ -d "$_d" ] || return 0
+    _rc=0
+    for _p in "$_d"/*.py; do
+        [ -e "$_p" ] || continue
+        # Each script exits 0 when it is legitimately inapplicable on this base
+        # ("no mla.py here — no staged write-back to gate") and non-zero only
+        # when an anchor it needs is absent, i.e. the layout moved. So the test
+        # is "nothing reported failure", NOT "every patch changed something".
+        (cd / && PYTHONPATH="$PYTREE${PYTHONPATH:+:$PYTHONPATH}" "$PY" "$_p") || {
+            echo "infera-exec: patch $(basename "$_p") FAILED" >&2
+            _rc=1
+        }
+    done
+    return $_rc
+}
+
+_patch_fatal(){
+    echo "infera-exec: engine patches did not apply cleanly to this base." >&2
+    echo "infera-exec: the payload's patches are cut against ONE engine release;" >&2
+    echo "infera-exec: mount it over that base, or set INFERA_SKIP_ENGINE_PATCHES=1" >&2
+    echo "infera-exec: to run an unpatched engine deliberately. Refusing to start." >&2
+    exit 92
+}
+
+if [ -z "${INFERA_SKIP_ENGINE_PATCHES:-}" ]; then
     if "$PY" -c 'import vllm' >/dev/null 2>&1; then
-        for _p in "$PAYLOAD_ROOT"/patches/vllm/*.py; do
-            [ -e "$_p" ] || continue
-            (cd / && PYTHONPATH="$PYTREE${PYTHONPATH:+:$PYTHONPATH}" "$PY" "$_p") \
-                || echo "infera-exec: patch $(basename "$_p") failed; continuing" >&2
-        done
+        _run_patch_dir vllm || _patch_fatal
+    elif "$PY" -c 'import sglang' >/dev/null 2>&1; then
+        # Patching mutates the container's SHARED sglang checkout, and both an
+        # engine leg and the router come through infera-exec in one container.
+        # Two of them rewriting the same file is a race, so it happens once,
+        # under a lock, behind a marker; the applier is itself idempotent.
+        _mark="${INFERA_SGLANG_PATCH_MARKER:-/tmp/.infera-sglang-patched}"
+        if [ ! -e "$_mark" ]; then
+            (
+                flock 9 2>/dev/null || true
+                if [ ! -e "$_mark" ]; then
+                    _ok=1
+                    _run_patch_dir sglang_disagg   || _ok=0
+                    _run_patch_dir sglang_responses || _ok=0
+                    _run_patch_dir sglang_rocm     || _ok=0
+                    _applier="$PAYLOAD_ROOT/bin/apply_sglang_dsa_patches.sh"
+                    if [ -d "$PAYLOAD_ROOT/patches/sglang_dsa" ] && [ -f "$_applier" ]; then
+                        # SGLANG_DIR is passed explicitly and always non-empty:
+                        # the applier drops __pycache__ under it with a find -exec
+                        # rm, and an empty value there would be a recursive delete
+                        # with no anchor.
+                        PATCH_DIR="$PAYLOAD_ROOT/patches/sglang_dsa" \
+                        SGLANG_DIR="${SGLANG_DIR:-/sgl-workspace/sglang}" \
+                        DSA_PATCH_SET="${DSA_PATCH_SET:-full}" \
+                            bash "$_applier" \
+                            || { echo "infera-exec: sglang_dsa patch set FAILED" >&2; _ok=0; }
+                    fi
+                    # The marker is written ONLY on success. Writing it after a
+                    # failure would make the next call in this container skip
+                    # patching and proceed on the half-patched tree -- the exact
+                    # state this is here to prevent.
+                    [ "$_ok" = 1 ] || exit 1
+                    : > "$_mark"
+                fi
+            ) 9>"${_mark}.lock" || _patch_fatal
+        fi
     fi
 fi
 

--- a/examples/recipes/README.md
+++ b/examples/recipes/README.md
@@ -7,6 +7,7 @@ serve them. Pick a model, pick a combo, `kubectl apply`.
 |---|---|---|
 | GLM-5.2-MXFP4 | SGLang | [`glm5.2/`](glm5.2/README.md) |
 | GLM-5.2-FP8 (gfx942) | SGLang | [`glm5.2-fp8-gfx942/`](glm5.2-fp8-gfx942/README.md) |
+| GLM-5.3-MXFP4 | SGLang | [`glm5.3/`](glm5.3/README.md) |
 | Kimi-K3 | vLLM | [`kimi-k3/`](kimi-k3/README.md) |
 | Kimi-K3 optimized (DSpark) | vLLM | [`kimi-k3-optimized/`](kimi-k3-optimized/README.md) |
 

--- a/examples/recipes/glm5.3/README.md
+++ b/examples/recipes/glm5.3/README.md
@@ -1,0 +1,214 @@
+# GLM-5.3-MXFP4 — SGLang — Kubernetes recipe
+
+GLM-5.3 "big" (`model_type: glm_moe_dsa`) served from a **stock** SGLang image with
+the infera overlay mounted over it. One combo today:
+
+| Combo | Serving | KV cache | Status |
+|---|---|---|---|
+| [`disaggregated/`](disaggregated/deploy.yaml) | 1 prefill + 1 decode, TP4 each | GPU only | **validated** on 2× MI355X |
+
+Not here: aggregated — use `examples/sglang_mix_glm5.3/` under docker for now.
+
+---
+
+## What was validated
+
+Two MI355X nodes, 4 cards per leg, `lmsysorg/sglang:v0.5.18-rocm720-mi35x`
+unmodified, self-installed k3s v1.36.4, KV over mooncake RDMA on 8 `ionic` rails.
+
+**Do not substitute another sglang base.** `patches/sglang_dsa/` is `--fuzz=0`
+diffs cut against v0.5.18, and GNU patch is not atomic across files: on a
+different release the set can land some files and reject others, and the engine
+then starts and serves on a half-patched tree with nothing in any log saying so.
+Measured on a 0.5.15 base. The baked image fails its build on a base bump; the
+overlay has no such gate, so the pin is yours to hold.
+
+```
+/v1/workers -> prefill dp_size=4, decode dp_size=4
+correctness  -> PASS, including a 7845-token needle recovered verbatim
+                and 0/32 degenerate at concurrency 8
+throughput   -> 348 tok/s output, ISL 8192 / OSL 1024 / conc 8
+```
+
+Identical, case for case, to the same recipe run under plain docker and to the
+baked-image reference.
+
+---
+
+## Two things you must do before `kubectl apply`
+
+### 1. Build the overlay payload from this repo
+
+**The published `inferaimage/infera-overlay` tag will not work.** It ships
+`patches/vllm/` only, and its `infera-exec` gates the patch loop on
+`import vllm` — so on an SGLang base it applies **nothing**, and the engine runs
+unpatched. On gfx950 the two that matter are a DP-attention host-sync deadlock and
+an aiter paged-MQA row-sizing bug: a hang, or wrong output returned with a 200.
+
+```bash
+docker build -f deploy/overlay/Dockerfile.payload -t infera-overlay:glm53-sglang-patches .
+```
+
+Then **stage the payload tree onto every node that will run a leg**, and point
+`PAYLOAD_DIR` at it. The manifest mounts it as a `hostPath`:
+
+```bash
+id=$(docker create infera-overlay:glm53-sglang-patches)
+docker cp "$id:/payload/." /var/tmp/infera-payload/   # then rsync to each node
+docker rm "$id"
+```
+
+**It must be node-local, not a shared mount.** The payload carries `.so` files
+that get mmap'd, and an NFS-backed path is the wrong place for that.
+
+Why a hostPath and not an initContainer copying the image into an `emptyDir`:
+the initContainer is the tidier pattern, but it needs a registry the **cluster**
+can pull from, and the image built above lives in the local docker store. Point
+it at a tag the cluster cannot resolve and every pod sits in
+`Init:ImagePullBackOff`. The hostPath form is the one with a measurement behind
+it; switching to an initContainer against a real registry is a reasonable change,
+but it is untested here.
+
+Confirm it worked after the pods start — the head of a worker's log is
+`infera-exec`'s own output and must show eight patches ending in
+`=== all sglang DSA patches verified in bytecode ===`.
+
+### 2. Decide about the GPU device plugin
+
+This manifest ships **without** `amd.com/gpu` requests. It pins GPUs with
+`HIP_VISIBLE_DEVICES` + `nodeSelector`, which is what the docker recipe does and is
+therefore the lower-variance choice against the run this was validated in. It also
+lets you place a leg on *specific* cards, which the device plugin cannot express.
+
+If your cluster has the plugin and you would rather use it, add
+`resources.requests/limits: {amd.com/gpu: 4}` to both worker legs and drop
+`HIP_VISIBLE_DEVICES`. **Do not do half of that**: leaving `amd.com/gpu` in with no
+plugin installed parks both pods in `Pending` forever on an extended resource
+nothing provides, and leaving `HIP_VISIBLE_DEVICES` in *with* the plugin silently
+masks GPUs, because the plugin renumbers the allocation from 0.
+
+---
+
+## Render and apply
+
+Use `render.py`, not `sed` — it refuses to emit a manifest with a placeholder left
+in it, and `kubectl` will happily accept `--disaggregation-ib-device
+<RDMA_IB_DEVICES>` and fail minutes later in a message about a device.
+
+```bash
+cd examples/recipes
+python3 render.py glm5.3/disaggregated \
+  --set PREFILL_NODE=<node-a> --set DECODE_NODE=<node-b> \
+  --set MODEL_DIR=/path/to/models \
+  --set PAYLOAD_DIR=/var/tmp/infera-payload \
+  --set RDMA_IB_DEVICES=ionic_0,ionic_1,ionic_2,ionic_3,ionic_4,ionic_5,ionic_6,ionic_7 \
+  --set PREFILL_GID_INDEX=1 --set DECODE_GID_INDEX=1 \
+  -o /tmp/glm53-pd.yaml
+
+kubectl create namespace infera
+kubectl apply -f /tmp/glm53-pd.yaml
+```
+
+`MODEL_DIR` must hold `GLM-5.3-MXFP4/` at the **same path on both nodes**, and must
+be the **resolved** path. A symlink that crosses an NFS mount boundary gives the
+container an empty directory, and the failure surfaces much later as something
+unrelated.
+
+The two GID indexes are separate placeholders because the index is **per node** —
+two identical machines routinely differ. Read them with `show_gids` on each node;
+a wrong one fails loudly with `GID is NULL` on every DP rank.
+
+Add `--pin-rail <rail> --check-rail` only if your rails carry **no IPv4** (every
+GID link-local `fe80::`, so Mooncake cannot tell them apart). This recipe assumes
+rails with IPv4, so it omits both — and correspondingly leaves `MC_TE_FILTERS`
+unset, matching the docker recipe's mode-A configuration.
+
+---
+
+## The one thing that will silently ruin this
+
+**DP-attention must be symmetric — `--dp-size 4` on BOTH legs.** Measured on this
+checkpoint:
+
+| shape | result |
+|---|---|
+| prefill dp1 → decode dp4 | first completion clean, then **every one garbage** |
+| prefill dp4 → decode dp4 | 6/6 clean, 7845-token needle verbatim, 0/32 degenerate |
+
+The failure is silent: zero faults, zero HIP errors, `MC_FORCE_TCP` 0, decode
+batches rolling with cuda graphs on. Nothing in any log says the tokens are wrong.
+Cause not diagnosed — the working configuration was adopted rather than the
+mechanism chased.
+
+**So the acceptance test must read the output, not the status code.** Use your own
+correctness probe, and give it repeat cases and a small concurrent load round —
+this failure appears *after* the first request, so a single-shot check passes a
+broken deployment.
+
+---
+
+## Verifying a bring-up
+
+```bash
+# 1. both roles registered — /health returns 200 with only one leg up,
+#    and every completion then returns 503
+kubectl -n infera exec deploy/glm53-mxfp4-pd-server -- \
+  curl -s http://127.0.0.1:8110/v1/workers | python3 -m json.tool | grep -E 'disagg_mode|dp_size'
+
+# 2. the overlay patched the engine
+kubectl -n infera logs <prefill-pod> | head -18
+
+# 3. KV really moved over RDMA rather than falling back
+kubectl -n infera logs <prefill-pod> | grep -c MC_FORCE_TCP     # want 0
+kubectl -n infera logs <prefill-pod> | grep -ci 'gid.*null'     # want 0
+
+# 4. correctness -- run your own probe against the forwarded port, and read the
+#    generated text rather than the status code
+kubectl -n infera port-forward svc/glm53-mxfp4-pd-server 18110:8110 &
+
+# 5. MTP is actually accepting. Nothing above catches a mis-wired draft: the
+#    deployment stays correct and simply gains nothing. Want a MEDIAN of 2-3.
+kubectl -n infera logs <decode-pod> | grep -o 'accept len: [0-9.]*' \
+  | awk '{print $3}' | sort -n \
+  | awk '{a[NR]=$1; if ($1>=4) f++} END {printf "n=%d median=%s at4.00=%d\n", \
+      NR, a[int(NR*0.5)+1], f+0}'          # reference: n=45 median=2.85 at4.00=0
+```
+
+Three ways step 5 misleads. A median at **4.00 is a failure**, not a win — the
+ceiling is `--speculative-num-draft-tokens` and a draft pinned there is
+predicting a repetition loop. Do **not** read `tail -5`: a few percent of batches
+sit at 4.00 on a perfectly healthy leg. And **no output does not mean MTP is
+off** — `decode_log_interval` defaults to 40, so a leg under 40 decode iterations
+prints no such line at all; `grep -c 'Decode batch'` disambiguates, non-zero with
+no `accept len:` means it really is off.
+
+## Notes on the shape
+
+- **TP4 per leg, not TP8.** That is the shape the symmetric-DP-attention result was
+  measured in. TP8 is untested for GLM-5.3 in this configuration.
+- **EAGLE MTP(3,1,4) on the decode leg.** Validated **on this manifest**: 6/6
+  correct, 0/32 degenerate over three load rounds, acceptance-length median 2.85
+  (n=45) with none at the 4.00 ceiling, and all seven DSA bytecode markers
+  verified at container start. Also validated on the two docker paths, where the
+  larger samples give a median of 2.35 (n≈505 each) and a clean single-variable
+  A/B: **+36 % output throughput, −30 % TPOT** against the same deployment with
+  MTP off. Read the acceptance *median*, never the last few lines: a few percent
+  of batches sit at the 4.00 ceiling even on a healthy leg, and a median at 4.00
+  is a repetition loop. Upstream's cookbook disables EAGLE on AMD; that line does
+  not govern this architecture, whose PD+DPA+MTP path is exactly what
+  `deploy/docker/patches/sglang_dsa/` exists for.
+- **`mem-fraction-static` is deliberately asymmetric** (0.70 prefill / 0.85 decode)
+  and the direction is counter-intuitive: a prefill OOM is fixed by *lowering* it.
+- **`hostNetwork: true` is required, not tuning.** The RoCE rails are host
+  interfaces; a CNI pod IP has no route to a peer's rail.
+- **`privileged: true` is not redundant with `IPC_LOCK`.** There is a recorded case
+  in this repo where `IPC_LOCK` plus `memlock=-1` was insufficient for RDMA
+  registration and `--privileged` was the entire fix.
+- The startup budget is **90 min** because 408 GB of weights on NFS can take that
+  long. Do not size it from a warm-cache observation.
+
+## If you have no cluster yet
+
+Any Kubernetes will do. If you stand k3s up on a GPU node that is already running
+other work, read the installer's shell source first — several of its hazards
+(what it stops, what it rewrites) are visible only there.

--- a/examples/recipes/glm5.3/disaggregated/deploy.yaml
+++ b/examples/recipes/glm5.3/disaggregated/deploy.yaml
@@ -1,0 +1,348 @@
+# GLM-5.3-MXFP4 — PD disaggregated — k3s + overlay
+#
+# The validated docker deployment expressed as an InferaDeployment: every engine
+# flag and env var below is one that was measured working, not a value copied
+# from another recipe. Where this file departs from the recipe templates it is
+# because the measurement said so, and each departure is commented.
+#
+# Structure from   examples/recipes/glm5.2-fp8-gfx942/disaggregated/deploy.yaml
+#                  (the only manifest in the repo with complete RDMA wiring)
+# Overlay pattern  examples/k8s-deployments/pd-1p1d-mooncake.yaml
+# Engine recipe    examples/sglang_1p1d_glm5.2/engine/leg.sh as driven by
+#                  examples/sglang_1p1d_glm5.3/cluster.2node.sh
+#
+# ---------------------------------------------------------------------------
+# THREE DEPARTURES FROM THE TEMPLATES, ALL DELIBERATE
+#
+# 1. No amd.com/gpu and no device plugin: the plugin advertises every GPU and
+#    cannot say WHICH ones a pod gets, and it renumbers the allocation from 0 so
+#    visible-device pinning on top of it silently masks GPUs. Pin with
+#    HIP_VISIBLE_DEVICES + nodeSelector; re-add the requests if you add the plugin.
+#
+# 2. The overlay payload is a hostPath staged on each node, NOT an initContainer
+#    copying an image into an emptyDir: the initContainer needs a registry the
+#    CLUSTER can pull from, and a locally-built tag it cannot resolve parks every
+#    pod in Init:ImagePullBackOff. Build the payload from THIS repo and stage it
+#    to <PAYLOAD_DIR> on both nodes — the published `inferaimage/infera-overlay`
+#    tag carries `patches/vllm/` only and its infera-exec gates the patch loop on
+#    `import vllm`, so on an SGLang base it applies nothing and the engine runs
+#    unpatched. See the README for both steps.
+#
+# 3. EAGLE MTP(3,1,4) on the decode leg, and TP4 rather than TP8. Both come from
+#    measurement: MTP is validated on all three deployment paths for this
+#    checkpoint, and the symmetric DP-attention result this whole deployment
+#    depends on was measured at TP4 per leg.
+#
+# ---------------------------------------------------------------------------
+# THE ONE THING THAT WILL SILENTLY RUIN THIS
+#
+# DP-attention must be SYMMETRIC — dp-size 4 on BOTH legs. Asymmetric (prefill
+# dp1 -> decode dp4) gives a clean first completion and then GARBAGE on every
+# one after it, with zero faults and zero HIP errors in any log. So the
+# acceptance test must READ THE OUTPUT, not check a status code.
+# ---------------------------------------------------------------------------
+apiVersion: infera.amd.com/v1alpha1
+kind: InferaDeployment
+metadata:
+  name: glm53-mxfp4-pd
+  namespace: infera
+spec:
+  backendFramework: sglang
+  # Replaces the etcd the docker recipe ran: workers self-register on their Pod
+  # annotation and the router watches them via the API server. No etcd tier, and
+  # therefore none of the 2379/2380 host-port contention the docker recipe hits.
+  discoveryBackend: kubernetes
+  nats:
+    deploy: false
+  services:
+
+    # ---- router: infera.server, kv-aware ------------------------------------
+    server:
+      componentType: server
+      port: 8110          # NOT 8100: that is the docker kit's port, kept free so
+                          # the two deployments can coexist if one is brought back.
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        containers:
+          - name: main
+            image: lmsysorg/sglang:v0.5.18-rocm720-mi35x
+            imagePullPolicy: IfNotPresent
+            # The overlay entrypoint, not python3 directly: infera lives only in
+            # the mounted payload on a stock base.
+            command: ["/overlay/bin/infera-exec",
+                      "python3","-m","infera.server",
+                      "--host","0.0.0.0","--port","8110","--router-backend","rust",
+                      "--router-tokenizer-path","/models/GLM-5.3-MXFP4",
+                      "--discovery-backend","kubernetes",
+                      "--request-transport","http","--kv-event-transport","zmq",
+                      "--router-policy","kv-aware",
+                      "--kv-prefill-overlap-weight","20.0",
+                      "--kv-decode-overlap-weight","2.0"]
+            env:
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+            # The operator injects a readiness probe for WORKERS only, so without
+            # this the Service takes traffic before uvicorn has bound the port.
+            readinessProbe:
+              httpGet: {path: /health, port: 8110}
+              periodSeconds: 5
+            resources:
+              requests: {cpu: "8", memory: 16Gi}
+              limits:   {cpu: "8", memory: 16Gi}
+            volumeMounts:
+              - {name: overlay, mountPath: /overlay}
+              - {name: model,   mountPath: /models,  readOnly: true}
+        volumes:
+          - {name: overlay, hostPath: {path: <PAYLOAD_DIR>, type: Directory}}
+          - {name: model,   hostPath: {path: <MODEL_DIR>,   type: Directory}}
+
+    # ---- prefill leg --------------------------------------------------------
+    prefill:
+      componentType: worker
+      role: prefill
+      replicas: 1
+      port: 30000
+      # Weight load is 408 GB over NFS. The startupProbe below is the readiness
+      # signal instead; an operator-injected readinessProbe would kill the pod
+      # long before the weights land.
+      skipReadinessProbe: true
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <PREFILL_NODE>}
+        # REQUIRED, not tuning. The RoCE rails are host interfaces, and a CNI pod
+        # IP has no route to a peer's rail.
+        hostNetwork: true
+        dnsPolicy: ClusterFirstWithHostNet
+        # Supplies /dev/shm at host size. Charged to the node, not to any limit.
+        hostIPC: true
+        containers:
+          - name: main
+            image: lmsysorg/sglang:v0.5.18-rocm720-mi35x
+            imagePullPolicy: IfNotPresent
+            # privileged is NOT redundant with IPC_LOCK. The repo records a case
+            # where IPC_LOCK plus memlock=-1 was insufficient for RDMA
+            # registration and adding --privileged was the whole fix. Failure
+            # signature is /health 503 forever with ranks spinning at 100% GPU.
+            securityContext: {privileged: true, capabilities: {add: ["IPC_LOCK","SYS_PTRACE"]}}
+            command: ["/overlay/bin/infera-exec",
+                      "python3","-m","infera.engine.sglang",
+                      "--model-path","/models/GLM-5.3-MXFP4",
+                      "--served-model-name","glm-5.3-mxfp4",
+                      "--host","0.0.0.0","--port","30000","--advertise-host","$(POD_IP)",
+                      "--discovery-backend","kubernetes",
+                      "--request-transport","http",
+                      "--kv-event-transport","zmq",
+                      "--kv-events-bind","tcp://0.0.0.0:5557","--kv-snapshot-port","8801",
+                      "--trust-remote-code",
+                      # --dsa-* rather than --nsa-*: verified equivalent on v0.5.18
+                      # (--nsa-* is a DeprecatedAliasStoreAction writing the same
+                      # attribute), but the alias is marked for removal.
+                      "--dsa-prefill-backend","tilelang","--dsa-decode-backend","tilelang",
+                      "--kv-cache-dtype","fp8_e4m3",
+                      "--tp-size","4",
+                      # ep-size is emitted UNCONDITIONALLY and outside the DP
+                      # branch: expert parallelism and attention parallelism are
+                      # different axes.
+                      "--ep-size","4",
+                      "--dp-size","4","--enable-dp-attention",
+                      # Batches arrivals so a DP step is not spent on one short
+                      # request. Only meaningful where there are DP ranks to fill.
+                      "--enable-prefill-delayer","--prefill-delayer-max-delay-ms","5000",
+                      "--mem-fraction-static","0.70",
+                      "--context-length","262144","--chunked-prefill-size","65536",
+                      "--cuda-graph-max-bs","128","--max-running-requests","2048",
+                      "--watchdog-timeout","3600",
+                      "--reasoning-parser","glm45",
+                      # Insurance, not a fix — this checkpoint's shared experts are
+                      # themselves MXFP4, and upstream #25261 shows the mismatch
+                      # failing SILENTLY with wrong output when shapes line up.
+                      "--disable-shared-experts-fusion",
+                      # The aiter custom all-reduce kernel deadlocks on gfx950.
+                      "--disable-custom-all-reduce",
+                      # Without it every client-side cache-hit metric reads 0.
+                      "--enable-cache-report",
+                      "--disaggregation-mode","prefill",
+                      "--disaggregation-bootstrap-port","8998",
+                      "--disaggregation-transfer-backend","mooncake",
+                      "--disaggregation-ib-device","<RDMA_IB_DEVICES>"]
+            env:
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              # Under hostNetwork $(POD_IP) is the node's primary address on the
+              # MANAGEMENT NIC, which is what the working deployment advertised.
+              # The RoCE rails are reached by DEVICE NAME via
+              # --disaggregation-ib-device, so the two do not conflict.
+              - {name: SGLANG_HOST_IP, value: "$(POD_IP)"}
+              - {name: HOST_IP,        value: "$(POD_IP)"}
+              # leg.sh derives the NIC at runtime by matching MY_IP; a manifest
+              # cannot, so these are literals read off the passing run.
+              - {name: SGLANG_LOCAL_IP_NIC,  value: "fenic"}
+              - {name: GLOO_SOCKET_IFNAME,   value: "fenic"}
+              # Per node, not per cluster. Two identical machines routinely
+              # differ; read it with show_gids on each node.
+              - {name: MC_GID_INDEX, value: "<PREFILL_GID_INDEX>"}
+              # Mode A registration (peer-mem present; ib_peer_mem is loaded).
+              - {name: MOONCAKE_DISABLE_HIP_DMABUF, value: "1"}
+              # Cards 0-3. All eight are visible because /dev/dri is a full
+              # hostPath, so this numbering is physical — the same convention the
+              # docker path uses.
+              - {name: HIP_VISIBLE_DEVICES, value: "0,1,2,3"}
+              - {name: SGLANG_DP_USE_GATHERV, value: "1"}
+              - {name: SGLANG_USE_AITER, value: "1"}
+              - {name: NCCL_IB_DISABLE, value: "1"}
+              - {name: NCCL_IGNORE_CPU_AFFINITY, value: "1"}
+              - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
+              - {name: SAFETENSORS_FAST_GPU, value: "1"}
+              - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
+              - {name: PYTHONHASHSEED, value: "0"}
+              # Fail LOUDLY if the payload has no mooncake, instead of degrading
+              # into a transport fallback we would then misdiagnose as a fabric
+              # problem.
+              - {name: INFERA_REQUIRE_NATIVE, value: "mooncake"}
+              - {name: SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT, value: "1800"}
+              - {name: SGLANG_DISAGGREGATION_WAITING_TIMEOUT, value: "1800"}
+              - {name: INFERA_SGLANG_READY_TIMEOUT, value: "3600"}
+            startupProbe:
+              httpGet: {path: /health, port: 30000}
+              periodSeconds: 15
+              timeoutSeconds: 10
+              # 90 min. The weights are 408 GB on NFS, and the repo records a
+              # shared NFS mount turning an 8-minute load into ~95 minutes. A warm
+              # page cache loads in seconds — do not size this from that.
+              failureThreshold: 360
+            resources:
+              requests: {cpu: "32", memory: 512Gi}
+              limits:   {cpu: "32", memory: 512Gi}
+            volumeMounts:
+              - {name: overlay,       mountPath: /overlay}
+              - {name: model,         mountPath: /models,  readOnly: true}
+              - {name: ib,            mountPath: /dev/infiniband}
+              - {name: kfd,           mountPath: /dev/kfd}
+              - {name: dri,           mountPath: /dev/dri}
+              - {name: host-libionic, mountPath: /host-libionic/libionic.so, readOnly: true}
+              - {name: dshm,          mountPath: /dev/shm}
+        volumes:
+          - {name: overlay, hostPath: {path: <PAYLOAD_DIR>, type: Directory}}
+          # The RESOLVED path. A symlink crossing an NFS mount boundary gives the
+          # container an EMPTY directory when its parent is bind-mounted, and the
+          # failure surfaces much later as an unrelated error.
+          - {name: model,   hostPath: {path: <MODEL_DIR>, type: Directory}}
+          - {name: ib,      hostPath: {path: /dev/infiniband, type: Directory}}
+          - {name: kfd,     hostPath: {path: /dev/kfd, type: CharDevice}}
+          - {name: dri,     hostPath: {path: /dev/dri, type: Directory}}
+          # The stock base ships libionic ABI 1; an ionic driver that accepts only
+          # ABI 4 makes libibverbs reject every device, after which Mooncake
+          # silently takes its HIP-IPC path, where a cross-NODE peer can never
+          # open the handle. infera-exec copies the host library in.
+          - {name: host-libionic, hostPath: {path: /usr/lib/x86_64-linux-gnu/libionic.so.1, type: File}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 64Gi}}
+
+    # ---- decode leg ---------------------------------------------------------
+    # Identical to prefill except: the node, the mode, no bootstrap port, no
+    # prefill delayer, GMU 0.85 instead of 0.70, and distinct KV-event ports.
+    decode:
+      componentType: worker
+      role: decode
+      replicas: 1
+      port: 30000
+      skipReadinessProbe: true
+      extraPodSpec:
+        nodeSelector: {kubernetes.io/hostname: <DECODE_NODE>}
+        hostNetwork: true
+        dnsPolicy: ClusterFirstWithHostNet
+        hostIPC: true
+        containers:
+          - name: main
+            image: lmsysorg/sglang:v0.5.18-rocm720-mi35x
+            imagePullPolicy: IfNotPresent
+            securityContext: {privileged: true, capabilities: {add: ["IPC_LOCK","SYS_PTRACE"]}}
+            command: ["/overlay/bin/infera-exec",
+                      "python3","-m","infera.engine.sglang",
+                      "--model-path","/models/GLM-5.3-MXFP4",
+                      "--served-model-name","glm-5.3-mxfp4",
+                      "--host","0.0.0.0","--port","30000","--advertise-host","$(POD_IP)",
+                      "--discovery-backend","kubernetes",
+                      "--request-transport","http",
+                      "--kv-event-transport","zmq",
+                      "--kv-events-bind","tcp://0.0.0.0:5567","--kv-snapshot-port","8811",
+                      "--trust-remote-code",
+                      "--dsa-prefill-backend","tilelang","--dsa-decode-backend","tilelang",
+                      "--kv-cache-dtype","fp8_e4m3",
+                      "--tp-size","4","--ep-size","4",
+                      # SYMMETRIC with prefill. See the header — asymmetry here
+                      # produced silently corrupt output.
+                      "--dp-size","4","--enable-dp-attention",
+                      # Decode wants KV pool where prefill wants activation
+                      # headroom. Do not equalise these: a prefill OOM is fixed by
+                      # LOWERING it, a decode retract by raising it.
+                      "--mem-fraction-static","0.85",
+                      "--context-length","262144","--chunked-prefill-size","65536",
+                      "--cuda-graph-max-bs","128","--max-running-requests","2048",
+                      "--watchdog-timeout","3600",
+                      "--reasoning-parser","glm45",
+                      "--disable-shared-experts-fusion",
+                      # Required WITH EAGLE, and kept independent of it: the aiter
+                      # custom all-reduce kernel deadlocks on gfx950 during
+                      # speculative verify. Letting it follow MTP would make any
+                      # "MTP on vs off" comparison a two-variable one.
+                      "--disable-custom-all-reduce",
+                      # EAGLE MTP(3,1,4), decode leg only. No draft path is passed
+                      # because the draft is the target's own MTP layer. Validated
+                      # on this manifest: 6/6 correct, 0/32 degenerate, acceptance
+                      # median 2.85. If missing: one token per decode step.
+                      "--speculative-algorithm","EAGLE",
+                      "--speculative-num-steps","3",
+                      "--speculative-eagle-topk","1",
+                      "--speculative-num-draft-tokens","4",
+                      "--enable-cache-report",
+                      "--disaggregation-mode","decode",
+                      "--disaggregation-transfer-backend","mooncake",
+                      "--disaggregation-ib-device","<RDMA_IB_DEVICES>"]
+            env:
+              - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
+              - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
+              - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
+              - {name: SGLANG_HOST_IP, value: "$(POD_IP)"}
+              - {name: HOST_IP,        value: "$(POD_IP)"}
+              - {name: SGLANG_LOCAL_IP_NIC, value: "fenic"}
+              - {name: GLOO_SOCKET_IFNAME,  value: "fenic"}
+              - {name: MC_GID_INDEX, value: "<DECODE_GID_INDEX>"}
+              - {name: MOONCAKE_DISABLE_HIP_DMABUF, value: "1"}
+              - {name: HIP_VISIBLE_DEVICES, value: "0,1,2,3"}
+              - {name: SGLANG_DP_USE_GATHERV, value: "1"}
+              - {name: SGLANG_USE_AITER, value: "1"}
+              - {name: NCCL_IB_DISABLE, value: "1"}
+              - {name: NCCL_IGNORE_CPU_AFFINITY, value: "1"}
+              - {name: HSA_NO_SCRATCH_RECLAIM, value: "1"}
+              - {name: SAFETENSORS_FAST_GPU, value: "1"}
+              - {name: HIP_FORCE_DEV_KERNARG, value: "1"}
+              - {name: PYTHONHASHSEED, value: "0"}
+              - {name: INFERA_REQUIRE_NATIVE, value: "mooncake"}
+              - {name: SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT, value: "1800"}
+              - {name: SGLANG_DISAGGREGATION_WAITING_TIMEOUT, value: "1800"}
+              - {name: INFERA_SGLANG_READY_TIMEOUT, value: "3600"}
+            startupProbe:
+              httpGet: {path: /health, port: 30000}
+              periodSeconds: 15
+              timeoutSeconds: 10
+              failureThreshold: 360
+            resources:
+              requests: {cpu: "32", memory: 512Gi}
+              limits:   {cpu: "32", memory: 512Gi}
+            volumeMounts:
+              - {name: overlay,       mountPath: /overlay}
+              - {name: model,         mountPath: /models,  readOnly: true}
+              - {name: ib,            mountPath: /dev/infiniband}
+              - {name: kfd,           mountPath: /dev/kfd}
+              - {name: dri,           mountPath: /dev/dri}
+              - {name: host-libionic, mountPath: /host-libionic/libionic.so, readOnly: true}
+              - {name: dshm,          mountPath: /dev/shm}
+        volumes:
+          - {name: overlay, hostPath: {path: <PAYLOAD_DIR>, type: Directory}}
+          - {name: model,   hostPath: {path: <MODEL_DIR>, type: Directory}}
+          - {name: ib,      hostPath: {path: /dev/infiniband, type: Directory}}
+          - {name: kfd,     hostPath: {path: /dev/kfd, type: CharDevice}}
+          - {name: dri,     hostPath: {path: /dev/dri, type: Directory}}
+          - {name: host-libionic, hostPath: {path: /usr/lib/x86_64-linux-gnu/libionic.so.1, type: File}}
+          - {name: dshm, emptyDir: {medium: Memory, sizeLimit: 64Gi}}

--- a/examples/recipes/kimi-k3/disaggregated-sglang/deploy.yaml
+++ b/examples/recipes/kimi-k3/disaggregated-sglang/deploy.yaml
@@ -10,6 +10,13 @@
 #                carrying Kimi-K3 support; the general v0.5.15 tag has none)
 #   overlay      inferaimage/infera-overlay@sha256:6918eff34f201548a738dd592d2a1ece0627354d2e88f24a87cfa8f787a72a44
 #
+# DO NOT "MODERNISE" THE BASE. v0.5.18 does carry kimi_k3, so the swap looks free,
+# and it is not: there --language-only no longer suppresses the multimodal
+# mem-fraction scaling, which caps the effective value at 0.85 even when you pass
+# 1.0. The weights alone occupy 0.866 of each card at TP8, so the engine loads all
+# 96 shards and then exits with "no GPU memory for the KV cache". The flag that
+# would suppress it, --language-model-only, is rejected under --disaggregation-mode.
+#
 #   <PREFILL_MODEL_DIR> / <DECODE_MODEL_DIR>
 #       the model directory on EACH node. They need NOT match: every pod mounts its
 #       own node's copy, so nodes that name their local NVMe differently
@@ -53,6 +60,10 @@ spec:
                       "--router-tokenizer-path","/models/Kimi-K3",
                       "--request-transport","http","--kv-event-transport","zmq"]
             env:
+              # Same reason as the workers below: this base is sglang 0.5.15 and the
+              # overlay's patches target v0.5.18. The router shares the base, so it
+              # would patch its own container too.
+              - {name: INFERA_SKIP_ENGINE_PATCHES, value: "1"}
               - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
               - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
               - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
@@ -135,6 +146,11 @@ spec:
                       "--disaggregation-transfer-backend","mooncake"]
             env:
               - {name: SGLANG_USE_AITER, value: "1"}
+              # This base is sglang 0.5.15; the overlay's patches are --fuzz=0 diffs
+              # cut against v0.5.18, and Kimi-K3 has never carried them. A no-op
+              # against the pinned overlay, which patches nothing here anyway -- it
+              # keeps a digest bump unpatched instead of refusing to start.
+              - {name: INFERA_SKIP_ENGINE_PATCHES, value: "1"}
               - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
               - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
               - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}
@@ -233,6 +249,11 @@ spec:
                       "--disaggregation-transfer-backend","mooncake"]
             env:
               - {name: SGLANG_USE_AITER, value: "1"}
+              # This base is sglang 0.5.15; the overlay's patches are --fuzz=0 diffs
+              # cut against v0.5.18, and Kimi-K3 has never carried them. A no-op
+              # against the pinned overlay, which patches nothing here anyway -- it
+              # keeps a digest bump unpatched instead of refusing to start.
+              - {name: INFERA_SKIP_ENGINE_PATCHES, value: "1"}
               - {name: POD_NAME, valueFrom: {fieldRef: {fieldPath: metadata.name}}}
               - {name: POD_NAMESPACE, valueFrom: {fieldRef: {fieldPath: metadata.namespace}}}
               - {name: POD_IP, valueFrom: {fieldRef: {fieldPath: status.podIP}}}

--- a/examples/recipes/render.py
+++ b/examples/recipes/render.py
@@ -45,6 +45,10 @@ PLACEHOLDERS = (
     "PREFILL_MODEL_DIR",
     "DECODE_MODEL_DIR",
     "KVD_L3_DIR",
+    # Node-local directory holding the overlay payload tree, mounted as a
+    # hostPath by the recipes that run a stock engine image. Node-local and not a
+    # shared mount: the payload carries .so files that get mmap'd.
+    "PAYLOAD_DIR",
     "RDMA_IB_DEVICES",
     "PREFILL_GID_INDEX",
     "DECODE_GID_INDEX",

--- a/examples/sglang_1p1d_glm5.2/common.sh
+++ b/examples/sglang_1p1d_glm5.2/common.sh
@@ -36,6 +36,14 @@ start_container(){
   local ep=(--entrypoint '')
   if [ "${ENTRYPOINT_KEEP:-0}" = "1" ]; then ep=(); fi
   local mounts=(-v "$MODEL_MOUNT:$MODEL_MOUNT")
+  # Overlay deployment: INFERA_IMAGE is a STOCK base carrying no infera; it arrives
+  # via OVERLAY_PAYLOAD, whose infera-exec sets PYTHONPATH. HOST_LIBIONIC is needed
+  # too and fails QUIETLY — a libionic the ionic driver's ABI rejects gives "No RDMA
+  # devices found", and cross-node PD then dies in hipIpcOpenMemHandle. Mount the host's.
+  if [ -n "${OVERLAY_PAYLOAD:-}" ]; then
+    mounts+=(-v "$OVERLAY_PAYLOAD:/payload:ro")
+    [ -n "${HOST_LIBIONIC:-}" ] && mounts+=(-v "$HOST_LIBIONIC:/host-libionic:ro")
+  fi
   # Only mount a host RDMA provider library if the site says it needs one.
   # HOST_RDMA_MOUNT must be the in-container path YOUR image's entrypoint reads — mount it
   # elsewhere and the injection silently no-ops: zero devices, and the leg still serves.
@@ -100,7 +108,10 @@ start_router(){
   # the `docker exec bash -c ...` command string that CONTAINS that text — i.e. this shell.
   docker exec "$CTR" bash -c "pgrep -f 'python3 -m infera.server' | xargs -r kill -9 2>/dev/null; true"
   sleep 2
-  docker exec -d "$CTR" bash -c "nohup python3 -m infera.server \
+  # INFERA_EXEC is the overlay's entrypoint shim, empty on a baked image. The
+  # router needs it for the same reason the legs do: on a stock base, infera
+  # itself lives only in the mounted payload.
+  docker exec -d "$CTR" bash -c "nohup ${INFERA_EXEC:-} python3 -m infera.server \
     --host 0.0.0.0 --port $ROUTER_PORT --router-backend $backend \
     --discovery-backend etcd --etcd-endpoint $ip:$ETCD_PORT \
     --request-transport http --kv-event-transport zmq \

--- a/examples/sglang_1p1d_glm5.2/engine/bench.sh
+++ b/examples/sglang_1p1d_glm5.2/engine/bench.sh
@@ -25,7 +25,12 @@ for C in $CONCS; do
   log "=== $TAG ==="
   # Three of the flags below are load-bearing in non-obvious ways (range-ratio, temperature,
   # cache-report). Do not change them without reading "Reference sweep" in the README.
-  $SSH_CMD "$PREFILL_NODE" "docker exec $CTR bash -c 'mkdir -p $OUT && \
+
+  # -w / is load-bearing on a STOCK base: WORKDIR is /sgl-workspace and Python puts
+  # it at sys.path[0], so `sglang` resolves to the repo ROOT as a namespace package
+  # and bench_serving dies on `No module named 'sglang.benchmark.serving'`. Harmless
+  # on a baked image, where sglang resolves correctly from any directory.
+  $SSH_CMD "$PREFILL_NODE" "docker exec -w / $CTR bash -c 'mkdir -p $OUT && \
     python3 -m sglang.bench_serving \
       --backend sglang-oai-chat --base-url $URL \
       --model $SERVED --tokenizer ${TOKENIZER:-$MODEL} \

--- a/examples/sglang_1p1d_glm5.2/engine/leg.sh
+++ b/examples/sglang_1p1d_glm5.2/engine/leg.sh
@@ -57,8 +57,17 @@ CHUNK="${CHUNK:-65536}"
 # pool, or a 5-20x slower TCP fallback. See cluster/README.md section 3.
 export MOONCAKE_DISABLE_HIP_DMABUF="${MOONCAKE_DISABLE_HIP_DMABUF:-1}"
 export MC_GID_INDEX="${MC_GID_INDEX:?MC_GID_INDEX is required — read it off the preflight report}"
-export MC_DISABLE_HIP_TRANSPORT=1
+# MC_DISABLE_HIP_TRANSPORT AND MC_ENABLE_HIP_TRANSPORT ARE DEAD NAMES: neither
+# string exists in the shipped mooncake build, and a leg launched with
+# MC_DISABLE_HIP_TRANSPORT=1 in /proc/<pid>/environ still logged "HIP transport
+# installed" 4x per leg. Kept overridable, but it has never had an effect.
+export MC_DISABLE_HIP_TRANSPORT="${MC_DISABLE_HIP_TRANSPORT:-1}"
 unset MC_ENABLE_HIP_TRANSPORT
+# MC_DISABLE_HIP is the knob that works. Forwarded only when set, so unset ==
+# today's behaviour and the two-node path does not move. Set it to 1 to actually
+# disable the hip transport — the only way to run a meaningful hip-on/hip-off A/B.
+# It gates SELECTION, not install, so no log line confirms it; see the README.
+
 # MC_TE_FILTERS pins mooncake to named device(s). Required in the dma-buf mode so a non-ODP
 # rail is never picked (it would pin and double the KV pool); harmless to leave unset when a
 # peer-mem module is loaded and every rail can carry KV.
@@ -143,7 +152,11 @@ CAR_ARGS=()
 
 # --enable-cache-report populates usage.prompt_tokens_details.cached_tokens. Without it every
 # client-side cache-hit metric reads 0 and a prefix-reuse target cannot be checked at all.
-EXTRA_ARGS=(--enable-cache-report)
+
+# EXTRA_ENGINE_ARGS is the cluster wrapper's escape hatch for flags this script does
+# not model, e.g. --disable-shared-experts-fusion. Unquoted on purpose: several flags
+# in one string must word-split. Empty by default, so unchanged when unset.
+EXTRA_ARGS=(--enable-cache-report ${EXTRA_ENGINE_ARGS:-})
 
 log "$ROLE on $MY_IP:$PORT — tp=$TP dpa=$DPA mtp=$MTP kvaware=$KVAWARE kvd=$KVD gmu=$GMU chunk=$CHUNK ctx=$CTX nic=$NIC ib=$RDMA_IB_DEVICES"
 
@@ -152,7 +165,8 @@ log "$ROLE on $MY_IP:$PORT — tp=$TP dpa=$DPA mtp=$MTP kvaware=$KVAWARE kvd=$KV
 docker exec -d "$CTR" env \
   HIP_VISIBLE_DEVICES="$GPUS" \
   MOONCAKE_DISABLE_HIP_DMABUF="$MOONCAKE_DISABLE_HIP_DMABUF" \
-  MC_GID_INDEX="$MC_GID_INDEX" MC_DISABLE_HIP_TRANSPORT=1 \
+  MC_GID_INDEX="$MC_GID_INDEX" MC_DISABLE_HIP_TRANSPORT="$MC_DISABLE_HIP_TRANSPORT" \
+  ${MC_DISABLE_HIP:+MC_DISABLE_HIP="$MC_DISABLE_HIP"} \
   ${MC_TE_FILTERS:+MC_TE_FILTERS="$MC_TE_FILTERS"} \
   ${RDMAV_FORK_SAFE:+RDMAV_FORK_SAFE="$RDMAV_FORK_SAFE"} \
   NCCL_IB_DISABLE=1 NCCL_IGNORE_CPU_AFFINITY=1 HSA_NO_SCRATCH_RECLAIM=1 \
@@ -164,7 +178,8 @@ docker exec -d "$CTR" env \
   SGLANG_USE_AITER=1 \
   SAFETENSORS_FAST_GPU=1 HIP_FORCE_DEV_KERNARG=1 PYTHONHASHSEED=0 \
   ${SGLANG_DP_USE_GATHERV:+SGLANG_DP_USE_GATHERV=1} \
-  bash -c "python3 -m infera.engine.sglang \
+  ${INFERA_REQUIRE_NATIVE:+INFERA_REQUIRE_NATIVE="$INFERA_REQUIRE_NATIVE"} \
+  bash -c "${INFERA_EXEC:-} python3 -m infera.engine.sglang \
     --model-path '$MODEL' --served-model-name '$SERVED' --tp-size $TP --trust-remote-code \
     --host '$MY_IP' --port $PORT \
     --nsa-prefill-backend tilelang --nsa-decode-backend tilelang \

--- a/examples/sglang_1p1d_glm5.2/engine/up.sh
+++ b/examples/sglang_1p1d_glm5.2/engine/up.sh
@@ -34,7 +34,13 @@ ${MC_TE_FILTERS:+MC_TE_FILTERS=$MC_TE_FILTERS} \
 ${RDMAV_FORK_SAFE:+RDMAV_FORK_SAFE=$RDMAV_FORK_SAFE} \
 ${HOST_RDMA_LIB:+HOST_RDMA_LIB=$HOST_RDMA_LIB} \
 ${ENTRYPOINT_KEEP:+ENTRYPOINT_KEEP=$ENTRYPOINT_KEEP} \
-${GMU_PREFILL:+GMU_PREFILL=$GMU_PREFILL} ${GMU_DECODE:+GMU_DECODE=$GMU_DECODE}"
+${GMU_PREFILL:+GMU_PREFILL=$GMU_PREFILL} ${GMU_DECODE:+GMU_DECODE=$GMU_DECODE} \
+${EXTRA_ENGINE_ARGS:+EXTRA_ENGINE_ARGS=\"$EXTRA_ENGINE_ARGS\"} \
+${MC_DISABLE_HIP:+MC_DISABLE_HIP=$MC_DISABLE_HIP} \
+${OVERLAY_PAYLOAD:+OVERLAY_PAYLOAD=$OVERLAY_PAYLOAD} \
+${HOST_LIBIONIC:+HOST_LIBIONIC=$HOST_LIBIONIC} \
+${INFERA_EXEC:+INFERA_EXEC=$INFERA_EXEC} \
+${INFERA_REQUIRE_NATIVE:+INFERA_REQUIRE_NATIVE=$INFERA_REQUIRE_NATIVE}"
 
 log "=== 1/4 containers ==="
 for h in "$PREFILL_NODE" "$DECODE_NODE"; do
@@ -63,11 +69,22 @@ if [ "${DECODE_KVD:-0}"  = "1" ]; then start_kvd "$DECODE_NODE"; fi
 log "=== 3/4 legs ==="
 # Launch both legs before waiting on either: they load ~400 GB of weights concurrently, and
 # serialising the waits doubles the bring-up for no reason.
+
+# GPUS and the KV-event ports are forwarded PER LEG with :+ (inject only when set),
+# so the two-node shape is unchanged — there leg.sh's own `seq 0..TP-1` and default
+# ports are already right. On a SINGLE-NODE pair, without these both legs land on the
+# same cards and the second leg dies at bind with "port_base at N is not available".
 on "$PREFILL_NODE" "$COMMON_ENV ROLE=prefill MY_IP=$PREFILL_IP PORT=$PREFILL_PORT \
   DPA=${PREFILL_DPA:-0} MTP=${PREFILL_MTP:-0} KVD=${PREFILL_KVD:-1} \
+  KV_PUB_PORT=${PREFILL_KV_PUB_PORT:-5557} KV_SNAP_PORT=${PREFILL_KV_SNAP_PORT:-8801} \
+  MC_DISABLE_HIP_TRANSPORT=${MC_DISABLE_HIP_TRANSPORT:-1} \
+  ${PREFILL_GPUS:+GPUS=$PREFILL_GPUS} \
   bash $KIT_DIR/engine/leg.sh"
 on "$DECODE_NODE" "$COMMON_ENV ROLE=decode MY_IP=$DECODE_IP PORT=$DECODE_PORT \
   DPA=${DECODE_DPA:-1} MTP=${DECODE_MTP:-1} KVD=${DECODE_KVD:-0} \
+  KV_PUB_PORT=${DECODE_KV_PUB_PORT:-5557} KV_SNAP_PORT=${DECODE_KV_SNAP_PORT:-8801} \
+  MC_DISABLE_HIP_TRANSPORT=${MC_DISABLE_HIP_TRANSPORT:-1} \
+  ${DECODE_GPUS:+GPUS=$DECODE_GPUS} \
   bash $KIT_DIR/engine/leg.sh"
 
 # Poll /health from INSIDE each node's container. Never curl a PD leg's port from another

--- a/examples/sglang_1p1d_glm5.3/README.md
+++ b/examples/sglang_1p1d_glm5.3/README.md
@@ -1,0 +1,514 @@
+# GLM-5.3 (big) — SGLang 1P1D
+
+Prefill/decode-disaggregated deployment for **GLM-5.3** and **GLM-5.3-MXFP4**,
+in two shapes: the usual **two-node** pair, and a **single-node** pair that
+splits one 8-GPU box into TP4 prefill + TP4 decode.
+
+## This kit does not fork the GLM-5.2 kit, and that is deliberate
+
+GLM-5.3 (big) is `glm_moe_dsa` / `GlmMoeDsaForCausalLM`. Its `config.json` is
+identical to GLM-5.2's field for field except `transformers_version` — same
+hidden size, same layer count, same expert count, same attention. So the engine
+recipe is not *similar* to the GLM-5.2 one, it **is** the GLM-5.2 one.
+
+[`examples/sglang_1p1d_glm5.2/`](../sglang_1p1d_glm5.2/) already carries that
+recipe in `engine/leg.sh`, validated end to end on two clusters and both RDMA
+fabric types. Copying those ~600 lines here to change a model path would create
+a second source of truth that drifts the first time either is fixed. So this kit
+ships **wrappers only** and points `KIT_DIR` at the GLM-5.2 kit, exactly as that
+kit's own `cluster/*.sh` files do.
+
+If you find yourself editing an engine script to serve GLM-5.3, something is
+wrong — say so, it is a bug in this arrangement.
+
+## Contents
+
+| path | what |
+|---|---|
+| [`cluster.2node.sh`](cluster.2node.sh) | two-node pair — the validated shape. Fill in and run |
+| [`cluster.singlenode.sh`](cluster.singlenode.sh) | one 8-GPU node split TP4 + TP4 |
+| everything else | comes from [`../sglang_1p1d_glm5.2/`](../sglang_1p1d_glm5.2/) — `common.sh`, `engine/*.sh`, `preflight_rdma.sh` |
+
+## The engine base is part of the configuration, not a detail
+
+**Verified base: `lmsysorg/sglang:v0.5.18-rocm720-mi35x` (sglang v0.5.18).** Both
+the baked image and the overlay were validated against it and nothing else.
+
+This is a harder constraint than a usual "tested with" note. `deploy/docker/patches/sglang_dsa/`
+is `--fuzz=0` diffs cut against that one release, and GNU patch has no atomicity
+across files: on a different sglang the set can land some files and reject
+others, leaving the engine to start and serve on a **half-patched tree** with
+nothing in any log saying so. Measured on a 0.5.15 base — six of seven files
+applied, all seven hunks of `dp_attn.py` rejected.
+
+The baked image catches this at build time, because bumping its pinned base fails
+the build. **The overlay does not** — it patches whatever base it is mounted
+over. So with the overlay, pin the base yourself. See the TODO in
+`deploy/overlay/Dockerfile.payload`.
+
+## Validation status
+
+Stated plainly, because the honest answer is short.
+
+| shape | status |
+|---|---|
+| the **deployment shape** (1P1D + mooncake + DPA + MTP + kvd + kv-aware) | validated for **GLM-5.2** on two clusters, both fabric types |
+| **GLM-5.3-MXFP4**, two-node TP4+TP4, **symmetric DP-attention** | **validated** on 2×MI355X (gfx950), mooncake over RoCE, all 8 `ionic` rails, mode A. 6/6 correct including a 7845-token needle recovered verbatim, and **0/32 degenerate at concurrency 8** |
+| **GLM-5.3-MXFP4**, two-node, **asymmetric** DPA (prefill dp1 → decode dp4) | **BROKEN — corrupt output.** This is the GLM-5.2 kit's default shape. See below |
+| **single-node** TP4+TP4, `DECODE_DPA=0` | **validated** on one 8-GPU node — 7845-token needle recovered, both legs' HIP transport installed 4/4, zero IPC failures |
+| **single-node** TP4+TP4, `DECODE_DPA=1` | **BROKEN — corrupt output.** Same signature as the asymmetric two-node case |
+| **EAGLE MTP(3,1,4)** on the decode leg, two-node symmetric DPA | **validated** on 2×MI355X. 6/6 correct, **0/32 degenerate** at concurrency 8, 7845-token needle verbatim — token counts and `finish_reason` identical to the same probe with MTP off. Acceptance length over 509 samples: median **2.35**, p90 2.73, only **0.2 %** at the 4.00 ceiling |
+| **EAGLE MTP** on the **single-node** shape | **not run.** That shape runs dp off, so it does not exercise the same draft path |
+
+### The DP-attention failure, because it is silent and it will cost you a day
+
+On GLM-5.3-MXFP4, DP-attention **plus** the PD path returns garbage: streams of
+repeated `</think>` interleaved with digit noise, every request finishing on
+`length` and never on `stop`. Measured:
+
+| arm | topology | prefill | decode | result |
+|---|---|---|---|---|
+| 1 | one node | dp1 | dp4 | first completion clean, **then every one garbage** |
+| 2 | one node | dp1 | dp1 | clean, 7845-token needle verbatim |
+| 3 | **two nodes** | **dp4** | **dp4** | **clean**, 6/6 + 0/32 degenerate at conc 8 |
+| 4 | aggregated, no PD | — | dp4 | clean, 5/5 including a repeat |
+
+Four things about it that each cost time to establish:
+
+- **It is silent.** Zero memory-access faults, zero HIP errors, zero non-dynamo
+  tracebacks, `MC_FORCE_TCP` 0, GID-is-NULL 0, decode batches rolling with cuda
+  graphs on. No log line anywhere says the tokens are wrong.
+- **It is not a long-prompt or long-output problem.** 19-token prompts fail as
+  readily as 7845-token ones; `max_tokens` 128, 1024 and 2048 all fail. The first
+  instinct — KV corruption on a big transfer — is wrong.
+- **It develops.** The first completion after bring-up was clean and every later
+  one was not, *including a repeat of that same prompt*. **A single clean answer
+  is not evidence.** Send a repeat and a small load round before believing a
+  green result.
+- **DP-attention alone is fine** (arm 4). It needs DP-attention and PD together.
+
+Cause **not diagnosed**. Arms 1 and 3 differ in two variables at once — DPA
+symmetry and topology — so arm 3 is a *working configuration*, not an isolation
+of the cause. Upstream search found nothing matching; sgl-project/sglang#30033
+is a different failure (a lockstep freeze, not corrupted output).
+
+The wrappers now default to what was measured clean: `cluster.2node.sh` is
+symmetric (`PREFILL_DPA=1`), `cluster.singlenode.sh` has DP-attention off.
+
+## The single-node path: HIP IPC over XGMI, not loopback RDMA
+
+The same-host KV handoff is **not** a loopback RDMA transfer, and the risk is
+**not** silent slowness — which changes what you check. Established by reading the
+mooncake tree and build cache inside the shipped image:
+
+The pinned mooncake commit is `01d1eb2a` (2026-07-01), *"[TE] Support rdma+hip
+multi-protocol segments for single-node disaggregation (#2682)"* — literally the
+single-node disaggregation commit, whose own message reports validation of
+single-node 1P1D on MI355X over the rdma+hip path.
+
+The image builds with `USE_HIP=ON`, `ENABLE_MULTI_PROTOCOL=ON`. On init,
+`auto_discover` installs `rdma` (HCAs present, `MC_FORCE_TCP` unset) and then
+**composes** `hip` on top — the local segment advertises `"rdma,hip"`.
+Registration fans out to every installed transport, so device KV gets both a HIP
+IPC buffer and an RDMA buffer, while host aux buffers land on rdma only.
+`MultiTransport::selectTransport` then routes **per request** by fixed priority
+`hip 4 > cxl 3 > rdma 2 > tcp 1`, so for KV **hip wins**: `hipIpcGetMemHandle` on
+the exporter, `hipIpcOpenMemHandle` on the importer, `hipMemcpyAsync` over
+enabled peer access. **GPU-to-GPU across XGMI, no NIC in the path.**
+
+### Everything in this section is single-node-specific, and that is by design
+
+**Two-node PD never uses hip, regardless of any setting.** `selectTransport`
+calls `isHipReachableTarget()` and skips hip buffers whenever the target is on
+another host. The in-source rationale, at the build commit:
+
+> *"This makes the intra-node fast path (hip) and the cross-node path (rdma) work
+> automatically from a single multi-protocol segment, without requiring the
+> operator to set `MC_DISABLE_HIP`."*
+
+So the multi-protocol segment is not a configuration problem to be solved — it
+resolves itself by target. **Every hip question in this kit is a single-node
+question**, and none of it applies to `cluster.2node.sh`.
+
+### Installation is unconditional; *selection* is what the knob controls
+
+`transfer_engine_impl.cpp:402-414` installs hip under a bare `#ifdef USE_HIP`
+with no runtime condition. The gate is one stage later, at
+`multi_transport.cpp:489`:
+
+```cpp
+if (p == "hip")  return std::getenv("MC_DISABLE_HIP") ? 0 : 4;
+if (p == "rdma") return 2;
+```
+
+`MC_DISABLE_HIP` demotes hip from priority 4 to 0, so rdma wins for the device KV
+pool — which is registered under both. **hip stays installed and stops being
+used.**
+
+**This is why the obvious check is useless.** `HIP transport installed for
+intra-node GPU P2P` is an **install-time** log, and the variable gates
+**selection**. It reads 4/4 whether hip is carrying KV or demoted to zero, in
+every state, forever. Verifying a hip-off arm requires `MC_DISABLE_HIP=1` present
+in `/proc/<pid>/environ` on both legs **plus** the source read above — there is
+no log line that will confirm it. Treating the non-flip as evidence of anything
+will get a correctly configured hip-off deployment discarded unmeasured.
+
+Two related names are **absent from the binary entirely** and do nothing:
+`MC_DISABLE_HIP_TRANSPORT` (which `leg.sh:60` sets) and
+`MC_ENABLE_HIP_TRANSPORT`. So: **two dead names, one live name whose effect is
+invisible to the natural check.**
+
+One trap that makes the config lie: sglang passes `protocol="rdma"` into
+`engine.initialize()` (`MOONCAKE_PROTOCOL` defaults to `"rdma"`). On this build
+that argument **does not choose the transport** — outside the EFA/CXI paths it
+only feeds `initMemoryAllocator()`. Setting `MOONCAKE_PROTOCOL` will not disable
+hip, and seeing `rdma` in the config does not mean KV moves over RDMA.
+
+### The real risk: the two legs cannot see each other's GPUs
+
+`cluster.singlenode.sh` sets `PREFILL_GPUS=0,1,2,3` and `DECODE_GPUS=4,5,6,7`,
+applied as `HIP_VISIBLE_DEVICES` (`../sglang_1p1d_glm5.2/engine/leg.sh:159`). The
+two legs therefore have **disjoint visible device sets**, each seeing 4 devices
+renumbered 0-3, and `setupP2PAccess()` only iterates visible devices — so peer
+access is enabled *within* each leg and never between them.
+
+> **This was not true as originally shipped, and the failure is worth knowing.**
+> `up.sh` forwards a fixed list of per-leg variables through `on()` — which runs a
+> fresh remote shell — and `GPUS` was not among them. Both legs therefore fell
+> through to `leg.sh:26`'s default, `seq 0..TP-1`, and **landed on the same four
+> cards**. Fixed by forwarding `${PREFILL_GPUS:+GPUS=$PREFILL_GPUS}` per leg;
+> conditional expansion, so an unset variable injects nothing and the two-node
+> path is unchanged.
+>
+> **The way it failed is the instructive part.** The prefill leg died with
+> `Loaded weights leave no GPU memory for the KV cache under
+> --mem-fraction-static=0.7. Raise --mem-fraction-static above 0.773` — a number
+> that is arithmetically correct and diagnostically wrong. Taking the engine's
+> advice would have let two legs coexist on four cards and produced a deployment
+> that *ran*, with every subsequent number meaningless and nothing saying so.
+> **Before trusting any memory error, check that both halves of the box are
+> loaded** — `rocm-smi --showmeminfo vram` should show weights on GPUs 0-3 *and*
+> 4-7 (~408 GB / TP4 ≈ 102 GB per card for GLM-5.3-MXFP4). That distinguishes a
+> tuning problem from a topology problem.
+>
+> **Do not use `base_gpu_id` for this.** It is tempting and it does not work:
+> `HIP_VISIBLE_DEVICES=4,5,6,7` renumbers the decode leg's devices to 0-3, so
+> `base_gpu_id` is an index into the *visible* set, not the physical one. It reads
+> `0` on both legs when the split is broken **and** `0` on both legs when it is
+> correct — it does not discriminate at all. The VRAM read is more expensive and
+> it is the only unambiguous check here.
+
+**It works.** Measured on gfx950 / ROCm 7.2 with the shipped engine image, two
+processes in one container, `--ipc=host`:
+
+```
+exporter  HIP_VISIBLE_DEVICES=0,1   writes pattern 7,3,9,1,4,1,5,9 to cuda:0
+importer  HIP_VISIBLE_DEVICES=2,3   imports the handle, reads back
+  -> READ BACK: [7, 3, 9, 1, 4, 1, 5, 9]   MATCH
+```
+
+Repeated **across two separate containers** (importer started with `--ipc=host`),
+which is the shape PD actually runs — same disjoint split, same pattern:
+
+```
+CROSS-CONTAINER IMPORT OK, bytes= 1048576
+READ BACK: [7, 3, 9, 1, 4, 1, 5, 9]   MATCH
+```
+
+The importer **cannot see the exporter's physical GPU** and still mapped its
+memory and read the correct bytes. A bare "import succeeded" would not have proved
+this — the handle records device index 0 and the importer's own ordinal 0 is a
+*different* physical GPU, so the import could plausibly have mapped local memory
+instead. The data pattern is what rules that out; **check the bytes, not the
+return code**, if you repeat this. The cross-container run closes the container
+boundary as a variable.
+
+Caveat on scope: measured with a 4-GPU visible set split 0,1 / 2,3 (physical
+4,5 / 6,7 of that host) rather than the 0-3 / 4-7 split this kit uses. Same node,
+same XGMI fabric. Strong evidence, not proof, for the exact split.
+
+Note `torch.cuda.cudart()` does **not** expose `cudaIpcGetMemHandle` in this
+build — use PyTorch's storage IPC path (`untyped_storage()._share_cuda_()` /
+`torch.UntypedStorage._new_shared_cuda(*info)`), which is what actually carries
+HIP IPC handles here.
+
+Two attempts to close this from source, both negative, recorded so nobody repeats
+them:
+
+- **The ROCm 7.2 header** (`hip_runtime_api.h:2535-2545`) says
+  `hipIpcOpenMemHandle` *"can attempt to enable peer access between the devices as
+  if the user called hipDeviceEnablePeerAccess"*, and points at
+  `hipDeviceCanAccessPeer` to test it. Suggestive, not decisive:
+  `hipDeviceCanAccessPeer` takes **visible** ordinals, and under disjoint
+  `HIP_VISIBLE_DEVICES` the importer cannot name the exporter's device at all. The
+  doc does not say what happens then.
+- **Mooncake's own HIP tests do not cover it.** All three harnesses
+  (`tests/hip_transport_test.cpp`, `mooncake-wheel/tests/test_transfer_on_hip.py`,
+  `tent/tests/hip_bandwidth_bench.cpp`) are single-process and single-device, and
+  `grep -rn HIP_VISIBLE_DEVICES` over the whole repo returns nothing. So the
+  pinned commit's *"prefill GPU0 / decode GPU1"* validation is not reproducible
+  from the tree, and its test suite does not exercise two processes with disjoint
+  visible devices — which is exactly what this kit configures.
+
+That is the argument for running the probe below rather than reasoning further.
+
+What *is* established is the shape of each outcome:
+
+- **If it works:** KV moves over XGMI, and the only positive evidence is the
+  install line plus the absence of hip errors.
+- **If it fails, it fails LOUDLY at transfer time, not silently.** Registration
+  still succeeds (`hipIpcGetMemHandle` is local), the segment still advertises
+  `"rdma,hip"`, `selectTransport` still picks hip, and then
+  `hipIpcOpenMemHandle failed` is logged and the transfer returns
+  `"device memory not registered"` — surfacing as *"Failed to get kvcache from
+  prefill instance"*, exactly the pre-fix symptom the pinned commit quotes.
+
+So **the single-node failure mode is a broken PD, not a slow one** — provided hip
+is installed. The silent-slow path exists only if hip is *absent*.
+
+> **And on this build hip cannot be turned off by the variable anyone would
+> reach for.** `leg.sh:60` exports `MC_DISABLE_HIP_TRANSPORT=1` and unsets
+> `MC_ENABLE_HIP_TRANSPORT`. **Neither name exists in the shipped mooncake
+> binary.** Exact-match against `mooncake/engine.*.so`:
+>
+> | env name | matches |
+> |---|---:|
+> | `MC_DISABLE_HIP` | **1** |
+> | `MC_USE_HIP_IPC` | 1 |
+> | `MC_FORCE_TCP` | 1 |
+> | `MC_DISABLE_HIP_TRANSPORT` | **0** |
+> | `MC_ENABLE_HIP_TRANSPORT` | **0** |
+>
+> Confirmed behaviourally as well as by inspection: a run launched with
+> `MC_DISABLE_HIP_TRANSPORT=1` — verified present in the process environment via
+> `/proc` — still logged `HIP transport installed for intra-node GPU P2P` **4×
+> per leg**, identical to a run without it.
+>
+> Two consequences. **`leg.sh:60` has never had an effect**, in either the
+> two-node or single-node path, so it is not evidence that anyone deliberately
+> disabled hip — which is likely why no reason for it could be established
+> (INFERRED: the author may have intended to disable hip and used a name that
+> does not exist). And **any A/B that varies hip must set `MC_DISABLE_HIP`**;
+> using the `_TRANSPORT` spelling produces a guaranteed-zero differential that
+> reads as a null result rather than as a broken experiment.
+>
+> Before trusting any such A/B, confirm the discriminator actually flipped:
+> `HIP transport installed for intra-node GPU P2P` must go **4/4 → 0/0**.
+
+If it fails, the fix is a topology change — give both legs all 8 GPUs and split
+with `--base-gpu-id` so each process can see its peer's cards — not a mooncake
+debug session.
+
+### Settle it in seconds, before loading any weights
+
+Two processes with the kit's own disjoint split, exchanging one IPC handle. No
+model, no server:
+
+```bash
+# exporter — the prefill leg's GPUs
+docker exec -e HIP_VISIBLE_DEVICES=0,1,2,3 <prefill-ctr> python - <<'EOF'
+import torch
+t = torch.zeros(1<<20, dtype=torch.uint8, device='cuda:0')
+h = torch.cuda.cudart().cudaIpcGetMemHandle(t.data_ptr())
+open('/dev/shm/ipc.h','wb').write(bytes(h)); print("exported, holding"); input()
+EOF
+
+# importer — the decode leg's GPUs
+docker exec -e HIP_VISIBLE_DEVICES=4,5,6,7 <decode-ctr> python - <<'EOF'
+import torch
+torch.zeros(1, device='cuda:0')                        # init the HIP context first
+h = open('/dev/shm/ipc.h','rb').read()
+print(torch.cuda.cudart().cudaIpcOpenMemHandle(h, 1))  # 1 = LazyEnablePeerAccess
+EOF
+```
+
+`--ipc=host` is already passed to both containers (`../sglang_1p1d_glm5.2/common.sh:46`),
+which HIP IPC across processes requires.
+
+### What to grep, and the two lines that are easy to miss
+
+| outcome | line |
+|---|---|
+| HIP transport installed | `HIP transport installed for intra-node GPU P2P` |
+| HIP install failed | `Failed to install HIP transport (intra-node GPU P2P unavailable)` |
+| RDMA installed | `installTransport, type=rdma` |
+| KV not IPC-exportable | `HipTransport: hipIpcGetMemHandle failed` |
+| peer's KV not importable | `HipTransport: hipIpcOpenMemHandle failed` |
+| two GPUs cannot reach each other | `HipTransport: P2P access not available between device i and device j` |
+| TCP forced | `MC_FORCE_TCP is set, using TCP transport only` |
+| **TCP fallback (no HCAs)** | **nothing — see below** |
+
+Two properties of this table matter more than the table:
+
+1. **The TCP fallback is silent.** TCP is installed with no success log where the
+   RDMA branch logs `installTransport, type=rdma`. Grep for the *positive* rdma
+   line and require it; there is no tcp line to find.
+2. **No log line says which transport a given transfer used.** `selectTransport`
+   chooses silently per request, and the two routing `LOG(ERROR)` calls in
+   `multi_transport.cpp` are commented out in this tree. The install lines tell
+   you the *capability*, never the *choice*. `MC_LOG_LEVEL=TRACE` adds
+   per-buffer registration lines — still not per-transfer routing.
+
+**The existing `MC_FORCE_TCP` / `GID is NULL` checks do not cover this case.**
+`MC_FORCE_TCP` is an env var the operator has to set, so counting it only
+confirms TCP was not forced by accident. (It does catch one real disaster: if
+set, init returns early *before* auto-discover, hip is never installed, and every
+KV byte goes over TCP loopback — that genuinely is the 5-20× case.) `GID is NULL`
+is per-RDMA-device rail health and is a **cross-host** signal; with the hip path
+live the single-node KV transfer never touches a GID, so a count of 0 tells you
+nothing about it.
+
+**So add one line to the single-node smoke: require `HIP transport installed for
+intra-node GPU P2P` in BOTH leg logs**, plus zero `hipIpcOpenMemHandle failed`.
+Without the first, the segment is `"rdma"` only and KV silently takes loopback
+RDMA with nothing raised anywhere.
+
+What a healthy node looks like, verified first-hand on the validated hardware:
+
+- 8 ionic RDMA devices on the host, all `PORT_ACTIVE`.
+- `ib_peer_mem` **loaded**, so registration **mode A** (bare `ibv_reg_mr` +
+  peer-mem: nothing pinned, KV pool not duplicated, every rail usable) is the
+  mode to expect. That is the best of the three.
+- Inside the engine image, `libionic 54.0-187-1` (ABI 4) and `ibv_devinfo`
+  reporting **8 HCAs**.
+
+**That last check has a trap worth knowing before you repeat it.** The container
+must be started with `--device=/dev/infiniband`. Without it `ibv_devinfo` reports
+zero HCAs from inside a container on a host that has eight — which is
+indistinguishable from a libionic ABI mismatch, and is the same reading that
+means "RDMA has silently degraded to TCP". `common.sh` passes it; an ad-hoc
+`docker run` will not unless you remember.
+
+Run `preflight_rdma.sh mode` before the first bring-up either way. Believe its
+verdict from inside the container over the host's view: only the vendor provider
+libraries the image ships can open a card.
+
+## Quick start
+
+```bash
+# 1. which registration mode does this fabric support?
+IMAGE=<infera-sglang-image> bash ../sglang_1p1d_glm5.2/preflight_rdma.sh mode
+
+# 2. fill in ONE wrapper, then
+bash cluster.singlenode.sh up      # or cluster.2node.sh
+bash cluster.singlenode.sh smoke
+bash cluster.singlenode.sh down
+```
+
+`smoke` is the GLM-5.2 kit's, and it checks each feature with a signal that goes
+red when the feature is silently absent — including **`MC_FORCE_TCP` and
+`GID is NULL` counts of 0 in both leg logs**, which is the check that catches a
+pair that paired successfully and is moving KV over TCP.
+
+## Notes carried over from the GLM-5.2 kit that still apply
+
+These cost real debugging time there and the architecture has not changed:
+
+1. **`--ep-size` and `--enable-dp-attention` are different axes.** Gate both on
+   one condition and turning DPA off silently collapses the MoE from ep8 to the
+   TP default, after which no latency delta is attributable to either.
+2. **`--chunked-prefill-size` is a GLOBAL budget** that SGLang divides by
+   `dp_size` only when DP-attention is on. One value serves both modes;
+   hardcoding the per-rank number in a DPA-off branch cuts it 8x.
+3. **Prefill activation OOM is fixed by LOWERING `--mem-fraction-static`**, the
+   opposite of the decode-side fix. Diagnose by phase: decode retract → raise;
+   prefill `HSA_STATUS_ERROR_OUT_OF_RESOURCES` at *low* token usage → lower.
+   Low token usage at the abort is the tell that it was never KV exhaustion.
+
+   **3a. A third form, and the engine's own advice is a trap in it.** On the
+   single-node shape a leg can abort at startup with
+
+   ```
+   ValueError: Loaded weights leave no GPU memory for the KV cache under
+   --mem-fraction-static=0.7. Raise --mem-fraction-static above 0.773
+   ```
+
+   That number is arithmetically correct and **diagnostically wrong**. It is
+   computed from the memory actually free at that moment, and the reason there
+   is none is usually that **the other leg is on the same cards** — measured
+   once as GPUs 0-3 at 263.8 GB each with 4-7 at 0.3 GB. Raising the fraction
+   as instructed produces a *working* deployment on the wrong topology: two
+   legs sharing half the node, every subsequent number meaningless, nothing
+   logged.
+
+   **Check the cards before you touch the knob.** `rocm-smi --showmeminfo vram`
+   must show load on *both* halves. Do not use `--showmemuse`'s `VRAM%` (it
+   does not fall when memory is released) and do not use each leg's
+   `base_gpu_id` (it is an index into the leg's **visible** set, so
+   `HIP_VISIBLE_DEVICES=4,5,6,7` renumbers the decode leg to 0-3 and it reads
+   `base_gpu_id=0` on both legs whether the split is broken or correct).
+
+   Distinguishing the three: **this** form aborts during startup profiling with
+   weights already loaded and no request served; the classic prefill form
+   aborts under load at low token usage; the decode form retracts under load at
+   high token usage.
+4. **`SGLANG_OPT_USE_TOPK_V2=0` is mandatory on gfx950.** Without it the model
+   serves, returns 200s, and returns garbage.
+5. **MTP and decode-side radix cache are mutually exclusive upstream**, so
+   `decode_prefix_len` is always 0 and every turn re-transfers the whole prompt
+   KV. A prefill-side cache hit saves compute, not bytes — which is why fabric
+   bandwidth matters on long-prompt agentic workloads even at a high hit rate.
+6. **An MTP acceptance length of a steady 4.00 is bad news**, not a good result:
+   the draft is predicting a repetition loop perfectly. 2-3 is healthy.
+
+## Two GLM-5.3-specific things to decide before you run
+
+**MTP.** The two-node wrapper defaults `DECODE_MTP=1`, which is the GLM-5.2 kit's
+split (prefill off, decode on) and is measured here. Upstream's GLM-5.3 cookbook
+says MTP/EAGLE is disabled on AMD because the gfx950 draft kernel is unvalidated,
+while the OneNexus model card runs EAGLE at `--speculative-num-steps 3`; the
+measurement above settles it for this deployment and the cookbook line does not
+govern.
+
+It should not have been a surprise. `deploy/docker/patches/sglang_dsa/` exists
+specifically to make PD + DP-attention + EAGLE MTP work on this architecture:
+patch 02b fixes an assert that only fires under MTP, patch 04 is entirely about
+the **draft** CUDA graph on the PD decode leg, and patch 01's `GLM52_P1V3` half
+exists for the MTP draft-extend path on an idle DP rank. GLM-5.3 big is the same
+`glm_moe_dsa` architecture as GLM-5.2, so the set applies unchanged — and turning
+MTP off was leaving four of that set's seven bytecode markers unexercised.
+
+**What it buys.** Single-variable A/B on the same deployment, same bench (random,
+ISL 8192 / OSL 1024, concurrency 8, 80 prompts), only `DECODE_MTP` changed:
+
+| | MTP=0 | MTP=1 |
+|---|---|---|
+| output token throughput | 343.5 tok/s | **466.8 tok/s** (+36 %) |
+| mean TPOT | 20.62 ms | **14.51 ms** (−30 %) |
+| mean TTFT | 1988 ms | 2139 ms (+8 %) |
+| `ITL / TPOT` | **1.00** | **2.38** |
+
+TTFT moves the wrong way, which is the expected shape: speculation is a
+decode-side mechanism and adds nothing to prefill, while the decode leg's extra
+draft work pushes the tail out. That last row is the cleanest identification of
+the feature there is — with speculation off a decode step emits exactly one
+token, with it on it emits 2.38, which is the measured acceptance length.
+
+The parameters are **(3, 1, 4)** and you cannot change them from a wrapper:
+`engine/up.sh`'s `COMMON_ENV` does not forward `SPEC_STEPS`/`SPEC_DRAFT`, so
+`engine/leg.sh`'s defaults are what land. They are also what sglang v0.5.18 picks
+for this architecture on its own.
+
+**Read the acceptance-length median, never the last few lines.** A few percent of
+batches sit at the 4.00 ceiling even on a healthy leg, so `tail -5` routinely
+lands on them and misreads as degenerate — `engine/smoke.sh` reports the
+distribution for exactly this reason. Two more traps: `decode_log_interval`
+defaults to 40, so a leg that has served fewer than 40 decode iterations prints
+**no** `accept len:` lines even with MTP working perfectly; and with dp on, each
+DP rank's scheduler appends to the same log, so the sample count is ~4× a
+single-rank leg and is not comparable across a DPA change. The median is.
+
+**Shared-experts fusion.** Not a concern for the big MXFP4 checkpoint: its
+shared experts are themselves MXFP4 (76 `.weight` / 75 `.weight_scale`, the odd
+one being the BF16 MTP layer 78, which the decode leg now loads as its draft), so
+the precondition for the mismatch does not hold. Even so, `glm4_moe.py`'s fusion gate only special-cases `w4afp8` and would fuse under
+`quark`, so the wrappers pass `--disable-shared-experts-fusion` as insurance;
+upstream #25261 shows this class failing *silently with wrong output* rather
+than crashing when the shapes happen to line up.
+
+## Source
+
+[`examples/sglang_1p1d_glm5.3/`](.) in [AMD-AGI/Infera](https://github.com/AMD-AGI/Infera)
+· [the GLM-5.2 kit this drives](../sglang_1p1d_glm5.2/)
+· [aggregated MIX kit for the GLM-5.3 checkpoints](../sglang_mix_glm5.3/)
+· [PD disaggregation concepts](../../manual/features/pd_disaggregation.md)

--- a/examples/sglang_1p1d_glm5.3/cluster.2node.sh
+++ b/examples/sglang_1p1d_glm5.3/cluster.2node.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# ============================================================================
+#  EDIT THIS FILE. Nothing else needs changing.
+# ============================================================================
+#
+# GLM-5.3 (big) 1P1D across TWO nodes -- one prefill, one decode, KV over
+# mooncake RDMA. This is the shape the GLM-5.2 kit validated end to end on two
+# clusters and both fabric types; only the weights differ here.
+#
+# It drives the GLM-5.2 kit's engine scripts unchanged -- GLM-5.3 (big) is the
+# same architecture, so there is nothing to fork. See the README.
+#
+# Usage:  bash cluster.2node.sh up | smoke | bench [conc...] | down
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# The kit whose engine/ and common.sh actually run. Do not point this at a copy.
+export KIT_DIR="${KIT_DIR:-$(cd "$HERE/../sglang_1p1d_glm5.2" && pwd)}"
+
+# ---------------------------------------------------------------------------
+# 1. Nodes -- one prefill, one decode
+# ---------------------------------------------------------------------------
+
+# Each node's SSH-reachable name and its DATA-PLANE IP -- not the management
+# NIC. The legs advertise these to each other for the KV handoff.
+export PREFILL_NODE="${PREFILL_NODE:-<prefill-host>}"
+export DECODE_NODE="${DECODE_NODE:-<decode-host>}"
+export PREFILL_IP="${PREFILL_IP:-<prefill-data-plane-ip>}"
+export DECODE_IP="${DECODE_IP:-<decode-data-plane-ip>}"
+
+# ---------------------------------------------------------------------------
+# 2. Image and weights (identical on BOTH nodes)
+# ---------------------------------------------------------------------------
+
+# The STOCK infera sglang image (deploy/docker/Dockerfile.sglang) -- GLM-5.3 big
+# needs no source overlay. TWO names for one image, and both are needed:
+# preflight_rdma.sh reads IMAGE, engine/up.sh and common.sh require INFERA_IMAGE.
+# Exporting only IMAGE makes `up` die at its first require_env, before any container.
+export IMAGE="${IMAGE:-<infera-sglang-image>}"
+export INFERA_IMAGE="${INFERA_IMAGE:-$IMAGE}"
+# GLM-5.3-MXFP4 or GLM-5.3. Resolve symlinks: where this path crosses an NFS
+# mount boundary, bind-mounting the symlink's parent gives the container an
+# empty directory, and the failure surfaces much later as an unrelated error.
+export MODEL="${MODEL:-<weights-dir>}"
+export MODEL_MOUNT="${MODEL_MOUNT:-$(dirname "$MODEL")}"   # same path on both nodes
+export SERVED="${SERVED:-glm-5.3-mxfp4}"
+
+# ---------------------------------------------------------------------------
+# 3. Transport
+# ---------------------------------------------------------------------------
+
+# From `preflight_rdma.sh mode`, run on BOTH nodes. Do not guess these.
+# MC_GID_INDEX is PER NODE and the two nodes can legitimately differ -- an empty
+# slot on one shifts every index after it. A wrong index fails loudly at init on
+# every DP rank (`GID is NULL`); the link-local fe80:: GID is never the answer.
+export RDMA_IB_DEVICES="${RDMA_IB_DEVICES:-<ionic_0,ionic_1,...>}"
+export MC_GID_INDEX="${MC_GID_INDEX:-<index-from-preflight>}"
+
+# preflight_rdma.sh recommends RDMAV_FORK_SAFE=1 in all three of its modes, and
+# engine/leg.sh honours it only when passed in -- so unset here, that recommendation
+# is silently dropped. NOT on by default: this shape was validated without it.
+# export RDMAV_FORK_SAFE=1
+
+# Leave MC_TE_FILTERS unset in mode A (peer-mem present). It is required only in
+# the dma-buf mode, where KV must be pinned to one ODP-capable card.
+# export MC_TE_FILTERS="ionic_0"
+
+# ---------------------------------------------------------------------------
+# 4. Shape
+# ---------------------------------------------------------------------------
+
+# A whole node per leg.
+export TP="${TP:-8}"
+# Left UNSET on purpose, now that engine/up.sh actually forwards these. A whole
+# node per leg means leg.sh's own `seq 0..TP-1` is already right and stays right
+# if TP changes; pinning a literal 0..7 here would silently contradict TP=4.
+# Set them only to place a leg on a specific subset of a node's cards.
+export PREFILL_GPUS="${PREFILL_GPUS:-}"
+export DECODE_GPUS="${DECODE_GPUS:-}"
+
+# Separate hosts, so these only need to be free on their own node.
+export PREFILL_PORT="${PREFILL_PORT:-30000}"
+export DECODE_PORT="${DECODE_PORT:-30001}"
+export BOOTSTRAP_PORT="${BOOTSTRAP_PORT:-8998}"
+export ROUTER_PORT="${ROUTER_PORT:-8100}"
+export ETCD_PORT="${ETCD_PORT:-12379}"
+
+# ---------------------------------------------------------------------------
+# 5. Features -- see the README before changing these two
+# ---------------------------------------------------------------------------
+
+# EVERY FEATURE KNOB THE KIT READS IS PER LEG. The bare MTP/DPA names below are a
+# convenience SEED only: engine/up.sh consumes the PREFILL_*/DECODE_* pair, and a
+# value set under the bare name alone silently does nothing and falls back.
+
+# EAGLE MTP, decode leg only -- the GLM-5.2 split, measured here at +36% throughput.
+# leg.sh emits MTP(3,1,4) and SPEC_STEPS/SPEC_DRAFT cannot override it: up.sh's
+# COMMON_ENV drops them. MTP=0 to A/B. Watch the acceptance-length MEDIAN, 2-3 is
+# healthy and 4.00 is the draft predicting a repetition loop. README has the traps.
+export MTP="${MTP:-1}"
+export PREFILL_MTP="${PREFILL_MTP:-0}"
+export DECODE_MTP="${DECODE_MTP:-$MTP}"
+# DP-attention must be SYMMETRIC here: dp on both legs. That is a MEASURED
+# departure from the GLM-5.2 kit's prefill dp1 -> decode dp8. On GLM-5.3-MXFP4
+# asymmetric returns a clean FIRST completion then garbage on every later one --
+# repeated `</think>`, digit noise, always `length`. Silent. Re-read the output.
+export DPA="${DPA:-1}"
+export PREFILL_DPA="${PREFILL_DPA:-$DPA}"
+export DECODE_DPA="${DECODE_DPA:-$DPA}"
+export KVAWARE="${KVAWARE:-1}"
+export PREFILL_KVD="${PREFILL_KVD:-0}"
+export DECODE_KVD="${DECODE_KVD:-0}"
+# Insurance, not a fix -- this checkpoint's shared experts are themselves MXFP4.
+# Kept on because upstream #25261 shows the mismatch failing SILENTLY with wrong
+# output when shapes happen to line up. See the README.
+export EXTRA_ENGINE_ARGS="${EXTRA_ENGINE_ARGS:---disable-shared-experts-fusion}"
+
+# Prefill wants activation headroom, decode wants KV pool. Do not equalise them.
+export GMU_PREFILL="${GMU_PREFILL:-0.70}"
+export GMU_DECODE="${GMU_DECODE:-0.85}"
+
+for v in PREFILL_IP IMAGE INFERA_IMAGE MODEL RDMA_IB_DEVICES MC_GID_INDEX; do
+  case "${!v}" in "<"*) echo "edit $(basename "$0"): $v is still a placeholder" >&2; exit 2;; esac
+done
+
+exec bash "$KIT_DIR/engine/${1:?usage: $(basename "$0") up|smoke|bench|down}.sh" "${@:2}"

--- a/examples/sglang_1p1d_glm5.3/cluster.singlenode.sh
+++ b/examples/sglang_1p1d_glm5.3/cluster.singlenode.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# ============================================================================
+#  EDIT THIS FILE. Nothing else needs changing.
+# ============================================================================
+#
+# GLM-5.3 (big) 1P1D on a SINGLE 8-GPU node: TP4 prefill on cards 0-3, TP4
+# decode on cards 4-7, KV moved between them over mooncake.
+#
+# Same-host KV moves over HIP IPC across XGMI rather than the NIC, which makes
+# this shape's checks different from the two-node one -- read the README's
+# single-node section before trusting any number this produces.
+#
+# It drives the GLM-5.2 kit's engine scripts unchanged -- GLM-5.3 (big) is the
+# same architecture, so there is nothing to fork. See the README.
+#
+# Usage:  bash cluster.singlenode.sh up | smoke | bench [conc...] | down
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# The kit whose engine/ and common.sh actually run. Do not point this at a copy.
+export KIT_DIR="${KIT_DIR:-$(cd "$HERE/../sglang_1p1d_glm5.2" && pwd)}"
+
+# ---------------------------------------------------------------------------
+# 1. Node -- the same host twice
+# ---------------------------------------------------------------------------
+
+# Both legs live here, so PREFILL_* and DECODE_* name one machine. up.sh reaches
+# each "node" through $SSH_CMD; pointing both at this host is what makes the
+# single-node shape work with no change to the engine scripts.
+export PREFILL_NODE="${PREFILL_NODE:-$(hostname -s)}"
+export DECODE_NODE="$PREFILL_NODE"
+# DATA-PLANE IP, not the management NIC -- the legs advertise it to each other.
+export PREFILL_IP="${PREFILL_IP:-<this-node-data-plane-ip>}"
+export DECODE_IP="$PREFILL_IP"
+
+# ---------------------------------------------------------------------------
+# 2. Image and weights
+# ---------------------------------------------------------------------------
+
+# The STOCK infera sglang image (deploy/docker/Dockerfile.sglang) -- GLM-5.3 big
+# needs no source overlay. TWO names for one image, and both are needed:
+# preflight_rdma.sh reads IMAGE, engine/up.sh and common.sh require INFERA_IMAGE.
+# Exporting only IMAGE makes `up` die at its first require_env, before any container.
+export IMAGE="${IMAGE:-<infera-sglang-image>}"
+export INFERA_IMAGE="${INFERA_IMAGE:-$IMAGE}"
+# GLM-5.3-MXFP4 or GLM-5.3. Resolve symlinks: where this path crosses an NFS
+# mount boundary, bind-mounting the symlink's parent gives the container an
+# empty directory, and the failure surfaces much later as an unrelated error.
+export MODEL="${MODEL:-<weights-dir>}"
+export MODEL_MOUNT="${MODEL_MOUNT:-$(dirname "$MODEL")}"
+export SERVED="${SERVED:-glm-5.3-mxfp4}"
+
+# ---------------------------------------------------------------------------
+# 3. Transport
+# ---------------------------------------------------------------------------
+
+# From `preflight_rdma.sh mode`, run on THIS node. Do not guess these; the
+# link-local fe80:: GID is never the answer. SINGLE-NODE RULE, differing from the
+# two-node one: pin ONE device, the same on both legs. It still matters with hip
+# enabled below -- if hip fails to install, the fallback is loopback RDMA.
+export RDMA_IB_DEVICES="${RDMA_IB_DEVICES:-<one-ionic-device, e.g. ionic_0>}"
+export MC_GID_INDEX="${MC_GID_INDEX:-<index-from-preflight>}"
+# preflight_rdma.sh asks for this in ALL THREE modes, and engine/leg.sh honours
+# it only when it is passed in ([ "${RDMAV_FORK_SAFE:-0}" = "1" ]). Unset here it
+# never reaches the engine, so the preflight's own recommendation would be
+# silently dropped.
+export RDMAV_FORK_SAFE="${RDMAV_FORK_SAFE:-1}"
+# Leave MC_TE_FILTERS unset in mode A (peer-mem present). It is required only in
+# the dma-buf mode, where KV must be pinned to one ODP-capable card.
+# export MC_TE_FILTERS="ionic_0"
+
+# DEAD NAME: MC_DISABLE_HIP_TRANSPORT does not exist in the shipped mooncake
+# binary, and a leg launched with it at 1 still installed hip 4x. Kept only
+# because it reads as the pair to MC_DISABLE_HIP below, which is the live knob.
+# hip is ON here whatever this line says. REQUIRED CHECK: no hipIpcOpenMemHandle failed.
+export MC_DISABLE_HIP_TRANSPORT="${MC_DISABLE_HIP_TRANSPORT:-0}"
+
+# MC_DISABLE_HIP is the live knob, left UNSET on purpose: hip on is what this
+# shape wants -- selectTransport prefers hip, so KV goes GPU-to-GPU over XGMI
+# with no NIC in the path. Set it to 1 for a hip-off A/B, but note it gates
+# SELECTION and not install, so no log line confirms it took. See the README.
+export MC_DISABLE_HIP="${MC_DISABLE_HIP:-}"
+
+# ---------------------------------------------------------------------------
+# 4. Shape
+# ---------------------------------------------------------------------------
+export TP="${TP:-4}"
+export PREFILL_GPUS="${PREFILL_GPUS:-0,1,2,3}"
+export DECODE_GPUS="${DECODE_GPUS:-4,5,6,7}"
+
+# Ports must not collide -- both legs share one host's network namespace. CHECK
+# with `ss -lnt`; on a shared node the obvious ones are often taken.
+export PREFILL_PORT="${PREFILL_PORT:-30000}"
+export DECODE_PORT="${DECODE_PORT:-30001}"
+export BOOTSTRAP_PORT="${BOOTSTRAP_PORT:-8998}"
+export ROUTER_PORT="${ROUTER_PORT:-8100}"
+export ETCD_PORT="${ETCD_PORT:-12379}"
+
+# The KV-event ports are PER LEG and on this shape they must differ. Two-node legs
+# take engine/leg.sh's defaults (5557/8801) and never meet; here they share one
+# network namespace, so identical values make the second leg's bind fail with
+# "port_base at N is not available" and it never serves. up.sh forwards these per leg.
+export PREFILL_KV_PUB_PORT="${PREFILL_KV_PUB_PORT:-5557}"
+export PREFILL_KV_SNAP_PORT="${PREFILL_KV_SNAP_PORT:-8801}"
+export DECODE_KV_PUB_PORT="${DECODE_KV_PUB_PORT:-5558}"
+export DECODE_KV_SNAP_PORT="${DECODE_KV_SNAP_PORT:-8802}"
+
+# ---------------------------------------------------------------------------
+# 5. Features -- see the README before changing these two
+# ---------------------------------------------------------------------------
+
+# EVERY FEATURE KNOB THE KIT READS IS PER LEG. The bare MTP/DPA names below are a
+# convenience SEED only: engine/up.sh consumes the PREFILL_*/DECODE_* pair, and a
+# value set under the bare name alone silently does nothing -- MTP=0 on its own
+# still launched the decode leg at mtp=1.
+
+# MTP off HERE ONLY: it is validated on the TWO-NODE symmetric-DPA shape, and this
+# wrapper runs dp OFF, so the draft never meets the idle-DP-rank path half the DSA
+# patch set exists for -- a different shape, not a smaller one. DECODE_MTP=1 to try
+# it, then read the acceptance-length median (2-3 healthy, 4.00 is a repetition loop).
+export MTP="${MTP:-0}"
+export PREFILL_MTP="${PREFILL_MTP:-$MTP}"
+export DECODE_MTP="${DECODE_MTP:-$MTP}"
+# DP-ATTENTION IS OFF HERE, AND THAT IS MEASURED, NOT CAUTION. Asymmetric
+# (prefill dp1 -> decode dp4) on GLM-5.3-MXFP4 returns a clean FIRST completion
+# then garbage on every later one -- repeated `</think>`, digit noise, always
+# `length`, at any prompt length. Silent: no faults, no HIP errors, nothing logged.
+
+# The TWO-NODE wrapper instead runs SYMMETRIC dp on both legs, which is clean.
+# Symmetric was never tried on one node, so DECODE_DPA=0 is what is validated
+# here. For DP-attention on one node try PREFILL_DPA=1 DECODE_DPA=1 first, and
+# read the output rather than the exit code.
+export DPA="${DPA:-0}"
+export PREFILL_DPA="${PREFILL_DPA:-0}"
+export DECODE_DPA="${DECODE_DPA:-$DPA}"
+export KVAWARE="${KVAWARE:-1}"
+export PREFILL_KVD="${PREFILL_KVD:-0}"
+export DECODE_KVD="${DECODE_KVD:-0}"
+# Insurance, not a fix -- this checkpoint's shared experts are themselves MXFP4.
+# Kept on because upstream #25261 shows the mismatch failing SILENTLY with wrong
+# output when shapes happen to line up. See the README.
+export EXTRA_ENGINE_ARGS="${EXTRA_ENGINE_ARGS:---disable-shared-experts-fusion}"
+
+# Prefill wants activation headroom, decode wants KV pool. Do not equalise them.
+export GMU_PREFILL="${GMU_PREFILL:-0.70}"
+export GMU_DECODE="${GMU_DECODE:-0.85}"
+
+for v in PREFILL_IP IMAGE INFERA_IMAGE MODEL RDMA_IB_DEVICES MC_GID_INDEX; do
+  case "${!v}" in "<"*) echo "edit $(basename "$0"): $v is still a placeholder" >&2; exit 2;; esac
+done
+
+exec bash "$KIT_DIR/engine/${1:?usage: $(basename "$0") up|smoke|bench|down}.sh" "${@:2}"

--- a/examples/sglang_mix_glm5.3/README.md
+++ b/examples/sglang_mix_glm5.3/README.md
@@ -1,0 +1,168 @@
+# GLM-5.3 series — SGLang MIX (aggregated) on MI355X
+
+Runnable deployment kit for **`GLM-5.3` and `GLM-5.3-MXFP4`** served the infera
+way on a single 8×MI355X (gfx950) node: one aggregated worker, prefix caching
+on, fronted by the **infera kv-aware router**. No PD, no RDMA, no second node.
+
+One file is site-specific. Fill it in and the deployment is three commands.
+
+```bash
+$EDITOR env.sh                 # the only file you edit
+bash engine/up.sh              # container -> etcd -> worker -> router
+bash engine/smoke.sh           # prove each feature is actually live
+```
+
+## Read this first: the big pair is GLM-5.2 with different weights
+
+`GLM-5.3` and `GLM-5.3-MXFP4` carry `model_type: glm_moe_dsa`, and their
+`config.json` is identical to GLM-5.2's field for field except
+`transformers_version`. The released engine therefore already serves them through
+`glm4_moe.py`, and the ordinary `Dockerfile.sglang` image is the only one this kit
+needs.
+
+| | `GLM-5.3`, `GLM-5.3-MXFP4` |
+|---|---|
+| `model_type` | `glm_moe_dsa` |
+| hidden / layers | 6144 / 78 |
+| routed experts | 256 |
+| attention | uniform MLA + DSA |
+| memory pools | paged KV only |
+| image | `Dockerfile.sglang` |
+
+## Contents
+
+| path | what |
+|---|---|
+| [`env.sh`](env.sh) | **the only file you edit** — variant, IP, weights, image, shape, ports |
+| `engine/worker.sh` | the real launcher; carries the tuned recipe for both big variants, no site values |
+| `engine/up.sh` | container → etcd → worker → router, waiting on health at each step |
+| `engine/smoke.sh` | six blocks, each red when a specific feature is *silently* absent |
+| `engine/bench.sh` | reference fixed-length sweep via sglang's own `bench_serving` |
+| `engine/down.sh` | tear down, then **wait** for VRAM to actually drain |
+
+## Validation status
+
+Stated plainly rather than implied. All on 8×MI355X, gfx950, ROCm 7.2, driver
+6.14.14, TP4, decode CUDA graphs on unless noted.
+
+| variant | status |
+|---|---|
+| `big-fp8` | **validated** — all smoke blocks green, `max_total_num_tokens=1148288` |
+| `big-mxfp4` | **validated, with numbers** — all smoke blocks green; AITER FP4 path confirmed dispatching (`torch.float4_e2m1fn_x2`, `per_1x32`) rather than dequantising to BF16; TP8+DPA+MTP fixed-length sweep lands at **0.92 / 1.06 / 0.89 / 1.10 ×** the GLM-5.2 MIX baseline at concurrency 1/8/16/24 |
+| PD (1P1D) | **not covered by this kit.** The shape is the same as [`sglang_1p1d_glm5.2`](../sglang_1p1d_glm5.2/); [`sglang_1p1d_glm5.3`](../sglang_1p1d_glm5.3/) wraps it for these checkpoints |
+
+## `--disable-shared-experts-fusion` here is insurance, not a fix
+
+On `big-mxfp4` the checkpoint's shared experts are **themselves MXFP4**, so the
+precondition for a mis-load is absent: `glm4_moe.py`'s fusion gate only
+special-cases `w4afp8` and would fuse under `quark`, but there is no
+higher-precision shared expert to rename into a packed routed slot.
+
+It is on by default anyway, because upstream **#25261** shows this class of
+mismatch failing *silently with wrong output* rather than crashing when the
+shapes happen to line up. Set `SHARED_EXPERT_FUSION=1` for a clean
+single-variable performance round.
+
+The health signal is a line that must be **ABSENT** from the worker log:
+`Shared experts fusion optimization enabled.`
+
+## Notes and gotchas
+
+**1. A startup line that reads like a clamp is a division.** Under DP-attention
+the engine prints **per-rank** values while `/get_server_info` reports the
+global ones. Ask for `--max-running-requests 256 --chunked-prefill-size 65536`
+at dp8 and the startup line says 32 and 8192 — that is 256/8 and 65536/8. Never
+compare a requested value against a resolved one; the GLM-5.2 baseline's log
+shows both numbers too, so this is not new to GLM-5.3.
+
+**2. DSA flags are `--dsa-*`, not GLM-5.2's `--nsa-*`.** Both spellings exist in
+v0.5.18; the `--nsa-*` ones are not what this model wants.
+
+**3. The DSA-on-ROCm env block is mandatory.** Without it the
+model serves, returns 200s, and returns garbage — the sparse-attention indexer
+takes a path not ported to gfx950. `worker.sh` sets it; `infera.engine.sglang`
+also defaults `SGLANG_OPT_USE_TOPK_V2` off on ROCm.
+
+**4. Do not copy the vendor card's `--cuda-graph-max-bs 2
+--max-running-requests 2`.** Those appear in the published GLM-5.3-MXFP4 recipe
+and cap the server at two concurrent requests. That is an accuracy
+configuration, not a throughput one.
+
+**5. Benchmark with `bench_serving`, not a shell loop.** A bash fan-out of
+concurrent `curl`s becomes the bottleneck before the engine does — at
+concurrency 32 one measured 350 output tok/s while the engine's own log reported
+2398 tok/s with an empty queue.
+
+**6. Resolve the weights symlink yourself.** Where the models path crosses an
+NFS mount boundary, bind-mounting the symlink's parent gives the container an
+empty directory. The failure appears minutes later as `Unrecognized processing
+class`, because `config.json` is the one file that still resolves. `up.sh` binds
+`realpath` output.
+
+**7. MTP/EAGLE is off here, but the question it used to raise is settled.** This
+note previously recorded a contradiction — upstream's GLM-5.3 cookbook disables
+speculative decoding on AMD, the OneNexus big-MXFP4 card runs EAGLE at three
+steps — as unresolved. It is resolved for the **PD** shape: EAGLE MTP(3,1,4) is
+validated on this checkpoint in
+[`../sglang_1p1d_glm5.3/`](../sglang_1p1d_glm5.3/), so the cookbook's AMD line
+does not govern this architecture. What remains untested is MTP in *this*
+kit — an aggregated, non-PD shape — so it stays off here for want of a
+measurement, not for want of a decision.
+
+**8. `Ctrl-C` on a log tail does not stop anything.** Use `engine/down.sh`, and
+check `docker ps`.
+
+## Reference numbers
+
+`big-mxfp4`, measured with `bench_serving` at fixed lengths against the GLM-5.2
+MIX baseline. Output tok/s, p50 of the sweep:
+
+| concurrency | 1 | 8 | 16 | 24 |
+|---|---:|---:|---:|---:|
+| TP8, DP-attention, EAGLE MTP | 76.26 | 417.63 | 606.33 | 825.07 |
+| GLM-5.2 MIX baseline | 82.56 | 395.58 | 679.82 | 746.75 |
+| ratio | 0.92 | **1.06** | 0.89 | **1.10** |
+
+At p90 the same arms give 0.99 / 1.03 / 0.98 / 1.01 — parity. The overall band
+is **0.89–1.11×**.
+
+**The parallelism is part of the result, not a detail.** The same checkpoint at
+TP4 with DP-attention and MTP off reaches only 0.58–0.83× of the same baseline.
+Comparing a TP4 arm against a TP8+DPA+MTP baseline measures the configuration,
+not the model.
+
+These are a reference point on one configuration, not a claim about the family.
+
+## What this kit exposes on the network, and why you should care on a shared node
+
+These scripts run with `--network=host` and bind on **all interfaces**. That is
+deliberate for a single-tenant benchmark box and is **wrong for a shared one**,
+where other users can be logged into the same node and claim its GPUs without
+notice.
+
+| what | where | exposed as |
+|---|---|---|
+| **etcd**, unauthenticated | `up.sh` | `0.0.0.0:$ETCD_PORT` and peer port |
+| router | `up.sh` | `0.0.0.0:$ROUTER_PORT` |
+| KV event / snapshot sockets | `worker.sh` | `tcp://0.0.0.0:$KV_PUB_PORT` |
+
+**etcd is the one that matters.** It holds worker discovery, it has no auth, and
+anyone who can reach the port can mutate the keys that tell the router where to
+send traffic. The engine and KV ports are lower stakes but still raw.
+
+The scripts are left as they were validated rather than quietly re-bound, because
+changing a bind changes a recipe that was measured. **If you run this on a shared
+or reachable host, change them yourself:** the router and workers are colocated,
+so `127.0.0.1` works for etcd and the KV sockets, and only the router port needs
+to be reachable — put something that authenticates in front of it.
+
+**`--trust-remote-code` is passed.** The risk it carries is in the checkpoint
+directory, not in the flag: where the weights live on a shared NFS mount,
+**anyone who can write there can execute code in your container.** If that matters
+to you, copy the checkpoint to a directory you own and verify permissions before
+launching.
+
+## Source
+
+[`examples/sglang_mix_glm5.3/`](.) in [AMD-AGI/Infera](https://github.com/AMD-AGI/Infera)
+· [GLM-5.2 1P1D kit](../sglang_1p1d_glm5.2/) · [PD disaggregation concepts](../../manual/features/pd_disaggregation.md)

--- a/examples/sglang_mix_glm5.3/engine/bench.sh
+++ b/examples/sglang_mix_glm5.3/engine/bench.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Reference fixed-length sweep using sglang's own bench_serving, which ships
+# inside the image. Use this rather than a shell fan-out of curl: a bash loop of
+# N concurrent curls becomes the bottleneck well before the engine does -- at
+# concurrency 32, 350 output tok/s client-side against 2398 tok/s in the engine
+# log with an empty queue.
+#
+# Three flags are load-bearing and are NOT defaults:
+#   --random-range-ratio 1.0   pins every prompt to exactly ISL. The default
+#                              draws uniformly and the percentiles then mix
+#                              request sizes; a fixed-length sweep wants a
+#                              delta, not a distribution.
+#   --temperature 1.0 --top-p 0.95   the checkpoint's own generation_config
+#                              defaults, deliberately NOT greedy. At temperature
+#                              0 this reasoning model falls into repetition on a
+#                              long prompt and the run reads like corruption.
+#   --num-prompts 10 x conc    enough requests per arm to reach steady state.
+
+# KNOWN LIMITATION -- long OSL produces degenerate output. The default OSL of 320
+# is clean (0-1 % of requests); at 3300 it is 40-65 %, at 17000 96-100 %. tok/s is
+# unaffected, so such a number is a valid throughput measurement of the engine
+# generating repetitive text and must not be quoted as a quality result.
+
+# Cause is not established, but one candidate is ELIMINATED: `apply_chat_template`
+# is parsed and never consumed on this backend, and --backend sglang-oai-chat posts
+# to /v1/chat/completions, which applies the template server-side anyway. Adding
+# --apply-chat-template will NOT help.
+
+# To defend a long-OSL number on quality, score the saved generations for n-gram
+# repetition (--output-details saves generated_texts) rather than trusting the
+# summary. Acceptance length does NOT detect this: an aggregate of 2.96 was seen
+# while 54 % of the very same requests were looping.
+
+# Usage: bash engine/bench.sh [conc ...]      (default 1 8 16 24)
+set -uo pipefail
+KIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../env.sh
+source "$KIT/env.sh"
+SERVED="${SERVED:-glm5.3-$VARIANT}"
+ISL="${ISL:-7400}"; OSL="${OSL:-320}"
+CONCS=("$@"); [ ${#CONCS[@]} -eq 0 ] && CONCS=(1 8 16 24)
+
+for c in "${CONCS[@]}"; do
+  echo "===== isl=$ISL osl=$OSL conc=$c ====="
+  docker exec "$CTR" python3 -m sglang.bench_serving --backend sglang-oai-chat \
+    --host "$MY_IP" --port "$PORT" --model "$SERVED" \
+    --dataset-name random --random-input-len "$ISL" --random-output-len "$OSL" \
+    --random-range-ratio 1.0 --max-concurrency "$c" --num-prompts $((c * 10)) \
+    --temperature 1.0 --top-p 0.95 2>&1 \
+    | grep -E "Successful requests|Benchmark duration|Request throughput|Output token throughput|Total token throughput|Median TTFT|P99 TTFT|Mean TPOT|Median E2E"
+done

--- a/examples/sglang_mix_glm5.3/engine/down.sh
+++ b/examples/sglang_mix_glm5.3/engine/down.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Tear down and WAIT for VRAM to actually drain. The wait is the point, not the
+# kill: `docker rm -f` returns before the driver has reclaimed the allocations,
+# and relaunching too early aborts the next distributed bootstrap with a
+# misleading "memory capacity is unbalanced" error that reads like a model or
+# config problem.
+set -uo pipefail
+KIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../env.sh
+source "$KIT/env.sh"
+
+# Named explicitly, never a pattern -- on a shared node a pattern is how you
+# remove somebody else's container.
+docker rm -f "$CTR" "${CTR}_etcd" >/dev/null 2>&1
+echo "removed $CTR and ${CTR}_etcd; waiting for VRAM to drain"
+for i in $(seq 1 60); do
+  busy=$(rocm-smi --showmemuse 2>/dev/null | awk -v want=",$GPUS," '
+    match($0, /GPU\[([0-9]+)\]/, m) && /VRAM%/ {
+      split($0, f, ": "); if (index(want, "," m[1] ",") && f[2]+0 > 5) printf "%s ", m[1] }')
+  [ -z "$busy" ] && { echo "GPUs $GPUS at baseline after $((i * 5))s"; exit 0; }
+  sleep 5
+done
+echo "TIMEOUT: GPU(s) $busy still above baseline." >&2
+echo "If they are not ours, that is expected on a shared node -- check first." >&2
+rocm-smi --showpids 2>/dev/null | sed -n '3,12p' >&2
+exit 1

--- a/examples/sglang_mix_glm5.3/engine/smoke.sh
+++ b/examples/sglang_mix_glm5.3/engine/smoke.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Prove the deployment is real, not merely alive.
+#
+# A green /health says a process is listening. It does not say the AITER fast
+# path is dispatching, that both memory pools exist, or that the model is
+# producing sense rather than noise. Each block below is chosen because it goes
+# RED when a specific feature is silently absent.
+set -uo pipefail
+KIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../env.sh
+source "$KIT/env.sh"
+SERVED="${SERVED:-glm5.3-$VARIANT}"
+R="http://$MY_IP:$ROUTER_PORT"
+
+echo "===== 1. router sees exactly one MIXED worker ====="
+curl -s "$R/v1/workers" | python3 -c '
+import json,sys
+d=json.load(sys.stdin); w=d if isinstance(d,list) else d.get("workers",d)
+w=w if isinstance(w,list) else []
+print(f"  workers: {len(w)}  (want 1)")
+for x in w: print(f"    {x.get('"'"'url'"'"',x.get('"'"'worker_id'"'"'))}  disagg_mode={x.get('"'"'disagg_mode'"'"')}  (want mixed)")
+'
+
+echo "===== 2. model is served under the expected name ====="
+curl -s "$R/v1/models" | python3 -c 'import json,sys; print("  ", [m["id"] for m in json.load(sys.stdin)["data"]])'
+
+echo "===== 3. coherent answer, and reasoning separated ====="
+# max_tokens is deliberately generous: this is a thinking model, so the chain of
+# thought lands in reasoning_content but is billed against the SAME budget, and a
+# small value returns empty content on finish_reason "length". Garbage or
+# repeated tokens here means the DSA-on-ROCm env block did not take effect.
+curl -s "$R/v1/chat/completions" -H 'Content-Type: application/json' -d "{
+  \"model\": \"$SERVED\",
+  \"messages\": [{\"role\": \"user\", \"content\": \"In two sentences, explain why prefix caching helps agentic workloads.\"}],
+  \"max_tokens\": 600, \"temperature\": 0}" | python3 -c '
+import json,sys
+d=json.load(sys.stdin); m=d["choices"][0]["message"]
+print("  content :", (m.get("content") or "")[:220])
+print("  reasoning_content chars:", len(m.get("reasoning_content") or ""), "(want > 0)")
+print("  finish  :", d["choices"][0].get("finish_reason"), "| usage:", d["usage"])'
+
+echo "===== 4. arithmetic, and instruction-following ====="
+curl -s "$R/v1/chat/completions" -H 'Content-Type: application/json' -d "{
+  \"model\": \"$SERVED\",
+  \"messages\": [{\"role\": \"user\", \"content\": \"What is 17 * 23? Reply with only the number.\"}],
+  \"max_tokens\": 512, \"temperature\": 0}" \
+  | python3 -c 'import json,sys; print("  answer:", repr(json.load(sys.stdin)["choices"][0]["message"]["content"]), "(want 391)")'
+
+echo "===== 5. engine-side evidence ====="
+docker exec "$CTR" bash -c '
+L=/tmp/glm53_mix.log
+# Must be ABSENT. Present means shared-experts fusion is on, which on a
+# mixed-precision Quark checkpoint mis-loads the BF16 shared expert into a
+# packed routed slot. See the note in worker.sh.
+echo "  fusion-enabled line    : $(grep -c "Shared experts fusion optimization enabled" $L)   (want 0 on mxfp4)"
+# The RESOLVED admission limit, which is not what /get_server_info reports:
+# under DP-attention the engine prints per-rank values (the global divided by
+# dp_size). Read this line before concluding a cap has fired.
+echo "  resolved max_running   : $(grep -o "max_running_requests=[0-9]*" $L | tail -1)"
+echo "  memory access fault    : $(grep -c "memory access fault" $L)   (want 0)"
+echo "  HIP error              : $(grep -c "HIP error" $L)   (want 0)"
+# torch._dynamo/metrics_context tracebacks are compile-telemetry noise and
+# appear in healthy runs; excluded here so a real one is visible.
+echo "  Traceback (non-dynamo) : $(grep "Traceback" $L | grep -vc "_dynamo")   (want 0)"
+grep -m1 "max_total_num_tokens" $L | cut -c1-150
+' 2>/dev/null
+
+echo "===== 6. router policy ====="
+docker exec "$CTR" grep -om1 "kv-aware" /tmp/router.log 2>/dev/null | sed 's/^/  policy: /'

--- a/examples/sglang_mix_glm5.3/engine/up.sh
+++ b/examples/sglang_mix_glm5.3/engine/up.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Bring up a single-node MIX (aggregated) GLM-5.3 deployment:
+#   container -> etcd -> infera worker -> kv-aware router.
+# Reads every site value from ../env.sh. Runs ON the node.
+set -uo pipefail
+KIT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../env.sh
+source "$KIT/env.sh"
+
+case "$MY_IP" in "<"*) echo "edit env.sh: MY_IP is still a placeholder" >&2; exit 2;; esac
+case "$IMAGE" in "<"*) echo "edit env.sh: IMAGE is still a placeholder" >&2; exit 2;; esac
+[ -d "$MODEL" ] || { echo "MODEL not a directory on this host: $MODEL" >&2; exit 2; }
+
+# Bind the REALPATH, not the symlink's parent. See the note in env.sh: where the
+# models path crosses an NFS mount boundary, binding the wrong side gives the
+# container an empty directory whose failure surfaces many minutes later as an
+# unrelated-looking processor error.
+MODEL_REAL="$(realpath "$MODEL")"
+MOUNT_REAL="$(dirname "$MODEL_REAL")"
+
+echo "===== 1. teardown (ours only) ====="
+# Named explicitly. Never a pattern: on a shared node a pattern is how you
+# remove somebody else's container.
+docker rm -f "$CTR" "${CTR}_etcd" >/dev/null 2>&1
+sleep 5
+
+echo "===== 2. GPUs $GPUS free? ====="
+# Advisory, not a kill. If a GPU we want is busy this stops and says so -- it
+# never reclaims a process, because on a shared node that process is somebody's
+# multi-day job.
+busy=$(rocm-smi --showmemuse 2>/dev/null | awk -v want=",$GPUS," '
+  match($0, /GPU\[([0-9]+)\]/, m) && /VRAM%/ {
+    split($0, f, ": "); if (index(want, "," m[1] ",") && f[2]+0 > 5) printf "%s ", m[1] }')
+[ -n "$busy" ] && { echo "  GPU(s) $busy already in use -- pick a free subset via GPUS=, or wait." >&2; exit 1; }
+echo "  clear"
+
+echo "===== 3. container ====="
+docker run -d --name "$CTR" --network=host --ipc=host --shm-size=64G \
+  --device=/dev/kfd --device=/dev/dri \
+  --group-add video --group-add render --cap-add=SYS_PTRACE --cap-add=IPC_LOCK \
+  --security-opt seccomp=unconfined --ulimit memlock=-1:-1 \
+  -v "$MOUNT_REAL":"$MOUNT_REAL":ro \
+  "$IMAGE" sleep infinity >/dev/null || exit 1
+sleep 5
+
+echo "===== 4. etcd ====="
+# Two etcd traps. The v3.5.x image has an empty ENTRYPOINT and
+# Cmd=[/usr/local/bin/etcd], so passing `etcd` as argv[0] dumps usage and exits
+# 2 -- hence --entrypoint. And the three peer flags below must move TOGETHER:
+# override only --listen-peer-urls and etcd exits 1 on --initial-cluster.
+docker run -d --name "${CTR}_etcd" --network=host --entrypoint /usr/local/bin/etcd \
+  quay.io/coreos/etcd:v3.5.14 \
+  --advertise-client-urls "http://$MY_IP:$ETCD_PORT" \
+  --listen-client-urls "http://0.0.0.0:$ETCD_PORT" \
+  --listen-peer-urls "http://0.0.0.0:$((ETCD_PORT + 1))" \
+  --initial-advertise-peer-urls "http://$MY_IP:$((ETCD_PORT + 1))" \
+  --initial-cluster "default=http://$MY_IP:$((ETCD_PORT + 1))" >/dev/null
+sleep 5
+curl -sf -m5 "http://$MY_IP:$ETCD_PORT/version" >/dev/null \
+  && echo "  etcd up" || { echo "  ETCD FAILED"; docker logs --tail 5 "${CTR}_etcd"; }
+
+echo "===== 5. worker ====="
+docker cp "$KIT/engine/worker.sh" "$CTR":/worker.sh >/dev/null
+docker exec -d "$CTR" env \
+  MY_IP="$MY_IP" ETCD_IP="$MY_IP" ETCD_PORT="$ETCD_PORT" \
+  MODEL="$MODEL_REAL" VARIANT="$VARIANT" TP="$TP" GPUS="$GPUS" PORT="$PORT" \
+  SERVED="${SERVED:-glm5.3-$VARIANT}" CUDA_GRAPH="${CUDA_GRAPH:-1}" \
+  bash /worker.sh
+echo "  launching -> /tmp/glm53_mix.log in $CTR"
+
+echo "===== 6. wait for /health ====="
+# Cold start is minutes, not seconds: several hundred GB of weights, then AITER
+# JIT, then graph capture. Silence is not a hang -- a cold NFS cache pushes this
+# to around 650 s.
+for i in $(seq 1 240); do
+  if docker exec "$CTR" curl -sf -m3 "http://$MY_IP:$PORT/health" >/dev/null 2>&1; then
+    echo "  serving after $((i * 10))s"; break
+  fi
+  docker exec "$CTR" pgrep -f infera.engine.sglang >/dev/null 2>&1 || {
+    echo "  worker died -- last lines:"; docker exec "$CTR" tail -25 /tmp/glm53_mix.log; exit 1; }
+  sleep 10
+done
+
+echo "===== 7. kv-aware router ====="
+docker exec "$CTR" bash -c "printf '%s\n' '#!/bin/bash' \
+  'exec python3 -m infera.server --host 0.0.0.0 --port $ROUTER_PORT \
+   --discovery-backend etcd --etcd-endpoint $MY_IP:$ETCD_PORT \
+   --request-transport http --kv-event-transport zmq --router-policy kv-aware \
+   --router-tokenizer-path $MODEL_REAL' > /run_router.sh && chmod +x /run_router.sh"
+docker exec -d "$CTR" bash -c 'nohup /run_router.sh > /tmp/router.log 2>&1'
+sleep 20
+docker exec "$CTR" bash -c \
+  "curl -sf -m5 http://$MY_IP:$ROUTER_PORT/health >/dev/null && echo '  router healthy' \
+   || { echo '  router not ready'; tail -20 /tmp/router.log; }"
+
+echo "===== up. clients use http://$MY_IP:$ROUTER_PORT ====="

--- a/examples/sglang_mix_glm5.3/engine/worker.sh
+++ b/examples/sglang_mix_glm5.3/engine/worker.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# The real launcher, and the file that carries the tuned recipe. Runs INSIDE
+# the container, staged there by up.sh. Every site-specific value arrives as an
+# env var from env.sh; there are no addresses or paths in here.
+#
+# Launches through `python3 -m infera.engine.sglang` rather than
+# sglang.launch_server so infera's etcd discovery and kv-aware routing work.
+set -u
+MY_IP="${MY_IP:?MY_IP=this node data-plane IP}"
+MODEL="${MODEL:?MODEL=weights dir inside the container}"
+VARIANT="${VARIANT:?VARIANT=big-mxfp4|big-fp8}"
+ETCD_IP="${ETCD_IP:-$MY_IP}"
+ETCD_PORT="${ETCD_PORT:-12379}"
+PORT="${PORT:-30000}"
+TP="${TP:-4}"
+GPUS="${GPUS:-$(seq -s, 0 $((TP - 1)))}"
+SERVED="${SERVED:-glm5.3-$VARIANT}"
+LOG="${LOG:-/tmp/glm53_mix.log}"
+
+# Decode CUDA graphs. ON by default: worth roughly 7.5x output throughput at
+# concurrency 1, for 33-82 s of capture. Prefill graphs stay disabled, which is
+# what upstream validated on gfx950. Pass --cuda-graph-*-decode, not the
+# deprecated --cuda-graph-max-bs: it still resolves but breaks on a base bump.
+CUDA_GRAPH="${CUDA_GRAPH:-1}"
+# The bs list is graph COVERAGE, not a concurrency cap: a decode batch is padded
+# up to the next captured size, anything larger runs eager, and sizes above
+# --max-running-requests are dropped at capture time. Budget VRAM per shape --
+# capture costs 15.4-17.4 GB per rank at TP4 against ~1.4 GB at TP8.
+GRAPH_BS="${GRAPH_BS:-1 2 4 8 16 24 32 48 64 96 128}"
+KVAWARE="${KVAWARE:-1}"
+
+# Cache-hit accounting. OFF by default because it is not free; turn it ON for any
+# workload whose result depends on prefix reuse. Without it the server answers
+# normally and reports nothing -- usage.prompt_tokens_details comes back null and
+# the engine logs `#cached-token: 0`, indistinguishable from a genuine 0 % rate.
+CACHE_REPORT="${CACHE_REPORT:-0}"
+
+# --- common ROCm env --------------------------------------------------------
+# SGLANG_USE_AITER gates the AITER fast paths on gfx950. Its absence is SILENT:
+# the server starts and answers correctly, only slower, with nothing in any log
+# saying so.
+export SGLANG_USE_AITER=1
+export SAFETENSORS_FAST_GPU=1 HIP_FORCE_DEV_KERNARG=1 HSA_NO_SCRATCH_RECLAIM=1
+export NCCL_IGNORE_CPU_AFFINITY=1
+# Stable block hashes -> stable kv-aware keys across restarts.
+export PYTHONHASHSEED=0
+export SGLANG_HOST_IP="$MY_IP" HOST_IP="$MY_IP"
+export INFERA_SGLANG_READY_TIMEOUT="${READY_TIMEOUT:-3600}"
+NIC=$(ip -o -4 addr show | awk -v ip="$MY_IP" '$4 ~ ("^" ip "/") {print $2; exit}')
+[ -n "$NIC" ] && export SGLANG_LOCAL_IP_NIC="$NIC" GLOO_SOCKET_IFNAME="$NIC"
+
+ARGS=()
+case "$VARIANT" in
+  big-*)
+    # --- glm_moe_dsa family: the GLM-5.2 code path. This env block is MANDATORY
+    # on gfx950. Without it the model serves, returns 200s, and returns GARBAGE,
+    # because the sparse-attention indexer takes a path not ported to this
+    # architecture. Mirrors infera/engine/rocm_dsa_env.py's ROCm defaults.
+    export SGLANG_ROCM_FUSED_DECODE_MLA=0 SGLANG_OPT_USE_TILELANG_INDEXER=1
+    export SGLANG_OPT_USE_TOPK_V2=0 SGLANG_OPT_USE_JIT_NORM=0
+
+    # Under DP-attention the engine prints PER-RANK values while
+    # /get_server_info reports the GLOBAL ones -- 256/8 and 65536/8 read exactly
+    # like a clamp. --ep-size stays outside any DPA branch (a different axis),
+    # and --max-running-requests is explicit so free VRAM cannot set the limit.
+    ARGS+=(--ep-size "${EP_SIZE:-$TP}"
+           --dsa-prefill-backend tilelang --dsa-decode-backend tilelang
+           --kv-cache-dtype "${KV_DTYPE:-fp8_e4m3}"
+           --context-length "${CTX:-262144}"
+           --max-running-requests "${MAX_RUNNING:-32}"
+           --mem-fraction-static "${GMU:-0.80}"
+           --chunked-prefill-size "${CHUNK:-65536}")
+
+    # The aiter custom all-reduce kernel deadlocks on this architecture under
+    # speculative verify. Disabled independently of MTP so that any "MTP on vs
+    # off" comparison stays a one-variable comparison.
+    ARGS+=(--disable-custom-all-reduce)
+
+    if [ "$VARIANT" = "big-mxfp4" ]; then
+      # Quantization is AUTO-DETECTED from config.json; the vendor card states
+      # no --quantization flag is required.
+      ARGS+=(--moe-runner-backend "${MOE_RUNNER:-aiter}")
+      # Insurance rather than a fix: glm4_moe.py's fusion gate only special-cases
+      # w4afp8, and this checkpoint's shared experts are themselves MXFP4, so the
+      # mis-load precondition is absent. Kept on because upstream #25261 shows
+      # this class failing SILENTLY with wrong output. SHARED_EXPERT_FUSION=1 lifts it.
+      [ "${SHARED_EXPERT_FUSION:-0}" = "0" ] && ARGS+=(--disable-shared-experts-fusion)
+    fi
+    ;;
+  flash-*)
+    echo "VARIANT=$VARIANT is not served by this kit, which covers the big family only." >&2
+    exit 2 ;;
+  *) echo "unknown VARIANT: $VARIANT (want big-mxfp4|big-fp8)" >&2; exit 2 ;;
+esac
+
+# MTP/EAGLE is NOT enabled here. Why: it is validated on this checkpoint only in
+# the 1P1D PD kit, and this is an aggregated shape -- untested, not ruled out.
+# How to try it: MTP(3,1,4) as the PD kit passes it, plus --disable-custom-all-reduce,
+# which is already on below. If missing: decode emits one token per step.
+
+# kvd / hierarchical cache is OFF. On gfx950 (xnack-) hicache stores raw host
+# data_ptr()s that a GPU kernel dereferences while hipHostRegister maps those
+# pages at a different device VA, and the process aborts with "Memory access
+# fault by GPU node-N". The fix is in patches/sglang_rocm/; confirm it is in your image.
+
+[ "$CACHE_REPORT" = "1" ] && ARGS+=(--enable-cache-report)
+
+if [ "$CUDA_GRAPH" = "1" ]; then
+  ARGS+=(--cuda-graph-backend-decode full --cuda-graph-backend-prefill disabled
+         --cuda-graph-bs-decode $GRAPH_BS)
+else
+  ARGS+=(--cuda-graph-backend-decode disabled --cuda-graph-backend-prefill disabled)
+fi
+
+INFERA_ARGS=(--advertise-host "$MY_IP" --etcd-endpoint "$ETCD_IP:$ETCD_PORT"
+             --discovery-backend etcd --request-transport http --kv-event-transport zmq)
+if [ "$KVAWARE" = "1" ]; then
+  INFERA_ARGS+=(--kv-events-bind "tcp://0.0.0.0:${KV_PUB_PORT:-5557}"
+                --kv-snapshot-port "${KV_SNAP_PORT:-8801}")
+else
+  INFERA_ARGS+=(--no-enable-kv-events)
+fi
+
+echo "[glm53-mix] variant=$VARIANT ip=$MY_IP:$PORT tp=$TP gpus=$GPUS graph=$CUDA_GRAPH -> $LOG"
+HIP_VISIBLE_DEVICES="$GPUS" python3 -m infera.engine.sglang \
+  --model-path "$MODEL" --served-model-name "$SERVED" --tp-size "$TP" --trust-remote-code \
+  --host "$MY_IP" --port "$PORT" \
+  --watchdog-timeout 3600 \
+  --reasoning-parser glm45 --tool-call-parser glm47 \
+  "${ARGS[@]}" "${INFERA_ARGS[@]}" > "$LOG" 2>&1

--- a/examples/sglang_mix_glm5.3/env.sh
+++ b/examples/sglang_mix_glm5.3/env.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# ============================================================================
+#  EDIT THIS FILE. Nothing else in this kit needs changing for your site.
+# ============================================================================
+#
+# Usage:  bash engine/up.sh | engine/smoke.sh | engine/bench.sh [conc...] | engine/down.sh
+# All of them source this file.
+
+# ---------------------------------------------------------------------------
+# 1. Which checkpoint
+# ---------------------------------------------------------------------------
+# big-mxfp4 | big-fp8 -- the `glm_moe_dsa` models. config.json is field-for-field
+# identical to GLM-5.2's except transformers_version, so a released engine already
+# serves them through glm4_moe.py and the ordinary deploy/docker/Dockerfile.sglang
+# image is all this kit needs.
+export VARIANT="${VARIANT:-big-mxfp4}"
+
+# ---------------------------------------------------------------------------
+# 2. Site
+# ---------------------------------------------------------------------------
+# This node's DATA-PLANE IP -- not the management NIC. Clients and the router
+# reach the worker here.
+export MY_IP="${MY_IP:-<this-node-data-plane-ip>}"
+
+# Weights: MODEL is the directory, MODEL_MOUNT its parent. Give the RESOLVED path
+# -- a symlink crossing an NFS mount boundary binds an EMPTY directory into the
+# container, surfacing far downstream as "Unrecognized processing class".
+# up.sh binds realpath for you.
+export MODEL="${MODEL:-<weights-dir>}"
+
+# Engine image. Build it from deploy/docker/Dockerfile.sglang -- see section 1.
+export IMAGE="${IMAGE:-<infera-sglang-image>}"
+
+# ---------------------------------------------------------------------------
+# 3. Shape
+# ---------------------------------------------------------------------------
+# TP4 fits ~704 GB of weights and leaves four GPUs free for a second arm on an
+# 8-GPU node. TP8 works too; raise GPUS with it.
+export TP="${TP:-4}"
+export GPUS="${GPUS:-0,1,2,3}"
+
+# Ports. CHECK THESE ARE FREE (`ss -lnt`) -- on a shared node they often are
+# not. 2379/2380 in particular are frequently held by somebody else's etcd.
+export ETCD_PORT="${ETCD_PORT:-12379}"
+export PORT="${PORT:-30000}"
+export ROUTER_PORT="${ROUTER_PORT:-8100}"
+
+export CTR="${CTR:-glm53_mix}"

--- a/manual/examples/k8s_glm5.3.md
+++ b/manual/examples/k8s_glm5.3.md
@@ -1,0 +1,243 @@
+# GLM-5.3-MXFP4 on Kubernetes — PD disaggregated, stock image + overlay
+
+Serve GLM-5.3 "big" across two GPU nodes as one prefill leg and one decode leg,
+with KV moving between them over RDMA. The engine image is an **unmodified vendor
+image**; everything infera adds arrives as a mounted overlay payload.
+
+Validated on 2× MI355X (gfx950) under self-installed k3s. Recipe:
+[`examples/recipes/glm5.3/disaggregated/deploy.yaml`](../../examples/recipes/glm5.3/README.md).
+
+```{admonition} This page is for the `big` family only
+:class: warning
+This page covers `model_type: glm_moe_dsa` (`GLM-5.3` and `GLM-5.3-MXFP4`), which a
+stock SGLang release already serves — its `config.json` is identical to GLM-5.2's
+field for field except `transformers_version`. The overlay presupposes a stock base
+that can already load the model.
+```
+
+## What you need
+
+| | |
+|---|---|
+| nodes | two, on a **mutually routable RoCE fabric**. The KV transfer is RDMA; there is no TCP fallback. |
+| GPUs | 4 free cards per node (TP4 per leg) |
+| weights | `GLM-5.3-MXFP4/` (408 GB) at the **same resolved path** on both nodes |
+| cluster | any Kubernetes. If you have none, see [standing up k3s safely](#if-you-have-no-cluster) |
+| operator | the infera operator and the `InferaDeployment` CRD |
+| engine base | **`lmsysorg/sglang:v0.5.18-rocm720-mi35x` — pinned, not a suggestion.** See below |
+
+```{admonition} The overlay payload is version-bound to the engine base
+:class: danger
+The payload carries `patches/sglang_dsa/`, which is `--fuzz=0` diffs cut against
+**sglang v0.5.18** and nothing else. GNU patch has no atomicity across files, so
+on a different release the set can land some files and reject others — and the
+engine then **starts, serves, and returns 200s on a half-patched tree**, with
+nothing in any log saying it is inconsistent. Measured on a 0.5.15 base: six of
+seven files applied, all seven hunks of one file rejected.
+
+A baked image catches this at build time, because bumping its pinned base fails
+the build. **The overlay has no such gate** — it patches whatever base it is
+mounted over, at container start. Holding the pin is therefore your job, not the
+tooling's. Tracked as a TODO in `deploy/overlay/Dockerfile.payload`.
+```
+
+## 1. The overlay payload — build it, do not pull it
+
+This is the step that most obviously looks skippable and is not.
+
+The published overlay image ships `patches/vllm/` only, and its `infera-exec` gates
+the runtime patch loop on `import vllm`. On an SGLang base that gate is closed, so
+**no engine patch is applied at all** — while the baked `Dockerfile.sglang` applies
+six. On gfx950 the two that matter are a DP-attention host-sync deadlock and an
+aiter paged-MQA row-sizing bug; the first hangs, the second returns wrong output
+with a 200.
+
+```bash
+docker build -f deploy/overlay/Dockerfile.payload -t infera-overlay:glm53-sglang-patches .
+```
+
+Then **stage the payload tree onto every node that will run a leg** and point
+`PAYLOAD_DIR` at it; the manifest mounts it as a `hostPath`:
+
+```bash
+id=$(docker create infera-overlay:glm53-sglang-patches)
+docker cp "$id:/payload/." /var/tmp/infera-payload/   # then rsync to each node
+docker rm "$id"
+```
+
+```{admonition} Node-local, not a shared mount
+:class: warning
+The payload carries `.so` files that get `mmap`'d. Put it on node-local disk.
+
+A `hostPath` rather than an initContainer copying the image into an `emptyDir`:
+the initContainer is tidier but needs a registry the **cluster** can pull from,
+and the image built above lives in the local docker store. Point it at a tag the
+cluster cannot resolve and every pod sits in `Init:ImagePullBackOff`.
+```
+
+The engine image, by contrast, *is* pulled by the nodes — and on k3s that is a
+**separate image store** from docker's, which does not read
+`/etc/docker/daemon.json`, so any mirrors configured there are invisible to it:
+
+```bash
+sudo k3s ctr -a /run/k3s/containerd/containerd.sock -n k8s.io \
+     images pull docker.io/lmsysorg/sglang:v0.5.18-rocm720-mi35x
+sudo k3s ctr -a /run/k3s/containerd/containerd.sock -n k8s.io images label \
+     docker.io/lmsysorg/sglang:v0.5.18-rocm720-mi35x io.cri-containerd.pinned=pinned
+```
+
+```{admonition} Pin large images
+:class: tip
+Kubelet garbage-collects any image no Pod references once the node is above the
+image-GC threshold, and the minimum-age protection is only **two minutes** — a
+large image can disappear shortly after an import reports success. The `pinned`
+label is a hard guarantee where a threshold is not.
+```
+
+## 2. Render and apply
+
+```bash
+cd examples/recipes
+python3 render.py glm5.3/disaggregated \
+  --set PREFILL_NODE=<node-a> --set DECODE_NODE=<node-b> \
+  --set MODEL_DIR=/path/to/models \
+  --set PAYLOAD_DIR=/var/tmp/infera-payload \
+  --set RDMA_IB_DEVICES=<rails> \
+  --set PREFILL_GID_INDEX=<n> --set DECODE_GID_INDEX=<m> \
+  -o /tmp/glm53-pd.yaml
+
+kubectl create namespace infera
+kubectl apply -f /tmp/glm53-pd.yaml
+```
+
+`render.py` refuses to emit a manifest with a placeholder left in it. That matters
+more than it sounds: `kubectl` rejects a literal `<NODE>` outright, but it
+*accepts* `--disaggregation-ib-device <RDMA_IB_DEVICES>`, and that one only fails
+once the engine opens the device — minutes later, in a message about a device
+rather than about a placeholder.
+
+**The two GID indexes are separate placeholders on purpose.** The index is per
+node, and two identical machines routinely differ because an empty slot on one
+shifts everything after it. Read them with `show_gids` on each node. A wrong one
+fails loudly with `GID is NULL` on every DP rank.
+
+**`MODEL_DIR` must be the resolved path.** A symlink that crosses an NFS mount
+boundary gives the container an empty directory, and the failure surfaces much
+later as something unrelated.
+
+## 3. Verify — in this order
+
+```{admonition} Do not trust `/health`
+:class: warning
+With only the prefill leg registered, `/health` returns **200** and every
+completion returns **503**. Check `/v1/workers` instead.
+```
+
+```bash
+# two workers, prefill and decode, both dp_size=4
+kubectl -n infera exec deploy/glm53-mxfp4-pd-server -- \
+  curl -s http://127.0.0.1:8110/v1/workers | python3 -m json.tool | grep -E 'disagg_mode|dp_size'
+
+# the overlay actually patched the engine: eight patches, ending in a
+# bytecode verification for the DSA group
+kubectl -n infera logs <prefill-pod> | head -18
+
+# KV moved over RDMA rather than silently falling back
+kubectl -n infera logs <prefill-pod> | grep -c MC_FORCE_TCP    # want 0
+kubectl -n infera logs <prefill-pod> | grep -ci 'gid.*null'    # want 0
+```
+
+Then check the **output**, not the status code. Forward the router port and run
+your own correctness probe against it — one that repeats a request and includes a
+small concurrent load round, for the reason in the warning below:
+
+```bash
+kubectl -n infera port-forward svc/glm53-mxfp4-pd-server 18110:8110 &
+```
+
+```{admonition} DP-attention must be symmetric, and asymmetry fails silently
+:class: danger
+`--dp-size 4` on **both** legs. Measured on this checkpoint: prefill dp1 → decode
+dp4 gives a clean *first* completion and then garbage on every subsequent one —
+streams of repeated `</think>` and digit noise, every request finishing on
+`length`. Zero faults, zero HIP errors, decode batches rolling with cuda graphs on.
+**Nothing in any log says the tokens are wrong.** That is why the probe must repeat
+a request and run a small load round; a single-shot check passes a broken
+deployment.
+```
+
+Reference result:
+
+```
+capital 19 tok stop | arith '391' | needle41 'ORANGE-4417-DELTA'
+repeat, repeat2 stop | long7845 7845 tok stop | load 32@conc8 degenerate 0/32
+==> VERDICT: PASS
+```
+
+Finally, confirm **MTP is accepting tokens** — a deployment with speculative
+decoding mis-wired serves correctly and simply gains nothing, so nothing above
+would catch it:
+
+```bash
+kubectl -n infera logs <decode-pod> | grep -o 'accept len: [0-9.]*' \
+  | awk '{print $3}' | sort -n \
+  | awk '{a[NR]=$1; if ($1>=4) f++} END {printf "n=%d median=%s at4.00=%d\n", \
+      NR, a[int(NR*0.5)+1], f+0}'
+```
+
+Reference: `n=45 median=2.85 at4.00=0`.
+
+```{admonition} Read the median, and know why 4.00 is bad
+:class: warning
+Healthy is a **median of 2–3** against a ceiling of 4, which is
+`--speculative-num-draft-tokens`. A median at **4.00 is a failure**, not a win:
+the draft is predicting a repetition loop perfectly, i.e. the model has
+degenerated and MTP is faithfully extending garbage.
+
+Do **not** read `tail -5`. A few percent of batches sit at 4.00 even on a healthy
+leg, so the last few lines land on them routinely and misread as degenerate.
+
+And an empty result does **not** mean MTP is off: `decode_log_interval` defaults
+to 40, so a leg that has served fewer than 40 decode iterations prints no such
+line at all. Disambiguate with `grep -c 'Decode batch'` — non-zero with no
+`accept len:` means MTP really is off; zero means send more traffic.
+```
+
+## 4. What this shape is, and what it is not
+
+| | |
+|---|---|
+| TP4 per leg | the shape the symmetric-DP-attention result was measured in. TP8 untested here. |
+| EAGLE MTP(3,1,4), decode leg only | validated **on this manifest**: 6/6 correct, 0/32 degenerate over three load rounds, acceptance-length median 2.85 (n=45) with none at the 4.00 ceiling. Also validated on the baked and plain-overlay docker paths |
+| kvd / hicache off | the overlay carries the ROCm hicache patches, but this arm does not enable them |
+| `mem-fraction-static` 0.70 / 0.85 | deliberately asymmetric; a prefill OOM is fixed by *lowering* it |
+| `hostNetwork: true` | required — RoCE rails are host interfaces and a CNI pod IP has no route to a peer's rail |
+| `privileged: true` | required, and **not** redundant with `IPC_LOCK`: there is a recorded case where `IPC_LOCK` plus `memlock=-1` was insufficient for RDMA registration and `--privileged` was the entire fix |
+| no `amd.com/gpu` | GPUs are pinned with `HIP_VISIBLE_DEVICES` + `nodeSelector`; see the recipe README before changing this |
+| startup budget 90 min | 408 GB on NFS. Do not size it from a warm-cache observation. |
+
+## Performance
+
+ISL 8192 / OSL 1024, concurrency 8, 80 prompts, 2× MI355X:
+
+| | docker + overlay | k3s + overlay |
+|---|---|---|
+| output throughput | 343.5 tok/s | 348.3 tok/s |
+| median TTFT | 1336 ms | 1507 ms |
+| mean TPOT | 20.62 ms | 20.64 ms |
+
+```{admonition} Read the cache-hit rate before believing a TTFT number
+:class: tip
+`bench_serving --dataset-name random` reuses its dataset across runs. A repeat run
+against a warm prefix cache gives a 449 ms TTFT — a 4× "improvement" that is
+entirely an artifact. The figures above are at a 1.2 % cache-hit rate. Change
+`--seed` between runs.
+```
+
+## If you have no cluster
+
+Any Kubernetes will do. Standing k3s up on a node that is **already doing someone
+else's work** — running docker workloads, under a scheduler that can drain it,
+alongside another kubelet — is possible, but read the installer's shell source
+first: several of its hazards are visible only there. Take a health snapshot of
+the node before and after, so "I did no harm" is evidence rather than a claim.

--- a/manual/sphinx/_toc.yml.in
+++ b/manual/sphinx/_toc.yml.in
@@ -81,6 +81,8 @@ subtrees:
         title: Kubernetes recipe — PD 1P1D (SGLang, Mooncake)
       - file: examples/k8s_glm5.2_sglang.md
         title: Kubernetes recipe — GLM-5.2 (SGLang, DSA)
+      - file: examples/k8s_glm5.3.md
+        title: Kubernetes recipe — GLM-5.3 PD (SGLang, overlay)
       - file: examples/sglang_1p2d_kimi2.6.md
         title: SGLang 1P2D — Kimi-K2.6
       - file: examples/sglang_mix_dsv4.md

--- a/tests/e2e/harness/matrix.py
+++ b/tests/e2e/harness/matrix.py
@@ -134,15 +134,17 @@ DEEPSEEK_V4_FLASH_FP8 = "sgl-project/DeepSeek-V4-Flash-FP8"
 GLM_5_1_FP8 = "zai-org/GLM-5.1-FP8"
 GLM_5_2_FP8 = "zai-org/GLM-5.2-FP8"
 
-# Which of GLM-5.2's 78 layers own a DSA lightning indexer and which reuse one.
-# The checkpoint's `indexer_types` marks layers 0, 1, 2 and then every 4th "full"
-# and the rest "shared", and it ships indexer weights for the "full" ones only.
-# ATOM spells the same thing as `index_topk_pattern`, where "S" means "skip the
-# top-k and reuse the last selection"; it is spelled out per layer because ATOM's
-# own index_topk_freq shorthand derives a different, off-by-one set of owners
-# (see the GLM-5.2 row in pd_mixed/atom/matrix.py). Consumed by the ATOM rows.
-# Hand-copied, so check it against the checkpoint's indexer_types, not by eye.
+# Which of GLM-5.2's 78 layers own a DSA lightning indexer ("F", per the checkpoint's
+# `indexer_types`: 0, 1, 2 then every 4th) and which reuse the last selection ("S").
+# Written out per layer for ATOM's `index_topk_pattern` because ATOM's index_topk_freq
+# shorthand derives an off-by-one owner set. Hand-copied — check it against the config.
 GLM_5_2_INDEXER_PATTERN = "FFFSSS" + "FSSS" * 18
+
+# GLM-5.3 "big": model_type glm_moe_dsa, GlmMoeDsaForCausalLM. Field-for-field
+# identical to GLM-5.2 except transformers_version, so the released engine already
+# serves both of these via glm4_moe.py on the stock Dockerfile.sglang image.
+GLM_5_3 = "zai-org/GLM-5.3"
+GLM_5_3_MXFP4 = "OneNexus/GLM-5.3-MXFP4"
 
 EXTRA_ARGS: dict[str, tuple[str, ...]] = {}  # default verbatim extra launch args
 

--- a/tests/e2e/pd_mixed/sglang/matrix.py
+++ b/tests/e2e/pd_mixed/sglang/matrix.py
@@ -15,26 +15,32 @@ from ...harness.matrix import (
     DEEPSEEK_V4_PRO,
     GLM_5_1_FP8,
     GLM_5_2_FP8,
+    GLM_5_3,
+    GLM_5_3_MXFP4,
     GPT_OSS,
     KIMI_K26_MXFP4,
     expand_cases,
 )
 
-# GLM-5.2 below is being brought up on the local MI300X fleet, where its weights
-# are staged and its recipe was measured. Whether the gfx950 CI fleet has it at
-# all is unconfirmed, so the skip claims only what is known — that nothing has
-# run it there — rather than asserting a staging fact. Retiring it is one edit,
-# and the row stays visible on both arches meanwhile.
+# GLM-5.2 below was brought up on the local MI300X fleet — weights staged there,
+# recipe measured there. Whether the gfx950 CI fleet has it at all is unconfirmed,
+# so the reason claims only what is known (nothing has run it there) rather than
+# asserting a staging fact; skip keeps the row visible on both arches meanwhile.
 _GFX950_UNMEASURED = {"skip": "brought up on gfx942; never run on the gfx950 CI fleet"}
+
+# The GLM-5.3 rows are the mirror image: brought up on gfx950 only. The recipe
+# below names gfx950 env and DSA backends throughout and has never been run on
+# MI300X, so the row stays visible there with its reason rather than silently
+# claiming coverage.
+_GFX950_ONLY = {"skip": "brought up on gfx950; never run on the gfx942 CI fleet"}
 
 # [enable, model, tp, ep, dp_attn] (+ optional opts dict). A tuple/list on an axis
 # enumerates it (e.g. (True, False) runs both). MoE models can exercise ep.
 CASES = [
-    # gpt-oss-120b: tp2, ep on/off. On triton, not the default aiter backend: the
-    # CK batch_prefill instance this case needs (page_size < kN0 over a >2GB KV
-    # cache, gfx950) is absent from the aiter in the v0.5.17 base, so both TP ranks
-    # raise "no matching kernel found" and the engine dies before serving. Drop this
-    # once a base image carries the instance; aiter stays on for MoE either way.
+    # gpt-oss-120b: tp2, ep on/off. Attention on triton, not aiter (which the env
+    # below keeps for MoE): the CK batch_prefill instance this case needs (page_size
+    # < kN0 over a >2GB KV cache, gfx950) is absent from the v0.5.17 base, so both TP
+    # ranks raise "no matching kernel found" and die before serving. Drop when it lands.
     [
         True,
         GPT_OSS,
@@ -121,48 +127,34 @@ CASES = [
                 "SGLANG_OPT_USE_TILELANG_MHC_POST": "false",
             },
             "server_ready_timeout": 2400,
-            # Two measured facts, and the second is why the first was not worth
-            # fixing. SGLang has no packed-MXFP4 expert kernel on gfx942, so this
-            # checkpoint needs an engine-side FP4->FP8 dequant to load at all —
-            # buildable, and built once: the dequant sits behind a branch
-            # `_is_fp8_fnuz` never lets gfx942 reach, and hoisting it ahead made
-            # the load log say "Dequantized FP4 expert weights to FP8". Then it
-            # does not fit. Unpacked, the experts need 186.5 GiB a card at tp8
-            # plus ~9.25 the runtime holds outside PyTorch, 195.8 against 191.98
-            # usable — short before a byte of KV cache, measured twice. So the
-            # patch is reverted rather than carried, and the dsv4 row SGLang
-            # actually serves here is DeepSeek-V4-Flash-FP8 below.
+            # No packed-MXFP4 expert kernel on gfx942, so the checkpoint needs an
+            # engine-side FP4->FP8 dequant to load at all. It is reachable — hoist
+            # it past `_is_fp8_fnuz` — and still does not fit, so the patch stays
+            # reverted: 186.5 GiB/card at tp8 + ~9.25 runtime = 195.8 vs 191.98 usable.
             "gfx942": {
                 "skip": "MXFP4 experts need an engine-side dequant SGLang cannot reach on gfx942, and unpacked they need 195.8 GiB/card against 191.98; run DeepSeek-V4-Flash-FP8 here, or Pro on vLLM which serves it packed",
             },
         },
     ],
-    # DeepSeek-V4-Flash-FP8 (MoE, tp4) — the dsv4 cell SGLang can actually serve
-    # on a 192 GiB card, and the reason is size rather than support. Same
-    # architecture as the Pro row above (43 layers / 4096 hidden against 61 /
-    # 7168) and block-FP8 throughout, so it never reaches the MXFP4 expert path
-    # that skips Pro: 274 GiB, 68.5 a card at tp4, against Pro's 195.8 unpacked.
+    # DeepSeek-V4-Flash-FP8 (MoE, tp4) — the dsv4 cell SGLang can actually serve on
+    # a 192 GiB card, for size rather than support: same architecture as the Pro row
+    # above (43 layers / 4096 hidden against 61 / 7168) and block-FP8 throughout, so
+    # it never reaches the MXFP4 path that skips Pro. 274 GiB, 68.5 a card at tp4.
     #
     # tp4, not tp8. It fits either way (34.2 a card at tp8) and tp4 keeps the row
     # to half a node, which is what makes it affordable next to the tp8 GLM-5.2
     # row below. Every dimension divides: 64 attention heads, 64 index heads,
     # moe_intermediate_size 2048, 256 experts.
     #
-    # The functional gfx942 knobs — `--attention-backend dsv4`,
-    # `--disable-shared-experts-fusion` and four env vars — are ALSO applied by
-    # infera.engine.dsv4_gfx942 at launch, set-if-unset. They are spelled out
-    # anyway so this row reads as a complete recipe, and because the MTP flags
-    # have to be: the speculation check reads `params.extra_args`, so flags that
-    # only ever appear inside the worker leave it reporting requested=False and
-    # unable to fail a run whose draft head silently did nothing.
+    # These gfx942 knobs are ALSO applied set-if-unset by infera.engine.dsv4_gfx942
+    # (dsv4 backend, --disable-shared-experts-fusion, four env vars); duplicated for
+    # a complete recipe, and required for the MTP flags — the speculation check reads
+    # `params.extra_args`, so worker-only flags cannot fail a no-op draft head.
     #
-    # NOTHING HERE IS MEASURED ON THIS FLEET. The env block is the Pro row's,
-    # which is the only dsv4-on-SGLang recipe that exists and was tuned on
-    # MI325X; the SGLANG_OPT_USE_TILELANG_* offs are the same gfx942 avoidance as
-    # the FlashMLA hack. MTP is on because the contract forces it for Flash — the
-    # claim being that Flash's compressed-MQA decode kernel is broken on gfx942
-    # and speculation routes around it, which no run here has checked either way.
-    # A first green run against `--speculative-*` removed would be a finding.
+    # NOTHING HERE IS MEASURED ON THIS FLEET. The env block is the Pro row's — the
+    # only dsv4-on-SGLang recipe that exists, tuned on MI325X. MTP is on because the
+    # contract forces it for Flash, on the unchecked claim that Flash's compressed-MQA
+    # decode kernel is broken on gfx942; a green run without `--speculative-*` is news.
     [
         True,
         DEEPSEEK_V4_FLASH_FP8,
@@ -234,13 +226,10 @@ CASES = [
             "gfx950": _GFX950_UNMEASURED,
         },
     ],
-    # GLM-5.1-FP8 (GlmMoeDsa = MLA + DSA lightning indexer, tp4). Minimal ON PURPOSE:
-    # SGLang routes GlmMoeDsaForCausalLM through the DeepSeek MLA+DSA path and
-    # auto-selects attention_backend=dsa / page_size=64 / tilelang / kv bf16 — do NOT
-    # force the DSv4 flags (--attention-backend dsv4, --page-size 256), they fight the
-    # auto-config. --reasoning-parser glm45 splits GLM reasoning_content; AITER on.
-    # Verified 2026-07-23 single-node mix, temp=0: France->Paris/China->Beijing/2+2->4.
-    # Long timeout covers the ~8-10 min silent tilelang-JIT + aiter-GEMM-tuning window.
+    # GLM-5.1-FP8 (GlmMoeDsa = MLA + DSA indexer, tp4). Minimal ON PURPOSE: SGLang
+    # routes GlmMoeDsaForCausalLM through the DeepSeek MLA+DSA path, auto-selecting
+    # dsa / page_size=64 / tilelang / kv bf16, and the DSv4 flags (dsv4, --page-size
+    # 256) fight it. Verified 2026-07-23; timeout covers a ~8-10 min silent JIT+tune.
     [
         True,
         GLM_5_1_FP8,
@@ -264,23 +253,18 @@ CASES = [
             "gfx942": {"skip": "GLM-5.1-FP8 not measured on gfx942 yet"},
         },
     ],
-    # GLM-5.2-FP8 (GlmMoeDsa, tp8 + dp-attention) — the knobs are the `aggregated`
-    # arm of manual/recipes/glm5.2-fp8-gfx942.md, which is the one GLM-5.2 shape
-    # measured on this hardware. Note this is a DIFFERENT model from the GLM-5.1
-    # row above (78 layers, index_topk 2048, 154880 vocab), not a newer tag for
-    # it, so both rows stand.
+    # GLM-5.2-FP8 (GlmMoeDsa, tp8 + dp-attention) — knobs are the `aggregated` arm of
+    # manual/recipes/glm5.2-fp8-gfx942.md, the one GLM-5.2 shape measured on this
+    # hardware. A DIFFERENT model from the GLM-5.1 row above (78 layers, index_topk
+    # 2048, 154880 vocab), not a newer tag for it, so both rows stand.
     #
     # tp8 is not a choice: ~700 GB of FP8 weights over 192 GB cards needs the whole
     # node, which also makes this the first mixed row to take one.
     #
-    # MTP is on because the checkpoint ships the draft head (a 79th layer,
-    # `model.layers.78.eh_proj.weight`, num_nextn_predict_layers 1) and the gfx942
-    # image exists partly to serve it: its SGLang v0.5.16 base is pinned because
-    # GLM-5.2 MTP needs sglang #30839 and GlmMoeDsaForCausalLMNextN, and on v0.5.15
-    # the draft weight-load and PD warmup fail. 5/1/6 is the recipe's measured
-    # depth — accept length 4.64 against a 4.00 break-even at 6.53 ms per draft
-    # step. 7/1/8 misses break-even AND runs prefill out of activation memory, so
-    # read it as a ceiling rather than a default.
+    # MTP is on: the checkpoint ships the draft head (num_nextn_predict_layers 1) and
+    # the image's SGLang v0.5.16 pin exists for it — v0.5.15 lacks #30839 /
+    # GlmMoeDsaForCausalLMNextN and fails draft load + PD warmup. 5/1/6 is measured
+    # (accept 4.64 vs 4.00 break-even at 6.53 ms/step); 7/1/8 misses it and OOMs.
     [
         True,
         GLM_5_2_FP8,
@@ -352,6 +336,99 @@ CASES = [
             # fresh container. Don't tighten this against a warm run.
             "server_ready_timeout": 5400,
             "gfx950": _GFX950_UNMEASURED,
+        },
+    ],
+    # ---- GLM-5.3 (big: glm_moe_dsa) -----------------------------------------
+    # Parked (enable=False) ON PURPOSE, not because they are unproven: each needs
+    # ~300-700 GB pre-staged and 4 GPUs for 10+ min of cold start. resolve_model()
+    # maps ids to <INFERA_E2E_MODEL_DIR>/<id>; symlink the vendor prefix on a flat tree.
+    [
+        False,
+        GLM_5_3_MXFP4,
+        4,
+        True,
+        False,
+        {
+            # Quantization is auto-detected from config.json; no --quantization.
+            # --disable-shared-experts-fusion is insurance, not a fix: the shared
+            # experts are themselves MXFP4 and #25261 shows the class failing
+            # SILENTLY with wrong output when shapes line up.
+            "args": [
+                "--kv-cache-dtype",
+                "fp8_e4m3",
+                "--moe-runner-backend",
+                "aiter",
+                "--dsa-prefill-backend",
+                "tilelang",
+                "--dsa-decode-backend",
+                "tilelang",
+                "--disable-shared-experts-fusion",
+                "--disable-custom-all-reduce",
+                "--reasoning-parser",
+                "glm45",
+                "--tool-call-parser",
+                "glm47",
+                "--context-length",
+                "262144",
+                "--mem-fraction-static",
+                "0.80",
+                "--chunked-prefill-size",
+                "65536",
+            ],
+            # MANDATORY on gfx950: without this block the model serves, returns
+            # 200s, and returns garbage, because the sparse-attention indexer
+            # takes a path not ported to this arch. Mirrors the ROCm defaults in
+            # infera/engine/rocm_dsa_env.py so a bare launch_server run matches.
+            "env": {
+                "SGLANG_USE_AITER": "1",
+                "SGLANG_ROCM_FUSED_DECODE_MLA": "0",
+                "SGLANG_OPT_USE_TILELANG_INDEXER": "1",
+                "SGLANG_OPT_USE_TOPK_V2": "0",
+                "SGLANG_OPT_USE_JIT_NORM": "0",
+            },
+            "server_ready_timeout": 3600,
+            "gfx942": _GFX950_ONLY,
+        },
+    ],
+    [
+        False,
+        GLM_5_3,
+        4,
+        True,
+        False,
+        {
+            # FP8 original of the big model. Same code path as the MXFP4 row;
+            # only the weights and the absent quantization flag differ. 704 GB
+            # at TP4 leaves ~55 GB per GPU for KV at GMU 0.80 -- measured, not
+            # estimated (max_total_num_tokens=1148288).
+            "args": [
+                "--kv-cache-dtype",
+                "fp8_e4m3",
+                "--dsa-prefill-backend",
+                "tilelang",
+                "--dsa-decode-backend",
+                "tilelang",
+                "--disable-custom-all-reduce",
+                "--reasoning-parser",
+                "glm45",
+                "--tool-call-parser",
+                "glm47",
+                "--context-length",
+                "262144",
+                "--mem-fraction-static",
+                "0.80",
+                "--chunked-prefill-size",
+                "65536",
+            ],
+            "env": {
+                "SGLANG_USE_AITER": "1",
+                "SGLANG_ROCM_FUSED_DECODE_MLA": "0",
+                "SGLANG_OPT_USE_TILELANG_INDEXER": "1",
+                "SGLANG_OPT_USE_TOPK_V2": "0",
+                "SGLANG_OPT_USE_JIT_NORM": "0",
+            },
+            "server_ready_timeout": 3600,
+            "gfx942": _GFX950_ONLY,
         },
     ],
 ]


### PR DESCRIPTION
## What

Adds GLM-5.3 (the `glm_moe_dsa` "big" family, including `-MXFP4`) as a supported
model, in three shapes:

- **single-node mixed** — `examples/sglang_mix_glm5.3/`
- **1P1D under docker** — `examples/sglang_1p1d_glm5.3/`, driving the GLM-5.2 kit
  rather than forking it
- **1P1D under Kubernetes** — `examples/recipes/glm5.3/disaggregated/deploy.yaml`
  plus `manual/examples/k8s_glm5.3.md`

and, to make the last one possible, teaches the **overlay payload to patch an
SGLang base**.

## Why the overlay change is the load-bearing part

`deploy/overlay/Dockerfile.payload` shipped `patches/vllm/` only, and
`deploy/overlay/infera-exec` gated its runtime patch loop on `import vllm`. On an
SGLang base that gate is closed, so **no engine patch was applied at all**, while
the baked `Dockerfile.sglang` applies six. On gfx950 the two that matter are a
DP-attention host-sync deadlock and an aiter paged-MQA row-sizing bug — the first
hangs, the second returns wrong output behind a 200.

This PR ships the four sglang patch trees plus `apply_sglang_dsa_patches.sh` and
gives `infera-exec` an `elif import sglang` branch. Three of the groups are plain
`.py` anchor scripts, which is already the runtime-patch contract; `sglang_dsa` is
one script plus three `--fuzz=0` diffs, so the applier that knows how to drive
them — and how to verify they reached the **bytecode**, not just the source — is
invoked for that group. It runs under a marker and a flock because an engine leg
and the router both pass through `infera-exec` inside one container.

Two omissions there are deliberate and commented in place: `sglang_carried/` is
not shipped (it perturbs MoE routing, is not GPU-validated, and the baked image
does not apply it either), and `sglang_dsa/` is deliberately not run through the
`*.py` glob (it contains a v0.5.16-only port that would fail noisily on v0.5.18).

## Validation

MI355X, 8× gfx950 per node, GLM-5.3-MXFP4, TP4 per leg, symmetric DP-attention,
mooncake RDMA over RoCE. Three configurations, each moving exactly one axis from
the last:

| | engine image | orchestration | correctness | output tok/s |
|---|---|---|---|---|
| baseline | baked | docker | PASS | — |
| overlay | **stock** `lmsysorg/sglang:v0.5.18-rocm720-mi35x` | docker | PASS | 343.5 |
| k8s | stock | **k3s** | PASS | 348.3 |

"PASS" is the same probe in all three: a short answer, arithmetic, a 41-token
needle, two **repeats**, a 7845-token needle recovered verbatim, and 32 requests
at concurrency 8 with 0/32 degenerate. Token counts and `finish_reason` are
identical across all three rows.

The repeats and the load round are not padding. The failure this configuration can
hit — asymmetric DP-attention under PD — returns a clean **first** completion and
garbage on every later one, with zero faults, zero HIP errors, and nothing in any
log. A single-shot check passes a broken deployment.

## Also in here

- `examples/sglang_1p1d_glm5.2/` gains overlay mode (`OVERLAY_PAYLOAD`,
  `HOST_LIBIONIC`, `INFERA_EXEC`), all defaulting to empty so a baked image
  behaves exactly as before, plus per-leg knobs a single-node pair needs.
- `bench.sh` gains `docker exec -w /`: on a stock base the image WORKDIR puts
  `sglang` on `sys.path[0]` as a namespace package and `bench_serving` dies on
  `No module named 'sglang.benchmark.serving'`.
- `deploy/docker/patches/sglang_carried/` — a GLM MoE gate-bias fp32 fix, carried
  **unwired**: bf16 collapses 238 distinct correction-bias values to 8, which
  reorders top-k routing. Not applied anywhere, because it is a routing
  perturbation rather than a crash and has not been GPU-validated.
- Two GLM-5.3 e2e rows in `tests/e2e/pd_mixed/sglang/matrix.py`, **`enable=False`**
  as the CI contract requires, recipes intact.
- `manual/sphinx/_toc.yml.in` — registers the new page so it appears in the built
  navigation rather than being reachable only by URL.

## CI

`lint` is red, and **none of it is from this branch**. `pre-commit` runs
`--all-files`, and the failures are 83 files under `infera/projection/**` and
`tests/unit/projection/**` that this PR does not touch; the same job is failing on
`main` at `6492209b`. The three Python files this PR does change are clean —
`ruff format --check` and `ruff check` both pass on them.

`e2e-*` are skipped by the repo's own gate. The GLM-5.3 e2e rows added here are
`enable=False` and do not run.

## Scope

**GLM-5.3-Flash is not in this PR.** It is `glm5_next` — a different architecture
that no published SGLang release can load — and it lands separately.
