### PR TITLE
Fix flaky `e2e-mixed (vllm)` GLM-5.1-FP8, and unblock CI lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,8 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.10"
-      - run: pip install -e ".[dev,gaie]"
+      # projection: tests/unit/projection reached numpy/pyyaml only transitively.
+      - run: pip install -e ".[dev,gaie,projection]"
       - name: pytest (unit only)
         run: pytest -m "not slow and not integration" -q
 

--- a/infera/projection/README.md
+++ b/infera/projection/README.md
@@ -31,6 +31,17 @@ pip install ".[projection]"          # projection + simulation
 pip install ".[projection-tuning]"   # + the DSPy tuning agent
 ```
 
+`--profiling-mode simulate` prices every GEMM and attention tile through
+[Origami](https://github.com/ROCm/rocm-libraries/tree/develop/shared/origami),
+which no extra can pull in: it builds against ROCm/HIP, and the `origami` name
+on PyPI is an unrelated project. On a ROCm host:
+
+```bash
+pip install 'git+https://github.com/ROCm/rocm-libraries.git#subdirectory=shared/origami/python'
+```
+
+Without it the simulate path raises and `tests/unit/projection` skips.
+
 `torch` and the serving engine (`vllm`) come from the engine base image, not
 pip. Neither is needed for the no-GPU path.
 

--- a/infera/projection/__init__.py
+++ b/infera/projection/__init__.py
@@ -19,4 +19,5 @@ def launch_projection_from_cli(args, overrides):
     from infera.projection.core.projection.inference_projection import (
         launch_projection_from_cli as _impl,
     )
+
     return _impl(args, overrides)

--- a/infera/projection/_tuning_shim/main.py
+++ b/infera/projection/_tuning_shim/main.py
@@ -15,6 +15,7 @@ The projection CLI lives at ``infera.projection.cli``. This shim maps the
 keep working unchanged. Only the ``inference`` suite is supported (the Megatron
 ``performance`` / ``memory`` training suites are not part of the serving path).
 """
+
 import sys
 
 
@@ -22,15 +23,13 @@ def main(argv=None):
     argv = list(sys.argv[1:] if argv is None else argv)
     if not argv or argv[0] != "projection":
         raise SystemExit(
-            "infera projection shim: expected 'projection <suite> ...' "
-            f"(got {argv!r})"
+            f"infera projection shim: expected 'projection <suite> ...' (got {argv!r})"
         )
     suite_argv = argv[1:]  # drop the leading 'projection'
     suite = suite_argv[0] if suite_argv else None
     if suite != "inference":
         raise SystemExit(
-            f"infera projection shim: only the 'inference' suite is supported "
-            f"(got {suite!r})."
+            f"infera projection shim: only the 'inference' suite is supported (got {suite!r})."
         )
     from infera.projection.cli import main as _projection_main
 

--- a/infera/projection/agents/tuning_agent/agent.py
+++ b/infera/projection/agents/tuning_agent/agent.py
@@ -259,7 +259,9 @@ class TuningSearchSignature(dspy.Signature):
     history_summary: str = dspy.InputField(desc="Compact text summary of prior trials")
     extra_guidance: str = dspy.InputField(desc="User-provided guidance")
 
-    best_config: str = dspy.OutputField(desc="JSON object: the winning trial config (or empty {} if none).")
+    best_config: str = dspy.OutputField(
+        desc="JSON object: the winning trial config (or empty {} if none)."
+    )
     summary: str = dspy.OutputField(
         desc="5-8 sentences on the search: what was tried, what worked, what didn't."
     )
@@ -442,7 +444,8 @@ def _cluster_blob(agent_cfg: AgentConfig) -> str:
             "name": agent_cfg.target_cluster.name,
             "num_nodes": agent_cfg.target_cluster.num_nodes,
             "gpus_per_node": agent_cfg.target_cluster.gpus_per_node,
-            "world_size": agent_cfg.target_cluster.num_nodes * agent_cfg.target_cluster.gpus_per_node,
+            "world_size": agent_cfg.target_cluster.num_nodes
+            * agent_cfg.target_cluster.gpus_per_node,
             "gpu_arch": agent_cfg.target_cluster.gpu_arch,
             "hbm_capacity_gb": agent_cfg.optimization.hbm_capacity_gb,
             "memory_safety_margin": agent_cfg.optimization.memory_safety_margin,

--- a/infera/projection/agents/tuning_agent/cli.py
+++ b/infera/projection/agents/tuning_agent/cli.py
@@ -66,7 +66,9 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     p.add_argument("--workload", required=True, type=Path, help="Path to a pretrain YAML.")
-    p.add_argument("--target-cluster", required=True, type=Path, help="Path to target_cluster.yaml.")
+    p.add_argument(
+        "--target-cluster", required=True, type=Path, help="Path to target_cluster.yaml."
+    )
     p.add_argument(
         "--out-dir", type=Path, default=None, help="Output directory for trials, plot, scratchpad."
     )
@@ -93,11 +95,18 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     )
     p.add_argument("--no-agent", action="store_true", help="Alias for --seed-only.")
     p.add_argument(
-        "--agent-only", action="store_true", help="Skip seed evaluation; run LLM agent on existing history."
+        "--agent-only",
+        action="store_true",
+        help="Skip seed evaluation; run LLM agent on existing history.",
     )
-    p.add_argument("--resume", action="store_true", help="Reuse an existing trials.jsonl in --out-dir.")
     p.add_argument(
-        "--seed-budget", type=int, default=12, help="Max seed candidates evaluated before the LLM takes over."
+        "--resume", action="store_true", help="Reuse an existing trials.jsonl in --out-dir."
+    )
+    p.add_argument(
+        "--seed-budget",
+        type=int,
+        default=12,
+        help="Max seed candidates evaluated before the LLM takes over.",
     )
     p.add_argument(
         "--inference",
@@ -142,16 +151,22 @@ def _run_inference(args, agent_cfg, arch, config_root) -> int:
 
     leg = derive_inference_legality(arch, agent_cfg.target_cluster)
     print(f"[tuning-agent] MODE: inference  objective={objective} ({direction})")
-    print(f"[tuning-agent] legal serving axes: TP={leg.tp} PP={leg.pp} EP={leg.ep} "
-          f"batch={leg.batch_size} kv_dtype={leg.kv_cache_dtype} "
-          f"weight_dtype={leg.weight_dtype}")
+    print(
+        f"[tuning-agent] legal serving axes: TP={leg.tp} PP={leg.pp} EP={leg.ep} "
+        f"batch={leg.batch_size} kv_dtype={leg.kv_cache_dtype} "
+        f"weight_dtype={leg.weight_dtype}"
+    )
 
     # ── 1. seed sweep (warm start) ───────────────────────────────────────
     if args.agent_only:
-        print(f"\n[tuning-agent] --agent-only: skipping seeds ({len(history.trials)} trials loaded)")
+        print(
+            f"\n[tuning-agent] --agent-only: skipping seeds ({len(history.trials)} trials loaded)"
+        )
     else:
         plan = build_inference_seed_plan(
-            arch, agent_cfg.target_cluster, agent_cfg.optimization,
+            arch,
+            agent_cfg.target_cluster,
+            agent_cfg.optimization,
             max_candidates=args.seed_budget,
         )
         print(f"\n[tuning-agent] seed plan: {plan.rationale}")
@@ -161,16 +176,20 @@ def _run_inference(args, agent_cfg, arch, config_root) -> int:
                 print(f"    [seed] skip (already evaluated): {sig}")
                 continue
             idx = len(history.trials)
-            tag = (f"inf_{idx:03d}_tp{cfg.tp}_pp{cfg.pp}_ep{cfg.ep}"
-                   f"_bs{cfg.batch_size}_{cfg.weight_dtype}_kv{cfg.kv_cache_dtype}")
+            tag = (
+                f"inf_{idx:03d}_tp{cfg.tp}_pp{cfg.pp}_ep{cfg.ep}"
+                f"_bs{cfg.batch_size}_{cfg.weight_dtype}_kv{cfg.kv_cache_dtype}"
+            )
             r = evaluator.evaluate_inference(cfg, tag)
             history.add(cfg.as_dict(), r, notes="inference[seed]")
             if not r.legal:
                 print(f"    [inf #{idx}] REJECT: {r.reason}")
                 continue
-            print(f"    [inf #{idx}] OK ttft={r.ttft_ms}ms itl={r.itl_ms}ms "
-                  f"dec_tps/gpu={r.decode_throughput_tps_per_gpu} "
-                  f"mem={r.memory_per_gpu_gb}GB maxconc={r.max_concurrent_sequences} cfg={sig}")
+            print(
+                f"    [inf #{idx}] OK ttft={r.ttft_ms}ms itl={r.itl_ms}ms "
+                f"dec_tps/gpu={r.decode_throughput_tps_per_gpu} "
+                f"mem={r.memory_per_gpu_gb}GB maxconc={r.max_concurrent_sequences} cfg={sig}"
+            )
 
     # ── 2. LLM agent stage ───────────────────────────────────────────────
     if not (args.seed_only or args.no_agent):
@@ -221,15 +240,15 @@ def _run_inference(args, agent_cfg, arch, config_root) -> int:
     print(f"  TP={cfg.tp} PP={cfg.pp} EP={cfg.ep} CP={cfg.cp}")
     print(f"  batch={cfg.batch_size} input_len={cfg.input_len} output_len={cfg.output_len}")
     print(f"  weight_dtype={cfg.weight_dtype} kv_cache_dtype={cfg.kv_cache_dtype}")
-    print(f"  chunked_prefill={cfg.chunked_prefill_size} "
-          f"speculative={cfg.speculative_num_tokens}")
+    print(f"  chunked_prefill={cfg.chunked_prefill_size} speculative={cfg.speculative_num_tokens}")
     print(f"  → TTFT               = {r.ttft_ms} ms")
     print(f"  → ITL / TPOT         = {r.itl_ms} ms")
-    print(f"  → decode throughput  = {r.decode_throughput_tps} tok/s "
-          f"({r.decode_throughput_tps_per_gpu} tok/s/gpu)")
+    print(
+        f"  → decode throughput  = {r.decode_throughput_tps} tok/s "
+        f"({r.decode_throughput_tps_per_gpu} tok/s/gpu)"
+    )
     print(f"  → prefill throughput = {r.prefill_throughput_tps} tok/s")
-    print(f"  → memory/GPU         = {r.memory_per_gpu_gb} GB "
-          f"(KV {r.kv_cache_gb} GB)")
+    print(f"  → memory/GPU         = {r.memory_per_gpu_gb} GB (KV {r.kv_cache_gb} GB)")
     print(f"  → max concurrency    = {r.max_concurrent_sequences} sequences")
 
     summary = {
@@ -242,8 +261,10 @@ def _run_inference(args, agent_cfg, arch, config_root) -> int:
     (agent_cfg.out_dir / "inference_summary.json").write_text(
         json.dumps(summary, indent=2, default=str)
     )
-    print(f"\n[tuning-agent] artifacts in {agent_cfg.out_dir}/ "
-          f"(inference_trials.jsonl, inference_summary.json, trials/*.yaml)")
+    print(
+        f"\n[tuning-agent] artifacts in {agent_cfg.out_dir}/ "
+        f"(inference_trials.jsonl, inference_summary.json, trials/*.yaml)"
+    )
     return 0
 
 
@@ -316,7 +337,9 @@ def main(argv: list[str] | None = None) -> int:
 
     # ── seed evaluation ─────────────────────────────────────────────────
     if args.agent_only:
-        print(f"\n[tuning-agent] --agent-only: skipping seeds ({len(history.trials)} trials loaded)")
+        print(
+            f"\n[tuning-agent] --agent-only: skipping seeds ({len(history.trials)} trials loaded)"
+        )
     seed = build_seed_plan(arch, agent_cfg, max_candidates=args.seed_budget)
     if not args.agent_only:
         print(f"\n[tuning-agent] seed plan: {seed.rationale}")
@@ -424,5 +447,5 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     print(f"\n[tuning-agent] artifacts in {agent_cfg.out_dir}/")
-    print(f"  trials.jsonl  trials.png  scratchpad.txt  summary.json  trials/*.yaml")
+    print("  trials.jsonl  trials.png  scratchpad.txt  summary.json  trials/*.yaml")
     return 0

--- a/infera/projection/agents/tuning_agent/config.py
+++ b/infera/projection/agents/tuning_agent/config.py
@@ -190,7 +190,9 @@ def _from_env(key: str, default: Any = None) -> Any:
     return val if val not in (None, "") else default
 
 
-def load_config(target_cluster_yaml: Path, workload_yaml: Path, out_dir: Path | None = None) -> AgentConfig:
+def load_config(
+    target_cluster_yaml: Path, workload_yaml: Path, out_dir: Path | None = None
+) -> AgentConfig:
     """Build the agent config from a target-cluster YAML and the env."""
     load_env()
 
@@ -248,9 +250,7 @@ def load_config(target_cluster_yaml: Path, workload_yaml: Path, out_dir: Path | 
         model=str(llm_raw.get("model") or _from_env("LLM_MODEL", DEFAULT_MODEL)),
         timeout=int(llm_raw.get("timeout", 300)),
         max_tokens=int(llm_raw.get("max_tokens", 16000)),
-        extra_headers={
-            str(k): str(v) for k, v in (llm_raw.get("extra_headers") or {}).items()
-        },
+        extra_headers={str(k): str(v) for k, v in (llm_raw.get("extra_headers") or {}).items()},
     )
 
     return AgentConfig(
@@ -260,5 +260,7 @@ def load_config(target_cluster_yaml: Path, workload_yaml: Path, out_dir: Path | 
         llm=llm,
         out_dir=Path(out_dir) if out_dir else Path("./tuning_runs") / target_cluster.name,
         workload_yaml=Path(workload_yaml).resolve(),
-        extra_prompt="\n".join(agent_raw.get("prompt_extras") or []) if isinstance(agent_raw, dict) else "",
+        extra_prompt="\n".join(agent_raw.get("prompt_extras") or [])
+        if isinstance(agent_raw, dict)
+        else "",
     )

--- a/infera/projection/agents/tuning_agent/evaluator.py
+++ b/infera/projection/agents/tuning_agent/evaluator.py
@@ -223,7 +223,9 @@ def write_trial_yaml(arch: ArchitectureRecord, cfg: TrialConfig, out_dir: Path, 
             PP_SCHEDULE_TO_RUNTIME_ALGORITHM,
         )
 
-        overrides["pp_algorithm"] = PP_SCHEDULE_TO_RUNTIME_ALGORITHM.get(cfg.pp_schedule, cfg.pp_schedule)
+        overrides["pp_algorithm"] = PP_SCHEDULE_TO_RUNTIME_ALGORITHM.get(
+            cfg.pp_schedule, cfg.pp_schedule
+        )
 
     # 3) MoE communication (Tier-A — biggest single MoE win per skill) ----
     # Required-by-runtime couplings for the Primus Turbo MoE stack:
@@ -521,7 +523,7 @@ def write_inference_trial_yaml(arch: ArchitectureRecord, cfg, out_dir: Path, tag
     """
     src = Path(arch.workload_path)
     raw = yaml.safe_load(src.read_text())
-    pre_trainer = ((raw.get("modules") or {}).get("pre_trainer") or {})
+    pre_trainer = (raw.get("modules") or {}).get("pre_trainer") or {}
     overrides = dict(pre_trainer.get("overrides") or {})
     overrides["tensor_model_parallel_size"] = cfg.tp
     overrides["pipeline_model_parallel_size"] = cfg.pp
@@ -557,16 +559,26 @@ def _build_inference_cmd(
     # skips the measurement and just calibrates.
     cmd: list[str] = [
         *_python_invoker(config_root),
-        "projection", "inference",
-        "--config", str(yaml_path),
-        "--inference-mode", "both",
-        "--gpu-arch", agent_cfg.target_cluster.gpu_arch,
-        "--input-len", str(cfg.input_len),
-        "--output-len", str(cfg.output_len),
-        "--inference-batch-size", str(cfg.batch_size),
-        "--weight-dtype", cfg.weight_dtype,
-        "--kv-cache-dtype", cfg.kv_cache_dtype,
-        "--hbm-capacity-gb", str(agent_cfg.optimization.hbm_capacity_gb),
+        "projection",
+        "inference",
+        "--config",
+        str(yaml_path),
+        "--inference-mode",
+        "both",
+        "--gpu-arch",
+        agent_cfg.target_cluster.gpu_arch,
+        "--input-len",
+        str(cfg.input_len),
+        "--output-len",
+        str(cfg.output_len),
+        "--inference-batch-size",
+        str(cfg.batch_size),
+        "--weight-dtype",
+        cfg.weight_dtype,
+        "--kv-cache-dtype",
+        cfg.kv_cache_dtype,
+        "--hbm-capacity-gb",
+        str(agent_cfg.optimization.hbm_capacity_gb),
     ]
     # Resident sequences. Left unset the projector admits its own default rather
     # than the batch being tuned, which prices every trial against a queue it
@@ -667,7 +679,9 @@ def _build_inference_cmd(
     return cmd
 
 
-def _build_env(agent_cfg: AgentConfig, config_root: Path, profiling_mode: str | None = None) -> dict:
+def _build_env(
+    agent_cfg: AgentConfig, config_root: Path, profiling_mode: str | None = None
+) -> dict:
     env = os.environ.copy()
     # For memory + simulate: pass the real target-cluster shape so
     # `projection memory`'s ``get_dp_size`` doesn't enter the "recompute min
@@ -731,7 +745,11 @@ def _run(cmd: list[str], cwd: Path, env: dict, timeout: int) -> tuple[int, str, 
     except subprocess.TimeoutExpired as e:
         return (
             124,
-            (e.stdout.decode("utf-8", "replace") if isinstance(e.stdout, bytes) else (e.stdout or "")),
+            (
+                e.stdout.decode("utf-8", "replace")
+                if isinstance(e.stdout, bytes)
+                else (e.stdout or "")
+            ),
             time.time() - started,
         )
 
@@ -886,8 +904,7 @@ class Evaluator:
 
         legality = derive_inference_legality(self.arch, self.cfg.target_cluster)
         ok, reason = validate_inference(cfg, self.arch, self.cfg.target_cluster, legality)
-        result = EvalResult(legal=ok, reason=reason, source="inference",
-                            config=cfg.as_dict())
+        result = EvalResult(legal=ok, reason=reason, source="inference", config=cfg.as_dict())
         if not ok:
             return result
 
@@ -899,8 +916,8 @@ class Evaluator:
             result.ttft_ms = 50.0 + cfg.input_len * 0.01
             result.itl_ms = 10.0 + cfg.tp * 2.0
             result.decode_throughput_tps = cfg.batch_size * 1000.0 / result.itl_ms
-            result.decode_throughput_tps_per_gpu = (
-                result.decode_throughput_tps / max(1, cfg.tp * cfg.pp)
+            result.decode_throughput_tps_per_gpu = result.decode_throughput_tps / max(
+                1, cfg.tp * cfg.pp
             )
             result.memory_per_gpu_gb = 80.0
             return result
@@ -940,14 +957,21 @@ class Evaluator:
         decode_floor = self._resolve_decode_floor(cfg) if is_bench else None
 
         cmd = _build_inference_cmd(
-            yaml_path, cfg, self.cfg, self.config_root,
-            load_benchmark=load_bench, profiling_mode=profiling_mode, bench_gpus=bench_gpus,
+            yaml_path,
+            cfg,
+            self.cfg,
+            self.config_root,
+            load_benchmark=load_bench,
+            profiling_mode=profiling_mode,
+            bench_gpus=bench_gpus,
             decode_floor=decode_floor,
         )
         rc, out, dur = _run(
-            cmd, cwd=self.config_root,
-            env=_build_env(self.cfg, self.config_root,
-                           profiling_mode=("benchmark" if profiling_mode else None)),
+            cmd,
+            cwd=self.config_root,
+            env=_build_env(
+                self.cfg, self.config_root, profiling_mode=("benchmark" if profiling_mode else None)
+            ),
             timeout=(3600 if profiling_mode == "benchmark" else 600),
         )
         if load_bench is not None or profiling_mode == "benchmark":
@@ -964,8 +988,7 @@ class Evaluator:
         if rc != 0 or result.ttft_ms is None:
             result.legal = False
             result.reason = (
-                f"projection inference failed (rc={rc}, ttft={result.ttft_ms}); "
-                f"see stdout_tail"
+                f"projection inference failed (rc={rc}, ttft={result.ttft_ms}); see stdout_tail"
             )
             return result
 
@@ -1065,7 +1088,9 @@ class Evaluator:
         # as ADVISORY: log it but proceed to benchmark, because real OOM is
         # the only authoritative answer. In simulate / memory-only modes
         # the projection remains authoritative.
-        cap = self.cfg.optimization.hbm_capacity_gb * (1 - self.cfg.optimization.memory_safety_margin)
+        cap = self.cfg.optimization.hbm_capacity_gb * (
+            1 - self.cfg.optimization.memory_safety_margin
+        )
         adjusted_mem = result.memory_per_gpu_gb
         if cfg.recompute_granularity == "selective" and adjusted_mem is not None:
             adjusted_mem = adjusted_mem * 0.55
@@ -1141,7 +1166,9 @@ class Evaluator:
         """
         import tempfile
 
-        cap = self.cfg.optimization.hbm_capacity_gb * (1 - self.cfg.optimization.memory_safety_margin)
+        cap = self.cfg.optimization.hbm_capacity_gb * (
+            1 - self.cfg.optimization.memory_safety_margin
+        )
 
         fd, tmp_path = tempfile.mkstemp(prefix="tuning_agent_bench_", suffix=".json")
         os.close(fd)
@@ -1172,7 +1199,9 @@ class Evaluator:
 
             if rc1 != 0:
                 result.legal = False
-                result.reason = f"projection performance --benchmark failed (rc={rc1}); " f"see stdout_tail"
+                result.reason = (
+                    f"projection performance --benchmark failed (rc={rc1}); see stdout_tail"
+                )
                 return result
 
             if not artifact.exists() or artifact.stat().st_size == 0:
@@ -1204,9 +1233,9 @@ class Evaluator:
             )
             self.n_memory_calls += 1
             result.duration_s += dur2
-            result.stdout_tail = (result.stdout_tail + "\n--- mem (bench/load) ---\n" + _tail(out2, 6000))[
-                -14000:
-            ]
+            result.stdout_tail = (
+                result.stdout_tail + "\n--- mem (bench/load) ---\n" + _tail(out2, 6000)
+            )[-14000:]
             mem_metrics = _parse_metrics(out2)
             for k, v in mem_metrics.items():
                 setattr(result, k, v)

--- a/infera/projection/agents/tuning_agent/history.py
+++ b/infera/projection/agents/tuning_agent/history.py
@@ -40,7 +40,7 @@ class History:
     seen_signatures: set[str] = field(default_factory=set)
 
     @classmethod
-    def load(cls, path: Path) -> "History":
+    def load(cls, path: Path) -> History:
         h = cls(path=path)
         if path.is_file():
             for line in path.read_text().splitlines():
@@ -84,7 +84,9 @@ class History:
         return _sig(config) in self.seen_signatures
 
     def best(self, objective: str = "tokens_per_s_per_gpu") -> TrialRecord | None:
-        legal = [t for t in self.trials if t.result.get("legal") and t.result.get(objective) is not None]
+        legal = [
+            t for t in self.trials if t.result.get("legal") and t.result.get(objective) is not None
+        ]
         if not legal:
             return None
         return max(legal, key=lambda t: t.result.get(objective) or 0.0)
@@ -105,8 +107,10 @@ class History:
                 f"VPP={cfg.get('vpp')} sched={cfg.get('pp_schedule')} "
                 f"recompute={cfg.get('recompute_granularity')}"
             )
-            tag = "OK" if r.get("legal") else f"REJECT({r.get('reason','')[:60]})"
-            lines.append(f"#{t.idx:03d} [{t.source:9s}] {tag:40s} tps={tps_s:>10s} mem={mem_s:>8s} | {cfg_s}")
+            tag = "OK" if r.get("legal") else f"REJECT({r.get('reason', '')[:60]})"
+            lines.append(
+                f"#{t.idx:03d} [{t.source:9s}] {tag:40s} tps={tps_s:>10s} mem={mem_s:>8s} | {cfg_s}"
+            )
         return "\n".join(lines) if lines else "(no trials yet)"
 
 

--- a/infera/projection/agents/tuning_agent/inference_agent.py
+++ b/infera/projection/agents/tuning_agent/inference_agent.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import json
 import sys
 from datetime import datetime
+from functools import partial
 from pathlib import Path
 
 import dspy
@@ -47,7 +48,6 @@ from .inference_tuning import (
     objective_is_minimize,
     resolve_objective,
     score_result,
-    validate_inference,
 )
 from .scratchpad import Scratchpad
 from .workload import ArchitectureRecord
@@ -241,6 +241,12 @@ def _best_by_score(history: History, objective: str):
     return best
 
 
+def _metric(result: dict, key: str, fmt: str = "{}") -> str:
+    """Format one trial metric, or an em dash when the trial never produced it."""
+    v = result.get(key)
+    return fmt.format(v) if isinstance(v, (int, float)) else "—"
+
+
 def _inference_history_summary(history: History, objective: str, k: int = 30) -> str:
     rows = history.trials[-k:] if k else history.trials
     obj = resolve_objective(objective)
@@ -249,13 +255,11 @@ def _inference_history_summary(history: History, objective: str, k: int = 30) ->
         r = t.result
         c = t.config
 
-        def _g(key, fmt="{}"):
-            v = r.get(key)
-            return fmt.format(v) if isinstance(v, (int, float)) else "—"
+        _g = partial(_metric, r)
 
         objval = r.get(obj)
         obj_s = f"{objval:,.2f}" if isinstance(objval, (int, float)) else "—"
-        tag = "OK" if r.get("legal") else f"REJECT({str(r.get('reason',''))[:48]})"
+        tag = "OK" if r.get("legal") else f"REJECT({str(r.get('reason', ''))[:48]})"
         cfg_s = (
             f"tp{c.get('tp')} pp{c.get('pp')} ep{c.get('ep')} bs{c.get('batch_size')} "
             f"w{c.get('weight_dtype')} kv{c.get('kv_cache_dtype')}"
@@ -274,9 +278,9 @@ def _inference_history_summary(history: History, objective: str, k: int = 30) ->
         cfg_s = cfg_s + ((" " + " ".join(extra)) if extra else "")
         lines.append(
             f"#{t.idx:03d} {tag:38s} {obj}={obj_s:>10s} "
-            f"ttft={_g('ttft_ms','{:.1f}')} itl={_g('itl_ms','{:.2f}')} "
-            f"dtps/gpu={_g('decode_throughput_tps_per_gpu','{:.0f}')} "
-            f"mem={_g('memory_per_gpu_gb','{:.1f}')}GB | {cfg_s}"
+            f"ttft={_g('ttft_ms', '{:.1f}')} itl={_g('itl_ms', '{:.2f}')} "
+            f"dtps/gpu={_g('decode_throughput_tps_per_gpu', '{:.0f}')} "
+            f"mem={_g('memory_per_gpu_gb', '{:.1f}')}GB | {cfg_s}"
         )
     return "\n".join(lines) if lines else "(no trials yet)"
 
@@ -329,7 +333,9 @@ def build_inference_tools(
                     return json.dumps({"already_evaluated": True, **t.result})
         if evaluator.n_simulate_calls >= budget.max_perf_calls:
             return json.dumps(
-                {"error": f"eval budget exhausted ({evaluator.n_simulate_calls}/{budget.max_perf_calls})"}
+                {
+                    "error": f"eval budget exhausted ({evaluator.n_simulate_calls}/{budget.max_perf_calls})"
+                }
             )
         idx = len(history.trials)
         tag = f"inf_{idx:03d}_tp{cfg.tp}_pp{cfg.pp}_ep{cfg.ep}_bs{cfg.batch_size}"

--- a/infera/projection/agents/tuning_agent/inference_tuning.py
+++ b/infera/projection/agents/tuning_agent/inference_tuning.py
@@ -31,10 +31,10 @@ from typing import Any
 from .config import OptimizationConfig, TargetCluster
 from .workload import ArchitectureRecord
 
-
 # ---------------------------------------------------------------------------
 # Trial config
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class InferenceTrialConfig:
@@ -120,7 +120,7 @@ class InferenceTrialConfig:
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, d: dict) -> "InferenceTrialConfig":
+    def from_dict(cls, d: dict) -> InferenceTrialConfig:
         f = cls()
         for k in f.as_dict():
             if k in d and d[k] is not None:
@@ -135,6 +135,7 @@ class InferenceTrialConfig:
 # ---------------------------------------------------------------------------
 # Legality
 # ---------------------------------------------------------------------------
+
 
 def _tier_tops(batch: int, dp: int, n: int = 6) -> list[int]:
     """Concurrencies at the top of an attention-DP tier, largest first.
@@ -219,9 +220,7 @@ class InferenceAxisLegality:
     kv_cache_dtype: list[str]
     chunked_prefill_size: list[int]
     speculative_num_tokens: list[int]
-    linear_weight_dtype: list[str] = field(
-        default_factory=lambda: ["bf16", "fp8", "mxfp4", "fp4"]
-    )
+    linear_weight_dtype: list[str] = field(default_factory=lambda: ["bf16", "fp8", "mxfp4", "fp4"])
     tp_allreduce_algo: list[str] = field(
         default_factory=lambda: ["auto", "ring", "one_shot", "two_shot", "hierarchical"]
     )
@@ -229,31 +228,17 @@ class InferenceAxisLegality:
         default_factory=lambda: ["auto", "direct", "single_shot", "hierarchical"]
     )
     use_turbo_deepep: list[bool] = field(default_factory=lambda: [False])
-    cudagraph_mode: list[str] = field(
-        default_factory=lambda: ["none", "piecewise", "full"]
-    )
-    kv_cache_memory_fraction: list[float] = field(
-        default_factory=lambda: [0.8, 0.85, 0.9]
-    )
-    transfer_backend: list[str] = field(
-        default_factory=lambda: ["nixl", "mooncake", "mori"]
-    )
+    cudagraph_mode: list[str] = field(default_factory=lambda: ["none", "piecewise", "full"])
+    kv_cache_memory_fraction: list[float] = field(default_factory=lambda: [0.8, 0.85, 0.9])
+    transfer_backend: list[str] = field(default_factory=lambda: ["nixl", "mooncake", "mori"])
     kv_block_size: list[int] = field(default_factory=lambda: [0, 16, 32])
-    max_num_batched_tokens: list[int] = field(
-        default_factory=lambda: [0, 2048, 8192]
-    )
+    max_num_batched_tokens: list[int] = field(default_factory=lambda: [0, 2048, 8192])
     ep_load_balance: list[float] = field(default_factory=lambda: [1.0, 1.2, 1.5])
     redundant_experts: list[int] = field(default_factory=lambda: [0, 8, 16])
-    arrival_model: list[str] = field(
-        default_factory=lambda: ["closed", "poisson", "deterministic"]
-    )
-    attention_backend: list[str] = field(
-        default_factory=lambda: ["aiter", "triton", "ck", "hip"]
-    )
+    arrival_model: list[str] = field(default_factory=lambda: ["closed", "poisson", "deterministic"])
+    attention_backend: list[str] = field(default_factory=lambda: ["aiter", "triton", "ck", "hip"])
     sparse_attention_topk: list[int] = field(default_factory=lambda: [0, 512, 2048])
-    moe_expert_dtype: list[str] = field(
-        default_factory=lambda: ["bf16", "fp8", "mxfp4"]
-    )
+    moe_expert_dtype: list[str] = field(default_factory=lambda: ["bf16", "fp8", "mxfp4"])
     # fused elementwise kernels (always available)
     fused_kernels: list[bool] = field(default_factory=lambda: [False, True])
     # TP-collective optimizations (only meaningful when TP>1)
@@ -262,7 +247,10 @@ class InferenceAxisLegality:
 
     def to_prompt_dict(self) -> dict:
         return {
-            "tp": self.tp, "pp": self.pp, "ep": self.ep, "cp": self.cp,
+            "tp": self.tp,
+            "pp": self.pp,
+            "ep": self.ep,
+            "cp": self.cp,
             "attention_dp": self.attention_dp,
             "batch_size": self.batch_size,
             "weight_dtype": self.weight_dtype,
@@ -296,8 +284,9 @@ def derive_inference_legality(
     world = cluster.num_nodes * cluster.gpus_per_node
     gpn = cluster.gpus_per_node
 
-    tp = sorted(set(_divisors(arch.num_attention_heads, gpn))
-                & set(_divisors(arch.hidden_size, gpn))) or [1]
+    tp = sorted(
+        set(_divisors(arch.num_attention_heads, gpn)) & set(_divisors(arch.hidden_size, gpn))
+    ) or [1]
     pp = _divisors(arch.num_layers, world) if arch.num_layers else [1]
     is_moe = bool(getattr(arch, "is_moe", False))
     if is_moe and arch.num_experts:
@@ -343,7 +332,10 @@ def derive_inference_legality(
     tp_collective = [False, True] if max(tp) > 1 else [False]
 
     return InferenceAxisLegality(
-        tp=tp, pp=pp, ep=ep, cp=cp,
+        tp=tp,
+        pp=pp,
+        ep=ep,
+        cp=cp,
         attention_dp=attention_dp,
         batch_size=batch_size,
         weight_dtype=weight_dtype,
@@ -371,32 +363,30 @@ def validate_inference(
     if cfg.ep not in legality.ep:
         return False, f"EP={cfg.ep} not in legal set {legality.ep}"
     if cfg.attention_dp not in legality.attention_dp:
-        return False, (
-            f"attention_dp={cfg.attention_dp} not in legal set {legality.attention_dp}"
-        )
+        return False, (f"attention_dp={cfg.attention_dp} not in legal set {legality.attention_dp}")
     if cfg.attention_dp > 1 and cfg.tp % cfg.attention_dp != 0:
         # The axis splits the TP group; a degree it does not divide describes no
         # rank layout, and the projector refuses it rather than rounding.
-        return False, (
-            f"attention_dp={cfg.attention_dp} must divide TP={cfg.tp}"
-        )
+        return False, (f"attention_dp={cfg.attention_dp} must divide TP={cfg.tp}")
     if cfg.batch_size <= 0:
         return False, f"batch_size must be positive, got {cfg.batch_size}"
     if cfg.weight_dtype not in legality.weight_dtype:
         return False, f"weight_dtype={cfg.weight_dtype} not in {legality.weight_dtype}"
     if cfg.kv_cache_dtype not in legality.kv_cache_dtype:
         return False, f"kv_cache_dtype={cfg.kv_cache_dtype} not in {legality.kv_cache_dtype}"
-    if (cfg.linear_weight_dtype is not None
-            and cfg.linear_weight_dtype not in legality.linear_weight_dtype):
+    if (
+        cfg.linear_weight_dtype is not None
+        and cfg.linear_weight_dtype not in legality.linear_weight_dtype
+    ):
         return False, (
-            f"linear_weight_dtype={cfg.linear_weight_dtype} not in "
-            f"{legality.linear_weight_dtype}"
+            f"linear_weight_dtype={cfg.linear_weight_dtype} not in {legality.linear_weight_dtype}"
         )
-    if (cfg.linear_weight_dtype is not None
-            and cfg.linear_weight_dtype not in legality.linear_weight_dtype):
+    if (
+        cfg.linear_weight_dtype is not None
+        and cfg.linear_weight_dtype not in legality.linear_weight_dtype
+    ):
         return False, (
-            f"linear_weight_dtype={cfg.linear_weight_dtype} not in "
-            f"{legality.linear_weight_dtype}"
+            f"linear_weight_dtype={cfg.linear_weight_dtype} not in {legality.linear_weight_dtype}"
         )
     if cfg.speculative_num_tokens < 0:
         return False, "speculative_num_tokens must be >= 0"
@@ -405,7 +395,10 @@ def validate_inference(
     if cfg.use_turbo_deepep and not getattr(arch, "is_moe", False):
         return False, "use_turbo_deepep is only meaningful for MoE workloads"
     if cfg.tp_allreduce_algo not in legality.tp_allreduce_algo:
-        return False, f"tp_allreduce_algo={cfg.tp_allreduce_algo} not in {legality.tp_allreduce_algo}"
+        return (
+            False,
+            f"tp_allreduce_algo={cfg.tp_allreduce_algo} not in {legality.tp_allreduce_algo}",
+        )
     if cfg.ep_a2a_algo not in legality.ep_a2a_algo:
         return False, f"ep_a2a_algo={cfg.ep_a2a_algo} not in {legality.ep_a2a_algo}"
     if cfg.cudagraph_mode is not None and cfg.cudagraph_mode not in legality.cudagraph_mode:
@@ -416,7 +409,10 @@ def validate_inference(
         if not cfg.disaggregate:
             return False, "transfer_backend only applies when disaggregate is set"
         if cfg.transfer_backend not in legality.transfer_backend:
-            return False, f"transfer_backend={cfg.transfer_backend} not in {legality.transfer_backend}"
+            return (
+                False,
+                f"transfer_backend={cfg.transfer_backend} not in {legality.transfer_backend}",
+            )
     if not (0.0 < cfg.des_range_ratio <= 1.0):
         return False, (
             f"des_range_ratio={cfg.des_range_ratio} must be in (0, 1] "
@@ -443,15 +439,24 @@ def validate_inference(
     if cfg.request_rate > 0 and cfg.arrival_model == "closed":
         return False, "request_rate>0 requires arrival_model in {poisson, deterministic}"
     # Kernel backend (attention library).
-    if cfg.attention_backend is not None and cfg.attention_backend not in legality.attention_backend:
-        return False, f"attention_backend={cfg.attention_backend} not in {legality.attention_backend}"
+    if (
+        cfg.attention_backend is not None
+        and cfg.attention_backend not in legality.attention_backend
+    ):
+        return (
+            False,
+            f"attention_backend={cfg.attention_backend} not in {legality.attention_backend}",
+        )
     # Native sparse attention.
     if cfg.sparse_attention_topk < 0:
         return False, f"sparse_attention_topk must be >= 0, got {cfg.sparse_attention_topk}"
     # MoE expert compute precision (MoE-only).
     if cfg.moe_expert_dtype is not None:
         if cfg.moe_expert_dtype not in legality.moe_expert_dtype:
-            return False, f"moe_expert_dtype={cfg.moe_expert_dtype} not in {legality.moe_expert_dtype}"
+            return (
+                False,
+                f"moe_expert_dtype={cfg.moe_expert_dtype} not in {legality.moe_expert_dtype}",
+            )
         if not is_moe:
             return False, "moe_expert_dtype is only meaningful for MoE workloads"
     # Speculative draft cost requires speculative decoding to be on.
@@ -502,9 +507,7 @@ def validate_inference(
             f"({cluster.num_nodes}×{cluster.gpus_per_node})"
         )
     if getattr(arch, "is_moe", False) and cfg.ep > 1 and replica_gpus % cfg.ep:
-        return False, (
-            f"EP={cfg.ep} must divide the replica's {replica_gpus} ranks (TP×PP)"
-        )
+        return False, (f"EP={cfg.ep} must divide the replica's {replica_gpus} ranks (TP×PP)")
 
     # Feature A: disaggregation — prefill/decode pools each need to fit.
     if cfg.disaggregate:
@@ -530,6 +533,7 @@ def validate_inference(
 # Seed plan
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class InferenceSeedPlan:
     candidates: list[InferenceTrialConfig]
@@ -549,7 +553,7 @@ def _profile_from_opt(opt: OptimizationConfig) -> dict:
 
 def default_inference_trial(
     arch: ArchitectureRecord, cluster: TargetCluster, opt: OptimizationConfig
-) -> "InferenceTrialConfig":
+) -> InferenceTrialConfig:
     """Profile-anchored baseline trial — the same defaults the seed sweep starts
     from (largest intra-budget TP, batch 1, bf16, request profile from opt).
 
@@ -579,7 +583,7 @@ def inference_trial_from_dict(
     arch: ArchitectureRecord,
     cluster: TargetCluster,
     opt: OptimizationConfig,
-) -> "InferenceTrialConfig":
+) -> InferenceTrialConfig:
     """Overlay a (possibly partial) proposal dict onto the profile baseline."""
     base = default_inference_trial(arch, cluster, opt)
     for k in base.as_dict():
@@ -633,15 +637,22 @@ def build_inference_seed_plan(
 
     def mk(**kw) -> InferenceTrialConfig:
         base = dict(
-            tp=base_tp, pp=1, ep=1, cp=1,
-            batch_size=1, input_len=in_len, output_len=out_len,
+            tp=base_tp,
+            pp=1,
+            ep=1,
+            cp=1,
+            batch_size=1,
+            input_len=in_len,
+            output_len=out_len,
             max_concurrency=profile["max_concurrency"],
             prefix_cache_hit_rate=profile["prefix_cache_hit_rate"],
-            weight_dtype="bf16", kv_cache_dtype="bf16",
+            weight_dtype="bf16",
+            kv_cache_dtype="bf16",
             chunked_prefill_size=0,
             max_num_batched_tokens=base_token_budget,
             sparse_attention_topk=base_sparse_topk,
-            speculative_num_tokens=0, speculative_acceptance_rate=0.0,
+            speculative_num_tokens=0,
+            speculative_acceptance_rate=0.0,
         )
         base.update(kw)
         return InferenceTrialConfig(**base)
@@ -676,20 +687,36 @@ def build_inference_seed_plan(
     #     the only precision they fit in, so it is seeded with the batch and the
     #     attention-DP degree that a fitting configuration would want.
     if "fp4" in leg.weight_dtype:
-        add(mk(batch_size=16, weight_dtype="fp4",
-               linear_weight_dtype="mxfp4", kv_cache_dtype="fp8"))
+        add(
+            mk(batch_size=16, weight_dtype="fp4", linear_weight_dtype="mxfp4", kv_cache_dtype="fp8")
+        )
         for dp in [d for d in leg.attention_dp if d > 1 and base_tp % d == 0]:
-            add(mk(batch_size=32, weight_dtype="fp4", linear_weight_dtype="mxfp4",
-                   kv_cache_dtype="fp8", attention_dp=dp))
+            add(
+                mk(
+                    batch_size=32,
+                    weight_dtype="fp4",
+                    linear_weight_dtype="mxfp4",
+                    kv_cache_dtype="fp8",
+                    attention_dp=dp,
+                )
+            )
     # 2c) 4-bit weights. Not one point on a precision sweep for these models but
     #     the only precision they fit in, so it is seeded with the batch and the
     #     attention-DP degree that a fitting configuration would want.
     if "fp4" in leg.weight_dtype:
-        add(mk(batch_size=16, weight_dtype="fp4",
-               linear_weight_dtype="mxfp4", kv_cache_dtype="fp8"))
+        add(
+            mk(batch_size=16, weight_dtype="fp4", linear_weight_dtype="mxfp4", kv_cache_dtype="fp8")
+        )
         for dp in [d for d in leg.attention_dp if d > 1 and base_tp % d == 0]:
-            add(mk(batch_size=32, weight_dtype="fp4", linear_weight_dtype="mxfp4",
-                   kv_cache_dtype="fp8", attention_dp=dp))
+            add(
+                mk(
+                    batch_size=32,
+                    weight_dtype="fp4",
+                    linear_weight_dtype="mxfp4",
+                    kv_cache_dtype="fp8",
+                    attention_dp=dp,
+                )
+            )
     # 2d) The high-throughput region. The deterministic plan used to stop at
     #     batch 64 with an unchunked prompt, which at agentic context is not a
     #     configuration that runs: batch 64 unchunked costs a ~50 s first token,
@@ -713,32 +740,61 @@ def build_inference_seed_plan(
         for dp in [d for d in leg.attention_dp if d > 1 and base_tp % d == 0]:
             for bs in [b for b in leg.batch_size if b in (64, 128, 256)]:
                 for mc in _tier_tops(bs, dp, n=9):
-                    add(mk(batch_size=bs, attention_dp=dp, max_concurrency=mc,
-                           weight_dtype="fp4", linear_weight_dtype="mxfp4",
-                           kv_cache_dtype="fp8", chunked_prefill_size=2048,
-                           max_num_batched_tokens=2048))
-                    add(mk(batch_size=bs, attention_dp=dp, max_concurrency=mc,
-                           weight_dtype="fp4", linear_weight_dtype="mxfp4",
-                           kv_cache_dtype="fp8"))
+                    add(
+                        mk(
+                            batch_size=bs,
+                            attention_dp=dp,
+                            max_concurrency=mc,
+                            weight_dtype="fp4",
+                            linear_weight_dtype="mxfp4",
+                            kv_cache_dtype="fp8",
+                            chunked_prefill_size=2048,
+                            max_num_batched_tokens=2048,
+                        )
+                    )
+                    add(
+                        mk(
+                            batch_size=bs,
+                            attention_dp=dp,
+                            max_concurrency=mc,
+                            weight_dtype="fp4",
+                            linear_weight_dtype="mxfp4",
+                            kv_cache_dtype="fp8",
+                        )
+                    )
                     if covering_budget != base_token_budget:
-                        add(mk(batch_size=bs, attention_dp=dp,
-                               max_concurrency=mc, weight_dtype="fp4",
-                               linear_weight_dtype="mxfp4",
-                               kv_cache_dtype="fp8",
-                               max_num_batched_tokens=covering_budget))
+                        add(
+                            mk(
+                                batch_size=bs,
+                                attention_dp=dp,
+                                max_concurrency=mc,
+                                weight_dtype="fp4",
+                                linear_weight_dtype="mxfp4",
+                                kv_cache_dtype="fp8",
+                                max_num_batched_tokens=covering_budget,
+                            )
+                        )
         # Elementwise fusion and the TP-collective optimizations are cheap and
         # compound with the above; kept as a separate point so their effect is
         # attributable rather than baked into every large-batch trial.
         best_dp = max([d for d in leg.attention_dp if base_tp % d == 0] or [1])
         for bs in [b for b in leg.batch_size if b in (64, 128)]:
-            add(mk(batch_size=bs, attention_dp=best_dp,
-                   max_concurrency=(_tier_tops(bs, best_dp) or [None])[0],
-                   weight_dtype="fp4", linear_weight_dtype="mxfp4",
-                   kv_cache_dtype="fp8", chunked_prefill_size=2048,
-                   max_num_batched_tokens=2048, fused_kernels=True,
-                   quick_reduce=(base_tp > 1),
-                   fuse_rmsnorm_allreduce=(base_tp > 1),
-                   attention_backend="aiter"))
+            add(
+                mk(
+                    batch_size=bs,
+                    attention_dp=best_dp,
+                    max_concurrency=(_tier_tops(bs, best_dp) or [None])[0],
+                    weight_dtype="fp4",
+                    linear_weight_dtype="mxfp4",
+                    kv_cache_dtype="fp8",
+                    chunked_prefill_size=2048,
+                    max_num_batched_tokens=2048,
+                    fused_kernels=True,
+                    quick_reduce=(base_tp > 1),
+                    fuse_rmsnorm_allreduce=(base_tp > 1),
+                    attention_backend="aiter",
+                )
+            )
         # Expert parallelism, seeded where the winners actually live. It used to
         # appear only at batch 16 in bf16, which always died on memory, so the
         # sweep never answered whether disjoint experts beat a TP all-reduce at
@@ -747,9 +803,17 @@ def build_inference_seed_plan(
         if ep_hi > 1:
             for bs in [b for b in leg.batch_size if b in (64, 128, 256)]:
                 for mc in _tier_tops(bs, best_dp, n=3):
-                    add(mk(batch_size=bs, attention_dp=best_dp, ep=ep_hi,
-                           max_concurrency=mc, weight_dtype="fp4",
-                           linear_weight_dtype="mxfp4", kv_cache_dtype="fp8"))
+                    add(
+                        mk(
+                            batch_size=bs,
+                            attention_dp=best_dp,
+                            ep=ep_hi,
+                            max_concurrency=mc,
+                            weight_dtype="fp4",
+                            linear_weight_dtype="mxfp4",
+                            kv_cache_dtype="fp8",
+                        )
+                    )
     # 3) batching / concurrency (throughput)
     for bs in [b for b in leg.batch_size if b in (4, 16, 64)]:
         add(mk(batch_size=bs))
@@ -764,8 +828,13 @@ def build_inference_seed_plan(
     if in_len >= 2048:
         add(mk(batch_size=16, chunked_prefill_size=1024))
     # 8) speculative decoding (latency)
-    add(mk(speculative_num_tokens=4, speculative_acceptance_rate=0.7,
-           speculative_draft_cost_factor=0.2))
+    add(
+        mk(
+            speculative_num_tokens=4,
+            speculative_acceptance_rate=0.7,
+            speculative_draft_cost_factor=0.2,
+        )
+    )
     # 8b) CUDA-graph capture (per-step launch overhead / mixed-step penalty).
     add(mk(batch_size=16, cudagraph_mode="full"))
     add(mk(batch_size=16, cudagraph_mode="piecewise"))
@@ -790,8 +859,7 @@ def build_inference_seed_plan(
     if is_moe:
         for ep in [e for e in leg.ep if e in (1, 2, 4, 8) and base_tp % e == 0]:
             if base_tp > 1 and base_tp in leg.attention_dp:
-                add(mk(ep=ep, batch_size=16,
-                       attention_dp=base_tp, kv_cache_dtype="fp8"))
+                add(mk(ep=ep, batch_size=16, attention_dp=base_tp, kv_cache_dtype="fp8"))
 
     # 9b) MoE DeepEP — overlap the EP All-to-All behind expert compute. Only
     #     meaningful with EP>1, so pair it with the largest feasible EP.
@@ -906,12 +974,23 @@ def build_inference_seed_plan(
 
 # Lower-is-better metrics.
 _MINIMIZE = {
-    "ttft_ms", "itl_ms", "request_latency_ms", "tpot_ms", "latency_ms",
+    "ttft_ms",
+    "itl_ms",
+    "request_latency_ms",
+    "tpot_ms",
+    "latency_ms",
     # Capacity and step-quality objectives: less is better.
-    "memory_per_gpu_gb", "kv_cache_gb", "decode_step_ms_pure",
-    "mixed_step_fraction_pct", "tpot_pollution_pct",
-    "decode_step_ms_mixed", "weights_gb", "activation_gb",
-    "prefill_comm_ms", "decode_comm_ms", "replica_gpus",
+    "memory_per_gpu_gb",
+    "kv_cache_gb",
+    "decode_step_ms_pure",
+    "mixed_step_fraction_pct",
+    "tpot_pollution_pct",
+    "decode_step_ms_mixed",
+    "weights_gb",
+    "activation_gb",
+    "prefill_comm_ms",
+    "decode_comm_ms",
+    "replica_gpus",
 }
 
 # Friendly aliases the user may put in the YAML `objective:` field.
@@ -976,30 +1055,30 @@ _OBJECTIVE_ALIASES = {
 # joules_per_{output,total}_token, and the projector models no power at all, so
 # there is nothing to optimize against and pretending otherwise would invent it.
 INFERENCEX_OBJECTIVES = {
-    "total_throughput_tps_per_gpu":  "tput_per_gpu (headline ranking)",
-    "total_throughput_tps":          "tput_per_gpu x GPUs (fleet total)",
+    "total_throughput_tps_per_gpu": "tput_per_gpu (headline ranking)",
+    "total_throughput_tps": "tput_per_gpu x GPUs (fleet total)",
     "decode_throughput_tps_per_gpu": "output_tput_per_gpu",
-    "decode_throughput_tps":         "output tokens/s (fleet)",
-    "prefill_throughput_tps_per_gpu":"input_tput_per_gpu",
-    "prefill_throughput_tps":        "input tokens/s (fleet)",
-    "interactivity_tok_s_per_user":  "mean_intvty",
-    "per_request_decode_tps":        "per-user generation rate",
-    "ttft_ms":                       "mean_ttft",
-    "itl_ms":                        "mean_tpot / mean_itl",
-    "request_latency_ms":            "mean_e2el",
-    "decode_step_ms_pure":           "uncontended step time",
-    "max_concurrent_sequences":      "kv_cache_pool_tokens (as sequences)",
-    "max_sustainable_concurrency":   "concurrency the pool sustains",
-    "memory_per_gpu_gb":             "HBM footprint",
-    "kv_cache_gb":                   "KV footprint",
-    "mixed_step_fraction_pct":       "prefill interference in decode",
-    "tpot_pollution_pct":            "TPOT inflation from interference",
-    "decode_step_ms_mixed":          "step time when a prefill chunk lands",
-    "weights_gb":                    "resident weight footprint",
-    "activation_gb":                 "activation working set",
-    "prefill_comm_ms":               "collective time in prefill",
-    "decode_comm_ms":                "collective time in decode",
-    "replica_gpus":                  "GPUs a replica costs",
+    "decode_throughput_tps": "output tokens/s (fleet)",
+    "prefill_throughput_tps_per_gpu": "input_tput_per_gpu",
+    "prefill_throughput_tps": "input tokens/s (fleet)",
+    "interactivity_tok_s_per_user": "mean_intvty",
+    "per_request_decode_tps": "per-user generation rate",
+    "ttft_ms": "mean_ttft",
+    "itl_ms": "mean_tpot / mean_itl",
+    "request_latency_ms": "mean_e2el",
+    "decode_step_ms_pure": "uncontended step time",
+    "max_concurrent_sequences": "kv_cache_pool_tokens (as sequences)",
+    "max_sustainable_concurrency": "concurrency the pool sustains",
+    "memory_per_gpu_gb": "HBM footprint",
+    "kv_cache_gb": "KV footprint",
+    "mixed_step_fraction_pct": "prefill interference in decode",
+    "tpot_pollution_pct": "TPOT inflation from interference",
+    "decode_step_ms_mixed": "step time when a prefill chunk lands",
+    "weights_gb": "resident weight footprint",
+    "activation_gb": "activation working set",
+    "prefill_comm_ms": "collective time in prefill",
+    "decode_comm_ms": "collective time in decode",
+    "replica_gpus": "GPUs a replica costs",
 }
 
 # Deliberately absent, because the serving projection reports none of them and
@@ -1008,8 +1087,12 @@ INFERENCEX_OBJECTIVES = {
 # at all, and MFU / TFLOP-per-second / iteration time are training-mode figures
 # the serving path never emits.
 UNSUPPORTED_OBJECTIVES = {
-    "avg_power_w", "joules_per_output_token", "joules_per_total_token",
-    "mfu", "tflops_per_s_per_gpu", "iteration_ms",
+    "avg_power_w",
+    "joules_per_output_token",
+    "joules_per_total_token",
+    "mfu",
+    "tflops_per_s_per_gpu",
+    "iteration_ms",
 }
 
 DEFAULT_INFERENCE_OBJECTIVE = "decode_throughput_tps_per_gpu"
@@ -1062,7 +1145,9 @@ _RE_PER_REQ_TPS = re.compile(rf"Per-request decode throughput:\s*{_FLOAT}", re.I
 _RE_STEP_PURE = re.compile(rf"Decode step latency \(pure\):\s*{_FLOAT}\s*ms", re.IGNORECASE)
 _RE_MIXED_FRAC = re.compile(rf"Mixed-step fraction:\s*{_FLOAT}\s*%", re.IGNORECASE)
 _RE_POLLUTION = re.compile(rf"TPOT pollution:\s*{_FLOAT}\s*%", re.IGNORECASE)
-_RE_STEP_MIXED = re.compile(rf"Decode step latency \(pure\):[^|]*\|\s*mixed:\s*{_FLOAT}\s*ms", re.IGNORECASE)
+_RE_STEP_MIXED = re.compile(
+    rf"Decode step latency \(pure\):[^|]*\|\s*mixed:\s*{_FLOAT}\s*ms", re.IGNORECASE
+)
 _RE_WEIGHTS = re.compile(rf"Weights \([^)]*\):\s*{_FLOAT}\s*GB", re.IGNORECASE)
 _RE_ACTIVATION = re.compile(rf"Activation working set:\s*{_FLOAT}\s*GB", re.IGNORECASE)
 _RE_PREFILL_COMM = re.compile(rf"prefill:\s*TP-AR.*?total\s+{_FLOAT}", re.IGNORECASE)
@@ -1075,51 +1160,51 @@ def _f(m) -> float | None:
 
 def parse_inference_metrics(stdout: str) -> dict[str, Any]:
     out: dict[str, Any] = {}
-    if (m := _RE_TTFT.search(stdout)):
+    if m := _RE_TTFT.search(stdout):
         out["ttft_ms"] = _f(m)
-    if (m := _RE_ITL.search(stdout)):
+    if m := _RE_ITL.search(stdout):
         out["itl_ms"] = _f(m)
-    if (m := _RE_REQ_LAT.search(stdout)):
+    if m := _RE_REQ_LAT.search(stdout):
         out["request_latency_ms"] = _f(m)
-    if (m := _RE_DEC_TPS.search(stdout)):
+    if m := _RE_DEC_TPS.search(stdout):
         out["decode_throughput_tps"] = _f(m)
-    if (m := _RE_DEC_TPS_GPU.search(stdout)):
+    if m := _RE_DEC_TPS_GPU.search(stdout):
         out["decode_throughput_tps_per_gpu"] = _f(m)
-    if (m := _RE_PREFILL_TPS.search(stdout)):
+    if m := _RE_PREFILL_TPS.search(stdout):
         out["prefill_throughput_tps"] = _f(m)
-    if (m := _RE_TOTAL_MEM.search(stdout)):
+    if m := _RE_TOTAL_MEM.search(stdout):
         out["memory_per_gpu_gb"] = _f(m)
-    if (m := _RE_KV.search(stdout)):
+    if m := _RE_KV.search(stdout):
         out["kv_cache_gb"] = _f(m)
-    if (m := _RE_MAXCONC.search(stdout)):
+    if m := _RE_MAXCONC.search(stdout):
         out["max_concurrent_sequences"] = int(m.group(1))
-    if (m := _RE_SUSTAINABLE.search(stdout)):
+    if m := _RE_SUSTAINABLE.search(stdout):
         out["max_sustainable_concurrency"] = int(m.group(1))
-    if (m := _RE_CONC_USED.search(stdout)):
+    if m := _RE_CONC_USED.search(stdout):
         out["concurrency_used"] = int(m.group(1))
-    if (m := _RE_TOTAL_TPS_GPU.search(stdout)):
+    if m := _RE_TOTAL_TPS_GPU.search(stdout):
         out["total_throughput_tps_per_gpu"] = _f(m)
-    if (m := _RE_REPLICA_GPUS.search(stdout)):
+    if m := _RE_REPLICA_GPUS.search(stdout):
         out["replica_gpus"] = int(m.group(1))
-    if (m := _RE_INTERACTIVITY.search(stdout)):
+    if m := _RE_INTERACTIVITY.search(stdout):
         out["interactivity_tok_s_per_user"] = _f(m)
-    if (m := _RE_PER_REQ_TPS.search(stdout)):
+    if m := _RE_PER_REQ_TPS.search(stdout):
         out["per_request_decode_tps"] = _f(m)
-    if (m := _RE_STEP_PURE.search(stdout)):
+    if m := _RE_STEP_PURE.search(stdout):
         out["decode_step_ms_pure"] = _f(m)
-    if (m := _RE_MIXED_FRAC.search(stdout)):
+    if m := _RE_MIXED_FRAC.search(stdout):
         out["mixed_step_fraction_pct"] = _f(m)
-    if (m := _RE_POLLUTION.search(stdout)):
+    if m := _RE_POLLUTION.search(stdout):
         out["tpot_pollution_pct"] = _f(m)
-    if (m := _RE_STEP_MIXED.search(stdout)):
+    if m := _RE_STEP_MIXED.search(stdout):
         out["decode_step_ms_mixed"] = _f(m)
-    if (m := _RE_WEIGHTS.search(stdout)):
+    if m := _RE_WEIGHTS.search(stdout):
         out["weights_gb"] = _f(m)
-    if (m := _RE_ACTIVATION.search(stdout)):
+    if m := _RE_ACTIVATION.search(stdout):
         out["activation_gb"] = _f(m)
-    if (m := _RE_PREFILL_COMM.search(stdout)):
+    if m := _RE_PREFILL_COMM.search(stdout):
         out["prefill_comm_ms"] = _f(m)
-    if (m := _RE_DECODE_COMM.search(stdout)):
+    if m := _RE_DECODE_COMM.search(stdout):
         out["decode_comm_ms"] = _f(m)
     # Per-GPU and fleet forms the projector prints only one side of. Ranking on
     # a fleet total rewards spending more GPUs, so both are kept and named.

--- a/infera/projection/agents/tuning_agent/legality.py
+++ b/infera/projection/agents/tuning_agent/legality.py
@@ -7,8 +7,8 @@ are rejected before reaching the projection tool.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from .config import TargetCluster
 from .workload import ArchitectureRecord
@@ -88,7 +88,7 @@ class TrialConfig:
         }
 
     @classmethod
-    def from_dict(cls, d: dict) -> "TrialConfig":
+    def from_dict(cls, d: dict) -> TrialConfig:
         def _opt_int(v):
             return int(v) if v not in (None, "null", "") else None
 
@@ -382,14 +382,16 @@ def validate(
         return False, f"derived DP={dp} (gpus_per_replica={gpus_per_replica})"
 
     if cfg.gbs % (cfg.mbs * dp) != 0:
-        return False, (f"GBS({cfg.gbs}) must be divisible by MBS({cfg.mbs}) × DP({dp}) = {cfg.mbs*dp}")
+        return False, (
+            f"GBS({cfg.gbs}) must be divisible by MBS({cfg.mbs}) × DP({dp}) = {cfg.mbs * dp}"
+        )
 
     # schedule × vpp coherence
     vpp_for_lookup = cfg.vpp or 1
     sched_set = legality.pp_schedules_by_vpp.get(vpp_for_lookup, ["auto"])
     if cfg.pp_schedule not in sched_set:
         return False, (
-            f"schedule '{cfg.pp_schedule}' not legal for VPP={vpp_for_lookup}; " f"legal: {sched_set}"
+            f"schedule '{cfg.pp_schedule}' not legal for VPP={vpp_for_lookup}; legal: {sched_set}"
         )
 
     if cfg.recompute_granularity not in (None, "none", "selective", "full"):

--- a/infera/projection/agents/tuning_agent/plan.py
+++ b/infera/projection/agents/tuning_agent/plan.py
@@ -55,7 +55,9 @@ class SeedPlan:
     rationale: str
 
 
-def build_seed_plan(arch: ArchitectureRecord, agent_cfg: AgentConfig, max_candidates: int = 12) -> SeedPlan:
+def build_seed_plan(
+    arch: ArchitectureRecord, agent_cfg: AgentConfig, max_candidates: int = 12
+) -> SeedPlan:
     """Generate the deterministic seed plan.
 
     Order of returned candidates (small ``--seed-budget`` runs the first N):
@@ -315,7 +317,15 @@ def build_seed_plan(arch: ArchitectureRecord, agent_cfg: AgentConfig, max_candid
             # Primary: match the workload's recompute knob (full + layer-id
             # count) to mirror the published reference as closely as possible.
             _push(
-                _make(btp, cand_pp, bep, bcp, bmbs, cand_vpp, recompute=arch.recompute_granularity or "full")
+                _make(
+                    btp,
+                    cand_pp,
+                    bep,
+                    bcp,
+                    bmbs,
+                    cand_vpp,
+                    recompute=arch.recompute_granularity or "full",
+                )
             )
 
         # Secondary: for the most-impactful (PP, VPP) pairs (those that match
@@ -336,7 +346,15 @@ def build_seed_plan(arch: ArchitectureRecord, agent_cfg: AgentConfig, max_candid
             # often dodges the v26.2 FP8 sub-node bench crash.
             if 1 != bmbs:
                 _push(
-                    _make(btp, cand_pp, bep, bcp, 1, cand_vpp, recompute=arch.recompute_granularity or "full")
+                    _make(
+                        btp,
+                        cand_pp,
+                        bep,
+                        bcp,
+                        1,
+                        cand_vpp,
+                        recompute=arch.recompute_granularity or "full",
+                    )
                 )
                 if _full():
                     break
@@ -366,7 +384,9 @@ def build_seed_plan(arch: ArchitectureRecord, agent_cfg: AgentConfig, max_candid
             moe_combos.append(("DeepEP", {"use_turbo_deepep": True}))
             # Then DeepEP + recompute=none — the highest-leverage achievable
             # combo on environments without TEGroupedMLP.
-            moe_combos.append(("DeepEP+recompute=none", {"use_turbo_deepep": True, "recompute": "none"}))
+            moe_combos.append(
+                ("DeepEP+recompute=none", {"use_turbo_deepep": True, "recompute": "none"})
+            )
         for _name, kw in moe_combos:
             _push(_make(btp, bp, bep, bcp, bmbs, bvpp, **kw))
             if _full():
@@ -380,7 +400,19 @@ def build_seed_plan(arch: ArchitectureRecord, agent_cfg: AgentConfig, max_candid
         if not _full():
             _push(_make(btp, bp, bep, bcp, bmbs, bvpp, fp8="hybrid", recompute="none"))
         if not _full() and arch.is_moe and not deepep_already_on:
-            _push(_make(btp, bp, bep, bcp, bmbs, bvpp, fp8="hybrid", use_turbo_deepep=True, recompute="none"))
+            _push(
+                _make(
+                    btp,
+                    bp,
+                    bep,
+                    bcp,
+                    bmbs,
+                    bvpp,
+                    fp8="hybrid",
+                    use_turbo_deepep=True,
+                    recompute="none",
+                )
+            )
 
     # ── 5. Combined-best Tier-A (DeepEP + SyncFree=3 + FP8 + recompute=none)
     # SyncFree=3 is best-case overlap per the skill but requires the
@@ -437,7 +469,11 @@ def build_seed_plan(arch: ArchitectureRecord, agent_cfg: AgentConfig, max_candid
     # ≤ gpus_per_node and divides num_layers). Common choice: 4 or 8.
     if bp == 1 and arch.num_layers:
         for cand in (8, 4, 2):
-            if cand in legality.pp and arch.num_layers % cand == 0 and cand not in schedule_pp_targets:
+            if (
+                cand in legality.pp
+                and arch.num_layers % cand == 0
+                and cand not in schedule_pp_targets
+            ):
                 schedule_pp_targets.append(cand)
                 break
     # Some workloads (notably DSv3 with 61 layers) encode interleaved staging
@@ -540,7 +576,9 @@ def build_seed_plan(arch: ArchitectureRecord, agent_cfg: AgentConfig, max_candid
 
     # ── 9. Coarse parallelism grid ────────────────────────────────────────
     if not _full():
-        for tp, pp, ep, cp, mbs, vpp in itertools.product(tp_set, pp_set, ep_set, cp_set, mbs_set, vpp_set):
+        for tp, pp, ep, cp, mbs, vpp in itertools.product(
+            tp_set, pp_set, ep_set, cp_set, mbs_set, vpp_set
+        ):
             if pp == 1 and vpp not in (None, 1):
                 continue
             _push(_make(tp, pp, ep, cp, mbs, vpp))

--- a/infera/projection/agents/tuning_agent/plotting.py
+++ b/infera/projection/agents/tuning_agent/plotting.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from .history import History
 
 
-def plot_history(history: History, out_path: Path, objective: str = "tokens_per_s_per_gpu") -> Path | None:
+def plot_history(
+    history: History, out_path: Path, objective: str = "tokens_per_s_per_gpu"
+) -> Path | None:
     try:
         import matplotlib
 

--- a/infera/projection/agents/tuning_agent/tools.py
+++ b/infera/projection/agents/tuning_agent/tools.py
@@ -22,8 +22,8 @@ Tools provided to the LLM:
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from datetime import datetime
-from typing import Callable
 
 from .config import AgentConfig
 from .evaluator import EvalResult, Evaluator
@@ -214,7 +214,8 @@ def build_tools(
                 "num_nodes": agent_cfg.target_cluster.num_nodes,
                 "gpus_per_node": agent_cfg.target_cluster.gpus_per_node,
                 "gpu_arch": agent_cfg.target_cluster.gpu_arch,
-                "world_size": agent_cfg.target_cluster.num_nodes * agent_cfg.target_cluster.gpus_per_node,
+                "world_size": agent_cfg.target_cluster.num_nodes
+                * agent_cfg.target_cluster.gpus_per_node,
                 "hbm_capacity_gb": agent_cfg.optimization.hbm_capacity_gb,
                 "memory_safety_margin": agent_cfg.optimization.memory_safety_margin,
                 "has_gpu_for_benchmark": agent_cfg.benchmark_host.has_gpu,

--- a/infera/projection/agents/tuning_agent/workload.py
+++ b/infera/projection/agents/tuning_agent/workload.py
@@ -204,7 +204,8 @@ def resolve_workload(workload_yaml: Path, config_root: Path | None = None) -> Ar
             model_path = candidate
         else:
             raise FileNotFoundError(
-                f"Could not find model YAML for '{model_filename}' " f"under {model_path} or {candidate}"
+                f"Could not find model YAML for '{model_filename}' "
+                f"under {model_path} or {candidate}"
             )
 
     model = _resolve_model_chain(model_path)
@@ -214,7 +215,9 @@ def resolve_workload(workload_yaml: Path, config_root: Path | None = None) -> Ar
 
     # precision: BF16 by default; FP8 if `fp8` block present at workload level
     precision = "bf16"
-    if any("fp8" in k.lower() for k in raw.keys()) or any("fp8" in k.lower() for k in overrides.keys()):
+    if any("fp8" in k.lower() for k in raw.keys()) or any(
+        "fp8" in k.lower() for k in overrides.keys()
+    ):
         precision = "fp8"
 
     return ArchitectureRecord(
@@ -242,14 +245,15 @@ def resolve_workload(workload_yaml: Path, config_root: Path | None = None) -> Ar
         # DeepSeek names its indexer ``index_topk``; the other sparse families
         # carry theirs as a serving-time property under its request name, so
         # both spellings are read and either one means "this model is sparse".
-        index_topk=int(model.get("index_topk")
-                       or model.get("sparse_attention_topk") or 0),
+        index_topk=int(model.get("index_topk") or model.get("sparse_attention_topk") or 0),
         moe_ffn_hidden_size=model.get("moe_ffn_hidden_size"),
         moe_shared_expert_intermediate_size=model.get("moe_shared_expert_intermediate_size"),
         vocab_size=model.get("padded_vocab_size") or model.get("vocab_size"),
         precision=precision,
         tensor_model_parallel_size=int(_strip_env(overrides.get("tensor_model_parallel_size", 1))),
-        pipeline_model_parallel_size=int(_strip_env(overrides.get("pipeline_model_parallel_size", 1))),
+        pipeline_model_parallel_size=int(
+            _strip_env(overrides.get("pipeline_model_parallel_size", 1))
+        ),
         expert_model_parallel_size=int(_strip_env(overrides.get("expert_model_parallel_size", 1))),
         context_parallel_size=int(_strip_env(overrides.get("context_parallel_size", 1))),
         # VPP can be set explicitly OR implied by ``pipeline_model_parallel_layout``

--- a/infera/projection/cli.py
+++ b/infera/projection/cli.py
@@ -23,7 +23,9 @@ Harvest a GPU-calibrated anchor (needs a ROCm GPU + vLLM), then project::
     python -m infera.projection anchor --model <hf-or-model-name> \
         --benchmark-gpus 1 --save anchor.json
 """
+
 import argparse
+import argparse as _argparse  # noqa: F401  (used by arg helpers)
 import sys
 
 from infera.projection.core.launcher.parser import add_pretrain_parser
@@ -31,7 +33,6 @@ from infera.projection.core.projection.inference_projection import (
     launch_projection_from_cli,
 )
 
-import argparse as _argparse  # noqa: F401  (used by arg helpers)
 
 def _add_pipeline_schedule_algorithm_arg(parser):
     parser.add_argument(
@@ -456,8 +457,7 @@ def _add_inference_args(parser):
         "--sampling-temperature",
         type=float,
         default=None,
-        help="Sampling temperature. !=1 adds a fused logits-scale pass. "
-        "Default: 1.0.",
+        help="Sampling temperature. !=1 adds a fused logits-scale pass. Default: 1.0.",
     )
     # ---- Runtime activation quantization / cast ----
     parser.add_argument(
@@ -602,11 +602,19 @@ def _add_inference_args(parser):
         action="store_true",
         help="Enable prefill/decode disaggregation (separate worker pools).",
     )
-    dis.add_argument("--prefill-tp", type=int, default=None, help="Prefill-pool tensor parallelism.")
-    dis.add_argument("--prefill-pp", type=int, default=None, help="Prefill-pool pipeline parallelism.")
-    dis.add_argument("--prefill-ep", type=int, default=None, help="Prefill-pool expert parallelism.")
+    dis.add_argument(
+        "--prefill-tp", type=int, default=None, help="Prefill-pool tensor parallelism."
+    )
+    dis.add_argument(
+        "--prefill-pp", type=int, default=None, help="Prefill-pool pipeline parallelism."
+    )
+    dis.add_argument(
+        "--prefill-ep", type=int, default=None, help="Prefill-pool expert parallelism."
+    )
     dis.add_argument("--decode-tp", type=int, default=None, help="Decode-pool tensor parallelism.")
-    dis.add_argument("--decode-pp", type=int, default=None, help="Decode-pool pipeline parallelism.")
+    dis.add_argument(
+        "--decode-pp", type=int, default=None, help="Decode-pool pipeline parallelism."
+    )
     dis.add_argument("--decode-ep", type=int, default=None, help="Decode-pool expert parallelism.")
     dis.add_argument(
         "--prefill-attention-dp",
@@ -739,46 +747,46 @@ def _add_inference_args(parser):
         type=float,
         default=None,
         help="Per-output-token host detokenization + streaming cost (us/token). Added to "
-             "ITL/TPOT and end-to-end latency only (not throughput), matching client-side "
-             "serving-harness ITL. Default 0.",
+        "ITL/TPOT and end-to-end latency only (not throughput), matching client-side "
+        "serving-harness ITL. Default 0.",
     )
     serv.add_argument(
         "--tokenize-overhead-us",
         type=float,
         default=None,
         help="Per-prompt-token host tokenization cost (us/token). The prompt is sent as text "
-             "and tokenized server-side after the TTFT clock starts, so it is added to TTFT "
-             "and end-to-end latency only (not throughput). Default 0.",
+        "and tokenized server-side after the TTFT clock starts, so it is added to TTFT "
+        "and end-to-end latency only (not throughput). Default 0.",
     )
     serv.add_argument(
         "--request-overhead-ms",
         type=float,
         default=None,
         help="Fixed per-request host cost on the TTFT path (ms): accept, parse, admit, "
-             "prefix-cache lookup, KV allocation, stream open. Constant in prompt length, "
-             "which is how it is measured -- difference TTFT across two prompt lengths at "
-             "concurrency 1 and take the intercept. Added to TTFT and end-to-end latency "
-             "only (not throughput). A property of the serving stack, so it has no default "
-             "worth guessing. Default 0.",
+        "prefix-cache lookup, KV allocation, stream open. Constant in prompt length, "
+        "which is how it is measured -- difference TTFT across two prompt lengths at "
+        "concurrency 1 and take the intercept. Added to TTFT and end-to-end latency "
+        "only (not throughput). A property of the serving stack, so it has no default "
+        "worth guessing. Default 0.",
     )
     serv.add_argument(
         "--prefill-rate-us-per-token",
         type=float,
         default=None,
         help="Measured prefill rate (us of TTFT per prompt token): the per-token slope from "
-             "the same concurrency-1 differencing that yields --request-overhead-ms. Used as a "
-             "level anchor, not as the cost -- the projector takes its own slope over the same "
-             "two lengths and scales modelled prefill compute by the ratio, so prefill keeps "
-             "its superlinear growth in context. Requires --prefill-rate-lo-tokens and "
-             "--prefill-rate-hi-tokens. Ignored in benchmark mode, which already prices "
-             "prefill from measured kernels. Default 0 (unanchored).",
+        "the same concurrency-1 differencing that yields --request-overhead-ms. Used as a "
+        "level anchor, not as the cost -- the projector takes its own slope over the same "
+        "two lengths and scales modelled prefill compute by the ratio, so prefill keeps "
+        "its superlinear growth in context. Requires --prefill-rate-lo-tokens and "
+        "--prefill-rate-hi-tokens. Ignored in benchmark mode, which already prices "
+        "prefill from measured kernels. Default 0 (unanchored).",
     )
     serv.add_argument(
         "--prefill-rate-lo-tokens",
         type=int,
         default=None,
         help="Shorter of the two prompt lengths --prefill-rate-us-per-token was fit over. "
-             "A rate is meaningless without the span it was measured on.",
+        "A rate is meaningless without the span it was measured on.",
     )
     serv.add_argument(
         "--prefill-rate-hi-tokens",
@@ -791,16 +799,16 @@ def _add_inference_args(parser):
         type=int,
         default=None,
         help="Output tokens buffered per streaming flush (vLLM/SGLang --stream-interval). "
-             "The client's first token, and so the measured TTFT, arrives only after this "
-             "many tokens are decoded. Default 1 (flush every token).",
+        "The client's first token, and so the measured TTFT, arrives only after this "
+        "many tokens are decoded. Default 1 (flush every token).",
     )
     serv.add_argument(
         "--decode-admission-steps",
         type=int,
         default=None,
         help="Decode-scheduler admission granularity in decode steps, i.e. "
-             "--num-continuous-decode-steps x --scheduler-recv-interval. A prefilled request "
-             "waits part of this window before joining the running batch; TTFT-only. Default 0.",
+        "--num-continuous-decode-steps x --scheduler-recv-interval. A prefilled request "
+        "waits part of this window before joining the running batch; TTFT-only. Default 0.",
     )
     serv.add_argument(
         "--mixed-batch-penalty",
@@ -1092,7 +1100,7 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_parser(
         "anchor",
         help="Harvest a GPU-calibrated anchor via the vLLM benchmark harness "
-             "(`inferasim anchor --help` lists its flags).",
+        "(`inferasim anchor --help` lists its flags).",
         add_help=False,
     )
     return parser
@@ -1109,6 +1117,7 @@ def main(argv=None):
         from infera.projection.core.projection.inference_projection import (
             benchmark_vllm,
         )
+
         return benchmark_vllm.main(argv[1:])
 
     parser = build_parser()

--- a/infera/projection/core/config/merge_utils.py
+++ b/infera/projection/core/config/merge_utils.py
@@ -5,10 +5,10 @@
 ###############################################################################
 
 import copy
-from typing import Any, Dict
+from typing import Any
 
 
-def deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
     """
     Recursively merge two dictionaries.
 
@@ -39,7 +39,7 @@ def deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]
     return result
 
 
-def shallow_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+def shallow_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
     """
     Shallow merge:
       - Only top-level keys

--- a/infera/projection/core/config/preset_loader.py
+++ b/infera/projection/core/config/preset_loader.py
@@ -5,7 +5,6 @@
 ###############################################################################
 
 import os
-from typing import Dict
 
 from infera.projection.configs import models as MODELS_ROOT
 from infera.projection.core.config.merge_utils import deep_merge
@@ -21,7 +20,7 @@ class PresetLoader:
     """
 
     @staticmethod
-    def load(name: str, framework: str, config_type: str = "models") -> Dict:
+    def load(name: str, framework: str, config_type: str = "models") -> dict:
         """
         Load:
             configs/<config_type>/<framework>/<name>[.yaml]
@@ -48,7 +47,9 @@ class PresetLoader:
         abs_preset_path = os.path.abspath(preset_path)
         abs_configs_root = os.path.abspath(configs_root)
         if os.path.commonpath([abs_preset_path, abs_configs_root]) != abs_configs_root:
-            raise ValueError(f"[inferasim] Invalid preset path: path traversal detected for '{preset_path}'.")
+            raise ValueError(
+                f"[inferasim] Invalid preset path: path traversal detected for '{preset_path}'."
+            )
 
         if not os.path.exists(abs_preset_path):
             raise FileNotFoundError(
@@ -61,7 +62,7 @@ class PresetLoader:
         return preset
 
     @staticmethod
-    def merge_with_user_params(preset: Dict, params: Dict) -> Dict:
+    def merge_with_user_params(preset: dict, params: dict) -> dict:
         """
         Combine:
             - model preset (base)

--- a/infera/projection/core/config/yaml_loader.py
+++ b/infera/projection/core/config/yaml_loader.py
@@ -30,7 +30,7 @@ def parse_yaml(path: str) -> dict:
 # 1. Load YAML
 # ================================================================
 def _load_yaml(path: str):
-    with open(path, "r") as f:
+    with open(path) as f:
         return yaml.load(f, Loader=yaml.SafeLoader)
 
 

--- a/infera/projection/core/launcher/config.py
+++ b/infera/projection/core/launcher/config.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 from infera.projection.core.utils import file_utils, yaml_utils
 
 
-class InferaSimConfig(object):
+class InferaSimConfig:
     def __init__(self, cli_args: argparse.Namespace, exp: SimpleNamespace):
         self._cli_args = cli_args
         self._exp = exp
@@ -69,7 +69,9 @@ class InferaSimConfig(object):
             if alias is not None and yaml_utils.has_key_in_namespace(self._exp.modules, alias):
                 module_name = alias
             else:
-                raise ValueError(f"Config ({self._exp.config_file}) has no module named {module_name}")
+                raise ValueError(
+                    f"Config ({self._exp.config_file}) has no module named {module_name}"
+                )
         module_config = yaml_utils.get_value_by_key(self._exp.modules, module_name)
         return module_config
 

--- a/infera/projection/core/launcher/parser.py
+++ b/infera/projection/core/launcher/parser.py
@@ -4,7 +4,7 @@ import argparse
 import os
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 from infera.projection.core.config.preset_loader import PresetLoader
 from infera.projection.core.launcher.config import InferaSimConfig
@@ -64,7 +64,9 @@ def add_posttrain_parser(parser: argparse.ArgumentParser):
     return add_pretrain_parser(parser)
 
 
-def _parse_args(extra_args_provider=None, ignore_unknown_args=False) -> Tuple[argparse.Namespace, List[str]]:
+def _parse_args(
+    extra_args_provider=None, ignore_unknown_args=False
+) -> tuple[argparse.Namespace, list[str]]:
     parser = argparse.ArgumentParser(description="InferaSim Arguments", allow_abbrev=False)
     parser = _add_common_train_args(parser, include_data_path=False)
 
@@ -97,13 +99,13 @@ def _check_keys_exist(ns: SimpleNamespace, overrides: dict, prefix=""):
         assert hasattr(ns, k), f"Override key '{full_key}' does not exist in pre_trainer config."
         attr_val = getattr(ns, k)
         if isinstance(v, dict):
-            assert isinstance(
-                attr_val, SimpleNamespace
-            ), f"Override key '{full_key}' expects a namespace/dict but got {type(attr_val)}"
+            assert isinstance(attr_val, SimpleNamespace), (
+                f"Override key '{full_key}' expects a namespace/dict but got {type(attr_val)}"
+            )
             _check_keys_exist(attr_val, v, prefix=full_key)
 
 
-def _split_known_unknown(ns: SimpleNamespace, overrides: dict) -> Tuple[dict, dict]:
+def _split_known_unknown(ns: SimpleNamespace, overrides: dict) -> tuple[dict, dict]:
     """
     Split overrides into two dictionaries:
       - known: keys that exist in the namespace
@@ -141,7 +143,7 @@ def parse_args(extra_args_provider=None, ignore_unknown_args=False):
     return config
 
 
-def _load_config(args: argparse.Namespace, overrides: List[str]) -> Tuple[Any, Dict[str, Any]]:
+def _load_config(args: argparse.Namespace, overrides: list[str]) -> tuple[Any, dict[str, Any]]:
     """
     Build the configuration with optional command-line overrides.
 
@@ -173,12 +175,12 @@ def _load_config(args: argparse.Namespace, overrides: List[str]) -> Tuple[Any, D
     return config, unknown_overrides
 
 
-def load_config(args: argparse.Namespace, overrides: List[str]) -> Tuple[Any, Dict[str, Any]]:
+def load_config(args: argparse.Namespace, overrides: list[str]) -> tuple[Any, dict[str, Any]]:
     """Parse the experiment config and apply CLI overrides."""
     return _load_config(args, overrides)
 
 
-class InferaSimParser(object):
+class InferaSimParser:
     def __init__(self):
         pass
 
@@ -292,7 +294,9 @@ class InferaSimParser(object):
         #     delattr(model_config, "model")
 
         # ---- Merge: config + model ----
-        yaml_utils.merge_namespace(module_config, model_config, allow_override=False, excepts=["name"])
+        yaml_utils.merge_namespace(
+            module_config, model_config, allow_override=False, excepts=["name"]
+        )
 
         # ---- Apply overrides if present ----
         if yaml_utils.has_key_in_namespace(module, "overrides"):
@@ -300,7 +304,9 @@ class InferaSimParser(object):
 
         # ---- Flatten and save back ----
         module_config.name = module_name
-        yaml_utils.set_value_by_key(self.exp.modules, module_name, module_config, allow_override=True)
+        yaml_utils.set_value_by_key(
+            self.exp.modules, module_name, module_config, allow_override=True
+        )
 
     def parse_modules(self):
         yaml_utils.check_key_in_namespace(self.exp, "modules")

--- a/infera/projection/core/projection/base_module_profiler.py
+++ b/infera/projection/core/projection/base_module_profiler.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from typing import Optional
 
 ###############################################################################
 # Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
@@ -8,9 +7,14 @@ from typing import Optional
 ###############################################################################
 
 
-class BaseModuleProfiler(ABC):
+class BaseModuleProfiler(ABC):  # noqa: B024 -- see below
     """Abstract base class for transformer-like module profiler.
     Provides both estimated and measured statistics.
+
+    The hooks below are deliberately concrete and raise ``NotImplementedError``
+    rather than being ``@abstractmethod``: a profiler is expected to implement
+    only the axes it can model (params, memory, or performance), and marking
+    them abstract would make every partial profiler uninstantiable.
     """
 
     def __init__(self, config, sub_profilers=None):
@@ -18,7 +22,7 @@ class BaseModuleProfiler(ABC):
         self.sub_profilers = sub_profilers
 
     # -------- Parameter related --------
-    def estimated_num_params(self, rank: Optional[int] = None) -> int:
+    def estimated_num_params(self, rank: int | None = None) -> int:
         """Return estimated parameter count (based on formula).
         If rank is provided, return the parameter count for the given rank,
         otherwise return the total parameter count for the entire model.

--- a/infera/projection/core/projection/config_validation.py
+++ b/infera/projection/core/projection/config_validation.py
@@ -14,7 +14,7 @@ memory projections and poor runtime memory behavior.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from infera.projection.core.projection.training_config import ModelParallelConfig, TrainingConfig
 
@@ -73,8 +73,8 @@ def recompute_is_enabled(
 
 def resolve_pipeline_schedule(
     *,
-    pipeline_schedule_algorithm: Optional[str] = None,
-    pp_algorithm: Optional[str] = None,
+    pipeline_schedule_algorithm: str | None = None,
+    pp_algorithm: str | None = None,
     enable_zero_bubble: bool = False,
 ) -> str:
     """Effective schedule name for validation (CLI overrides YAML)."""
@@ -98,12 +98,12 @@ def uses_split_wgrad_schedule(schedule: str, *, enable_zero_bubble: bool = False
 
 def check_recompute_pipeline_compat(
     *,
-    recompute_granularity: Optional[str] = None,
+    recompute_granularity: str | None = None,
     recompute_num_layers: int = 0,
-    recompute_layer_ids: Optional[list] = None,
+    recompute_layer_ids: list | None = None,
     pipeline_schedule: str = "auto",
-    pp_algorithm: Optional[str] = None,
-    enable_zero_bubble: Optional[bool] = None,
+    pp_algorithm: str | None = None,
+    enable_zero_bubble: bool | None = None,
 ) -> tuple[bool, str]:
     """Return (ok, reason). Used by the tuning agent before launching projection."""
     granularity = recompute_granularity
@@ -134,7 +134,7 @@ def assert_recompute_pipeline_compat(
     training_config: TrainingConfig,
     *,
     config: Any = None,
-    pipeline_schedule_algorithm: Optional[str] = None,
+    pipeline_schedule_algorithm: str | None = None,
 ) -> None:
     """Raise AssertionError when recompute + split-wgrad schedule are combined."""
     mp = training_config.model_parallel_config

--- a/infera/projection/core/projection/inference_projection/benchmark.py
+++ b/infera/projection/core/projection/inference_projection/benchmark.py
@@ -25,9 +25,7 @@ import tempfile
 
 def _resolve_bench_model(args) -> str:
     """Which checkpoint to serve while measuring."""
-    model = getattr(args, "bench_model", None) or os.environ.get(
-        "INFERASIM_BENCH_MODEL"
-    )
+    model = getattr(args, "bench_model", None) or os.environ.get("INFERASIM_BENCH_MODEL")
     if model:
         return model
     # INFERASIM_MODEL carries a preset spelling ("gpt_oss_120B") for matching
@@ -59,34 +57,43 @@ def spawn_inference_benchmark(args, inference_config):
     ep = max(1, int(getattr(mp, "expert_model_parallel_size", 1) or 1))
 
     argv = [
-        "--model", _resolve_bench_model(args),
-        "--save", str(save),
-        "--tp", str(max(tp, ep)),
-        "--pp", str(int(getattr(mp, "pipeline_model_parallel_size", 1) or 1)),
-        "--input-len", str(int(req.input_seq_len)),
-        "--output-len", str(int(req.output_seq_len)),
+        "--model",
+        _resolve_bench_model(args),
+        "--save",
+        str(save),
+        "--tp",
+        str(max(tp, ep)),
+        "--pp",
+        str(int(getattr(mp, "pipeline_model_parallel_size", 1) or 1)),
+        "--input-len",
+        str(int(req.input_seq_len)),
+        "--output-len",
+        str(int(req.output_seq_len)),
         # --concurrency, not --batch: it sweeps the engine's own CUDA-graph
         # capture ladder up to this batch and characterises decode against
         # context in the same engine build. A single batch point would leave the
         # projector holding one measurement flat across both axes, which is
         # wrong for anything asking off the measured point -- a load sweep, the
         # tuning agent, or a longer context.
-        "--concurrency", str(int(req.max_concurrency or req.batch_size or 1)),
+        "--concurrency",
+        str(int(req.max_concurrency or req.batch_size or 1)),
     ]
     # Which engine measures. The harness launches all three through the same
     # adapters the platform serves with, so this decides whose kernels the
     # anchor describes -- and it is what makes an architecture measurable at
     # all when the default engine's build cannot load it.
-    backend = (getattr(args, "bench_serving_backend", None)
-               or os.environ.get("INFERASIM_BENCH_SERVING_BACKEND"))
+    backend = getattr(args, "bench_serving_backend", None) or os.environ.get(
+        "INFERASIM_BENCH_SERVING_BACKEND"
+    )
     if backend:
         argv += ["--serving-backend", str(backend)]
     # Flags the checkpoint needs before it will load at all -- a remote-code
     # architecture, a non-default attention backend. Without a way through,
     # such a model is unmeasurable for a reason that has nothing to do with
     # its performance.
-    server_args = (getattr(args, "bench_server_args", None)
-                   or os.environ.get("INFERASIM_BENCH_SERVER_ARGS"))
+    server_args = getattr(args, "bench_server_args", None) or os.environ.get(
+        "INFERASIM_BENCH_SERVER_ARGS"
+    )
     if server_args:
         # "=" form: the value is itself a flag string, which argparse would
         # otherwise read as the next option rather than as this one's argument.

--- a/infera/projection/core/projection/inference_projection/benchmark_serving.py
+++ b/infera/projection/core/projection/inference_projection/benchmark_serving.py
@@ -63,6 +63,7 @@ import time
 _ATTENTION_RE = re.compile(r"Overriding with ([A-Z0-9_]+)|Using ([A-Z0-9_]+) backend")
 _MOE_RE = re.compile(r"Using '([A-Za-z0-9_]+)' Mxfp4 MoE backend")
 
+
 def resolved_kernels(log_text: str) -> dict:
     """The attention and MoE backends vLLM actually chose, from its own log.
 
@@ -118,8 +119,16 @@ def _engine_argv(args, port: int, tp: int) -> list[str]:
     shared. Caller flags come last so they win over anything derived here.
     """
     if args.serving_backend == "sglang":
-        argv = ["--model-path", args.model, "--host", "127.0.0.1",
-                "--port", str(port), "--tp", str(tp)]
+        argv = [
+            "--model-path",
+            args.model,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--tp",
+            str(tp),
+        ]
         if args.max_model_len:
             argv += ["--context-length", str(args.max_model_len)]
         if args.enable_expert_parallel:
@@ -131,9 +140,18 @@ def _engine_argv(args, port: int, tp: int) -> list[str]:
         # the torch-distributed MASTER_PORT, so the HTTP listener the client
         # and the health probe use is --server-port. Sharing one number here
         # would collide the rendezvous with the API.
-        argv = ["--model", args.model, "--host", "127.0.0.1",
-                "--server-port", str(port), "--port", str(_free_port()),
-                "--tensor-parallel-size", str(tp)]
+        argv = [
+            "--model",
+            args.model,
+            "--host",
+            "127.0.0.1",
+            "--server-port",
+            str(port),
+            "--port",
+            str(_free_port()),
+            "--tensor-parallel-size",
+            str(tp),
+        ]
         if args.max_model_len:
             argv += ["--max-model-len", str(args.max_model_len)]
         if args.enable_expert_parallel:
@@ -141,8 +159,15 @@ def _engine_argv(args, port: int, tp: int) -> list[str]:
         if args.enforce_eager:
             argv += ["--enforce-eager"]
     else:
-        argv = [args.model, "--host", "127.0.0.1", "--port", str(port),
-                "--tensor-parallel-size", str(tp)]
+        argv = [
+            args.model,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--tensor-parallel-size",
+            str(tp),
+        ]
         if args.max_model_len:
             argv += ["--max-model-len", str(args.max_model_len)]
         if args.enable_expert_parallel:
@@ -177,16 +202,23 @@ def _build_engine(args, argv: list[str], port: int, tp: int):
     if args.serving_backend == "atom":
         from infera.engine.atom.worker import AtomEngine
 
-        return AtomEngine(atom_argv=argv, model_name=args.model,
-                          host="127.0.0.1", port=port)
+        return AtomEngine(atom_argv=argv, model_name=args.model, host="127.0.0.1", port=port)
     from infera.engine.vllm.worker import VllmEngine
 
-    return VllmEngine(vllm_argv=argv, model_name=args.model,
-                      host="127.0.0.1", port=port)
+    return VllmEngine(vllm_argv=argv, model_name=args.model, host="127.0.0.1", port=port)
 
 
-def _run_client(port: int, args, out_dir: str, tag: str, *, batch: int,
-                input_len: int, output_len: int, num_prompts: int) -> dict:
+def _run_client(
+    port: int,
+    args,
+    out_dir: str,
+    tag: str,
+    *,
+    batch: int,
+    input_len: int,
+    output_len: int,
+    num_prompts: int,
+) -> dict:
     """One closed-loop client run against the live server; its whole result."""
     result = os.path.join(out_dir, f"bench_{tag}.json")
     kind = client_kind(args)
@@ -195,30 +227,67 @@ def _run_client(port: int, args, out_dir: str, tag: str, *, batch: int,
         # plain OpenAI completions route rather than vLLM's own.
         client = "vllm" if args.serving_backend == "vllm" else "openai"
         cmd = [
-            "vllm", "bench", "serve", "--backend", client, "--model", args.model,
-            "--host", "127.0.0.1", "--port", str(port), "--endpoint", "/v1/completions",
-            "--dataset-name", "random",
-            "--random-input-len", str(input_len),
-            "--random-output-len", str(output_len),
-            "--num-prompts", str(num_prompts), "--max-concurrency", str(batch),
-            "--ignore-eos", "--percentile-metrics", "ttft,tpot,itl,e2el",
-            "--save-result", "--result-filename", result,
+            "vllm",
+            "bench",
+            "serve",
+            "--backend",
+            client,
+            "--model",
+            args.model,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--endpoint",
+            "/v1/completions",
+            "--dataset-name",
+            "random",
+            "--random-input-len",
+            str(input_len),
+            "--random-output-len",
+            str(output_len),
+            "--num-prompts",
+            str(num_prompts),
+            "--max-concurrency",
+            str(batch),
+            "--ignore-eos",
+            "--percentile-metrics",
+            "ttft,tpot,itl,e2el",
+            "--save-result",
+            "--result-filename",
+            result,
         ]
     else:
         cmd = [
-            sys.executable, "-m", "sglang.bench_serving",
-            "--backend", "sglang-oai", "--model", args.model,
-            "--host", "127.0.0.1", "--port", str(port),
-            "--dataset-name", "random",
-            "--random-input-len", str(input_len),
-            "--random-output-len", str(output_len),
+            sys.executable,
+            "-m",
+            "sglang.bench_serving",
+            "--backend",
+            "sglang-oai",
+            "--model",
+            args.model,
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--dataset-name",
+            "random",
+            "--random-input-len",
+            str(input_len),
+            "--random-output-len",
+            str(output_len),
             # Exact lengths, not a sampled band. The anchor prices one prompt
             # length and one output length; left at its default this client
             # samples below both, and the TPOT it reported would belong to a
             # mixture of shapes rather than to the shape recorded beside it.
-            "--random-range-ratio", "1.0",
-            "--num-prompts", str(num_prompts), "--max-concurrency", str(batch),
-            "--output-file", result,
+            "--random-range-ratio",
+            "1.0",
+            "--num-prompts",
+            str(num_prompts),
+            "--max-concurrency",
+            str(batch),
+            "--output-file",
+            result,
         ]
         # This client appends, so a stale file from an earlier harvest at the
         # same tag would leave its last line -- another run's numbers -- as the
@@ -273,9 +342,16 @@ def _measure_concurrency(port: int, batch: int, args, out_dir: str) -> float:
     """Mean TPOT in ms at ``batch`` concurrent requests -- the decode step."""
     # Three waves is enough for the anchor concurrencies: re-running c128 with
     # ten waves and varied lengths moved TPOT by 5%, and c<=32 by less.
-    doc = _run_client(port, args, out_dir, f"c{batch}", batch=batch,
-                      input_len=args.input_len, output_len=args.output_len,
-                      num_prompts=max(24, batch * 3))
+    doc = _run_client(
+        port,
+        args,
+        out_dir,
+        f"c{batch}",
+        batch=batch,
+        input_len=args.input_len,
+        output_len=args.output_len,
+        num_prompts=max(24, batch * 3),
+    )
     return float(doc["mean_tpot_ms"])
 
 
@@ -331,19 +407,30 @@ def prefill_rate_ms_per_token(port: int, args, out_dir: str) -> tuple:
     lengths = prefill_probe_lengths(args)
     pts = []
     for length in lengths:
-        doc = _run_client(port, args, out_dir, f"prefill_L{length}", batch=1,
-                          input_len=length, output_len=_PREFILL_PROBE_OUTPUT_LEN,
-                          num_prompts=_PREFILL_PROBE_PROMPTS)
+        doc = _run_client(
+            port,
+            args,
+            out_dir,
+            f"prefill_L{length}",
+            batch=1,
+            input_len=length,
+            output_len=_PREFILL_PROBE_OUTPUT_LEN,
+            num_prompts=_PREFILL_PROBE_PROMPTS,
+        )
         ttft = float(doc["mean_ttft_ms"])
         pts.append((length, ttft))
-        print(f"[inferasim:Inference:Serving] prefill probe L={length} "
-              f"TTFT={ttft:.2f}ms")
+        print(f"[inferasim:Inference:Serving] prefill probe L={length} TTFT={ttft:.2f}ms")
 
     # Every adjacent pair is its own estimate of the slope; consistency between
     # them is the evidence that the cancelled terms really were constant.
-    pairwise = [{"from": pts[i][0], "to": pts[i + 1][0],
-                 "ms_per_token": (pts[i + 1][1] - pts[i][1]) / (pts[i + 1][0] - pts[i][0])}
-                for i in range(len(pts) - 1)]
+    pairwise = [
+        {
+            "from": pts[i][0],
+            "to": pts[i + 1][0],
+            "ms_per_token": (pts[i + 1][1] - pts[i][1]) / (pts[i + 1][0] - pts[i][0]),
+        }
+        for i in range(len(pts) - 1)
+    ]
     # Least squares over all points; identical to the lone difference when there
     # are only two, and a better estimate than any single pair when there are more.
     n = len(pts)
@@ -370,14 +457,18 @@ def prefill_rate_ms_per_token(port: int, args, out_dir: str) -> tuple:
         spread = max(rates) / min(rates)
         diag["pairwise_spread"] = spread
         if spread > 1.25:
-            print(f"[inferasim:Inference:Serving] WARNING: prefill probes "
-                  f"disagree by {spread:.2f}x across length ({rates}); the "
-                  f"prompt curve is not linear over this range, so the anchor "
-                  f"is a chord through it rather than a rate.")
+            print(
+                f"[inferasim:Inference:Serving] WARNING: prefill probes "
+                f"disagree by {spread:.2f}x across length ({rates}); the "
+                f"prompt curve is not linear over this range, so the anchor "
+                f"is a chord through it rather than a rate."
+            )
     if rate <= 0:
-        print("[inferasim:Inference:Serving] WARNING: prefill slope did not "
-              "resolve (non-increasing TTFT across length); leaving prefill "
-              "simulated.")
+        print(
+            "[inferasim:Inference:Serving] WARNING: prefill slope did not "
+            "resolve (non-increasing TTFT across length); leaving prefill "
+            "simulated."
+        )
         return 0.0, diag
     return rate, diag
 
@@ -387,15 +478,23 @@ def run_serving_benchmark(args) -> dict:
     # Package import; falls back to the flat form when this is run as a script,
     # which is how Hyperloom invokes it.
     try:
-        from .benchmark_vllm import (_capture_batches_up_to,
-                                     _default_capture_sizes, _regime_env,
-                                     _resolved_weight_dtype, _server_arg_value,
-                                     warmup_gpu_count)
+        from .benchmark_vllm import (
+            _capture_batches_up_to,
+            _default_capture_sizes,
+            _regime_env,
+            _resolved_weight_dtype,
+            _server_arg_value,
+            warmup_gpu_count,
+        )
     except ImportError:
-        from benchmark_vllm import (_capture_batches_up_to,  # type: ignore
-                                    _default_capture_sizes, _regime_env,
-                                    _resolved_weight_dtype, _server_arg_value,
-                                    warmup_gpu_count)
+        from benchmark_vllm import (
+            _capture_batches_up_to,  # type: ignore
+            _default_capture_sizes,
+            _regime_env,
+            _resolved_weight_dtype,
+            _server_arg_value,
+            warmup_gpu_count,
+        )
 
     # Resolved before anything is launched. A missing load generator makes the
     # run pointless, and finding that out after the weights are resident costs
@@ -416,8 +515,10 @@ def run_serving_benchmark(args) -> dict:
     capture_sizes = _default_capture_sizes(concurrency) if concurrency else None
     if concurrency:
         batches = _capture_batches_up_to(capture_sizes, concurrency)
-        print(f"[inferasim:Inference:Serving] concurrency={concurrency} -> "
-              f"capture-size batches {batches}")
+        print(
+            f"[inferasim:Inference:Serving] concurrency={concurrency} -> "
+            f"capture-size batches {batches}"
+        )
     elif args.batches:
         batches = [int(b) for b in args.batches.split(",") if b]
     else:
@@ -428,8 +529,10 @@ def run_serving_benchmark(args) -> dict:
 
     out_dir = tempfile.mkdtemp(prefix="inferasim_serving_")
     log_path = os.path.join(out_dir, "server.log")
-    print(f"[inferasim:Inference:Serving] {args.serving_backend} "
-          f"{' '.join(shlex.quote(c) for c in argv)}")
+    print(
+        f"[inferasim:Inference:Serving] {args.serving_backend} "
+        f"{' '.join(shlex.quote(c) for c in argv)}"
+    )
     started = time.time()
     try:
         with _capture_engine_output(log_path):
@@ -438,19 +541,18 @@ def run_serving_benchmark(args) -> dict:
         # The adapter tears down its own process group on a failed start; this
         # only makes sure a half-started engine cannot keep holding the GPUs.
         asyncio.run(engine.stop())
-        raise RuntimeError(
-            f"{args.serving_backend} did not come up; see {log_path}"
-        ) from exc
+        raise RuntimeError(f"{args.serving_backend} did not come up; see {log_path}") from exc
     boot_s = time.time() - started
     print(f"[inferasim:Inference:Serving] ready in {boot_s:.0f}s")
     try:
         client_started = time.time()
-        sweep = [{"batch": b,
-                  "decode_ms": _measure_concurrency(port, b, args, out_dir)}
-                 for b in batches]
+        sweep = [
+            {"batch": b, "decode_ms": _measure_concurrency(port, b, args, out_dir)} for b in batches
+        ]
         prefill_rate, prefill_diag = (
             prefill_rate_ms_per_token(port, args, out_dir)
-            if getattr(args, "prefill_anchor", False) else (0.0, None)
+            if getattr(args, "prefill_anchor", False)
+            else (0.0, None)
         )
         client_s = time.time() - client_started
     finally:
@@ -482,8 +584,7 @@ def run_serving_benchmark(args) -> dict:
         # None under --no-prefill-anchor or when the slope did not resolve. A
         # raw TTFT is not an invertible prefill observable, and is never
         # inverted here.
-        "measured": {"model": {"prefill_ms": ref.get("prefill_ms"),
-                               "decode_ms": ref["decode_ms"]}},
+        "measured": {"model": {"prefill_ms": ref.get("prefill_ms"), "decode_ms": ref["decode_ms"]}},
         "sweep": sweep,
         "meta": {
             "batch": ref["batch"],
@@ -503,18 +604,18 @@ def run_serving_benchmark(args) -> dict:
             "use_aiter": os.environ.get("VLLM_ROCM_USE_AITER", "0") == "1",
             "server_args": args.server_args or None,
             "env_overrides": dict(kv.split("=", 1) for kv in args.env or []) or None,
-            "attention_backend": _server_arg_value(args.server_args or "",
-                                                   "--attention-backend"),
+            "attention_backend": _server_arg_value(args.server_args or "", "--attention-backend"),
             "load_format": "auto",
             "real_weights": True,
             "model": args.model,
             # What this anchor cost, so its own artifact carries the accounting.
             "boot_s": round(boot_s, 1),
             "anchor_client_s": round(client_s, 1),
-            "derived_from": ("serving benchmark (mean TPOT; prefill by TTFT "
-                             "difference across prompt lengths)"
-                             if prefill_rate > 0
-                             else "serving benchmark (mean TPOT)"),
+            "derived_from": (
+                "serving benchmark (mean TPOT; prefill by TTFT difference across prompt lengths)"
+                if prefill_rate > 0
+                else "serving benchmark (mean TPOT)"
+            ),
             "prefill_anchor": prefill_diag,
             # Capture-size sweep mode: the projector pads decode UP to the
             # nearest measured size instead of interpolating.
@@ -530,7 +631,8 @@ def run_serving_benchmark(args) -> dict:
             from .search.regime import recipe_from_bench_args, regime_signature
         except ImportError:
             from search.regime import (  # type: ignore
-                recipe_from_bench_args, regime_signature,
+                recipe_from_bench_args,
+                regime_signature,
             )
         artifact["meta"]["regime_signature"] = regime_signature(
             recipe_from_bench_args(args, _regime_env())

--- a/infera/projection/core/projection/inference_projection/benchmark_vllm.py
+++ b/infera/projection/core/projection/inference_projection/benchmark_vllm.py
@@ -65,7 +65,6 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import math
 import os
 import shlex
 import statistics
@@ -80,10 +79,17 @@ try:  # pragma: no cover - import shim for in-container script execution
     sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
     from search.regime import (  # type: ignore
         aiter_ops_axis as _regime_aiter_ops,
+    )
+    from search.regime import (
         config_key as _regime_config_key,
+    )
+    from search.regime import (
         recipe_from_bench_args as _regime_recipe_from_bench_args,
+    )
+    from search.regime import (
         regime_signature as _regime_signature,
     )
+
     _HAVE_REGIME = True
 except Exception:  # noqa: BLE001 - any import failure => inline fallback
     _HAVE_REGIME = False
@@ -103,7 +109,7 @@ except Exception:  # noqa: BLE001 - any import failure => inline fallback
 
 
 def _harmonic(num_experts: int, s: float) -> float:
-    return sum(1.0 / (r ** s) for r in range(1, int(num_experts) + 1))
+    return sum(1.0 / (r**s) for r in range(1, int(num_experts) + 1))
 
 
 def _imbalance_for_s(num_experts: int, s: float) -> float:
@@ -174,8 +180,13 @@ def _num_experts(model: str, trust_remote_code: bool) -> int:
         cfg = AutoConfig.from_pretrained(model, trust_remote_code=trust_remote_code)
     except Exception:
         return 0
-    for attr in ("num_local_experts", "n_routed_experts", "num_experts",
-                 "moe_num_experts", "num_experts_per_tok"):
+    for attr in (
+        "num_local_experts",
+        "n_routed_experts",
+        "num_experts",
+        "moe_num_experts",
+        "num_experts_per_tok",
+    ):
         v = getattr(cfg, attr, None)
         if isinstance(v, int) and v > 1 and attr != "num_experts_per_tok":
             return v
@@ -254,9 +265,9 @@ _ZIPF_MARKER = "INFERASIM_ZIPF_ROUTING"
 # Bump when the injected strategy changes; the installer replaces older blocks.
 _ZIPF_VERSION = "v2-pooled"
 
-_ZIPF_PATCH = '''
+_ZIPF_PATCH = f'''
 
-# === BEGIN {marker} {version} (appended by InferaSim benchmark; idempotent) ===
+# === BEGIN {_ZIPF_MARKER} {_ZIPF_VERSION} (appended by InferaSim benchmark; idempotent) ===
 import os as _isim_os
 import torch as _isim_torch
 
@@ -343,8 +354,8 @@ class _ISimZipfRouting(RoutingStrategy):
 RoutingSimulator.register_strategy(
     "zipf", _ISimZipfRouting(s=float(_isim_os.environ.get("INFERASIM_ZIPF_S", "1.0")))
 )
-# === END {marker} ===
-'''.format(marker=_ZIPF_MARKER, version=_ZIPF_VERSION)
+# === END {_ZIPF_MARKER} ===
+'''
 
 
 def _install_zipf_routing(zipf_s: float) -> bool:
@@ -365,7 +376,7 @@ def _install_zipf_routing(zipf_s: float) -> bool:
     if spec is None or not spec.origin:
         return False
     path = spec.origin
-    with open(path, "r") as f:
+    with open(path) as f:
         src = f.read()
     want = f"BEGIN {_ZIPF_MARKER} {_ZIPF_VERSION}"
     if want not in src:
@@ -430,10 +441,7 @@ def _engine_kwargs_from_server_args(server_args: str) -> dict:
     }
     defaults = vars(parser.parse_args([]))
     given = vars(parser.parse_args(tokens))
-    return {
-        k: v for k, v in given.items()
-        if k != "model" and (k in named or v != defaults.get(k))
-    }
+    return {k: v for k, v in given.items() if k != "model" and (k in named or v != defaults.get(k))}
 
 
 def _server_arg_value(server_args: str, flag: str):
@@ -538,7 +546,7 @@ def _free_llm(llm) -> None:
         pass
 
 
-def _speculative_config(args) -> "dict | None":
+def _speculative_config(args) -> dict | None:
     """vLLM ``speculative_config`` from the CLI, or None when not requested.
 
     Returns None unless ``--speculative-method`` is given, so the default path is
@@ -570,8 +578,15 @@ def _measure(llm, prompts, out_len: int, reps: int) -> float:
     return best
 
 
-def _measure_batch(llm, input_len: int, batch: int, decode_steps: int,
-                   random_tokens: bool = False, vocab: int = 30000, seed: int = 0) -> dict:
+def _measure_batch(
+    llm,
+    input_len: int,
+    batch: int,
+    decode_steps: int,
+    random_tokens: bool = False,
+    vocab: int = 30000,
+    seed: int = 0,
+) -> dict:
     """Measure whole-model prefill + steady-state decode step latency at ``batch``.
 
     The decode step differences two long runs, K and K/2 tokens, which share the
@@ -670,12 +685,16 @@ def run_vllm_benchmark(args) -> dict:
             zipf_s = _s_for_imbalance(n_experts, float(imbalance_target))
             imbalance_realized = _imbalance_for_s(n_experts, zipf_s)
             routing = "zipf"
-            print(f"[inferasim:Inference:vLLM-Benchmark] MoE imbalance "
-                  f"I={float(imbalance_target):.2f} -> zipf s={zipf_s:.3f} "
-                  f"(N={n_experts} experts, realized I={imbalance_realized:.2f})")
+            print(
+                f"[inferasim:Inference:vLLM-Benchmark] MoE imbalance "
+                f"I={float(imbalance_target):.2f} -> zipf s={zipf_s:.3f} "
+                f"(N={n_experts} experts, realized I={imbalance_realized:.2f})"
+            )
         else:
-            print("[inferasim:Inference:vLLM-Benchmark] WARNING: could not read "
-                  "expert count; falling back to --zipf-s")
+            print(
+                "[inferasim:Inference:vLLM-Benchmark] WARNING: could not read "
+                "expert count; falling back to --zipf-s"
+            )
     if routing == "zipf":
         if _install_zipf_routing(zipf_s):
             routing_applied = f"zipf(s={zipf_s})"
@@ -718,7 +737,9 @@ def run_vllm_benchmark(args) -> dict:
     decode_ctx_grid = None
     if concurrency:
         if getattr(args, "decode_context_grid", None):
-            decode_ctx_grid = [int(x) for x in str(args.decode_context_grid).split(",") if x.strip()]
+            decode_ctx_grid = [
+                int(x) for x in str(args.decode_context_grid).split(",") if x.strip()
+            ]
         else:
             decode_ctx_grid = [args.input_len, 2 * args.input_len, 4 * args.input_len]
         decode_ctx_grid = sorted({c for c in decode_ctx_grid if c >= args.input_len})
@@ -744,23 +765,29 @@ def run_vllm_benchmark(args) -> dict:
     benchmark_gpus = getattr(args, "benchmark_gpus", None)
     if benchmark_gpus is None:
         benchmark_gpus = warmup_gpu_count(target_tp, target_ep, target_pp)
-        print(f"[inferasim:Inference:vLLM-Benchmark] warmup size not given; "
-              f"measuring on {benchmark_gpus} GPU(s) for a TP={target_tp} "
-              f"EP={target_ep} target (footprint capped at {WARMUP_GPU_CAP}). "
-              f"Pass --benchmark-gpus to measure on a different number.")
+        print(
+            f"[inferasim:Inference:vLLM-Benchmark] warmup size not given; "
+            f"measuring on {benchmark_gpus} GPU(s) for a TP={target_tp} "
+            f"EP={target_ep} target (footprint capped at {WARMUP_GPU_CAP}). "
+            f"Pass --benchmark-gpus to measure on a different number."
+        )
     bench_tp, bench_pp, bench_ep = _reduce_parallelism(
         target_tp, target_pp, target_ep, benchmark_gpus
     )
     reduced_parallelism = (bench_tp, bench_pp, bench_ep) != (target_tp, target_pp, target_ep)
     if reduced_parallelism:
-        print(f"[inferasim:Inference:vLLM-Benchmark] REDUCE PARALLELISM (pp->ep->tp) to fit "
-              f"{benchmark_gpus} GPU(s): TP {target_tp}->{bench_tp}, EP {target_ep}->{bench_ep}, "
-              f"PP {target_pp}->{bench_pp} (performance.py restores to target)")
+        print(
+            f"[inferasim:Inference:vLLM-Benchmark] REDUCE PARALLELISM (pp->ep->tp) to fit "
+            f"{benchmark_gpus} GPU(s): TP {target_tp}->{bench_tp}, EP {target_ep}->{bench_ep}, "
+            f"PP {target_pp}->{bench_pp} (performance.py restores to target)"
+        )
 
     server_kwargs = _engine_kwargs_from_server_args(getattr(args, "server_args", ""))
     if server_kwargs:
-        print(f"[inferasim:Inference:vLLM-Benchmark] server args -> engine kwargs: "
-              f"{json.dumps(server_kwargs, default=str)}")
+        print(
+            f"[inferasim:Inference:vLLM-Benchmark] server args -> engine kwargs: "
+            f"{json.dumps(server_kwargs, default=str)}"
+        )
 
     def _build_llm(num_layers_override):
         """Build a vLLM engine at the (possibly reduced) benchmark parallelism,
@@ -789,9 +816,7 @@ def run_vllm_benchmark(args) -> dict:
         # With this enabled, prefill_ms intentionally measures a near-100% cache
         # hit (block lookup), not cold prompt processing. Keep the mode explicit
         # in metadata so consumers can distinguish the two observables.
-        kwargs["enable_prefix_caching"] = bool(
-            getattr(args, "prefix_caching", False)
-        )
+        kwargs["enable_prefix_caching"] = bool(getattr(args, "prefix_caching", False))
         # Expert parallelism: shard MoE experts across the TP ranks (EP = TP)
         # instead of tensor-slicing each expert. Required to expose the
         # imbalance-sensitive effects — the MoE step is then gated by the BUSIEST
@@ -836,15 +861,23 @@ def run_vllm_benchmark(args) -> dict:
         raw = []
         for b in batches:
             for sd in seeds:
-                entry = _measure_batch(llm, args.input_len, b, args.decode_steps,
-                                       random_tokens=random_tokens, vocab=args.vocab,
-                                       seed=sd)
+                entry = _measure_batch(
+                    llm,
+                    args.input_len,
+                    b,
+                    args.decode_steps,
+                    random_tokens=random_tokens,
+                    vocab=args.vocab,
+                    seed=sd,
+                )
                 entry["seed"] = sd
                 raw.append(entry)
                 if len(seeds) > 1:
-                    print(f"[inferasim:Inference:vLLM-Benchmark]   batch={b} seed={sd} "
-                          f"prefill={entry['prefill_ms']:.2f}ms "
-                          f"decode_step={entry['decode_ms']:.2f}ms")
+                    print(
+                        f"[inferasim:Inference:vLLM-Benchmark]   batch={b} seed={sd} "
+                        f"prefill={entry['prefill_ms']:.2f}ms "
+                        f"decode_step={entry['decode_ms']:.2f}ms"
+                    )
         sweep = []
         for b in batches:
             pts = [e for e in raw if e["batch"] == b]
@@ -867,11 +900,16 @@ def run_vllm_benchmark(args) -> dict:
                 "n_seeds": len(dvals),
             }
             sweep.append(entry)
-            spread = (f" (+/-{entry['decode_ms_std']:.2f} over {len(dvals)} seeds)"
-                      if len(dvals) > 1 else "")
-            print(f"[inferasim:Inference:vLLM-Benchmark] batch={b} "
-                  f"prefill={entry['prefill_ms']:.2f}ms "
-                  f"decode_step={entry['decode_ms']:.2f}ms{spread}")
+            spread = (
+                f" (+/-{entry['decode_ms_std']:.2f} over {len(dvals)} seeds)"
+                if len(dvals) > 1
+                else ""
+            )
+            print(
+                f"[inferasim:Inference:vLLM-Benchmark] batch={b} "
+                f"prefill={entry['prefill_ms']:.2f}ms "
+                f"decode_step={entry['decode_ms']:.2f}ms{spread}"
+            )
         return sweep, raw
 
     def _resolve_capture_batches(llm):
@@ -880,9 +918,11 @@ def run_vllm_benchmark(args) -> dict:
         engine_caps = _engine_capture_sizes(llm)
         caps = engine_caps or _default_capture_sizes(concurrency)
         bs = _capture_batches_up_to(caps, concurrency)
-        print(f"[inferasim:Inference:vLLM-Benchmark] concurrency={concurrency} -> "
-              f"capture-size batches {bs} "
-              f"(source={'engine' if engine_caps else 'default'})")
+        print(
+            f"[inferasim:Inference:vLLM-Benchmark] concurrency={concurrency} -> "
+            f"capture-size batches {bs} "
+            f"(source={'engine' if engine_caps else 'default'})"
+        )
         return bs, caps
 
     def _measure_decode_context(llm):
@@ -893,12 +933,20 @@ def run_vllm_benchmark(args) -> dict:
         pts = []
         for c in decode_ctx_grid:
             for b in ctx_batches:
-                e = _measure_batch(llm, c, b, args.decode_steps,
-                                   random_tokens=random_tokens, vocab=args.vocab,
-                                   seed=seeds[0])
+                e = _measure_batch(
+                    llm,
+                    c,
+                    b,
+                    args.decode_steps,
+                    random_tokens=random_tokens,
+                    vocab=args.vocab,
+                    seed=seeds[0],
+                )
                 pts.append({"batch": b, "context": c, "decode_ms": e["decode_ms"]})
-                print(f"[inferasim:Inference:vLLM-Benchmark]   decode-ctx b={b} "
-                      f"ctx={c} decode_step={e['decode_ms']:.2f}ms")
+                print(
+                    f"[inferasim:Inference:vLLM-Benchmark]   decode-ctx b={b} "
+                    f"ctx={c} decode_step={e['decode_ms']:.2f}ms"
+                )
         return pts
 
     # --- REDUCE -> BENCHMARK -> RESTORE -------------------------------------
@@ -916,14 +964,18 @@ def run_vllm_benchmark(args) -> dict:
     sweep_raw = None
     decode_ctx = None
     if len(bench_counts) >= 2:
-        full_layers = int(args.full_layers or _full_num_layers(args.model, args.trust_remote_code) or 0)
+        full_layers = int(
+            args.full_layers or _full_num_layers(args.model, args.trust_remote_code) or 0
+        )
         if full_layers <= 0:
             raise SystemExit(
                 "[inferasim:Inference:vLLM-Benchmark] --bench-layers restore needs the full "
                 "layer count; could not read it from the HF config. Pass --full-layers."
             )
-        print(f"[inferasim:Inference:vLLM-Benchmark] REDUCE->BENCHMARK->RESTORE: "
-              f"bench layer counts {bench_counts} -> restore to {full_layers} layers")
+        print(
+            f"[inferasim:Inference:vLLM-Benchmark] REDUCE->BENCHMARK->RESTORE: "
+            f"bench layer counts {bench_counts} -> restore to {full_layers} layers"
+        )
         bench_sweeps = {}
         for li, L in enumerate(bench_counts):
             print(f"[inferasim:Inference:vLLM-Benchmark] --- benchmarking {L} layers ---")
@@ -937,21 +989,31 @@ def run_vllm_benchmark(args) -> dict:
         sweep = []
         per_layer = []
         for b in batches:
-            pre_pts = [(L, bench_sweeps[L][b]["prefill_ms"]) for L in bench_counts if b in bench_sweeps[L]]
-            dec_pts = [(L, bench_sweeps[L][b]["decode_ms"]) for L in bench_counts if b in bench_sweeps[L]]
+            pre_pts = [
+                (L, bench_sweeps[L][b]["prefill_ms"]) for L in bench_counts if b in bench_sweeps[L]
+            ]
+            dec_pts = [
+                (L, bench_sweeps[L][b]["decode_ms"]) for L in bench_counts if b in bench_sweeps[L]
+            ]
             bp, ap = _linfit(pre_pts)
             bd, ad = _linfit(dec_pts)
             full_prefill = max(1e-3, ap + bp * full_layers)
             full_decode = max(1e-6, ad + bd * full_layers)
             sweep.append({"batch": b, "prefill_ms": full_prefill, "decode_ms": full_decode})
-            per_layer.append({
-                "batch": b,
-                "per_layer_prefill_ms": bp, "overhead_prefill_ms": ap,
-                "per_layer_decode_ms": bd, "overhead_decode_ms": ad,
-            })
-            print(f"[inferasim:Inference:vLLM-Benchmark] RESTORED batch={b} "
-                  f"prefill={full_prefill:.2f}ms decode_step={full_decode:.2f}ms "
-                  f"(per-layer decode={bd:.3f}ms, overhead={ad:.2f}ms)")
+            per_layer.append(
+                {
+                    "batch": b,
+                    "per_layer_prefill_ms": bp,
+                    "overhead_prefill_ms": ap,
+                    "per_layer_decode_ms": bd,
+                    "overhead_decode_ms": ad,
+                }
+            )
+            print(
+                f"[inferasim:Inference:vLLM-Benchmark] RESTORED batch={b} "
+                f"prefill={full_prefill:.2f}ms decode_step={full_decode:.2f}ms "
+                f"(per-layer decode={bd:.3f}ms, overhead={ad:.2f}ms)"
+            )
         restore_meta = {
             "bench_layers": bench_counts,
             "full_layers": full_layers,
@@ -1022,9 +1084,8 @@ def run_vllm_benchmark(args) -> dict:
             # The lever set this run actually executed under. Without these an
             # anchor cannot be told apart from one measured on different flags.
             "server_args": getattr(args, "server_args", "") or None,
-            "env_overrides": dict(
-                kv.split("=", 1) for kv in getattr(args, "env", None) or []
-            ) or None,
+            "env_overrides": dict(kv.split("=", 1) for kv in getattr(args, "env", None) or [])
+            or None,
             "attention_backend": _server_arg_value(
                 getattr(args, "server_args", "") or "", "--attention-backend"
             ),
@@ -1071,17 +1132,37 @@ _CACHE_IGNORE_ARGS = {"save", "cache_dir", "no_cache", "force"}
 # as ``extra`` so the cache stays exact while regime/transport come from the
 # shared signature scheme.
 _CACHE_EXTRA_ARGS = (
-    "decode_steps", "batches", "bench_layers", "full_layers", "benchmark_gpus",
-    "random_tokens", "vocab", "gpu_mem_util", "routing_dist", "zipf_s",
-    "moe_imbalance", "load_format", "skip_tokenizer_init", "no_aiter",
-    "max_model_len", "output_len", "seed", "seeds", "concurrency",
-    "decode_context_grid", "server_args", "env",
+    "decode_steps",
+    "batches",
+    "bench_layers",
+    "full_layers",
+    "benchmark_gpus",
+    "random_tokens",
+    "vocab",
+    "gpu_mem_util",
+    "routing_dist",
+    "zipf_s",
+    "moe_imbalance",
+    "load_format",
+    "skip_tokenizer_init",
+    "no_aiter",
+    "max_model_len",
+    "output_len",
+    "seed",
+    "seeds",
+    "concurrency",
+    "decode_context_grid",
+    "server_args",
+    "env",
     # Serving and offline anchors of the same config are different measurements,
     # as are two engines serving it, so none of them may share a cache entry.
-    "offline", "serving_backend",
+    "offline",
+    "serving_backend",
     # A prefill-anchored artifact carries a measurement a decode-only one does
     # not, so the two cannot share an entry even at an identical config.
-    "prefill_anchor", "prefill_anchor_short", "prefill_anchor_validate",
+    "prefill_anchor",
+    "prefill_anchor_short",
+    "prefill_anchor_validate",
 )
 
 
@@ -1098,8 +1179,9 @@ def _regime_env() -> dict:
     server flag, and it reaches the regime through ``args`` instead.
     """
     env = {"VLLM_ROCM_USE_AITER": os.environ.get("VLLM_ROCM_USE_AITER", "0")}
-    env.update({k: v for k, v in os.environ.items()
-                if k.upper().startswith("VLLM_ROCM_USE_AITER_")})
+    env.update(
+        {k: v for k, v in os.environ.items() if k.upper().startswith("VLLM_ROCM_USE_AITER_")}
+    )
     return env
 
 
@@ -1124,17 +1206,26 @@ def _cache_path(cache_dir: str, key: str) -> str:
 def main(argv=None):
     ap = argparse.ArgumentParser(description="vLLM inference benchmark backend")
     ap.add_argument("--model", required=True, help="HF model id or local path")
-    ap.add_argument("--tp", type=int, default=1,
-                    help="TARGET tensor parallel size to project to (the benchmark "
-                         "may run at a smaller TP via --benchmark-gpus and restore).")
-    ap.add_argument("--pp", type=int, default=1,
-                    help="TARGET pipeline parallel size to project to.")
-    ap.add_argument("--benchmark-gpus", type=int, default=None,
-                    help="GPUs available for the actual vLLM run. When smaller than "
-                         "TP*PP, parallelism is reduced (pp->ep->tp) to fit and "
-                         "performance.py restores the whole-model latency to the "
-                         "target TP/EP/PP. E.g. --tp 8 --benchmark-gpus 1 runs TP=1 "
-                         "on 1 GPU and projects to TP=8.")
+    ap.add_argument(
+        "--tp",
+        type=int,
+        default=1,
+        help="TARGET tensor parallel size to project to (the benchmark "
+        "may run at a smaller TP via --benchmark-gpus and restore).",
+    )
+    ap.add_argument(
+        "--pp", type=int, default=1, help="TARGET pipeline parallel size to project to."
+    )
+    ap.add_argument(
+        "--benchmark-gpus",
+        type=int,
+        default=None,
+        help="GPUs available for the actual vLLM run. When smaller than "
+        "TP*PP, parallelism is reduced (pp->ep->tp) to fit and "
+        "performance.py restores the whole-model latency to the "
+        "target TP/EP/PP. E.g. --tp 8 --benchmark-gpus 1 runs TP=1 "
+        "on 1 GPU and projects to TP=8.",
+    )
     ap.add_argument("--quantization", default=None, help="e.g. fp8, mxfp4 (None=from config)")
     ap.add_argument("--kv-cache-dtype", default=None, help="e.g. fp8 (None=auto)")
     ap.add_argument("--input-len", type=int, default=1024)
@@ -1142,159 +1233,256 @@ def main(argv=None):
     ap.add_argument("--decode-steps", type=int, default=32, help="K for decode-step timing")
     ap.add_argument("--batch", type=int, default=16, help="ref batch (anchor) when no --batches")
     ap.add_argument("--batches", default=None, help="comma list to sweep, e.g. 4,8,16,32,64")
-    ap.add_argument("--concurrency", type=int, default=None,
-                    help="derive the sweep from the engine's CUDA-graph capture "
-                         "sizes up to this concurrency (overrides --batch/--batches). "
-                         "Decode is then looked up by padding the batch UP to the "
-                         "nearest captured size at projection time.")
-    ap.add_argument("--decode-context-grid", default=None,
-                    help="[capture mode] comma list of context (KV) lengths to "
-                         "measure the decode step at (default: input_len x {1,2,4}), "
-                         "so the projector fits the attention KV term instead of "
-                         "assuming decode is flat in context.")
-    ap.add_argument("--seed", type=int, default=0,
-                    help="single RNG seed for random token content (default 0)")
-    ap.add_argument("--seeds", default="0,1,2",
-                    help="comma list of seeds to sweep in ONE engine build, e.g. "
-                         "'0,1,2'. Each seed re-rolls random token content and adds "
-                         "an independent timing sample; the emitted sweep carries the "
-                         "per-batch mean + std across seeds (no engine re-init). "
-                         "Three by default because a single seed gives an artifact "
-                         "with no error bar at all: two independent single-seed runs "
-                         "of one identical config can disagree by enough to be "
-                         "mistaken for model error. Seeds are nearly free -- they "
-                         "reuse the engine, "
-                         "and the build is almost all of the cost.")
+    ap.add_argument(
+        "--concurrency",
+        type=int,
+        default=None,
+        help="derive the sweep from the engine's CUDA-graph capture "
+        "sizes up to this concurrency (overrides --batch/--batches). "
+        "Decode is then looked up by padding the batch UP to the "
+        "nearest captured size at projection time.",
+    )
+    ap.add_argument(
+        "--decode-context-grid",
+        default=None,
+        help="[capture mode] comma list of context (KV) lengths to "
+        "measure the decode step at (default: input_len x {1,2,4}), "
+        "so the projector fits the attention KV term instead of "
+        "assuming decode is flat in context.",
+    )
+    ap.add_argument(
+        "--seed", type=int, default=0, help="single RNG seed for random token content (default 0)"
+    )
+    ap.add_argument(
+        "--seeds",
+        default="0,1,2",
+        help="comma list of seeds to sweep in ONE engine build, e.g. "
+        "'0,1,2'. Each seed re-rolls random token content and adds "
+        "an independent timing sample; the emitted sweep carries the "
+        "per-batch mean + std across seeds (no engine re-init). "
+        "Three by default because a single seed gives an artifact "
+        "with no error bar at all: two independent single-seed runs "
+        "of one identical config can disagree by enough to be "
+        "mistaken for model error. Seeds are nearly free -- they "
+        "reuse the engine, "
+        "and the build is almost all of the cost.",
+    )
     ap.add_argument("--max-model-len", type=int, default=None)
-    ap.add_argument("--bench-layers", default=None,
-                    help="comma list of REDUCED layer counts to benchmark and "
-                         "RESTORE from, e.g. '4,8'. Enables the reduce->benchmark->"
-                         "restore policy: the engine is built at each count, the "
-                         "step latency is fit vs layer count, and the full model "
-                         "(--full-layers, or the HF config) is reconstructed. The "
-                         "emitted sweep is the restored full-model latency.")
-    ap.add_argument("--full-layers", type=int, default=None,
-                    help="full transformer layer count to restore to when using "
-                         "--bench-layers (default: read num_hidden_layers from the "
-                         "HF config)")
-    ap.add_argument("--num-hidden-layers", type=int, default=None,
-                    help="[legacy, no restore] override the model's transformer "
-                         "layer count for a single sub-scale run. Prefer "
-                         "--bench-layers for a full-model projection.")
-    ap.add_argument("--load-format", default="dummy",
-                    help="vLLM load_format: 'dummy' (random weights, needs an "
-                         "imposed routing dist) or 'auto'/'safetensors' (REAL "
-                         "weights -> the trained router sets the distribution; "
-                         "use with --routing-dist none for a constant-free run)")
-    ap.add_argument("--random-tokens", action="store_true",
-                    help="use independent random token ids per sequence "
-                         "(auto-on for real weights; matches InferenceX random data)")
-    ap.add_argument("--vocab", type=int, default=30000,
-                    help="upper bound for random token ids")
+    ap.add_argument(
+        "--bench-layers",
+        default=None,
+        help="comma list of REDUCED layer counts to benchmark and "
+        "RESTORE from, e.g. '4,8'. Enables the reduce->benchmark->"
+        "restore policy: the engine is built at each count, the "
+        "step latency is fit vs layer count, and the full model "
+        "(--full-layers, or the HF config) is reconstructed. The "
+        "emitted sweep is the restored full-model latency.",
+    )
+    ap.add_argument(
+        "--full-layers",
+        type=int,
+        default=None,
+        help="full transformer layer count to restore to when using "
+        "--bench-layers (default: read num_hidden_layers from the "
+        "HF config)",
+    )
+    ap.add_argument(
+        "--num-hidden-layers",
+        type=int,
+        default=None,
+        help="[legacy, no restore] override the model's transformer "
+        "layer count for a single sub-scale run. Prefer "
+        "--bench-layers for a full-model projection.",
+    )
+    ap.add_argument(
+        "--load-format",
+        default="dummy",
+        help="vLLM load_format: 'dummy' (random weights, needs an "
+        "imposed routing dist) or 'auto'/'safetensors' (REAL "
+        "weights -> the trained router sets the distribution; "
+        "use with --routing-dist none for a constant-free run)",
+    )
+    ap.add_argument(
+        "--random-tokens",
+        action="store_true",
+        help="use independent random token ids per sequence "
+        "(auto-on for real weights; matches InferenceX random data)",
+    )
+    ap.add_argument("--vocab", type=int, default=30000, help="upper bound for random token ids")
     ap.add_argument("--gpu-mem-util", type=float, default=0.9)
-    ap.add_argument("--prefix-caching", action="store_true",
-                    help="enable vLLM prefix caching. In the offline repeated-"
-                         "prompt sweep this measures near-100% cache-hit lookup "
-                         "latency, not cold-prefill latency.")
+    ap.add_argument(
+        "--prefix-caching",
+        action="store_true",
+        help="enable vLLM prefix caching. In the offline repeated-"
+        "prompt sweep this measures near-100% cache-hit lookup "
+        "latency, not cold-prefill latency.",
+    )
     ap.add_argument("--trust-remote-code", action="store_true")
-    ap.add_argument("--skip-tokenizer-init", action="store_true",
-                    help="skip loading the tokenizer (benchmark uses token ids "
-                         "directly; auto-on for --load-format dummy)")
-    ap.add_argument("--enable-expert-parallel", action="store_true",
-                    help="shard MoE experts across the TP ranks (EP=TP) instead of "
-                         "tensor-slicing each expert; exposes imbalance-sensitive "
-                         "busiest-rank + all-to-all effects")
+    ap.add_argument(
+        "--skip-tokenizer-init",
+        action="store_true",
+        help="skip loading the tokenizer (benchmark uses token ids "
+        "directly; auto-on for --load-format dummy)",
+    )
+    ap.add_argument(
+        "--enable-expert-parallel",
+        action="store_true",
+        help="shard MoE experts across the TP ranks (EP=TP) instead of "
+        "tensor-slicing each expert; exposes imbalance-sensitive "
+        "busiest-rank + all-to-all effects",
+    )
     ap.add_argument("--enforce-eager", action="store_true")
-    ap.add_argument("--speculative-method", default=None,
-                    help="speculative-decoding method, e.g. 'deepseek_mtp' "
-                         "(DeepSeek V3/R1 NextN head) or 'ngram'. Changes how "
-                         "many tokens a step emits, so it is regime-defining: "
-                         "an anchor measured without it cannot be transported "
-                         "to a target that uses it")
-    ap.add_argument("--speculative-num-tokens", type=int, default=None,
-                    help="draft tokens proposed per step (k). Bounded above by "
-                         "the checkpoint's num_nextn_predict_layers for "
-                         "'deepseek_mtp'")
-    ap.add_argument("--speculative-draft-model", default=None,
-                    help="draft model path for methods that need a separate "
-                         "checkpoint (unused for 'deepseek_mtp')")
-    ap.add_argument("--no-aiter", action="store_true",
-                    help="disable AMD AITER kernels (default: enabled on ROCm)")
-    ap.add_argument("--server-args", default="",
-                    help="vLLM server flags to apply to the engine, as one string "
-                         "(e.g. '--max-num-seqs 512 --enable-chunked-prefill'). "
-                         "Parsed with vLLM's own parser and applied as LLM() "
-                         "kwargs, so a flag means what it means to a real server. "
-                         "This is what lets a reduced-scale run screen a serving "
-                         "variant: the variant's own flags are what execute.")
-    ap.add_argument("--env", action="append", default=[], metavar="K=V",
-                    help="environment override applied before vLLM is imported "
-                         "(repeatable), e.g. --env VLLM_ROCM_USE_AITER=0. Needed "
-                         "for levers vLLM reads from the environment rather than "
-                         "from a flag.")
-    ap.add_argument("--routing-dist", default="zipf",
-                    choices=["zipf", "uniform", "normal", "none"],
-                    help="MoE token->expert distribution for the benchmark "
-                         "(default: zipf; 'none' uses the model's own router)")
-    ap.add_argument("--zipf-s", type=float, default=1.0,
-                    help="Zipfian skew exponent (0=uniform, larger=more skewed)")
-    ap.add_argument("--moe-imbalance", type=float, default=None,
-                    help="Target MoE expert-load imbalance I=max/mean tokens-per-"
-                         "expert (1.0=balanced). Overrides --zipf-s by solving for "
-                         "the Zipf exponent at the model's expert count. Use a "
-                         "measured/expected production value (random data ~ low I, "
-                         "domain-clustered traffic ~ higher I).")
-    ap.add_argument("--serving-backend", default="vllm",
-                    choices=("vllm", "sglang", "atom"),
-                    help="Which engine to launch for the anchor. Launched through "
-                         "the same adapters the platform serves with. Ignored with "
-                         "--offline, which is vLLM-only.")
-    ap.add_argument("--prefill-anchor", dest="prefill_anchor",
-                    action="store_true", default=None,
-                    help="Anchor prefill by differencing mean TTFT across two "
-                         "prompt lengths at concurrency 1. ON by default on the "
-                         "serving path, because the alternative is pricing "
-                         "prefill from the analytical roofline, whose absolute "
-                         "level the GEMM backend's own authors disclaim -- "
-                         "decode escapes it by being anchored, prefill has no "
-                         "such escape. Costs two extra client runs.")
-    ap.add_argument("--no-prefill-anchor", dest="prefill_anchor",
-                    action="store_false",
-                    help="Leave prefill simulated (the historical behaviour). "
-                         "Saves the probe runs; pays the roofline bias.")
-    ap.add_argument("--prefill-anchor-short", type=int, default=0,
-                    help="Short probe length for --prefill-anchor. The long "
-                         "probe is always --input-len, so the rate covers the "
-                         "lengths the anchor is used at. Default: half of it.")
-    ap.add_argument("--prefill-anchor-validate", action="store_true",
-                    help="Probe a third, interior length so the pairwise slopes "
-                         "can be compared. Checks the linearity the difference "
-                         "assumes, at the cost of one more client run.")
-    ap.add_argument("--offline", action="store_true",
-                    help="Measure with the offline LLM() entrypoint instead of a "
-                         "real server. Off by default: the two do not resolve the "
-                         "same kernels, so an offline anchor can mispredict a "
-                         "served target badly. See benchmark_serving.py.")
+    ap.add_argument(
+        "--speculative-method",
+        default=None,
+        help="speculative-decoding method, e.g. 'deepseek_mtp' "
+        "(DeepSeek V3/R1 NextN head) or 'ngram'. Changes how "
+        "many tokens a step emits, so it is regime-defining: "
+        "an anchor measured without it cannot be transported "
+        "to a target that uses it",
+    )
+    ap.add_argument(
+        "--speculative-num-tokens",
+        type=int,
+        default=None,
+        help="draft tokens proposed per step (k). Bounded above by "
+        "the checkpoint's num_nextn_predict_layers for "
+        "'deepseek_mtp'",
+    )
+    ap.add_argument(
+        "--speculative-draft-model",
+        default=None,
+        help="draft model path for methods that need a separate "
+        "checkpoint (unused for 'deepseek_mtp')",
+    )
+    ap.add_argument(
+        "--no-aiter",
+        action="store_true",
+        help="disable AMD AITER kernels (default: enabled on ROCm)",
+    )
+    ap.add_argument(
+        "--server-args",
+        default="",
+        help="vLLM server flags to apply to the engine, as one string "
+        "(e.g. '--max-num-seqs 512 --enable-chunked-prefill'). "
+        "Parsed with vLLM's own parser and applied as LLM() "
+        "kwargs, so a flag means what it means to a real server. "
+        "This is what lets a reduced-scale run screen a serving "
+        "variant: the variant's own flags are what execute.",
+    )
+    ap.add_argument(
+        "--env",
+        action="append",
+        default=[],
+        metavar="K=V",
+        help="environment override applied before vLLM is imported "
+        "(repeatable), e.g. --env VLLM_ROCM_USE_AITER=0. Needed "
+        "for levers vLLM reads from the environment rather than "
+        "from a flag.",
+    )
+    ap.add_argument(
+        "--routing-dist",
+        default="zipf",
+        choices=["zipf", "uniform", "normal", "none"],
+        help="MoE token->expert distribution for the benchmark "
+        "(default: zipf; 'none' uses the model's own router)",
+    )
+    ap.add_argument(
+        "--zipf-s",
+        type=float,
+        default=1.0,
+        help="Zipfian skew exponent (0=uniform, larger=more skewed)",
+    )
+    ap.add_argument(
+        "--moe-imbalance",
+        type=float,
+        default=None,
+        help="Target MoE expert-load imbalance I=max/mean tokens-per-"
+        "expert (1.0=balanced). Overrides --zipf-s by solving for "
+        "the Zipf exponent at the model's expert count. Use a "
+        "measured/expected production value (random data ~ low I, "
+        "domain-clustered traffic ~ higher I).",
+    )
+    ap.add_argument(
+        "--serving-backend",
+        default="vllm",
+        choices=("vllm", "sglang", "atom"),
+        help="Which engine to launch for the anchor. Launched through "
+        "the same adapters the platform serves with. Ignored with "
+        "--offline, which is vLLM-only.",
+    )
+    ap.add_argument(
+        "--prefill-anchor",
+        dest="prefill_anchor",
+        action="store_true",
+        default=None,
+        help="Anchor prefill by differencing mean TTFT across two "
+        "prompt lengths at concurrency 1. ON by default on the "
+        "serving path, because the alternative is pricing "
+        "prefill from the analytical roofline, whose absolute "
+        "level the GEMM backend's own authors disclaim -- "
+        "decode escapes it by being anchored, prefill has no "
+        "such escape. Costs two extra client runs.",
+    )
+    ap.add_argument(
+        "--no-prefill-anchor",
+        dest="prefill_anchor",
+        action="store_false",
+        help="Leave prefill simulated (the historical behaviour). "
+        "Saves the probe runs; pays the roofline bias.",
+    )
+    ap.add_argument(
+        "--prefill-anchor-short",
+        type=int,
+        default=0,
+        help="Short probe length for --prefill-anchor. The long "
+        "probe is always --input-len, so the rate covers the "
+        "lengths the anchor is used at. Default: half of it.",
+    )
+    ap.add_argument(
+        "--prefill-anchor-validate",
+        action="store_true",
+        help="Probe a third, interior length so the pairwise slopes "
+        "can be compared. Checks the linearity the difference "
+        "assumes, at the cost of one more client run.",
+    )
+    ap.add_argument(
+        "--offline",
+        action="store_true",
+        help="Measure with the offline LLM() entrypoint instead of a "
+        "real server. Off by default: the two do not resolve the "
+        "same kernels, so an offline anchor can mispredict a "
+        "served target badly. See benchmark_serving.py.",
+    )
     ap.add_argument("--save", required=True)
-    ap.add_argument("--cache-dir", default=os.environ.get("INFERASIM_BENCH_CACHE"),
-                    help="Directory of cached results keyed by run config. On a "
-                         "cache HIT the vLLM engine is never built (skips ~all the "
-                         "wall time). Defaults to $INFERASIM_BENCH_CACHE; caching is "
-                         "off when neither is set.")
-    ap.add_argument("--no-cache", action="store_true",
-                    help="Ignore any cached result and do not write one.")
-    ap.add_argument("--force", action="store_true",
-                    help="Re-run and OVERWRITE the cached result for this config.")
+    ap.add_argument(
+        "--cache-dir",
+        default=os.environ.get("INFERASIM_BENCH_CACHE"),
+        help="Directory of cached results keyed by run config. On a "
+        "cache HIT the vLLM engine is never built (skips ~all the "
+        "wall time). Defaults to $INFERASIM_BENCH_CACHE; caching is "
+        "off when neither is set.",
+    )
+    ap.add_argument(
+        "--no-cache", action="store_true", help="Ignore any cached result and do not write one."
+    )
+    ap.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-run and OVERWRITE the cached result for this config.",
+    )
     args = ap.parse_args(argv)
     # Asking for both is a contradiction rather than a preference: the offline
     # path measures a prefill step of its own, so honouring the flag there would
     # anchor on the offline kernels, which is the one thing it exists to avoid.
     if args.offline and args.prefill_anchor:
-        ap.error("--prefill-anchor is a serving-path measurement and --offline "
-                 "runs the LLM() entrypoint, which resolves different attention "
-                 "and MoE kernels and already reports its own prefill_ms. Drop "
-                 "one: --prefill-anchor alone for a served anchor, --offline "
-                 "alone for the offline one.")
+        ap.error(
+            "--prefill-anchor is a serving-path measurement and --offline "
+            "runs the LLM() entrypoint, which resolves different attention "
+            "and MoE kernels and already reports its own prefill_ms. Drop "
+            "one: --prefill-anchor alone for a served anchor, --offline "
+            "alone for the offline one."
+        )
     # Unset resolves per path: the serving anchor measures prefill, the offline
     # one already has its own. Resolved to a concrete value before the cache key
     # is built, so an anchored artifact cannot collide with a decode-only one.
@@ -1319,8 +1507,10 @@ def main(argv=None):
             result = json.load(f)
         with open(args.save, "w") as f:
             json.dump(result, f)
-        print(f"[inferasim:Inference:vLLM-Benchmark] CACHE HIT {cpath} "
-              f"(config key {key}); skipped vLLM run")
+        print(
+            f"[inferasim:Inference:vLLM-Benchmark] CACHE HIT {cpath} "
+            f"(config key {key}); skipped vLLM run"
+        )
         print("[inferasim:Inference:vLLM-Benchmark] " + json.dumps(result))
         print(f"[inferasim:Inference:vLLM-Benchmark] wrote {args.save}")
         return
@@ -1339,8 +1529,7 @@ def main(argv=None):
         os.makedirs(cache_dir, exist_ok=True)
         with open(cpath, "w") as f:
             json.dump(result, f)
-        print(f"[inferasim:Inference:vLLM-Benchmark] cached result -> {cpath} "
-              f"(config key {key})")
+        print(f"[inferasim:Inference:vLLM-Benchmark] cached result -> {cpath} (config key {key})")
     print("[inferasim:Inference:vLLM-Benchmark] " + json.dumps(result))
     print(f"[inferasim:Inference:vLLM-Benchmark] wrote {args.save}")
 

--- a/infera/projection/core/projection/inference_projection/collectives.py
+++ b/infera/projection/core/projection/inference_projection/collectives.py
@@ -40,8 +40,8 @@ from infera.projection.core.projection.training_config import (
 _PROTOCOLS = ("simple", "ll", "ll64", "ll128")
 
 # Representative extra TP-AllReduce speedups for custom collective ops.
-_QUICK_REDUCE_SPEEDUP = 0.6        # ROCm low-latency quantized AR (small msgs).
-_FUSED_RMSNORM_AR_SPEEDUP = 0.8    # RMSNorm+AR fusion hides part of the AR.
+_QUICK_REDUCE_SPEEDUP = 0.6  # ROCm low-latency quantized AR (small msgs).
+_FUSED_RMSNORM_AR_SPEEDUP = 0.8  # RMSNorm+AR fusion hides part of the AR.
 
 # Intra-node serving collective latency floor.
 #
@@ -85,9 +85,7 @@ _INFER_AR_MEASURED_GBPS = {2: (7.81, 65.9), 4: (10.06, 120.7), 8: (11.40, 117.6)
 # 250x larger and nowhere near the sizes the fit was measured over. Applying the
 # small-message bandwidth there charged 232 ms of all-reduce to a prefill that
 # measured 177 ms in total, i.e. more communication than the whole step.
-_VLLM_CUSTOM_AR_MAX_BYTES = float(
-    os.getenv("INFERASIM_CUSTOM_AR_MAX_MB", "8") or 8
-) * 1024 * 1024
+_VLLM_CUSTOM_AR_MAX_BYTES = float(os.getenv("INFERASIM_CUSTOM_AR_MAX_MB", "8") or 8) * 1024 * 1024
 
 # Intra-node expert-parallel all-to-all, measured the same way and fitted to
 # the same ``t_us = floor_us + bytes / bw`` shape, at r^2 >= 0.996. Maps world
@@ -115,9 +113,9 @@ _INFER_A2A_MEASURED_GBPS = {2: (26.59, 57.2), 4: (22.52, 148.3), 8: (18.6, 290.3
 # that measures far less. The all-reduce already guards its own fit for the same
 # reason (see ``_VLLM_CUSTOM_AR_MAX_BYTES``); above this size the analytical
 # bandwidth model describes the transfer better than the small-message fit.
-_INFER_A2A_MEASURED_MAX_BYTES = float(
-    os.getenv("INFERASIM_A2A_MEASURED_MAX_MB", "32") or 32
-) * 1024 * 1024
+_INFER_A2A_MEASURED_MAX_BYTES = (
+    float(os.getenv("INFERASIM_A2A_MEASURED_MAX_MB", "32") or 32) * 1024 * 1024
+)
 
 
 def _measured_intra_node_a2a_us(msg_bytes: float, gpus: int) -> float | None:
@@ -229,7 +227,7 @@ def _allreduce_overhead_us(args, msg_size, gpus) -> float:
         ratio = min(1.0, per_nic_bytes / warmup) if warmup > 0 else 1.0
         if ratio < 1.0:
             setup_us = getattr(args, "nic_rdma_setup_us", 0.0) * node_steps
-            overhead += setup_us * (1.0 - ratio ** 2.5)
+            overhead += setup_us * (1.0 - ratio**2.5)
     return overhead
 
 
@@ -240,7 +238,9 @@ def _alltoall_overhead_us(args, gpus) -> float:
     inter_node_peers = max(0, gpus - gpus_per_node)
     intra_sync = getattr(args, "a2a_intra_sync_overhead", 50.0)
     intra_per_peer = getattr(args, "a2a_intra_node_peer_lat", 2.5)
-    intra_overhead = (intra_sync + intra_per_peer * intra_node_peers) if intra_node_peers > 0 else 0.0
+    intra_overhead = (
+        (intra_sync + intra_per_peer * intra_node_peers) if intra_node_peers > 0 else 0.0
+    )
     inter_per_peer = getattr(args, "a2a_peer_lat", 0.45)
     inter_overhead = inter_per_peer * inter_node_peers
     return intra_overhead + inter_overhead + getattr(args, "a2a_rccl_overhead_us", 0.0)
@@ -351,13 +351,17 @@ class InferenceCollectiveModel:
             if algo == "ring":
                 raw = _min_over_protocols(cm.RingAllreduce, self._args, msg, self.tp, ["tp"])
             elif algo == "one_shot":
-                raw = _min_over_protocols(cm.single_shot_allreduce, self._args, msg, self.tp, ["tp"])
+                raw = _min_over_protocols(
+                    cm.single_shot_allreduce, self._args, msg, self.tp, ["tp"]
+                )
             elif algo == "two_shot":
                 rs = _min_over_protocols(cm.run_reduce_scatter, self._args, msg, self.tp, ["tp"])
                 ag = _min_over_protocols(cm.run_allgather, self._args, msg, self.tp, ["tp"])
                 raw = rs + ag
             elif algo == "hierarchical":
-                raw = _min_over_protocols(cm.hierarchical_allreduce, self._args, msg, self.tp, ["tp"])
+                raw = _min_over_protocols(
+                    cm.hierarchical_allreduce, self._args, msg, self.tp, ["tp"]
+                )
             else:
                 raw = _min_over_protocols(cm.RingAllreduce, self._args, msg, self.tp, ["tp"])
             # Forced algorithms must carry the same fixed overhead as ``auto``.
@@ -390,9 +394,13 @@ class InferenceCollectiveModel:
             if algo == "direct":
                 raw = _min_over_protocols(cm.run_alltoall, self._a2a_args, msg, self.ep, ["ep"])
             elif algo == "single_shot":
-                raw = _min_over_protocols(cm.single_shot_alltoall, self._a2a_args, msg, self.ep, ["ep"])
+                raw = _min_over_protocols(
+                    cm.single_shot_alltoall, self._a2a_args, msg, self.ep, ["ep"]
+                )
             elif algo == "hierarchical":
-                raw = _min_over_protocols(cm.hierarchical_alltoall, self._a2a_args, msg, self.ep, ["ep"])
+                raw = _min_over_protocols(
+                    cm.hierarchical_alltoall, self._a2a_args, msg, self.ep, ["ep"]
+                )
             else:
                 raw = _min_over_protocols(cm.run_alltoall, self._a2a_args, msg, self.ep, ["ep"])
             # Forced algorithms must carry the same fixed overhead as ``auto``.
@@ -403,10 +411,7 @@ class InferenceCollectiveModel:
         # dispatch + combine, scaled by the custom-op efficiency and reduced by
         # the DeepEP/SyncFree compute-overlap fraction (exposed A2A only).
         return (
-            2.0
-            * (one / 1000.0)
-            * float(self.cc.ep_a2a_efficiency)
-            * (1.0 - self._deepep_overlap)
+            2.0 * (one / 1000.0) * float(self.cc.ep_a2a_efficiency) * (1.0 - self._deepep_overlap)
         )
 
     def _floor_small_msg_overhead(self, us: float, msg: int, gpus: int, *, is_a2a: bool) -> float:
@@ -491,7 +496,9 @@ class InferenceCollectiveModel:
 
     # -- KV-cache transfer (disaggregation) ------------------------------------
 
-    def kv_transfer_ms(self, kv_bytes: float, *, bw_gbps: float | None = None, latency_us: float = 0.0) -> float:
+    def kv_transfer_ms(
+        self, kv_bytes: float, *, bw_gbps: float | None = None, latency_us: float = 0.0
+    ) -> float:
         """Time to move ``kv_bytes`` of KV cache prefill→decode worker.
 
         Uses the inter-node (pod) bandwidth from the collective args unless an
@@ -502,7 +509,7 @@ class InferenceCollectiveModel:
             return 0.0
         bw = bw_gbps if (bw_gbps and bw_gbps > 0) else self._args.pod_bw
         bw = max(bw, 1e-6)
-        gb = kv_bytes / (1024.0 ** 3)
+        gb = kv_bytes / (1024.0**3)
         return (gb / bw) * 1000.0 + latency_us / 1000.0
 
     # -- combined per-layer ----------------------------------------------------

--- a/infera/projection/core/projection/inference_projection/des.py
+++ b/infera/projection/core/projection/inference_projection/des.py
@@ -45,7 +45,6 @@ import math
 import random
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple
 
 from infera.projection.core.projection.training_config import InferenceConfig
 
@@ -60,7 +59,7 @@ _CTX_BUCKET = 256
 _TOK_BUCKET = 64
 
 
-def _slope(xs: List[float], ys: List[float]) -> float:
+def _slope(xs: list[float], ys: list[float]) -> float:
     """Least-squares slope dy/dx; 0.0 for degenerate input."""
     n = len(xs)
     if n < 2:
@@ -74,7 +73,7 @@ def _slope(xs: List[float], ys: List[float]) -> float:
     return sxy / sxx
 
 
-def _pct(xs: List[float], p: float) -> float:
+def _pct(xs: list[float], p: float) -> float:
     """Linear-interpolation percentile (p in [0, 1]); 0.0 for empty input."""
     if not xs:
         return 0.0
@@ -97,17 +96,17 @@ class _Req:
     arrival_ms: float
     prompt_len: int
     output_len: int
-    num_computed: int = 0        # prompt tokens already processed (prefill progress)
-    prefix_id: int = -1          # shared-prefix identity (-1 = unique / no pool)
-    cached_prefix: int = 0       # prompt tokens served from a prefix-cache hit
-    blocks: List[int] = field(default_factory=list)  # ordered KV block-hash ids
-    generated: int = 0           # output tokens emitted so far
+    num_computed: int = 0  # prompt tokens already processed (prefill progress)
+    prefix_id: int = -1  # shared-prefix identity (-1 = unique / no pool)
+    cached_prefix: int = 0  # prompt tokens served from a prefix-cache hit
+    blocks: list[int] = field(default_factory=list)  # ordered KV block-hash ids
+    generated: int = 0  # output tokens emitted so far
     prefill_done: bool = False
-    status: str = "WAITING"      # WAITING | RUNNING | FINISHED
-    admit_ms: float = -1.0       # when it left the waiting queue (server admit)
+    status: str = "WAITING"  # WAITING | RUNNING | FINISHED
+    admit_ms: float = -1.0  # when it left the waiting queue (server admit)
     first_token_ms: float = -1.0
     finish_ms: float = -1.0
-    itls: List[float] = field(default_factory=list)
+    itls: list[float] = field(default_factory=list)
 
     @property
     def reserved_kv(self) -> int:
@@ -127,30 +126,30 @@ class _Req:
 @dataclass
 class DESResult:
     arrival_model: str
-    offered_rate: float            # req/s requested
-    achieved_rate: float           # req/s completed over makespan
-    utilization: float             # busy time / makespan
+    offered_rate: float  # req/s requested
+    achieved_rate: float  # req/s completed over makespan
+    utilization: float  # busy time / makespan
     num_requests: int
     makespan_ms: float
-    system_throughput_tps: float   # output tokens/s
+    system_throughput_tps: float  # output tokens/s
     saturated: bool
     # latency distributions (ms)
-    ttft: Dict[str, float] = field(default_factory=dict)          # from admission (queue-excluded)
-    ttft_arrival: Dict[str, float] = field(default_factory=dict)  # from arrival (incl. queue wait)
-    queue_wait: Dict[str, float] = field(default_factory=dict)    # arrival -> admission
-    tpot: Dict[str, float] = field(default_factory=dict)
-    itl: Dict[str, float] = field(default_factory=dict)
-    e2e: Dict[str, float] = field(default_factory=dict)
+    ttft: dict[str, float] = field(default_factory=dict)  # from admission (queue-excluded)
+    ttft_arrival: dict[str, float] = field(default_factory=dict)  # from arrival (incl. queue wait)
+    queue_wait: dict[str, float] = field(default_factory=dict)  # arrival -> admission
+    tpot: dict[str, float] = field(default_factory=dict)
+    itl: dict[str, float] = field(default_factory=dict)
+    e2e: dict[str, float] = field(default_factory=dict)
     # batch-composition / packing summary (serving_sim-style)
-    packing: Dict[str, float] = field(default_factory=dict)
+    packing: dict[str, float] = field(default_factory=dict)
     # multi-instance routing / prefix-cache summary (only when instances>1 or a
     # prefix pool is configured)
-    prefix: Dict[str, float] = field(default_factory=dict)
+    prefix: dict[str, float] = field(default_factory=dict)
     # optional per-step records (only when record_steps=True)
-    steps: Optional[List[dict]] = None
+    steps: list[dict] | None = None
     # optional raw per-request latency samples (only when return_samples=True);
     # used to pool distributions across instances in the multi-instance driver.
-    samples: Optional[Dict[str, List[float]]] = None
+    samples: dict[str, list[float]] | None = None
 
 
 class _CostKernel:
@@ -159,8 +158,8 @@ class _CostKernel:
     def __init__(self, projector: InferencePerformanceProjector, q_len: int):
         self._p = projector
         self._q = q_len
-        self._decode: Dict[tuple, float] = {}
-        self._mixed: Dict[tuple, float] = {}
+        self._decode: dict[tuple, float] = {}
+        self._mixed: dict[tuple, float] = {}
 
     @staticmethod
     def _bucket(ctx: int) -> int:
@@ -178,7 +177,9 @@ class _CostKernel:
             self._decode[key] = v
         return v
 
-    def mixed_step_ms(self, num_decode: int, prefill_tokens: int, ctx: int, prefill_kv: int) -> float:
+    def mixed_step_ms(
+        self, num_decode: int, prefill_tokens: int, ctx: int, prefill_kv: int
+    ) -> float:
         key = (num_decode, self._tok(prefill_tokens), self._bucket(ctx), self._bucket(prefill_kv))
         v = self._mixed.get(key)
         if v is None:
@@ -189,7 +190,7 @@ class _CostKernel:
 
 def _generate_arrivals(
     n: int, rate_per_s: float, model: str, rng: random.Random, burstiness: float = 1.0
-) -> List[float]:
+) -> list[float]:
     """Arrival timestamps (ms) for ``n`` requests at ``rate_per_s`` req/s.
 
     ``deterministic`` → fixed spacing; ``poisson`` → gamma inter-arrivals with
@@ -200,7 +201,7 @@ def _generate_arrivals(
         return [0.0] * n
     mean_dt_ms = 1000.0 / rate_per_s
     t = 0.0
-    out: List[float] = []
+    out: list[float] = []
     for _ in range(n):
         if model == "deterministic":
             dt = mean_dt_ms
@@ -241,7 +242,7 @@ def _sample_len(rng: random.Random, max_len: int, range_ratio: float) -> int:
     return rng.randint(lo, max_len)
 
 
-def _load_workload_file(path: str) -> List[Tuple[float, int, int]]:
+def _load_workload_file(path: str) -> list[tuple[float, int, int]]:
     """Load ``(arrival_ms, isl, osl)`` rows from JSON (list of dicts) or CSV.
 
     Keys/columns are case-insensitive: ``arrival`` (ms; aliases arrival_ms/time/
@@ -262,7 +263,7 @@ def _load_workload_file(path: str) -> List[Tuple[float, int, int]]:
                 return float(lower[nm])
         return default
 
-    out: List[Tuple[float, int, int]] = []
+    out: list[tuple[float, int, int]] = []
     for row in rows:
         arrival = get(row, "arrival", "arrival_ms", "time", "step", default=0.0)
         isl = int(get(row, "isl", "input_len", "prompt_len", default=1.0))
@@ -273,15 +274,15 @@ def _load_workload_file(path: str) -> List[Tuple[float, int, int]]:
 
 def _build_workload(
     n: int,
-    arrivals: List[float],
+    arrivals: list[float],
     input_len: int,
     output_len: int,
     range_ratio: float,
     rng: random.Random,
-) -> List[_Req]:
+) -> list[_Req]:
     """Construct ``n`` requests with per-request sampled lengths (homogeneous
     when ``range_ratio >= 1``)."""
-    reqs: List[_Req] = []
+    reqs: list[_Req] = []
     for i in range(n):
         isl = _sample_len(rng, input_len, range_ratio)
         osl = _sample_len(rng, output_len, range_ratio)
@@ -298,13 +299,13 @@ def simulate_once(
     num_requests: int = 400,
     warmup_frac: float = 0.1,
     seed: int = 0,
-    arrivals: Optional[List[float]] = None,
+    arrivals: list[float] | None = None,
     burstiness: float = 1.0,
     range_ratio: float = 1.0,
     kv_cache_tokens: int = 0,
-    workload_file: Optional[str] = None,
+    workload_file: str | None = None,
     record_steps: bool = False,
-    prebuilt: Optional[List["_Req"]] = None,
+    prebuilt: list[_Req] | None = None,
     return_samples: bool = False,
 ) -> DESResult:
     """Run one single-engine DES at a fixed offered load.
@@ -319,13 +320,13 @@ def simulate_once(
     input_len = max(1, req.input_seq_len)
     output_len = max(1, req.output_seq_len)
     max_running = max(1, req.resolved_max_concurrency())
-    token_budget = int(req.max_num_batched_tokens or 0)      # 0 = unlimited
-    long_prefill = int(req.chunked_prefill_size or 0)        # per-request chunk cap
+    token_budget = int(req.max_num_batched_tokens or 0)  # 0 = unlimited
+    long_prefill = int(req.chunked_prefill_size or 0)  # per-request chunk cap
     max_model_len = max(2, int(req.resolved_max_context_len()))
     spec_k = int(req.speculative_num_tokens or 0)
     accept = float(req.speculative_acceptance_rate or 0.0)
     q_len = (spec_k + 1) if spec_k > 0 else 1
-    kv_pool = int(kv_cache_tokens or 0)                       # 0 = unlimited
+    kv_pool = int(kv_cache_tokens or 0)  # 0 = unlimited
 
     rng = random.Random(seed)
 
@@ -367,15 +368,15 @@ def simulate_once(
 
     kernel = _CostKernel(projector, q_len)
     next_arrival = 0
-    waiting: List[_Req] = []
-    running: List[_Req] = []
-    done: List[_Req] = []
+    waiting: list[_Req] = []
+    running: list[_Req] = []
+    done: list[_Req] = []
     kv_used = 0
 
     now = 0.0
     busy_ms = 0.0
-    backlog: List[tuple] = []       # (time_ms, waiting depth) for saturation test
-    step_records: List[dict] = [] if record_steps else []
+    backlog: list[tuple] = []  # (time_ms, waiting depth) for saturation test
+    step_records: list[dict] = [] if record_steps else []
     # packing accumulators
     pk_steps = pk_batch = pk_maxbatch = pk_prefill_reqs = pk_decode_reqs = 0
     pk_qtokens = 0
@@ -407,7 +408,7 @@ def simulate_once(
         # 3) Build the step: Phase 1 (running) then Phase 2 (admit), sharing the
         #    per-step token budget. ``scheduled`` = (req, q, is_prefill, kv_start).
         budget = token_budget if token_budget > 0 else math.inf
-        scheduled: List[Tuple[_Req, int, bool, int]] = []
+        scheduled: list[tuple[_Req, int, bool, int]] = []
 
         def _schedule_tokens(r: _Req, budget: float) -> int:
             if r.prefill_done:
@@ -474,13 +475,13 @@ def simulate_once(
         busy_ms += step_dt
 
         # 6) Apply the forward pass (prefill progress; decode commits w/ spec).
-        for (r, q, is_prefill, _kv) in scheduled:
+        for r, q, is_prefill, _kv in scheduled:
             if not r.prefill_done:
                 r.num_computed += q
                 if r.num_computed >= r.prompt_len:
                     r.prefill_done = True
                     r.first_token_ms = now
-                    r.generated = 1              # last prefill chunk emits token 1
+                    r.generated = 1  # last prefill chunk emits token 1
                     r.itls.append(step_dt)
                     if r.generated >= r.output_len:
                         r.status = "FINISHED"
@@ -498,7 +499,7 @@ def simulate_once(
                     r.finish_ms = now
 
         # 7) Retire finished requests, free their KV reservation.
-        still: List[_Req] = []
+        still: list[_Req] = []
         for r in running:
             if r.status == "FINISHED":
                 kv_used -= r.reserved_kv
@@ -562,16 +563,15 @@ def simulate_once(
 
     ttft = [
         (r.first_token_ms - _admit(r)) + tok_ms_pt * r.prompt_len
-        for r in sample if r.first_token_ms >= 0
+        for r in sample
+        if r.first_token_ms >= 0
     ]
     ttft_arrival = [
         (r.first_token_ms - r.arrival_ms) + tok_ms_pt * r.prompt_len
-        for r in sample if r.first_token_ms >= 0
+        for r in sample
+        if r.first_token_ms >= 0
     ]
-    queue_wait = [
-        _admit(r) - r.arrival_ms
-        for r in sample if r.first_token_ms >= 0
-    ]
+    queue_wait = [_admit(r) - r.arrival_ms for r in sample if r.first_token_ms >= 0]
     # Per-output-token detokenization + streaming (client-side host cost).
     # Latency-only: added to ITL/TPOT/e2e but not to the server step, so the
     # scheduler, makespan and throughput above are unchanged. Matches the
@@ -579,14 +579,15 @@ def simulate_once(
     detok_ms = max(0.0, req.detokenize_overhead_us) / 1000.0
     e2e = [
         (r.finish_ms - r.arrival_ms) + tok_ms_pt * r.prompt_len + detok_ms * r.generated
-        for r in sample if r.finish_ms >= 0
+        for r in sample
+        if r.finish_ms >= 0
     ]
     tpot = [
         (r.finish_ms - r.first_token_ms) / max(1, r.generated - 1) + detok_ms
         for r in sample
         if r.finish_ms >= 0 and r.generated > 1
     ]
-    itl_all: List[float] = []
+    itl_all: list[float] = []
     for r in sample:
         itl_all.extend(x + detok_ms for x in r.itls)
 
@@ -616,7 +617,7 @@ def simulate_once(
     if rate_per_s > 0 and achieved_rate < 0.5 * rate_per_s:
         saturated = True
 
-    def dist(xs: List[float]) -> Dict[str, float]:
+    def dist(xs: list[float]) -> dict[str, float]:
         return {
             "mean": (sum(xs) / len(xs)) if xs else 0.0,
             "p50": _pct(xs, 0.50),
@@ -687,11 +688,11 @@ class _BlockCache:
     """
 
     def __init__(self, capacity_blocks: int = 0) -> None:
-        self.capacity = int(capacity_blocks or 0)   # 0 = unbounded
-        self._lru: "OrderedDict[int, None]" = OrderedDict()
+        self.capacity = int(capacity_blocks or 0)  # 0 = unbounded
+        self._lru: OrderedDict[int, None] = OrderedDict()
         self.evictions = 0
 
-    def prefix_match(self, blocks: List[int]) -> int:
+    def prefix_match(self, blocks: list[int]) -> int:
         """Number of leading blocks already resident (contiguous from the head)."""
         m = 0
         for b in blocks:
@@ -701,7 +702,7 @@ class _BlockCache:
                 break
         return m
 
-    def insert(self, blocks: List[int]) -> None:
+    def insert(self, blocks: list[int]) -> None:
         """Warm a request's blocks (mark MRU); evict LRU beyond capacity."""
         for b in blocks:
             if b in self._lru:
@@ -721,7 +722,7 @@ class _BlockHasher:
     """Deterministic ``tuple -> small int`` block-hash id allocator."""
 
     def __init__(self) -> None:
-        self._m: Dict[tuple, int] = {}
+        self._m: dict[tuple, int] = {}
 
     def hid(self, key: tuple) -> int:
         h = self._m.get(key)
@@ -732,8 +733,13 @@ class _BlockHasher:
 
 
 def _blocks_from_prefix(
-    idx: int, prompt_len: int, prefix_id: int, prefix_len: int, block_size: int, hasher: _BlockHasher
-) -> List[int]:
+    idx: int,
+    prompt_len: int,
+    prefix_id: int,
+    prefix_len: int,
+    block_size: int,
+    hasher: _BlockHasher,
+) -> list[int]:
     """Blockify a synthetic prompt: leading blocks shared by same-``prefix_id``
     requests, trailing blocks unique to this request.
 
@@ -742,13 +748,15 @@ def _blocks_from_prefix(
     """
     bs = max(1, block_size)
     n_blocks = max(1, math.ceil(prompt_len / bs))
-    n_shared = min(n_blocks, math.ceil(prefix_len / bs)) if (prefix_id >= 0 and prefix_len > 0) else 0
+    n_shared = (
+        min(n_blocks, math.ceil(prefix_len / bs)) if (prefix_id >= 0 and prefix_len > 0) else 0
+    )
     blocks = [hasher.hid(("P", prefix_id, b)) for b in range(n_shared)]
     blocks += [hasher.hid(("U", idx, b)) for b in range(n_blocks - n_shared)]
     return blocks
 
 
-def _load_mooncake_trace(path: str) -> List[Tuple[float, int, int, List[int]]]:
+def _load_mooncake_trace(path: str) -> list[tuple[float, int, int, list[int]]]:
     """Load a Mooncake-format trace: ``(arrival_ms, isl, osl, hash_ids)`` rows.
 
     Accepts JSON-lines (one object per line) or a JSON array. Each record uses
@@ -757,7 +765,7 @@ def _load_mooncake_trace(path: str) -> List[Tuple[float, int, int, List[int]]]:
     content-addressed prefix-cache matching directly -- consecutive requests that
     share a system prompt share leading ``hash_ids``.
     """
-    records: List[dict] = []
+    records: list[dict] = []
     with open(path) as f:
         text = f.read()
     stripped = text.lstrip()
@@ -776,7 +784,7 @@ def _load_mooncake_trace(path: str) -> List[Tuple[float, int, int, List[int]]]:
                 return low[nm]
         return default
 
-    rows: List[Tuple[float, int, int, List[int]]] = []
+    rows: list[tuple[float, int, int, list[int]]] = []
     for r in records:
         ts = float(_g(r, "timestamp", "arrival", "arrival_ms", "time", default=0.0))
         isl = int(_g(r, "input_length", "isl", "input_len", "prompt_len", default=1))
@@ -786,9 +794,7 @@ def _load_mooncake_trace(path: str) -> List[Tuple[float, int, int, List[int]]]:
     return rows
 
 
-def _draw_prefix_ids(
-    n: int, num_prefixes: int, zipf: float, rng: random.Random
-) -> List[int]:
+def _draw_prefix_ids(n: int, num_prefixes: int, zipf: float, rng: random.Random) -> list[int]:
     """Assign each of ``n`` requests a shared-prefix id in ``[0, num_prefixes)``.
 
     ``zipf <= 0`` → uniform popularity; ``zipf > 0`` → power-law skew (a few
@@ -826,7 +832,7 @@ _KV_UNKNOWN_COST_BLOCKS = 1.0
 
 
 def _route_and_warm(
-    reqs: List["_Req"],
+    reqs: list[_Req],
     *,
     policy: str,
     num_instances: int,
@@ -834,7 +840,7 @@ def _route_and_warm(
     cache_blocks: int,
     rng: random.Random,
     overlap_weight: float = 1.0,
-) -> Tuple[List[List["_Req"]], Dict[str, float]]:
+) -> tuple[list[list[_Req]], dict[str, float]]:
     """Route requests across instances and derive per-request prefix-cache hits
     from a content-addressed block cache (as real serving engines do).
 
@@ -851,7 +857,7 @@ def _route_and_warm(
     leading block so same-prefix requests co-locate; ``round_robin``/``random``
     ignore locality.
     """
-    per_inst: List[List["_Req"]] = [[] for _ in range(num_instances)]
+    per_inst: list[list[_Req]] = [[] for _ in range(num_instances)]
     caches = [_BlockCache(cache_blocks) for _ in range(num_instances)]
     # Decayed history of blocks each instance had to compute. The router's load
     # term also counts in-flight blocks, which are unknowable here (routing is
@@ -897,9 +903,7 @@ def _route_and_warm(
             # prompt accrues it and the next cold prompt goes elsewhere.
             for i in range(num_instances):
                 recent[i] *= _KV_RECENT_DECAY
-            recent[inst] += (
-                float(len(blocks) - matched) if blocks else _KV_UNKNOWN_COST_BLOCKS
-            )
+            recent[inst] += float(len(blocks) - matched) if blocks else _KV_UNKNOWN_COST_BLOCKS
         cached = max(0, min(matched * block_size, r.prompt_len - 1))
         if cached > 0:
             r.cached_prefix = cached
@@ -925,29 +929,34 @@ def _route_and_warm(
         "avg_cached_tokens": (cached_total / n) if n else 0.0,
         "min_inst_hit_rate": min(
             (inst_hits[i] / inst_reqs[i]) for i in range(num_instances) if inst_reqs[i]
-        ) if any(inst_reqs) else 0.0,
+        )
+        if any(inst_reqs)
+        else 0.0,
         "max_inst_hit_rate": max(
             (inst_hits[i] / inst_reqs[i]) for i in range(num_instances) if inst_reqs[i]
-        ) if any(inst_reqs) else 0.0,
+        )
+        if any(inst_reqs)
+        else 0.0,
     }
     return per_inst, summary
 
 
-def _aggregate_instances(results: List[DESResult], prefix_summary: Dict[str, float]) -> DESResult:
+def _aggregate_instances(results: list[DESResult], prefix_summary: dict[str, float]) -> DESResult:
     """Pool per-instance DESResults into one fleet-level DESResult.
 
     Latency distributions are recomputed from the pooled raw samples; system
     throughput / achieved rate sum across instances; makespan is the slowest
     instance; utilization is the per-instance mean.
     """
-    def _pool(key: str) -> List[float]:
-        out: List[float] = []
+
+    def _pool(key: str) -> list[float]:
+        out: list[float] = []
         for r in results:
             if r.samples and r.samples.get(key):
                 out.extend(r.samples[key])
         return out
 
-    def dist(xs: List[float]) -> Dict[str, float]:
+    def dist(xs: list[float]) -> dict[str, float]:
         return {
             "mean": (sum(xs) / len(xs)) if xs else 0.0,
             "p50": _pct(xs, 0.50),
@@ -997,7 +1006,7 @@ def simulate_multi_instance(
     prefix_zipf: float,
     block_size: int,
     cache_blocks: int,
-    mooncake_rows: Optional[List[Tuple[float, int, int, List[int]]]] = None,
+    mooncake_rows: list[tuple[float, int, int, list[int]]] | None = None,
 ) -> DESResult:
     """Route one arrival stream across ``num_instances`` replicas and pool.
 
@@ -1027,7 +1036,9 @@ def simulate_multi_instance(
         arrivals = _generate_arrivals(num_requests, rate_per_s, arrival_model, rng, burstiness)
         reqs = _build_workload(len(arrivals), arrivals, input_len, output_len, range_ratio, rng)
         # A prefix pool with ``prefix_len == 0`` defaults to half the prompt.
-        eff_prefix_len = prefix_len if prefix_len > 0 else (input_len // 2 if num_prefixes > 0 else 0)
+        eff_prefix_len = (
+            prefix_len if prefix_len > 0 else (input_len // 2 if num_prefixes > 0 else 0)
+        )
         for r, pid in zip(reqs, _draw_prefix_ids(len(reqs), num_prefixes, prefix_zipf, rng)):
             r.prefix_id = pid
             r.blocks = _blocks_from_prefix(r.idx, r.prompt_len, pid, eff_prefix_len, bs, hasher)
@@ -1041,10 +1052,12 @@ def simulate_multi_instance(
         rng=rng,
         overlap_weight=overlap_weight,
     )
-    prefix_summary["routing"] = float(_ROUTING_POLICIES.index(routing)) if routing in _ROUTING_POLICIES else -1.0
+    prefix_summary["routing"] = (
+        float(_ROUTING_POLICIES.index(routing)) if routing in _ROUTING_POLICIES else -1.0
+    )
     prefix_summary["trace_driven"] = 1.0 if mooncake_rows is not None else 0.0
 
-    results: List[DESResult] = []
+    results: list[DESResult] = []
     for i, sub in enumerate(per_inst):
         if not sub:
             continue
@@ -1080,7 +1093,7 @@ def run_des(
     burstiness: float = 1.0,
     range_ratio: float = 1.0,
     kv_cache_tokens: int = 0,
-    workload_file: Optional[str] = None,
+    workload_file: str | None = None,
     record_steps: bool = False,
     num_instances: int = 1,
     routing: str = "round_robin",
@@ -1091,8 +1104,8 @@ def run_des(
     cache_slots: int = 0,
     block_size: int = 0,
     cache_blocks: int = 0,
-    mooncake_trace: Optional[str] = None,
-) -> Dict[str, object]:
+    mooncake_trace: str | None = None,
+) -> dict[str, object]:
     """Run the DES at the configured load and (optionally) a load sweep.
 
     Returns ``{"point": DESResult, "curve": [DESResult, ...],
@@ -1100,7 +1113,7 @@ def run_des(
     rate ``mu`` from the steady-state projection and samples fractions of it to
     trace the throughput-vs-latency knee.
     """
-    out: Dict[str, object] = {}
+    out: dict[str, object] = {}
     # ``cache_blocks`` is the block-cache capacity; fall back to the legacy
     # ``cache_slots`` flag when the new one is unset.
     eff_cache_blocks = max(0, cache_blocks or cache_slots or 0)
@@ -1117,7 +1130,9 @@ def run_des(
             inference_config,
             projector,
             rate_per_s=eff_rate,
-            arrival_model=arrival_model if arrival_model in ("poisson", "deterministic") else "poisson",
+            arrival_model=arrival_model
+            if arrival_model in ("poisson", "deterministic")
+            else "poisson",
             num_requests=num_requests,
             seed=seed,
             warmup_frac=warmup_frac,
@@ -1154,7 +1169,7 @@ def run_des(
         steady = projector.project()
         osl = max(1, inference_config.request_config.output_seq_len)
         mu = (steady.decode_throughput_tps / osl) if steady.decode_throughput_tps > 0 else 0.0
-        curve: List[DESResult] = []
+        curve: list[DESResult] = []
         if mu > 0:
             sweep_n = min(num_requests, 300)
             fracs = [0.3, 0.5, 0.7, 0.8, 0.9, 0.95]

--- a/infera/projection/core/projection/inference_projection/kv_cache.py
+++ b/infera/projection/core/projection/inference_projection/kv_cache.py
@@ -35,12 +35,12 @@ class KVCacheBreakdown:
 
     bytes_per_token_per_layer: float
     layers_on_rank: int
-    bytes_per_token: float          # across all layers on this rank
-    bytes_per_sequence: float       # at max_context_len
-    bytes_total: float              # across the sequences resident on this rank
+    bytes_per_token: float  # across all layers on this rank
+    bytes_per_sequence: float  # at max_context_len
+    bytes_total: float  # across the sequences resident on this rank
     max_context_len: int
-    concurrency: int                # resident sequences across the replica
-    sequences_on_rank: int          # concurrency / attention-DP size
+    concurrency: int  # resident sequences across the replica
+    sequences_on_rank: int  # concurrency / attention-DP size
     kv_cache_dtype: str
 
 
@@ -108,10 +108,7 @@ def linear_state_bytes_per_layer(inference_config: InferenceConfig) -> float:
         return 0.0
     mp = inference_config.model_parallel_config
     tp = max(1, mp.tensor_model_parallel_size)
-    heads_on_rank = (
-        heads if attention_dp_size(inference_config) > 1
-        else max(1, heads // tp)
-    )
+    heads_on_rank = heads if attention_dp_size(inference_config) > 1 else max(1, heads // tp)
     elem = dtype_num_bytes("bf16")
     state = heads_on_rank * d * d * elem
     kernel = int(getattr(mc, "linear_attention_conv_kernel", 0) or 0)
@@ -184,9 +181,7 @@ def estimate_kv_cache(
     lin_frac = 1.0 - full_frac
     if lin_frac > 0.0:
         per_sequence += (
-            linear_state_bytes_per_layer(inference_config)
-            * max(1, layers_on_rank)
-            * lin_frac
+            linear_state_bytes_per_layer(inference_config) * max(1, layers_on_rank) * lin_frac
         )
 
     # Data-parallel attention splits the running requests across ranks, so a

--- a/infera/projection/core/projection/inference_projection/launcher.py
+++ b/infera/projection/core/projection/inference_projection/launcher.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Dict
 
 from infera.projection.core.launcher.parser import load_config
 from infera.projection.core.projection.training_config import (
@@ -17,7 +16,7 @@ from infera.projection.core.projection.training_config import (
 )
 
 from .memory import project_inference_memory
-from .performance import InferencePerformanceProjector, project_inference_performance
+from .performance import InferencePerformanceProjector
 
 # Map CLI arg attribute names → InferenceRequestConfig field names.
 _ARG_TO_FIELD = {
@@ -96,11 +95,11 @@ _DISAGG_ARG_TO_FIELD = {
     "transfer_backend": "disagg_transfer_backend",
 }
 
-_GB = 1024.0 ** 3
+_GB = 1024.0**3
 
 
-def _collect_inference_overrides(args) -> Dict[str, object]:
-    overrides: Dict[str, object] = {}
+def _collect_inference_overrides(args) -> dict[str, object]:
+    overrides: dict[str, object] = {}
     for mapping in (_ARG_TO_FIELD, _COLL_ARG_TO_FIELD, _DISAGG_ARG_TO_FIELD):
         for arg_name, field_name in mapping.items():
             if hasattr(args, arg_name):
@@ -150,8 +149,7 @@ def _print_performance(inference_config, perf, gpu_cost_per_hour=None) -> None:
         feats.append(f"prefix_cache_hit={req.resolved_prefix_cache_hit_rate():.2f}")
     if req.speculative_num_tokens:
         feats.append(
-            f"speculative(k={req.speculative_num_tokens}, "
-            f"accept={req.speculative_acceptance_rate})"
+            f"speculative(k={req.speculative_num_tokens}, accept={req.speculative_acceptance_rate})"
         )
     if req.kv_cache_dtype != "bf16":
         feats.append(f"kv_dtype={req.kv_cache_dtype}")
@@ -160,15 +158,17 @@ def _print_performance(inference_config, perf, gpu_cost_per_hour=None) -> None:
         _frac = req.resolved_sliding_window_fraction(
             getattr(mc, "sink_window_even_layers_only", False)
         )
-        feats.append(
-            f"sliding_window={_win}" + (f"(frac={_frac:g})" if _frac < 1.0 else "")
-        )
+        feats.append(f"sliding_window={_win}" + (f"(frac={_frac:g})" if _frac < 1.0 else ""))
     if not getattr(req, "sampling_enabled", True):
         feats.append("sampling=off")
     elif getattr(req, "sampling_top_k", 0) or 0.0 < getattr(req, "sampling_top_p", 1.0) < 1.0:
         feats.append(
             "sampling("
-            + (f"top_k={req.sampling_top_k}" if req.sampling_top_k else f"top_p={req.sampling_top_p}")
+            + (
+                f"top_k={req.sampling_top_k}"
+                if req.sampling_top_k
+                else f"top_p={req.sampling_top_p}"
+            )
             + ")"
         )
     _adq = req.resolved_act_quant_dtype(getattr(mc, "fp8", None))
@@ -186,9 +186,7 @@ def _print_performance(inference_config, perf, gpu_cost_per_hour=None) -> None:
     if req.kv_block_size:
         feats.append(f"kv_block={req.kv_block_size}")
     if req.kv_offload_gb_per_gpu:
-        feats.append(
-            f"kv_offload={req.kv_offload_gb_per_gpu:g}GB@{req.kv_offload_bw_gbps:g}GB/s"
-        )
+        feats.append(f"kv_offload={req.kv_offload_gb_per_gpu:g}GB@{req.kv_offload_bw_gbps:g}GB/s")
     if req.max_num_batched_tokens:
         feats.append(f"max_batched_tokens={req.max_num_batched_tokens}")
     if req.ep_load_balance and req.ep_load_balance != 1.0:
@@ -202,8 +200,7 @@ def _print_performance(inference_config, perf, gpu_cost_per_hour=None) -> None:
     n_lin = mc.linear_attention_layer_count()
     if n_lin:
         feats.append(
-            f"linear_attn={n_lin}/{mc.num_layers}"
-            f"(state={mc.linear_attention_state_len()})"
+            f"linear_attn={n_lin}/{mc.num_layers}(state={mc.linear_attention_state_len()})"
         )
     if getattr(req, "moe_expert_dtype", None):
         feats.append(f"moe_expert_dtype={req.moe_expert_dtype}")
@@ -244,7 +241,9 @@ def _print_performance(inference_config, perf, gpu_cost_per_hour=None) -> None:
     print("-" * 100)
     print(f"  TTFT (time to first token):      {perf.ttft_ms:.2f} ms")
     if perf.is_disaggregated:
-        print(f"    prefill compute:               {perf.extras.get('prefill_compute_ttft_ms', 0.0):.2f} ms")
+        print(
+            f"    prefill compute:               {perf.extras.get('prefill_compute_ttft_ms', 0.0):.2f} ms"
+        )
         print(f"    KV-cache transfer:             {perf.kv_transfer_ms:.2f} ms")
     print(f"  ITL / TPOT (per token):          {perf.itl_ms:.2f} ms")
     print(f"  Interactivity (per user):        {perf.per_request_decode_tps:.1f} tok/s/user")
@@ -276,17 +275,20 @@ def _print_performance(inference_config, perf, gpu_cost_per_hour=None) -> None:
     print(f"  Aggregate decode throughput:     {perf.decode_throughput_tps:.1f} tok/s")
     print(f"  Decode throughput / GPU:         {perf.decode_throughput_tps_per_gpu:.1f} tok/s/gpu")
     if perf.is_disaggregated:
-        fleet_gpus = (perf.prefill_replica_gpus * int(perf.extras.get("prefill_replicas", 1))
-                      + perf.decode_replica_gpus * int(perf.extras.get("decode_replicas", 1)))
+        fleet_gpus = perf.prefill_replica_gpus * int(
+            perf.extras.get("prefill_replicas", 1)
+        ) + perf.decode_replica_gpus * int(perf.extras.get("decode_replicas", 1))
     else:
         fleet_gpus = perf.replica_gpus
     # Billed tokens, not computed ones: a prompt served from the prefix cache is
     # still charged, so this is what a $/token figure divides into. Prefill and
     # decode GPUs are both in the denominator, which is what makes it comparable
     # across P:D ratios that a decode-only figure would rank identically.
-    total_tps = perf.decode_throughput_tps * (
-        req.input_seq_len + req.output_seq_len
-    ) / max(1, req.output_seq_len)
+    total_tps = (
+        perf.decode_throughput_tps
+        * (req.input_seq_len + req.output_seq_len)
+        / max(1, req.output_seq_len)
+    )
     print(
         f"  Total throughput / GPU:          {total_tps / max(1, fleet_gpus):.1f} tok/s/gpu"
         f"   (in+out over {fleet_gpus} GPU)"
@@ -305,8 +307,7 @@ def _print_performance(inference_config, perf, gpu_cost_per_hour=None) -> None:
         print(f"  Replica GPUs (TP×PP):            {perf.replica_gpus}")
     if perf.extras.get("speculative_tokens_per_step", 1.0) > 1.0:
         print(
-            f"  Speculative tokens / step:       "
-            f"{perf.extras['speculative_tokens_per_step']:.2f}"
+            f"  Speculative tokens / step:       {perf.extras['speculative_tokens_per_step']:.2f}"
         )
     # Throughput priced in the unit a serving budget is quoted in. Prefill and
     # decode share the GPUs under continuous batching, so a token's cost is the
@@ -397,7 +398,7 @@ def _emit_restore_confidence(anchor_paths, target_gpus: int) -> None:
         pass
 
 
-def _print_des(des: Dict[str, object]) -> None:
+def _print_des(des: dict[str, object]) -> None:
     point = des["point"]
     print("\n" + "=" * 100)
     print("[inferasim:Inference] Discrete-Event Simulation (arrival-driven)")
@@ -415,7 +416,7 @@ def _print_des(des: Dict[str, object]) -> None:
     print("-" * 100)
     print(f"  {'metric':<22}{'mean':>12}{'p50':>12}{'p90':>12}{'p99':>12}")
 
-    def _row(label: str, d: Dict[str, float], unit: str = "ms") -> None:
+    def _row(label: str, d: dict[str, float], unit: str = "ms") -> None:
         print(
             f"  {label:<22}"
             f"{d.get('mean', 0.0):>10.2f} {unit:<1}"
@@ -444,9 +445,7 @@ def _print_des(des: Dict[str, object]) -> None:
             else f"prefix pool: {int(pfx.get('num_prefixes', 0))} prefixes"
         )
         print("-" * 100)
-        print(
-            f"  Fleet: {int(pfx['num_instances'])} instance(s), routing={rname} | {source}"
-        )
+        print(f"  Fleet: {int(pfx['num_instances'])} instance(s), routing={rname} | {source}")
         bs = int(pfx.get("block_size", 0))
         cap = int(pfx.get("cache_blocks", 0))
         cap_str = f"{cap} blocks" if cap > 0 else "unbounded"
@@ -515,9 +514,7 @@ def _target_model_id(args=None):
     already does that for the benchmark path, so it is honoured here too, and
     the preset remains the fallback when nothing names the checkpoint.
     """
-    explicit = getattr(args, "bench_model", None) or os.environ.get(
-        "INFERASIM_BENCH_MODEL"
-    )
+    explicit = getattr(args, "bench_model", None) or os.environ.get("INFERASIM_BENCH_MODEL")
     return explicit or os.environ.get("INFERASIM_MODEL")
 
 
@@ -566,9 +563,7 @@ def _assert_anchor_is_this_model(path, artifact, args=None):
     preset = _target_model_id(args)
     if not measured or not preset:
         return
-    if models_match(preset, measured) or os.environ.get(
-        "INFERASIM_ALLOW_FOREIGN_ANCHOR"
-    ):
+    if models_match(preset, measured) or os.environ.get("INFERASIM_ALLOW_FOREIGN_ANCHOR"):
         return
     raise ValueError(
         f"[inferasim:Inference] anchor {path} was measured on {measured!r}, but "
@@ -593,14 +588,13 @@ def _anchor_from_store(args, inference_config):
 
     Returns the anchor path to load, or None to project analytically.
     """
-    root = getattr(args, "anchor_store", None) or os.environ.get(
-        "INFERASIM_ANCHOR_STORE"
-    )
+    root = getattr(args, "anchor_store", None) or os.environ.get("INFERASIM_ANCHOR_STORE")
     if not root:
         return None
     if not os.path.isdir(root):
-        print(f"[inferasim:Inference] anchor store '{root}' does not exist — "
-              "projecting analytically.")
+        print(
+            f"[inferasim:Inference] anchor store '{root}' does not exist — projecting analytically."
+        )
         return None
 
     try:
@@ -612,25 +606,29 @@ def _anchor_from_store(args, inference_config):
         model = _anchor_model_filter(store, args)
         entry, distance = store.nearest(recipe, model=model)
     except Exception as exc:  # noqa: BLE001 - a broken store must not fail a projection
-        print(f"[inferasim:Inference] anchor store unusable ({exc}) — "
-              "projecting analytically.")
+        print(f"[inferasim:Inference] anchor store unusable ({exc}) — projecting analytically.")
         return None
 
     if entry is None:
-        print(f"[inferasim:Inference] no anchor in {root} for this model — "
-              "projecting analytically.")
+        print(
+            f"[inferasim:Inference] no anchor in {root} for this model — projecting analytically."
+        )
         return None
     if distance:
-        print(f"[inferasim:Inference] nearest anchor differs on {distance} regime "
-              f"axis(es) ({entry.get('path')}); it describes different kernels, so "
-              "projecting analytically instead. Warm up in this regime to calibrate.")
+        print(
+            f"[inferasim:Inference] nearest anchor differs on {distance} regime "
+            f"axis(es) ({entry.get('path')}); it describes different kernels, so "
+            "projecting analytically instead. Warm up in this regime to calibrate."
+        )
         return None
 
     path = entry.get("path")
     tr = entry.get("transport") or {}
-    print(f"[inferasim:Inference] calibrating from warmup anchor {path} "
-          f"(same regime, measured at TP={tr.get('tp')} EP={tr.get('ep')} "
-          f"PP={tr.get('pp')})")
+    print(
+        f"[inferasim:Inference] calibrating from warmup anchor {path} "
+        f"(same regime, measured at TP={tr.get('tp')} EP={tr.get('ep')} "
+        f"PP={tr.get('pp')})"
+    )
     return path
 
 
@@ -643,9 +641,7 @@ def launch_projection_from_cli(args, overrides):
     config, _unknown = load_config(args, overrides or [])
 
     inf_overrides = _collect_inference_overrides(args)
-    inference_config = convert_config_to_inference_config(
-        config, inference_overrides=inf_overrides
-    )
+    inference_config = convert_config_to_inference_config(config, inference_overrides=inf_overrides)
 
     # Serving weight precision drives the *compute* GEMM dtype, not just the
     # memory report. The layer profilers pick the GEMM dtype from
@@ -671,9 +667,11 @@ def launch_projection_from_cli(args, overrides):
         inference_config.model_config.moe_router_coverage = {
             int(k): float(v) for k, v in _curve.items()
         }
-        print(f"[inferasim:Inference] measured router coverage from {_cov} "
-              f"({len(_curve)} batch points, "
-              f"min {min(float(v) for v in _curve.values()):.2f}x independent)")
+        print(
+            f"[inferasim:Inference] measured router coverage from {_cov} "
+            f"({len(_curve)} batch points, "
+            f"min {min(float(v) for v in _curve.values()):.2f}x independent)"
+        )
 
     explicit_wdt = getattr(args, "weight_dtype", None)
     if explicit_wdt is not None:
@@ -806,7 +804,9 @@ def launch_projection_from_cli(args, overrides):
     # anchor (per-GPU decode throughput not yet flat within one doubling of the
     # target) and recommend the GPU count to benchmark next.
     if mode in ("performance", "both"):
-        _tgt_pp = int(getattr(inference_config.model_parallel_config, "pipeline_model_parallel_size", 1) or 1)
+        _tgt_pp = int(
+            getattr(inference_config.model_parallel_config, "pipeline_model_parallel_size", 1) or 1
+        )
         _tgt_tp = int(inference_config.model_parallel_config.tensor_model_parallel_size)
         _anchor_paths = ([load_bench] if load_bench else []) + _scaling_bench_paths(args)
         if getattr(args, "decode_floor_benchmark", None):
@@ -823,12 +823,14 @@ def launch_projection_from_cli(args, overrides):
         )
     if mode in ("performance", "both"):
         projector = InferencePerformanceProjector(
-            inference_config, args=args, benchmark_layer_times=benchmark_layer_times,
-            scaling_benchmarks=scaling_benchmarks, decode_floor=decode_floor,
+            inference_config,
+            args=args,
+            benchmark_layer_times=benchmark_layer_times,
+            scaling_benchmarks=scaling_benchmarks,
+            decode_floor=decode_floor,
         )
         perf = projector.project()
-        _print_performance(inference_config, perf,
-                           getattr(args, "gpu_cost_per_hour", None))
+        _print_performance(inference_config, perf, getattr(args, "gpu_cost_per_hour", None))
         results["performance"] = perf
 
         # Phase 3: opt-in discrete-event simulation for arrival-driven
@@ -840,15 +842,19 @@ def launch_projection_from_cli(args, overrides):
         dump_steps = getattr(args, "des_dump_steps", None)
         mooncake_trace = getattr(args, "des_mooncake_trace", None)
         run_des_enabled = (
-            arrival_model in ("poisson", "deterministic") and (req.request_rate or 0) > 0
-        ) or bool(workload_file) or bool(mooncake_trace)
+            (arrival_model in ("poisson", "deterministic") and (req.request_rate or 0) > 0)
+            or bool(workload_file)
+            or bool(mooncake_trace)
+        )
         if run_des_enabled:
             from .des import run_des
 
             des = run_des(
                 inference_config,
                 projector,
-                arrival_model=arrival_model if arrival_model in ("poisson", "deterministic") else "poisson",
+                arrival_model=arrival_model
+                if arrival_model in ("poisson", "deterministic")
+                else "poisson",
                 rate_per_s=float(req.request_rate or 0.0),
                 num_requests=int(getattr(args, "des_num_requests", 400) or 400),
                 seed=int(getattr(args, "des_seed", 0) or 0),
@@ -893,6 +899,8 @@ def launch_projection_from_cli(args, overrides):
                 }
                 with open(dump_steps, "w") as _f:
                     _json.dump(payload, _f)
-                print(f"[inferasim:Inference] wrote {len(des['point'].steps)} DES step records to {dump_steps}")
+                print(
+                    f"[inferasim:Inference] wrote {len(des['point'].steps)} DES step records to {dump_steps}"
+                )
 
     return results

--- a/infera/projection/core/projection/inference_projection/memory.py
+++ b/infera/projection/core/projection/inference_projection/memory.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, replace
-from typing import Optional
 
 from infera.projection.core.projection.module_profilers.language_model import (
     build_profiler,
@@ -46,12 +45,12 @@ class InferenceMemoryResult:
     total_bytes: int
     kv: KVCacheBreakdown
     layers_on_rank: int
-    hbm_capacity_bytes: Optional[int] = None
-    max_concurrent_sequences: Optional[int] = None
-    fits: Optional[bool] = None
+    hbm_capacity_bytes: int | None = None
+    max_concurrent_sequences: int | None = None
+    fits: bool | None = None
 
 
-_GB = 1024.0 ** 3
+_GB = 1024.0**3
 
 
 def _layers_on_rank(inference_config: InferenceConfig) -> int:
@@ -95,8 +94,8 @@ def _forward_activation_bytes(inference_config: InferenceConfig, profiler) -> in
 def project_inference_memory(
     inference_config: InferenceConfig,
     *,
-    rank: Optional[int] = None,
-    hbm_capacity_gb: Optional[float] = None,
+    rank: int | None = None,
+    hbm_capacity_gb: float | None = None,
     verbose: bool = True,
 ) -> InferenceMemoryResult:
     eff_rank = int(os.getenv("RANK", "0")) if rank is None else int(rank)
@@ -121,9 +120,7 @@ def project_inference_memory(
         local = max(1, int(inference_config.request_config.resolved_max_concurrency()) // reps)
         inference_config = replace(
             inference_config,
-            model_parallel_config=disagg.decode_parallel(
-                inference_config.model_parallel_config
-            ),
+            model_parallel_config=disagg.decode_parallel(inference_config.model_parallel_config),
             request_config=replace(
                 inference_config.request_config,
                 batch_size=local,
@@ -142,9 +139,7 @@ def project_inference_memory(
     # weight class -- experts by expert assignment, everything else by tensor
     # sharding. Counting the expert split here as well would shard experts
     # twice and report a fraction of the weights a rank really loads.
-    view.model_parallel_config = replace(
-        view.model_parallel_config, expert_model_parallel_size=1
-    )
+    view.model_parallel_config = replace(view.model_parallel_config, expert_model_parallel_size=1)
     profiler = build_profiler(get_language_model_profiler_spec(view))
 
     # With experts left whole above, ``estimated_num_params`` counts this rank's
@@ -224,9 +219,7 @@ def _print_memory(inference_config: InferenceConfig, r: InferenceMemoryResult) -
         print(f"  HBM capacity:             {r.hbm_capacity_bytes / _GB:.4f} GB")
         if req.kv_cache_memory_fraction:
             usable = r.hbm_capacity_bytes * float(req.kv_cache_memory_fraction)
-            print(
-                f"  Usable HBM (frac={req.kv_cache_memory_fraction:.2f}): {usable / _GB:.4f} GB"
-            )
+            print(f"  Usable HBM (frac={req.kv_cache_memory_fraction:.2f}): {usable / _GB:.4f} GB")
         print(f"  Fits:                     {r.fits}")
         if req.kv_offload_gb_per_gpu:
             print(

--- a/infera/projection/core/projection/inference_projection/performance.py
+++ b/infera/projection/core/projection/inference_projection/performance.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import math
 import os
 from dataclasses import dataclass, field, replace
-from typing import Dict, Optional
 
 from infera.projection.core.projection.module_profilers.language_model import (
     build_profiler,
@@ -53,6 +52,7 @@ from .collectives import (
     InferenceCollectiveModel,
     deepep_overlap_efficiency,
 )
+
 
 def _safe_forward(profiler, batch: int, seq_len: int) -> float:
     """Forward time of a sub-profiler, or 0 if it does not implement timing.
@@ -122,27 +122,33 @@ class PhaseForwardTimes:
 class InferencePerfResult:
     ttft_ms: float
     decode_total_ms: float
-    itl_ms: float                 # inter-token latency per sequence (= TPOT)
-    request_latency_ms: float     # TTFT + full decode for one sequence
+    itl_ms: float  # inter-token latency per sequence (= TPOT)
+    request_latency_ms: float  # TTFT + full decode for one sequence
     per_request_decode_tps: float
-    decode_throughput_tps: float          # aggregate, whole batch
+    decode_throughput_tps: float  # aggregate, whole batch
     decode_throughput_tps_per_gpu: float
     prefill_throughput_tps: float
-    decode_step_latency_ms: float          # one decode forward (whole batch)
+    decode_step_latency_ms: float  # one decode forward (whole batch)
     replica_gpus: int
     # Disaggregation (feature A). ``is_disaggregated`` toggles the extra report.
     is_disaggregated: bool = False
     kv_transfer_ms: float = 0.0
     prefill_replica_gpus: int = 0
     decode_replica_gpus: int = 0
-    extras: Dict[str, float] = field(default_factory=dict)
+    extras: dict[str, float] = field(default_factory=dict)
 
 
 class InferencePerformanceProjector:
     """Builds the profiler once and answers prefill / decode timing queries."""
 
-    def __init__(self, inference_config: InferenceConfig, args=None, benchmark_layer_times=None,
-                 scaling_benchmarks=None, decode_floor=None):
+    def __init__(
+        self,
+        inference_config: InferenceConfig,
+        args=None,
+        benchmark_layer_times=None,
+        scaling_benchmarks=None,
+        decode_floor=None,
+    ):
         self.cfg = inference_config
         self._args_ref = args
         # Optional measured decode latency floor {batch: ms} from a sharded
@@ -250,9 +256,11 @@ class InferencePerformanceProjector:
         # expert-GEMM simulator can apply imbalance *inside* the roofline, per
         # view (EP lives on each view's parallel config). Default ("roofline")
         # mode; INFERASIM_MOE_IMB_ROOFLINE=0 falls back to the outer multiplier.
-        self._imb_roofline = os.getenv(
-            "INFERASIM_MOE_IMB_ROOFLINE", "1"
-        ).strip().lower() not in ("0", "false", "no")
+        self._imb_roofline = os.getenv("INFERASIM_MOE_IMB_ROOFLINE", "1").strip().lower() not in (
+            "0",
+            "false",
+            "no",
+        )
         try:
             mc.ep_load_balance = float(self.cfg.request_config.ep_load_balance or 1.0)
             mc.redundant_experts = int(self.cfg.request_config.redundant_experts or 0)
@@ -272,7 +280,9 @@ class InferencePerformanceProjector:
         # sparse-attention selection, and MoE expert-dtype (mxfp4/fp8/bf16)
         # compute speedup.  All affect the *simulation* path only (the measured
         # path bundles these into the whole-model step).  Defaults are no-ops.
-        self._attn_backend_mult = inference_config.request_config.resolved_attention_backend_multiplier()
+        self._attn_backend_mult = (
+            inference_config.request_config.resolved_attention_backend_multiplier()
+        )
         # The expert dtype is now priced inside the expert GEMM roofline (real
         # operand bytes + matrix throughput), so there is no outer multiplier to
         # apply. Kept at 1.0 rather than removed so the restore/ratio paths that
@@ -312,7 +322,7 @@ class InferencePerformanceProjector:
         #     one MoE layer per phase. Composed directly by layer counts.
         #
         # Empty => pure simulation.
-        self._meas_whole: Dict[str, list] = {}   # {"prefill": [(batch, ms)], "decode": [...]}
+        self._meas_whole: dict[str, list] = {}  # {"prefill": [(batch, ms)], "decode": [...]}
         # When the benchmark swept the decode curve at the engine's CUDA-graph
         # capture sizes, runtime pads the decode batch UP to the nearest captured
         # size — so decode latency is a staircase and we look it up by bucket
@@ -323,15 +333,15 @@ class InferencePerformanceProjector:
         # over context is nearly the same at low and high batch, so it is NOT
         # proportional to batch). Fit from the benchmark's decode-vs-context grid;
         # 0 => flat (no grid), preserving prior behaviour.
-        self._decode_kv_slope_ms: float = 0.0     # ms per KV token (batch-independent)
-        self._decode_ctx_ref: float = 0.0         # context the batch curve was measured at
-        self._decode_ctx_max: float = 0.0         # largest measured context (guard)
+        self._decode_kv_slope_ms: float = 0.0  # ms per KV token (batch-independent)
+        self._decode_ctx_ref: float = 0.0  # context the batch curve was measured at
+        self._decode_ctx_max: float = 0.0  # largest measured context (guard)
         self._meas_prefill_rate_ms_per_tok: float = 0.0  # for sub-prompt prefill pieces
         # True when the benchmark deliberately repeated prompts with prefix
         # caching enabled. Such a curve is a cache-hit lookup curve and is only
         # usable for a target configured as a full prefix hit.
         self._meas_prefill_cache_hit: bool = False
-        self._meas_layer: Dict[tuple, float] = {}        # {(phase, ltype): ms}
+        self._meas_layer: dict[tuple, float] = {}  # {(phase, ltype): ms}
         self._meas_ref_input: int = 0
         self._bench_backend: str = "megatron"
         self._bench_measured = benchmark_layer_times
@@ -345,7 +355,7 @@ class InferencePerformanceProjector:
         # phase -> batch -> tp -> (ms, ep, pp), and the split fitted from it.
         self._bench_scaling_raw: dict = {}
         self._bench_scaling_fit: dict = {}
-        for _blob in (scaling_benchmarks or []):
+        for _blob in scaling_benchmarks or []:
             self.add_scaling_benchmark(_blob)
         if benchmark_layer_times:
             self.set_benchmark_calibration(benchmark_layer_times)
@@ -477,7 +487,7 @@ class InferencePerformanceProjector:
 
     # -- measured-time accessors (benchmark-based projection) ------------------
 
-    def _measured_decode_step_ms(self, batch: int, context: Optional[float] = None) -> float:
+    def _measured_decode_step_ms(self, batch: int, context: float | None = None) -> float:
         """Measured whole-model / composed decode *step* latency at ``batch``.
 
         ``context`` (the resident KV length) adds the fitted attention KV term on
@@ -489,12 +499,18 @@ class InferencePerformanceProjector:
                 base = self._bucket_up(batch, pts)
             else:
                 base = self._transport_batch(batch, pts)
-            if context is not None and self._decode_kv_slope_ms > 0.0 and self._decode_ctx_ref > 0.0:
+            if (
+                context is not None
+                and self._decode_kv_slope_ms > 0.0
+                and self._decode_ctx_ref > 0.0
+            ):
                 base += self._decode_kv_slope_ms * max(0.0, float(context) - self._decode_ctx_ref)
             return base
         # Per-layer schema: restore each layer to the target TP/EP, then sum by
         # layer count. Decode processes 1 token/step.
-        d = self._restore_per_layer("dense", self._meas_layer.get(("decode", "dense"), 0.0), batch, 1)
+        d = self._restore_per_layer(
+            "dense", self._meas_layer.get(("decode", "dense"), 0.0), batch, 1
+        )
         m = self._restore_per_layer("moe", self._meas_layer.get(("decode", "moe"), 0.0), batch, 1)
         return self._n_dense * d + self._n_moe * m + self._restore_pp_ms(batch, 1)
 
@@ -503,8 +519,12 @@ class InferencePerformanceProjector:
         if self._meas_whole.get("prefill"):
             return self._transport_batch(batch, self._meas_whole["prefill"])
         tok = self._meas_ref_input or 1
-        d = self._restore_per_layer("dense", self._meas_layer.get(("prefill", "dense"), 0.0), batch, tok)
-        m = self._restore_per_layer("moe", self._meas_layer.get(("prefill", "moe"), 0.0), batch, tok)
+        d = self._restore_per_layer(
+            "dense", self._meas_layer.get(("prefill", "dense"), 0.0), batch, tok
+        )
+        m = self._restore_per_layer(
+            "moe", self._meas_layer.get(("prefill", "moe"), 0.0), batch, tok
+        )
         return self._n_dense * d + self._n_moe * m + self._restore_pp_ms(batch, tok)
 
     def _measured_prefill_tokens_ms(self, total_tokens: int) -> float:
@@ -518,8 +538,9 @@ class InferencePerformanceProjector:
             # Decode-only artifact (or an untrusted prefill, see
             # set_benchmark_calibration): simulate the chunk rather than bill it
             # as free.
-            return self._forward_times(1, max(1, total_tokens), "prefill",
-                                       max(1, total_tokens)).total_ms
+            return self._forward_times(
+                1, max(1, total_tokens), "prefill", max(1, total_tokens)
+            ).total_ms
         return rate * max(1, total_tokens)
 
     # -- benchmark ingestion ---------------------------------------------------
@@ -530,7 +551,9 @@ class InferencePerformanceProjector:
         if ltype == "moe":
             # EP>1 (expert_tp==1) drops the post-expert TP-AR (combined by A2A).
             n_ar = _moe_tp_allreduce_count(self._view)
-            return n_ar * tp_ar_one + _estimate_moe_a2a_time_ms(self._view, batch, q_len, self._gemm)
+            return n_ar * tp_ar_one + _estimate_moe_a2a_time_ms(
+                self._view, batch, q_len, self._gemm
+            )
         return _dense_tp_allreduce_count(self._view) * tp_ar_one
 
     def set_benchmark_calibration(self, benchmark_layer_times: dict) -> None:
@@ -637,7 +660,9 @@ class InferencePerformanceProjector:
                 pre_pts = []
             if self._restore:
                 # Prefill processes ``ref_input`` tokens/seq; decode 1 token/step.
-                pre_pts = [(b, self._restore_whole(ms, b, ref_input, "prefill")) for b, ms in pre_pts]
+                pre_pts = [
+                    (b, self._restore_whole(ms, b, ref_input, "prefill")) for b, ms in pre_pts
+                ]
                 dec_pts = [(b, self._restore_whole(ms, b, 1, "decode")) for b, ms in dec_pts]
             self._meas_whole = {
                 k: v for k, v in (("prefill", sorted(pre_pts)), ("decode", sorted(dec_pts))) if v
@@ -665,7 +690,7 @@ class InferencePerformanceProjector:
 
         # Per-layer schema (Megatron worker): measured forward time of one dense
         # and one MoE layer per phase. Used directly, composed by layer counts.
-        layer: Dict[tuple, float] = {}
+        layer: dict[tuple, float] = {}
         for ltype in ("dense", "moe"):
             entry = measured.get(ltype)
             if not entry:
@@ -692,9 +717,7 @@ class InferencePerformanceProjector:
         tgt_ep = max(1, getattr(mp, "expert_model_parallel_size", 1) or 1)
         tgt_pp = max(1, mp.pipeline_model_parallel_size)
         self._restore = (
-            self._bench_tp != self._tgt_tp
-            or self._bench_ep != tgt_ep
-            or self._bench_pp != tgt_pp
+            self._bench_tp != self._tgt_tp or self._bench_ep != tgt_ep or self._bench_pp != tgt_pp
         )
         if not self._restore:
             return
@@ -734,31 +757,39 @@ class InferencePerformanceProjector:
         if self._scaling_mode == "origami":
             try:
                 self._gemm_sim = get_gemm_simulation_backend(
-                    backend_name=self._gemm_name, gpu_arch=self._gpu_arch,
-                    gpu_clock_mhz=self._gpu_clock, require_simulation=True,
+                    backend_name=self._gemm_name,
+                    gpu_arch=self._gpu_arch,
+                    gpu_clock_mhz=self._gpu_clock,
+                    require_simulation=True,
                 )
                 self._sdpa_sim = get_sdpa_simulation_backend(
-                    gpu_arch=self._gpu_arch, gpu_clock_mhz=self._gpu_clock,
+                    gpu_arch=self._gpu_arch,
+                    gpu_clock_mhz=self._gpu_clock,
                 )
                 rc = self.cfg.request_config
                 saved_mp = self.cfg.model_parallel_config
                 self.cfg.model_parallel_config = bench_mp
                 self._view_bench = self.cfg.as_training_config(
-                    batch_size=rc.batch_size, seq_len=rc.input_seq_len,
+                    batch_size=rc.batch_size,
+                    seq_len=rc.input_seq_len,
                 )
                 self.cfg.model_parallel_config = saved_mp
                 self._lm_ratio_tgt = build_profiler(
-                    get_language_model_profiler_spec(self._view_tgt))
+                    get_language_model_profiler_spec(self._view_tgt)
+                )
                 self._lm_ratio_tgt.set_simulation_backends(self._gemm_sim, self._sdpa_sim)
                 self._lm_ratio_bench = build_profiler(
-                    get_language_model_profiler_spec(self._view_bench))
+                    get_language_model_profiler_spec(self._view_bench)
+                )
                 self._lm_ratio_bench.set_simulation_backends(self._gemm_sim, self._sdpa_sim)
             except Exception as e:  # pragma: no cover - arch-dependent
                 self._lm_ratio_bench = None
-                print(f"[inferasim:Inference] origami-ratio unavailable ({e}); "
-                      "falling back to measured fit / blind TP^-1.")
+                print(
+                    f"[inferasim:Inference] origami-ratio unavailable ({e}); "
+                    "falling back to measured fit / blind TP^-1."
+                )
 
-    def _comm_model_at_tp(self, tp: int, ep: int, pp: int) -> "InferenceCollectiveModel":
+    def _comm_model_at_tp(self, tp: int, ep: int, pp: int) -> InferenceCollectiveModel:
         """Collective model at an arbitrary parallelism, for the scaling fit."""
         mp = self.cfg.model_parallel_config
         return InferenceCollectiveModel(
@@ -787,10 +818,10 @@ class InferencePerformanceProjector:
             for tp, (ms, ep, pp) in sorted(per_tp.items()):
                 tokens = 1 if phase == "decode" else self._meas_ref_input
                 cm = self._comm_model_at_tp(tp, ep, pp)
-                dense = (cm.layer_comm_ms(batch, tokens, is_moe=False).total_ms
-                         if self._n_dense else 0.0)
-                moe = (cm.layer_comm_ms(batch, tokens, is_moe=True).total_ms
-                       if self._n_moe else 0.0)
+                dense = (
+                    cm.layer_comm_ms(batch, tokens, is_moe=False).total_ms if self._n_dense else 0.0
+                )
+                moe = cm.layer_comm_ms(batch, tokens, is_moe=True).total_ms if self._n_moe else 0.0
                 comm = self._n_dense * dense + self._n_moe * moe
                 xs.append(1.0 / tp)
                 ys.append(max(0.0, ms - comm))
@@ -823,8 +854,11 @@ class InferencePerformanceProjector:
 
     def _report_tp_scaling(self) -> None:
         """Print the TP-scaling law the restore will use."""
-        if (self._scaling_mode == "origami" and self._restore
-                and getattr(self, "_lm_ratio_bench", None) is not None):
+        if (
+            self._scaling_mode == "origami"
+            and self._restore
+            and getattr(self, "_lm_ratio_bench", None) is not None
+        ):
             print(
                 f"[inferasim:Inference] TP scaling: origami-ratio (simulate vLLM-fused "
                 f"MoE) — scaling measured TP={self._bench_tp} anchor to TP="
@@ -879,14 +913,19 @@ class InferencePerformanceProjector:
         model_step = measured.get("model") or {}
         ref_batch = int(meta.get("batch") or self.cfg.request_config.batch_size or 1)
         for phase, key in (("decode", "decode_ms"), ("prefill", "prefill_ms")):
-            rows = [(int(e["batch"]), float(e[key])) for e in sweep
-                    if e.get("batch") is not None and e.get(key)]
+            rows = [
+                (int(e["batch"]), float(e[key]))
+                for e in sweep
+                if e.get("batch") is not None and e.get(key)
+            ]
             if not rows and model_step.get(key):
                 rows = [(ref_batch, float(model_step[key]))]
             for batch, ms in rows:
-                self._bench_scaling_raw.setdefault(phase, {}).setdefault(
-                    batch, {}
-                )[tp] = (ms, ep, pp)
+                self._bench_scaling_raw.setdefault(phase, {}).setdefault(batch, {})[tp] = (
+                    ms,
+                    ep,
+                    pp,
+                )
 
     def _restore_per_layer(self, ltype: str, ms_bench: float, batch: int, tokens: int) -> float:
         """Restore a per-layer time measured at the benchmark's (reduced) TP/EP to
@@ -912,7 +951,7 @@ class InferencePerformanceProjector:
             return 0.0
         return self._comm_tgt.pp_p2p_ms(batch, tokens) - self._comm_bench.pp_p2p_ms(batch, tokens)
 
-    def _origami_steps(self, batch: int, tokens: int, phase: str) -> Optional[tuple]:
+    def _origami_steps(self, batch: int, tokens: int, phase: str) -> tuple | None:
         """Simulated whole-step time at the target and bench views, ``(tgt, bench)``.
 
         Reuses the analytical ``_forward_times`` at the bench and target views by
@@ -945,8 +984,7 @@ class InferencePerformanceProjector:
         comm_free = phase == "decode"
 
         def _step(lm, comm, view, imb) -> float:
-            saved = (self._lm, self._comm, self._view, self._gemm, self._sdpa,
-                     self._moe_imbalance)
+            saved = (self._lm, self._comm, self._view, self._gemm, self._sdpa, self._moe_imbalance)
             self._lm, self._comm, self._view = lm, comm, view
             self._gemm, self._sdpa = self._gemm_sim, self._sdpa_sim
             # Per-view imbalance: bench-EP vs target-EP (see _setup_restoration).
@@ -954,12 +992,18 @@ class InferencePerformanceProjector:
             try:
                 ft = self._forward_times(batch, q_len, phase, kv)
                 if comm_free:
-                    return max(0.0, ft.total_ms - ft.comm.tp_allreduce_ms
-                               - ft.comm.ep_a2a_ms - ft.comm.pp_p2p_ms)
+                    return max(
+                        0.0,
+                        ft.total_ms
+                        - ft.comm.tp_allreduce_ms
+                        - ft.comm.ep_a2a_ms
+                        - ft.comm.pp_p2p_ms,
+                    )
                 return ft.total_ms
             finally:
-                (self._lm, self._comm, self._view, self._gemm, self._sdpa,
-                 self._moe_imbalance) = saved
+                (self._lm, self._comm, self._view, self._gemm, self._sdpa, self._moe_imbalance) = (
+                    saved
+                )
 
         try:
             s_tgt = _step(self._lm_ratio_tgt, comm_tgt, self._view_tgt, self._imb_tgt)
@@ -970,7 +1014,9 @@ class InferencePerformanceProjector:
             return None
         return s_tgt, s_bench
 
-    def _restore_whole(self, ms_bench: float, batch: int, tokens: int, phase: str = "decode") -> float:
+    def _restore_whole(
+        self, ms_bench: float, batch: int, tokens: int, phase: str = "decode"
+    ) -> float:
         """Restore a whole-model (vLLM) step latency measured at the benchmark's
         reduced parallelism to the target TP/EP/PP, training-style and in the same
         ``pp -> ep -> tp`` order as the Megatron per-layer path:
@@ -1009,9 +1055,11 @@ class InferencePerformanceProjector:
                 else:
                     restored = ms_bench * (s_tgt / s_bench)
                 if os.getenv("INFERASIM_DEBUG_RESTORE"):
-                    print(f"[dbg-restore] phase={phase} b={batch} "
-                          f"sim_tgt={s_tgt:.3f} sim_bench={s_bench:.3f} "
-                          f"ms_bench={ms_bench:.3f} restored={restored:.3f}")
+                    print(
+                        f"[dbg-restore] phase={phase} b={batch} "
+                        f"sim_tgt={s_tgt:.3f} sim_bench={s_bench:.3f} "
+                        f"ms_bench={ms_bench:.3f} restored={restored:.3f}"
+                    )
                 return restored
 
         def _comm_total(cm) -> float:
@@ -1163,7 +1211,8 @@ class InferencePerformanceProjector:
         # while the fixed-shape 8k sweep, where the floor barely binds, does not
         # move at all.
         sparse_scale = (
-            1.0 if phase == "decode"
+            1.0
+            if phase == "decode"
             else self.cfg.request_config.resolved_sparse_attention_scale(kv_len)
         )
         # Attention-DP: the memory model has always known that a rank under DP
@@ -1192,8 +1241,7 @@ class InferencePerformanceProjector:
                     continue
                 charged = sub.measured_forward_time(batch, q_len)
                 actual = (
-                    sub.measured_forward_time(attn_batch, q_len)
-                    if attn_batch != batch else charged
+                    sub.measured_forward_time(attn_batch, q_len) if attn_batch != batch else charged
                 ) * factor
                 if is_moe:
                     moe_compute = max(0.0, moe_compute + actual - charged)
@@ -1235,9 +1283,7 @@ class InferencePerformanceProjector:
             # engine can do it: ``deepep_overlap_efficiency``, already applied
             # inside ``ep_a2a_ms`` and zero unless DeepEP/SyncFree is on. What
             # remains after that is exposed like any other collective.
-            keep_a2a = (
-                self._overlap_keep(phase, new_ep_a2a, moe_compute) if has_moe else 1.0
-            )
+            keep_a2a = self._overlap_keep(phase, new_ep_a2a, moe_compute) if has_moe else 1.0
             ep_a2a_exposed = new_ep_a2a * keep_a2a
 
             dense_comm = new_tp_ar
@@ -1245,9 +1291,7 @@ class InferencePerformanceProjector:
             keep_moe_ar = self._overlap_keep(phase, moe_tp_ar, moe_compute) if has_moe else 1.0
 
             dense_fwd = dense_compute + (dense_comm * keep_dense if has_dense else 0.0)
-            moe_fwd = moe_compute + (
-                moe_tp_ar * keep_moe_ar + ep_a2a_exposed if has_moe else 0.0
-            )
+            moe_fwd = moe_compute + (moe_tp_ar * keep_moe_ar + ep_a2a_exposed if has_moe else 0.0)
 
             # TP-AR appears in both layer types; charge each at its own exposure.
             comm.tp_allreduce_ms = (
@@ -1357,7 +1401,7 @@ class InferencePerformanceProjector:
 
             per_token_gb = estimate_kv_cache(
                 self.cfg, _layers_on_rank(self.cfg), concurrency=1, context_len=1
-            ).bytes_per_token / (1024.0 ** 3)
+            ).bytes_per_token / (1024.0**3)
             fetched_gb = min(cached * per_token_gb, req.kv_offload_gb_per_gpu)
             fetch_ms = fetched_gb / req.kv_offload_bw_gbps * 1000.0
 
@@ -1444,8 +1488,10 @@ class InferencePerformanceProjector:
             return cached
         # The model's slope over the same span, in us per token. Batch 1 and no
         # prefix reuse, matching the concurrency-1 rows the fit came from.
-        span_ms = (self._forward_times(1, hi, "prefill", hi).total_ms
-                   - self._forward_times(1, lo, "prefill", lo).total_ms)
+        span_ms = (
+            self._forward_times(1, hi, "prefill", hi).total_ms
+            - self._forward_times(1, lo, "prefill", lo).total_ms
+        )
         modelled = span_ms * 1000.0 / float(hi - lo)
         scale = (rate / modelled) if modelled > 0 else 1.0
         # A slope fit from two points on a handful of runs is not precise enough
@@ -1590,10 +1636,16 @@ class InferencePerformanceProjector:
         if self._measured_mode:
             spec = q_len if q_len > 1 else 1
             prefill_piece = self._measured_prefill_tokens_ms(chunk_tokens)
-            dec_piece = self._measured_decode_step_ms(num_decode, decode_ctx) * spec if num_decode > 0 else 0.0
+            dec_piece = (
+                self._measured_decode_step_ms(num_decode, decode_ctx) * spec
+                if num_decode > 0
+                else 0.0
+            )
             return (prefill_piece + dec_piece) * (1.0 + penalty) + ov
-        prefill_piece = (self._forward_times(1, chunk_tokens, "prefill", max(1, prefill_kv_len)).total_ms
-                         * self._prefill_rate_scale())
+        prefill_piece = (
+            self._forward_times(1, chunk_tokens, "prefill", max(1, prefill_kv_len)).total_ms
+            * self._prefill_rate_scale()
+        )
         dec_piece = (
             self._forward_times(num_decode, q_len, "decode", max(1, decode_ctx)).total_ms
             if num_decode > 0
@@ -1638,7 +1690,9 @@ class InferencePerformanceProjector:
 
     # -- continuous batching (steady-state TPOT) -------------------------------
 
-    def _continuous_decode_metrics(self, input_len: int, output_len: int, concurrency: int) -> Dict[str, float]:
+    def _continuous_decode_metrics(
+        self, input_len: int, output_len: int, concurrency: int
+    ) -> dict[str, float]:
         """Steady-state decode under *continuous batching*.
 
         Real servers (vLLM, SGLang, ...) keep ``concurrency`` sequences resident
@@ -1753,7 +1807,9 @@ class InferencePerformanceProjector:
                 ctx = int(ctx_lo + frac * (ctx_hi - ctx_lo))
                 pure_fwd = self._forward_times(C, q_len, "decode", ctx).total_ms
                 t_pure = pure_fwd + self._draft_overhead_ms(pure_fwd / max(1, q_len)) + ov + occ
-                prefill_piece = self._forward_times(1, chunk_tokens, "prefill", min(ctx, ISL)).total_ms
+                prefill_piece = self._forward_times(
+                    1, chunk_tokens, "prefill", min(ctx, ISL)
+                ).total_ms
                 dec_piece = self._forward_times(max(1, C - 1), q_len, "decode", ctx).total_ms
                 t_mixed = (prefill_piece + dec_piece) * (1.0 + penalty) + ov + occ
                 pure.append(t_pure)
@@ -1856,8 +1912,9 @@ class InferencePerformanceProjector:
         return admit_ms, buffered * max(0.0, itl_ms)
 
     @staticmethod
-    def _closed_loop_wait_ms(service_ms: float, think_ms: float, clients: int,
-                             demand_ms: float = None) -> float:
+    def _closed_loop_wait_ms(
+        service_ms: float, think_ms: float, clients: int, demand_ms: float = None
+    ) -> float:
         """Mean response time of one shared server under a closed load.
 
         A serving benchmark run with ``--max-concurrency C`` is a closed
@@ -1902,7 +1959,7 @@ class InferencePerformanceProjector:
 
     def _request_rate_queueing(
         self, system_decode_tps: float, output_len: int, ttft_ms: float, request_latency_ms: float
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         """First-order open-loop queueing delay for a given offered load.
 
         Closed-loop (``request_rate == 0`` or ``arrival_model == "closed"``) is
@@ -1931,7 +1988,7 @@ class InferencePerformanceProjector:
             return {}
         rho = rate / mu
         ts_ms = 1000.0 / mu  # mean service time per request
-        out: Dict[str, float] = {
+        out: dict[str, float] = {
             "offered_request_rate": rate,
             "max_sustainable_request_rate": mu,
             "utilization": rho,
@@ -1966,7 +2023,7 @@ class InferencePerformanceProjector:
             return (1.0 - accept ** (spec_k + 1)) / (1.0 - accept)
         return float(spec_k + 1 if spec_k > 0 else 1)
 
-    def _overlap_keep(self, phase: str, comm_ms: float, compute_ms: Optional[float]) -> float:
+    def _overlap_keep(self, phase: str, comm_ms: float, compute_ms: float | None) -> float:
         """Exposed-comm fraction (1 - hidden) after compute/comm overlap.
 
         The configured ``prefill_overlap`` / ``decode_overlap`` is the *ceiling*
@@ -1982,9 +2039,7 @@ class InferencePerformanceProjector:
         compute is not separately modelled) falls back to the constant ceiling,
         preserving the previous behaviour there.
         """
-        ceiling = float(
-            self._cc.prefill_overlap if phase == "prefill" else self._cc.decode_overlap
-        )
+        ceiling = float(self._cc.prefill_overlap if phase == "prefill" else self._cc.decode_overlap)
         ceiling = min(max(ceiling, 0.0), 1.0)
         if ceiling <= 0.0:
             return 1.0
@@ -2021,8 +2076,8 @@ class InferencePerformanceProjector:
         return comm
 
     def _comm_extras(
-        self, batch: int, input_len: int, output_len: int, prefill_batch: Optional[int] = None
-    ) -> Dict[str, float]:
+        self, batch: int, input_len: int, output_len: int, prefill_batch: int | None = None
+    ) -> dict[str, float]:
         """Representative per-phase comm breakdown (ms) for reporting.
 
         ``prefill_batch`` sizes the prefill breakdown; it defaults to ``batch``
@@ -2074,7 +2129,7 @@ class InferencePerformanceProjector:
 
             if torch.cuda.is_available():
                 props = torch.cuda.get_device_properties(0)
-                return props.total_memory / (1024.0 ** 3), f"device({props.name})"
+                return props.total_memory / (1024.0**3), f"device({props.name})"
         except Exception:
             pass
         raise ValueError(
@@ -2084,7 +2139,7 @@ class InferencePerformanceProjector:
             "No default is assumed."
         )
 
-    def _sustainable_concurrency(self) -> tuple[Optional[int], float, str]:
+    def _sustainable_concurrency(self) -> tuple[int | None, float, str]:
         """KV-feasible max concurrent sequences at the target context length,
         i.e. how many sequences fit in the HBM left after weights + activations.
         Reuses the memory projection so there is a single sizing formula. Returns
@@ -2093,9 +2148,7 @@ class InferencePerformanceProjector:
         try:
             from .memory import project_inference_memory
 
-            mem = project_inference_memory(
-                self.cfg, hbm_capacity_gb=hbm_gb, verbose=False
-            )
+            mem = project_inference_memory(self.cfg, hbm_capacity_gb=hbm_gb, verbose=False)
             return mem.max_concurrent_sequences, hbm_gb, source
         except Exception:
             return None, hbm_gb, source
@@ -2158,7 +2211,11 @@ class InferencePerformanceProjector:
         # riding mixed steps, so its own service time is ``chunks * mixed_step``
         # and the queue it waits in is the closed-loop one below.
         continuous = self._use_continuous_batching(concurrency, output_len)
-        m = self._continuous_decode_metrics(input_len, output_len, concurrency) if continuous else None
+        m = (
+            self._continuous_decode_metrics(input_len, output_len, concurrency)
+            if continuous
+            else None
+        )
         if continuous:
             prefill_service_ms = max(m["prefill_chunks"] * m["mixed_step_ttft_ms"], 0.0)
             # Under attention-DP each rank owns a subset of the requests and
@@ -2173,8 +2230,9 @@ class InferencePerformanceProjector:
 
             dp = attention_dp_size(self.cfg)
             queued_clients = max(1, math.ceil(concurrency / dp)) if dp > 1 else concurrency
-            ttft = self._closed_loop_wait_ms(prefill_service_ms, m["decode_total_ms"],
-                                             queued_clients, m["prefill_demand_ms"])
+            ttft = self._closed_loop_wait_ms(
+                prefill_service_ms, m["decode_total_ms"], queued_clients, m["prefill_demand_ms"]
+            )
             prefill_full_ms = self.prefill_latency_ms(batch, input_len)
         else:
             ttft = prefill_full_ms = self.prefill_latency_ms(batch, input_len)
@@ -2247,7 +2305,11 @@ class InferencePerformanceProjector:
         if q:
             extras.update(q)
 
-        extras.update(self._comm_extras(batch, input_len, output_len, prefill_batch=(1 if continuous else batch)))
+        extras.update(
+            self._comm_extras(
+                batch, input_len, output_len, prefill_batch=(1 if continuous else batch)
+            )
+        )
         if self.is_benchmark_calibrated:
             extras["benchmark_calibrated"] = 1.0
 
@@ -2265,7 +2327,9 @@ class InferencePerformanceProjector:
             extras=extras,
         )
 
-    def _kv_transfer_ms(self, decode_proj: "InferencePerformanceProjector", batch: int, input_len: int) -> float:
+    def _kv_transfer_ms(
+        self, decode_proj: InferencePerformanceProjector, batch: int, input_len: int
+    ) -> float:
         """KV-cache transfer time prefill→decode worker, for ONE request's KV.
 
         Both callers are per-request quantities -- the TTFT this handoff delays,
@@ -2362,9 +2426,7 @@ class InferencePerformanceProjector:
         denom = resp1 + decode_total
         n_prefill = per_replica
         if denom > 0:
-            n_prefill = max(1, min(per_replica, int(round(
-                per_replica * resp1 / denom
-            ))))
+            n_prefill = max(1, min(per_replica, int(round(per_replica * resp1 / denom))))
         prefill_full_ms = prefill_proj.prefill_latency_ms(n_prefill, input_len)
         ttft_compute = prefill_full_ms
         # Host prompt-tokenization cost (latency-only, TTFT side).
@@ -2397,8 +2459,10 @@ class InferencePerformanceProjector:
         # per-request TPOT improved. The co-located path gets this from the
         # continuous-batching model's ``system_tps``.
         decode_tps_replica = (
-            decode_batch * self._spec_tokens_per_step() * 1000.0 / step_latency
-        ) if step_latency > 0 else 0.0
+            (decode_batch * self._spec_tokens_per_step() * 1000.0 / step_latency)
+            if step_latency > 0
+            else 0.0
+        )
         decode_tps = decode_tps_replica * max(1, disagg.decode_replicas)
 
         # Capacity of the prefill pool at the offered load, not at the
@@ -2406,8 +2470,7 @@ class InferencePerformanceProjector:
         # report a nearly-idle station as unable to feed decode.
         prefill_cap_ms = prefill_proj.prefill_latency_ms(per_replica, input_len)
         prefill_tps_replica = (
-            (per_replica * input_len * 1000.0 / prefill_cap_ms)
-            if prefill_cap_ms > 0 else 0.0
+            (per_replica * input_len * 1000.0 / prefill_cap_ms) if prefill_cap_ms > 0 else 0.0
         )
         prefill_tps = prefill_tps_replica * max(1, disagg.prefill_replicas)
 
@@ -2417,8 +2480,8 @@ class InferencePerformanceProjector:
         # pool's unfed ceiling: low prefill:decode ratios came out optimistic
         # and throughput did not respond to the prefix-cache hit rate at all.
         if input_len > 0 and output_len > 0:
-            supply = prefill_tps / input_len        # requests/s the prefill pool feeds
-            demand = decode_tps / output_len        # requests/s the decode pool could run
+            supply = prefill_tps / input_len  # requests/s the prefill pool feeds
+            demand = decode_tps / output_len  # requests/s the decode pool could run
             if 0.0 < supply < demand:
                 decode_tps = supply * output_len
 

--- a/infera/projection/core/projection/inference_projection/search/anchor_store.py
+++ b/infera/projection/core/projection/inference_projection/search/anchor_store.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 from . import regime
 
@@ -52,7 +52,7 @@ class AnchorStore:
     def __init__(self, root: str, discover: bool = True):
         self.root = os.path.abspath(root)
         self.index_path = os.path.join(self.root, "index.json")
-        self._entries: List[Dict[str, Any]] = []
+        self._entries: list[dict[str, Any]] = []
         self._load_index()
         if discover:
             self.discover()
@@ -112,9 +112,7 @@ class AnchorStore:
             isinstance(art, dict)
             and isinstance(art.get("meta"), dict)
             and isinstance(art.get("sweep"), list)
-            and any(
-                isinstance(e, dict) and e.get("decode_ms") for e in art["sweep"]
-            )
+            and any(isinstance(e, dict) and e.get("decode_ms") for e in art["sweep"])
         )
 
     def _load_index(self) -> None:
@@ -164,7 +162,7 @@ class AnchorStore:
 
     # -- ingestion -------------------------------------------------------------
 
-    def add_artifact(self, artifact_path: str) -> Dict[str, Any]:
+    def add_artifact(self, artifact_path: str) -> dict[str, Any]:
         """Index a benchmark artifact JSON already on disk.  Idempotent by path
         (re-adding refreshes the entry)."""
         path = os.path.abspath(artifact_path)
@@ -176,7 +174,7 @@ class AnchorStore:
         self._save_index()
         return entry
 
-    def add_result(self, result: Dict[str, Any], artifact_path: str) -> Dict[str, Any]:
+    def add_result(self, result: dict[str, Any], artifact_path: str) -> dict[str, Any]:
         """Write a benchmark result dict to ``artifact_path`` and index it."""
         path = os.path.abspath(artifact_path)
         os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
@@ -184,7 +182,7 @@ class AnchorStore:
             json.dump(result, f)
         return self.add_artifact(path)
 
-    def _make_entry(self, path: str, art: Dict[str, Any]) -> Dict[str, Any]:
+    def _make_entry(self, path: str, art: dict[str, Any]) -> dict[str, Any]:
         meta = art.get("meta", {})
         recipe = regime.recipe_from_meta(meta)
         sig = meta.get("regime_signature") or regime.regime_signature(recipe)
@@ -213,16 +211,16 @@ class AnchorStore:
 
     # -- query -----------------------------------------------------------------
 
-    def entries(self) -> List[Dict[str, Any]]:
+    def entries(self) -> list[dict[str, Any]]:
         return list(self._entries)
 
-    def load_artifact(self, entry: Dict[str, Any]) -> Dict[str, Any]:
+    def load_artifact(self, entry: dict[str, Any]) -> dict[str, Any]:
         with open(entry["path"]) as f:
             return json.load(f)
 
     def nearest(
-        self, recipe: Dict[str, Any], *, model: Optional[str] = None
-    ) -> Tuple[Optional[Dict[str, Any]], Optional[int]]:
+        self, recipe: dict[str, Any], *, model: str | None = None
+    ) -> tuple[dict[str, Any] | None, int | None]:
         """Return ``(entry, regime_distance)`` for the best anchor, or
         ``(None, None)`` if the store is empty.  Distance 0 => same regime
         (fully transportable).  Candidates are optionally filtered to a model;
@@ -239,7 +237,7 @@ class AnchorStore:
         target_tp = max(1, int(recipe.get("tp") or 1))
         preferred_tp = 4 if target_tp >= 4 else target_tp
 
-        def tp_policy_gap(e: Dict[str, Any]) -> float:
+        def tp_policy_gap(e: dict[str, Any]) -> float:
             """Distance from the anchor TP mandated for this target.
 
             TP1 and TP2 are cheap enough to benchmark directly and should not
@@ -255,7 +253,7 @@ class AnchorStore:
                 return float("inf")
             return abs(float(anchor_tp) - float(preferred_tp))
 
-        def shards_experts(e: Dict[str, Any]) -> int:
+        def shards_experts(e: dict[str, Any]) -> int:
             """1 if this anchor disagrees with the target on *whether* EP shards.
 
             Ranked ahead of transport distance rather than folded into it, because
@@ -264,10 +262,10 @@ class AnchorStore:
             EP proximity makes up for crossing the line. A weight would have to be
             larger than every distance the store can produce; an order does not.
             """
-            ep = (e.get("transport", {}).get("ep") or 1)
+            ep = e.get("transport", {}).get("ep") or 1
             return int(bool(ep > 1) != bool((recipe.get("ep") or 1) > 1))
 
-        def transport_gap(e: Dict[str, Any]) -> float:
+        def transport_gap(e: dict[str, Any]) -> float:
             t = e.get("transport", {})
             gap = 0.0
             # Prefer anchors whose measured parallelism matches the target

--- a/infera/projection/core/projection/inference_projection/search/reconstruct.py
+++ b/infera/projection/core/projection/inference_projection/search/reconstruct.py
@@ -26,7 +26,7 @@ or escalate the recipe to a real run:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any
 
 from . import regime
 from .anchor_store import AnchorStore
@@ -34,15 +34,15 @@ from .anchor_store import AnchorStore
 
 @dataclass
 class ReconstructionResult:
-    perf: Any                       # InferencePerfResult
-    anchor: Dict[str, Any]          # the anchor store entry used
-    regime_distance: int            # 0 == same regime (fully transportable)
-    confidence: str                 # "high" | "interp" | "escalate"
+    perf: Any  # InferencePerfResult
+    anchor: dict[str, Any]  # the anchor store entry used
+    regime_distance: int  # 0 == same regime (fully transportable)
+    confidence: str  # "high" | "interp" | "escalate"
     reason: str = ""
     projector: Any = field(default=None, repr=False)
 
 
-def _confidence(recipe: Dict[str, Any], entry: Dict[str, Any], distance: int) -> tuple:
+def _confidence(recipe: dict[str, Any], entry: dict[str, Any], distance: int) -> tuple:
     if distance > 0:
         return "escalate", f"nearest anchor differs on {distance} regime axis(es)"
     t = entry.get("transport", {})
@@ -57,7 +57,10 @@ def _confidence(recipe: Dict[str, Any], entry: Dict[str, Any], distance: int) ->
     nl = t.get("num_layers")
     tgt_layers = recipe.get("num_layers")
     if full is None and nl and tgt_layers and int(tgt_layers) != int(nl):
-        return "interp", f"target depth {tgt_layers} != anchor depth {nl} (no depth restore in anchor)"
+        return (
+            "interp",
+            f"target depth {tgt_layers} != anchor depth {nl} (no depth restore in anchor)",
+        )
     return "high", "same regime, within measured coverage"
 
 
@@ -66,8 +69,8 @@ def reconstruct(
     store: AnchorStore,
     *,
     args: Any = None,
-    model: Optional[str] = None,
-) -> Optional[ReconstructionResult]:
+    model: str | None = None,
+) -> ReconstructionResult | None:
     """Reconstruct the target ``inference_config``'s performance from the nearest
     anchor in ``store``.  Returns ``None`` when the store has no anchors.
 

--- a/infera/projection/core/projection/inference_projection/search/regime.py
+++ b/infera/projection/core/projection/inference_projection/search/regime.py
@@ -34,7 +34,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-from typing import Any, Dict, Iterable, Optional
+from collections.abc import Iterable
+from typing import Any
 
 # Regime-defining axes: differ on any of these → a different measured anchor.
 #
@@ -124,6 +125,7 @@ def models_match(a: Any, b: Any) -> bool:
     refusing to reuse a warmup that is genuinely for this model, and the regime
     axes still have to agree before it is used for anything.
     """
+
     def leaf(v: Any) -> str:
         return normalise_model_id(str(v or "").rstrip("/").rsplit("/", 1)[-1])
 
@@ -133,19 +135,19 @@ def models_match(a: Any, b: Any) -> bool:
     return na in nb or nb in na
 
 
-def _sig(recipe: Dict[str, Any], axes: Iterable[str]) -> str:
+def _sig(recipe: dict[str, Any], axes: Iterable[str]) -> str:
     payload = {k: _canon(recipe.get(k)) for k in axes}
     blob = json.dumps(payload, sort_keys=True)
     return hashlib.sha256(blob.encode()).hexdigest()[:16]
 
 
-def regime_signature(recipe: Dict[str, Any]) -> str:
+def regime_signature(recipe: dict[str, Any]) -> str:
     """Hash over the regime-defining axes only.  Two recipes with the same
     signature are mutually transportable (same kernels/regime)."""
     return _sig(recipe, REGIME_AXES)
 
 
-def config_key(recipe: Dict[str, Any], extra: Optional[Dict[str, Any]] = None) -> str:
+def config_key(recipe: dict[str, Any], extra: dict[str, Any] | None = None) -> str:
     """Exact-run identity: hash over regime + transport axes, plus any ``extra``
     (measurement knobs that change the number but not the regime, e.g.
     decode-steps).  Used by the benchmark result cache."""
@@ -157,9 +159,7 @@ def config_key(recipe: Dict[str, Any], extra: Optional[Dict[str, Any]] = None) -
     return hashlib.sha256(blob.encode()).hexdigest()[:16]
 
 
-def regime_distance(
-    a: Dict[str, Any], b: Dict[str, Any], *, ignore_missing: bool = True
-) -> int:
+def regime_distance(a: dict[str, Any], b: dict[str, Any], *, ignore_missing: bool = True) -> int:
     """Hamming distance over the regime axes.  0 => same regime (fully
     transportable).  When ``ignore_missing`` (default), an axis absent/None on
     *either* side is not counted — so a partially-specified target still matches
@@ -199,9 +199,7 @@ def regime_distance(
     return d
 
 
-def speculative_axis(
-    method: Optional[str], num_tokens: Optional[int] = None
-) -> Optional[str]:
+def speculative_axis(method: str | None, num_tokens: int | None = None) -> str | None:
     """Canonical ``speculative`` axis value: ``None``, ``"off"`` or ``"spec:k"``.
 
     ``None`` propagates as "unknown" (artifact predates the tracking); an
@@ -222,7 +220,7 @@ def speculative_axis(
     return f"spec:{int(num_tokens)}" if num_tokens else "spec"
 
 
-def aiter_ops_axis(env: Optional[Dict[str, str]]) -> Optional[str]:
+def aiter_ops_axis(env: dict[str, str] | None) -> str | None:
     """Canonical ``aiter_ops`` value: ``None``, ``"default"`` or ``"op=v,..."``.
 
     A recipe can turn off one AITER kernel family while the master switch stays
@@ -240,7 +238,7 @@ def aiter_ops_axis(env: Optional[Dict[str, str]]) -> Optional[str]:
     if env is None:
         return None
     ops = sorted(
-        (k[len(_AITER_OP_PREFIX):].lower(), _canon(v))
+        (k[len(_AITER_OP_PREFIX) :].lower(), _canon(v))
         for k, v in env.items()
         if str(k).upper().startswith(_AITER_OP_PREFIX)
     )
@@ -251,7 +249,8 @@ def aiter_ops_axis(env: Optional[Dict[str, str]]) -> Optional[str]:
 # Adapters: build a canonical recipe from the three sources that produce one.
 # --------------------------------------------------------------------------
 
-def recipe_from_meta(meta: Dict[str, Any], *, model: Optional[str] = None) -> Dict[str, Any]:
+
+def recipe_from_meta(meta: dict[str, Any], *, model: str | None = None) -> dict[str, Any]:
     """Canonical recipe from a benchmark artifact's ``meta`` block.  The
     *benchmark* parallelism (what it actually ran at) is recorded on the
     transport axes so the anchor's coverage is described in benchmark space;
@@ -299,7 +298,7 @@ def recipe_from_meta(meta: Dict[str, Any], *, model: Optional[str] = None) -> Di
     }
 
 
-def recipe_from_bench_args(args: Any, env: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+def recipe_from_bench_args(args: Any, env: dict[str, str] | None = None) -> dict[str, Any]:
     """Canonical recipe from ``benchmark_vllm.py`` CLI args (stdlib-only path).
 
     Also returns nothing extra here — measurement-only knobs are passed as the
@@ -335,7 +334,7 @@ def recipe_from_bench_args(args: Any, env: Optional[Dict[str, str]] = None) -> D
     }
 
 
-def recipe_from_inference_config(cfg: Any) -> Dict[str, Any]:
+def recipe_from_inference_config(cfg: Any) -> dict[str, Any]:
     """Canonical recipe from an ``InferenceConfig`` (the reconstruction target).
 
     Structural configs carry no HF model *name*, so ``model`` is left ``None``
@@ -377,7 +376,7 @@ def recipe_from_inference_config(cfg: Any) -> Dict[str, Any]:
     }
 
 
-def _cudagraph_from_mode(mode: Optional[str]) -> Optional[str]:
+def _cudagraph_from_mode(mode: str | None) -> str | None:
     if mode is None:
         return None
     return "eager" if str(mode).lower() in ("none", "off", "eager") else "graph"

--- a/infera/projection/core/projection/inference_projection/sweep.py
+++ b/infera/projection/core/projection/inference_projection/sweep.py
@@ -29,8 +29,9 @@ import io
 import itertools
 import os
 import time
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import asdict, dataclass, field
-from typing import Any, Callable, Iterable, Sequence
+from typing import Any
 
 
 @dataclass
@@ -69,21 +70,33 @@ class SweepResult:
     def feasible(self) -> list[SweepPoint]:
         return [p for p in self.points if p.feasible]
 
-    def ranked(self, objective: str = "decode_tps_per_gpu",
-               maximize: bool = True) -> list[SweepPoint]:
+    def ranked(
+        self, objective: str = "decode_tps_per_gpu", maximize: bool = True
+    ) -> list[SweepPoint]:
         """Feasible points ordered by ``objective``."""
-        return sorted(self.feasible, key=lambda p: getattr(p, objective),
-                      reverse=maximize)
+        return sorted(self.feasible, key=lambda p: getattr(p, objective), reverse=maximize)
 
-    def shortlist(self, n: int = 5, objective: str = "decode_tps_per_gpu",
-                  maximize: bool = True) -> list[SweepPoint]:
+    def shortlist(
+        self, n: int = 5, objective: str = "decode_tps_per_gpu", maximize: bool = True
+    ) -> list[SweepPoint]:
         return self.ranked(objective, maximize)[:n]
 
 
 def _project_one(
-    model: str, tp: int, ep: int, pp: int, conc: int, isl: int, osl: int,
-    *, gpu_arch: str, hbm_gb: float, weight_dtype: str, kv_dtype: str,
-    workload: str, attention_backend: str,
+    model: str,
+    tp: int,
+    ep: int,
+    pp: int,
+    conc: int,
+    isl: int,
+    osl: int,
+    *,
+    gpu_arch: str,
+    hbm_gb: float,
+    weight_dtype: str,
+    kv_dtype: str,
+    workload: str,
+    attention_backend: str,
 ) -> tuple[Any, Any]:
     """Run one projection, returning ``(performance, memory)``."""
     os.environ["INFERASIM_MODEL"] = model
@@ -94,14 +107,32 @@ def _project_one(
 
     argv = [
         "inference",
-        "--config", workload,
-        "--inference-mode", "both", "--profiling-mode", "simulate",
-        "--serving-model", "static",
-        "--input-len", str(isl), "--output-len", str(osl),
-        "--inference-batch-size", str(conc), "--max-concurrency", str(conc),
-        "--weight-dtype", weight_dtype, "--kv-cache-dtype", kv_dtype,
-        "--attention-backend", attention_backend,
-        "--gpu-arch", gpu_arch, "--hbm-capacity-gb", str(hbm_gb),
+        "--config",
+        workload,
+        "--inference-mode",
+        "both",
+        "--profiling-mode",
+        "simulate",
+        "--serving-model",
+        "static",
+        "--input-len",
+        str(isl),
+        "--output-len",
+        str(osl),
+        "--inference-batch-size",
+        str(conc),
+        "--max-concurrency",
+        str(conc),
+        "--weight-dtype",
+        weight_dtype,
+        "--kv-cache-dtype",
+        kv_dtype,
+        "--attention-backend",
+        attention_backend,
+        "--gpu-arch",
+        gpu_arch,
+        "--hbm-capacity-gb",
+        str(hbm_gb),
         f"tensor_model_parallel_size={tp}",
         f"expert_model_parallel_size={ep}",
         f"pipeline_model_parallel_size={pp}",
@@ -143,14 +174,15 @@ def sweep(
         # .../core/projection/inference_projection -> infera/projection/configs
         workload = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "..", "..", "..", "configs",
+            "..",
+            "..",
+            "..",
+            "configs",
             "inferasim_workload.yaml",
         )
         workload = os.path.normpath(workload)
 
-    combos: Iterable[tuple[int, int, int, int]] = itertools.product(
-        tp, ep, pp, concurrency
-    )
+    combos: Iterable[tuple[int, int, int, int]] = itertools.product(tp, ep, pp, concurrency)
     out = SweepResult()
     t0 = time.perf_counter()
     for _tp, _ep, _pp, _conc in combos:
@@ -159,9 +191,18 @@ def sweep(
         pt = SweepPoint(tp=_tp, ep=_ep, pp=_pp, concurrency=_conc, isl=isl, osl=osl)
         try:
             perf, mem = _project_one(
-                model, _tp, _ep, _pp, _conc, isl, osl,
-                gpu_arch=gpu_arch, hbm_gb=hbm_gb, weight_dtype=weight_dtype,
-                kv_dtype=kv_dtype, workload=workload,
+                model,
+                _tp,
+                _ep,
+                _pp,
+                _conc,
+                isl,
+                osl,
+                gpu_arch=gpu_arch,
+                hbm_gb=hbm_gb,
+                weight_dtype=weight_dtype,
+                kv_dtype=kv_dtype,
+                workload=workload,
                 attention_backend=attention_backend,
             )
             pt.ttft_ms = float(getattr(perf, "ttft_ms", 0.0) or 0.0)
@@ -175,13 +216,13 @@ def sweep(
             ) or (pt.decode_tps / pt.gpus())
             if mem is not None:
                 total = float(getattr(mem, "total_bytes", 0) or 0)
-                pt.memory_per_gpu_gb = total / (1024.0 ** 3)
+                pt.memory_per_gpu_gb = total / (1024.0**3)
                 cap = float(getattr(mem, "hbm_capacity_bytes", 0) or 0)
                 if getattr(mem, "fits", True) is False:
                     pt.feasible = False
                     pt.reason = (
                         f"needs {pt.memory_per_gpu_gb:.0f} GB/GPU, device has "
-                        f"{cap / (1024.0 ** 3):.0f} GB"
+                        f"{cap / (1024.0**3):.0f} GB"
                     )
         except Exception as exc:  # noqa: BLE001 - a bad point must not stop a sweep
             pt.feasible = False
@@ -189,10 +230,12 @@ def sweep(
         out.points.append(pt)
         out.n_projected += 1
         if progress:
-            print(f"  tp{_tp} ep{_ep} pp{_pp} c{_conc:<4d} "
-                  f"{'ok ' if pt.feasible else 'X  '}"
-                  f"tpot={pt.tpot_ms:7.2f} ms  tps/gpu={pt.decode_tps_per_gpu:8.1f}"
-                  f"{'  ' + pt.reason if pt.reason else ''}")
+            print(
+                f"  tp{_tp} ep{_ep} pp{_pp} c{_conc:<4d} "
+                f"{'ok ' if pt.feasible else 'X  '}"
+                f"tpot={pt.tpot_ms:7.2f} ms  tps/gpu={pt.decode_tps_per_gpu:8.1f}"
+                f"{'  ' + pt.reason if pt.reason else ''}"
+            )
     out.elapsed_s = time.perf_counter() - t0
     return out
 
@@ -203,6 +246,7 @@ def to_json(result: SweepResult) -> dict[str, Any]:
         "n_projected": result.n_projected,
         "elapsed_s": result.elapsed_s,
         "per_config_ms": (result.elapsed_s / result.n_projected * 1e3)
-        if result.n_projected else 0.0,
+        if result.n_projected
+        else 0.0,
         "points": [asdict(p) for p in result.points],
     }

--- a/infera/projection/core/projection/module_profilers/attention.py
+++ b/infera/projection/core/projection/module_profilers/attention.py
@@ -4,17 +4,21 @@
 # See LICENSE for license information.
 ###############################################################################
 
-from typing import Optional
 
 from infera.projection.core.projection.base_module_profiler import BaseModuleProfiler
-
 
 # Bytes per element the KV cache is stored at. The cache dtype is set
 # independently of the compute dtype (fp8 KV with bf16 activations is common),
 # and at decode the cache read is the dominant attention cost.
 _KV_CACHE_BYTES = {
-    "fp8": 1.0, "fp8_e4m3": 1.0, "fp8_e5m2": 1.0, "int8": 1.0,
-    "bf16": 2.0, "fp16": 2.0, "auto": 2.0, "": 2.0,
+    "fp8": 1.0,
+    "fp8_e4m3": 1.0,
+    "fp8_e5m2": 1.0,
+    "int8": 1.0,
+    "bf16": 2.0,
+    "fp16": 2.0,
+    "auto": 2.0,
+    "": 2.0,
     "fp32": 4.0,
 }
 
@@ -68,7 +72,7 @@ class AttentionProfiler(BaseModuleProfiler):
         self._cached_results = None
         self._cache_key = None
 
-    def estimated_num_params(self, rank: Optional[int] = None) -> int:
+    def estimated_num_params(self, rank: int | None = None) -> int:
         args = self.config.model_config
         # Group-query & multi-latent attention support.
         # If GQA not enabled, fall back to per-head queries.
@@ -99,7 +103,11 @@ class AttentionProfiler(BaseModuleProfiler):
                 q_term
                 # kv lora + rope + kv norm
                 + args.kv_lora_rank
-                * (args.hidden_size + args.num_attention_heads * (args.qk_head_dim + args.v_head_dim) + 1)
+                * (
+                    args.hidden_size
+                    + args.num_attention_heads * (args.qk_head_dim + args.v_head_dim)
+                    + 1
+                )
                 # pos emb
                 + args.hidden_size * args.qk_pos_emb_head_dim
                 # out proj
@@ -277,9 +285,8 @@ class AttentionProfiler(BaseModuleProfiler):
         if self._gemm_backend is not None:
             # The checkpoint's own weight precision where it is known, so an
             # fp4 model streams fp4 projection weights rather than fp8 ones.
-            gemm_dtype = (
-                getattr(args, "linear_weight_dtype", None)
-                or ("fp8" if getattr(args, "fp8", None) else "bf16")
+            gemm_dtype = getattr(args, "linear_weight_dtype", None) or (
+                "fp8" if getattr(args, "fp8", None) else "bf16"
             )
 
             if getattr(args, "multi_latent_attention", False):
@@ -338,12 +345,12 @@ class AttentionProfiler(BaseModuleProfiler):
                     str(getattr(args, "kv_cache_dtype", "") or "").lower(), 2.0
                 )
                 if getattr(args, "multi_latent_attention", False):
-                    kv_bytes_per_token = (
-                        args.kv_lora_rank + args.qk_pos_emb_head_dim
-                    ) * kv_bpe
+                    kv_bytes_per_token = (args.kv_lora_rank + args.qk_pos_emb_head_dim) * kv_bpe
                 else:
                     kv_bytes_per_token = (
-                        kv_heads_per_rank * (sdpa_head_dim + (sdpa_head_dim_v or sdpa_head_dim)) * kv_bpe
+                        kv_heads_per_rank
+                        * (sdpa_head_dim + (sdpa_head_dim_v or sdpa_head_dim))
+                        * kv_bpe
                     )
                 # Prefill keeps causal masking; decode (single query) attends
                 # to the whole cache so masking is irrelevant.
@@ -395,12 +402,12 @@ class AttentionProfiler(BaseModuleProfiler):
                 # Effective sequence length per rank if CP is used
                 slen_per_cp = seq_len // cp_size
 
-
                 # Imported here, not at module scope: this pulls in torch, which costs
                 # ~0.66 s and is only needed to benchmark on a real GPU. A simulate-only
                 # projection should not pay for it -- Hyperloom spawns one process per
                 # config, where that import dwarfed the ~28 ms the projection takes.
                 from .utils import benchmark_layer
+
                 self._cached_results = benchmark_layer(
                     self.module,
                     [

--- a/infera/projection/core/projection/module_profilers/collective_args.py
+++ b/infera/projection/core/projection/module_profilers/collective_args.py
@@ -10,7 +10,7 @@ Hardware parameters can be customized via config file.
 """
 
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any
 
 
 @dataclass
@@ -61,7 +61,7 @@ class CollectiveArgs:
     # Network topology
     switch_topology: bool = True  # Whether using switch-based topology
     node_topology: str = "switch"  # Node topology: "switch" or "mesh" (for mesh derate)
-    nics_per_node: Optional[int] = 8  # NICs per node (None = gpus_per_node)
+    nics_per_node: int | None = 8  # NICs per node (None = gpus_per_node)
 
     # Hierarchical AllReduce pipelining
     ar_overlap_factor: float = 0.9  # Peak overlap between intra-node and inter-node phases (0-1)
@@ -128,7 +128,7 @@ def get_default_args(
     _dp: int = -1,  # Auto-calculated if -1 (currently unused, retained for API compatibility)
     ep: int = 1,
     cp: int = 1,
-    hardware_config: Optional[Dict[str, Any]] = None,
+    hardware_config: dict[str, Any] | None = None,
 ) -> CollectiveArgs:
     """
     Get CollectiveArgs with customizable hardware configuration.
@@ -212,19 +212,19 @@ def get_default_args(
                 # Convert value to the expected type if it's a string representation of a number
                 if isinstance(value, str) and field_type in (int, float):
                     try:
-                        if field_type == int:
+                        if field_type is int:
                             # Handle scientific notation for int (e.g., "1e3" -> 1000)
                             if "e" in value.lower() or "E" in value.lower():
                                 value = int(float(value))
                             else:
                                 value = int(value)
-                        elif field_type == float:
+                        elif field_type is float:
                             # Handle scientific notation for float (e.g., "3.2e12" -> 3.2e12)
                             value = float(value)
                     except (ValueError, TypeError):
                         # If conversion fails, keep original value and let it fail later
                         pass
-                elif field_type == bool and isinstance(value, str):
+                elif field_type is bool and isinstance(value, str):
                     # Convert string booleans to actual booleans
                     if value.lower() in ("true", "1", "yes", "on"):
                         value = True
@@ -233,7 +233,9 @@ def get_default_args(
 
                 setattr(args, key, value)
             else:
-                print(f"[inferasim:WARNING] Unknown hardware parameter '{key}' in config. Skipping.")
+                print(
+                    f"[inferasim:WARNING] Unknown hardware parameter '{key}' in config. Skipping."
+                )
 
     # Set nics_per_node to gpus_per_node if not explicitly set
     if args.nics_per_node is None:

--- a/infera/projection/core/projection/module_profilers/collective_model.py
+++ b/infera/projection/core/projection/module_profilers/collective_model.py
@@ -195,7 +195,7 @@ def sendrecv(args, msg_size):
     return t
 
 
-def direct_alltoall(args, msg_size, gpus, groups=["ep"], protocol=None, original_msg_size=None):
+def direct_alltoall(args, msg_size, gpus, groups=("ep",), protocol=None, original_msg_size=None):
     """
     Direct alltoall for HP=1, hierarchical with parallel NIC utilization.
 
@@ -229,7 +229,8 @@ def direct_alltoall(args, msg_size, gpus, groups=["ep"], protocol=None, original
 
     # Intra-node time (with A2A contention derate)
     t_intra = (
-        intra_vol_adj / get_effective_node_bw(args, group_size=gpus_per_node, a2a=True) * 1.0e-3 + node_lat
+        intra_vol_adj / get_effective_node_bw(args, group_size=gpus_per_node, a2a=True) * 1.0e-3
+        + node_lat
     )
 
     # Inter-node time with all NICs — A2A uses P2P-like NIC streams
@@ -265,7 +266,7 @@ def direct_alltoall(args, msg_size, gpus, groups=["ep"], protocol=None, original
     return t_a2a
 
 
-def run_alltoall(args, msg_size, gpus, groups=["ep"], protocol=None):
+def run_alltoall(args, msg_size, gpus, groups=("ep",), protocol=None):
     """
     Run alltoall collective.
     Chooses between node, pod, or cluster domain based on GPU count.
@@ -325,7 +326,7 @@ def cp_allgather(args, msg_size, gpus, protocol=None):
     return t
 
 
-def run_allgather(args, msg_size, gpus, groups=["hp"], protocol=None):
+def run_allgather(args, msg_size, gpus, groups=("hp",), protocol=None):
     """
     Run allgather collective.
     Handles node and pod domains, and CP group special case.
@@ -363,7 +364,7 @@ def run_allgather(args, msg_size, gpus, groups=["hp"], protocol=None):
     return t
 
 
-def run_reduce_scatter(args, msg_size, gpus, groups=["hp"], protocol=None):
+def run_reduce_scatter(args, msg_size, gpus, groups=("hp",), protocol=None):
     """
     Run reduce_scatter collective.
     Handles node and pod domains, includes compute time for reduction.
@@ -401,7 +402,7 @@ def run_reduce_scatter(args, msg_size, gpus, groups=["hp"], protocol=None):
     return t
 
 
-def RingAllreduce(args, msg_size, gpus, groups=["dp"], protocol=None):
+def RingAllreduce(args, msg_size, gpus, groups=("dp",), protocol=None):
     """
     Ring Allreduce algorithm.
     Communication is performed in a ring, with two passes.
@@ -434,7 +435,7 @@ def RingAllreduce(args, msg_size, gpus, groups=["dp"], protocol=None):
     return t
 
 
-def RingAllgather(args, msg_size, gpus, groups=["dp"], protocol=None):
+def RingAllgather(args, msg_size, gpus, groups=("dp",), protocol=None):
     """
     Ring Allgather algorithm.
     Communication is performed in a ring, single pass.
@@ -461,7 +462,7 @@ def RingAllgather(args, msg_size, gpus, groups=["dp"], protocol=None):
     return t
 
 
-def RingRS(args, msg_size, gpus, groups=["hp"], protocol=None):
+def RingRS(args, msg_size, gpus, groups=("hp",), protocol=None):
     """
     Ring ReduceScatter algorithm.
     Communication is performed in a ring, single pass, includes compute.
@@ -490,7 +491,7 @@ def RingRS(args, msg_size, gpus, groups=["hp"], protocol=None):
     return t
 
 
-def oneshotHCallreduce(args, msg_size, gpus, groups=["dp"], protocol=None):
+def oneshotHCallreduce(args, msg_size, gpus, groups=("dp",), protocol=None):
     """
     One-shot Hypercube Allreduce algorithm.
     Uses log2 steps for communication, includes compute.
@@ -508,7 +509,7 @@ def oneshotHCallreduce(args, msg_size, gpus, groups=["dp"], protocol=None):
         t = node_msg_volume / bw * 1.0e-3
         lat += node_lat * np.ceil(np.log2(args.node_size))
         bw = args.pod_bw
-        pod_msg_volume = msg_size * np.ceil(np.log2((gpus - args.node_size)))
+        pod_msg_volume = msg_size * np.ceil(np.log2(gpus - args.node_size))
         t += pod_msg_volume / bw * 1.0e-3
         lat += pod_lat * np.ceil(np.log2(gpus / args.node_size))
     else:
@@ -552,7 +553,9 @@ def single_shot_alltoall(args, msg_size, gpus, groups=None, protocol=None):
     t_intra_node = 0
     t_inter_node = 0
     if intra_node_gpus > 0:
-        node_lat, msg_size_per_peer_adj = node_latency_and_volume_protocol(args, msg_size_per_peer, protocol)
+        node_lat, msg_size_per_peer_adj = node_latency_and_volume_protocol(
+            args, msg_size_per_peer, protocol
+        )
         node_bw = get_effective_node_bw(args, group_size=gpus_per_node, a2a=True)
         intra_node_rounds = ceil(intra_node_gpus / intra_node_fanout)
         t_intra_node = intra_node_rounds * node_lat
@@ -646,7 +649,9 @@ def single_shot_allgather(args, msg_size, gpus, groups=None, protocol=None):
     t_intra_node = 0
     t_inter_node = 0
     if intra_node_gpus > 0:
-        node_lat, msg_size_per_peer_node = node_latency_and_volume_protocol(args, msg_size_per_peer, protocol)
+        node_lat, msg_size_per_peer_node = node_latency_and_volume_protocol(
+            args, msg_size_per_peer, protocol
+        )
         node_bw = get_effective_node_bw(args)
         intra_node_rounds = ceil(intra_node_gpus / intra_node_fanout)
         t_intra_node = intra_node_rounds * node_lat
@@ -663,7 +668,7 @@ def single_shot_allgather(args, msg_size, gpus, groups=None, protocol=None):
     return t_ag
 
 
-def single_shot_reduce_scatter(args, msg_size, gpus, groups=["hp"], protocol=None):
+def single_shot_reduce_scatter(args, msg_size, gpus, groups=("hp",), protocol=None):
     """
     Single shot reduce scatter with max fanout and overlap.
     Includes compute time for reduction.
@@ -678,7 +683,9 @@ def single_shot_reduce_scatter(args, msg_size, gpus, groups=["hp"], protocol=Non
     t_intra_node = 0
     t_inter_node = 0
     if intra_node_gpus > 0:
-        node_lat, msg_size_per_peer_node = node_latency_and_volume_protocol(args, msg_size_per_peer, protocol)
+        node_lat, msg_size_per_peer_node = node_latency_and_volume_protocol(
+            args, msg_size_per_peer, protocol
+        )
         node_bw = get_effective_node_bw(args)
         intra_node_rounds = ceil(intra_node_gpus / intra_node_fanout)
         t_intra_node = intra_node_rounds * node_lat
@@ -698,7 +705,7 @@ def single_shot_reduce_scatter(args, msg_size, gpus, groups=["hp"], protocol=Non
     return t_rs
 
 
-def single_shot_allreduce(args, msg_size, gpus, groups=["hp"], protocol=None):
+def single_shot_allreduce(args, msg_size, gpus, groups=("hp",), protocol=None):
     """
     Single shot allreduce = reduce scatter + allgather.
     Combines single shot reduce scatter and allgather.
@@ -716,7 +723,7 @@ def single_shot_allreduce(args, msg_size, gpus, groups=["hp"], protocol=None):
 # ---------------------------
 
 
-def hierarchical_allreduce(args, msg_size, gpus, groups=["dp"], protocol=None):
+def hierarchical_allreduce(args, msg_size, gpus, groups=("dp",), protocol=None):
     """
     Hierarchical AllReduce: intra-RS → inter-AR → intra-AG with pipelining.
 
@@ -789,7 +796,7 @@ def hierarchical_allreduce(args, msg_size, gpus, groups=["dp"], protocol=None):
 # ---------------------------
 
 
-def allreduce(args, msg_size, gpus, groups=["dp"]):
+def allreduce(args, msg_size, gpus, groups=("dp",)):
     """
     Select best allreduce algorithm among several options.
     Tries multiple protocols and algorithms, returns fastest.
@@ -807,7 +814,9 @@ def allreduce(args, msg_size, gpus, groups=["dp"]):
         ss_allreduce = single_shot_allreduce(args, msg_size, gpus, protocol=p)
         ringallreduce = RingAllreduce(args, msg_size, gpus, protocol=p)
         hier_allreduce = hierarchical_allreduce(args, msg_size, gpus, groups, protocol=p)
-        min_ar_alg_time = min(ringallreduce, bruck_time, hypercubeallreduce, ss_allreduce, hier_allreduce)
+        min_ar_alg_time = min(
+            ringallreduce, bruck_time, hypercubeallreduce, ss_allreduce, hier_allreduce
+        )
         if min_ar_alg_time < min_ar_time:
             min_ar_time = min_ar_alg_time
     rccl_overhead = getattr(args, "rccl_overhead_us", 0.0)
@@ -825,7 +834,7 @@ def allreduce(args, msg_size, gpus, groups=["dp"]):
     return min_ar_time
 
 
-def alltoall(args, msg_size, gpus, groups=["ep"]):
+def alltoall(args, msg_size, gpus, groups=("ep",)):
     """
     Select best alltoall algorithm among several options.
     Tries multiple protocols and algorithms, returns fastest.
@@ -865,7 +874,7 @@ def alltoall(args, msg_size, gpus, groups=["ep"]):
     return min_a2a_time
 
 
-def allgather(args, msg_size, gpus, groups=["hp"]):
+def allgather(args, msg_size, gpus, groups=("hp",)):
     """
     Select best allgather algorithm among several options.
     Tries multiple protocols and algorithms, returns fastest.
@@ -881,7 +890,7 @@ def allgather(args, msg_size, gpus, groups=["hp"]):
     return min_ag_time
 
 
-def reduce_scatter(args, msg_size, gpus, groups=["hp"]):
+def reduce_scatter(args, msg_size, gpus, groups=("hp",)):
     """
     Select best reduce_scatter algorithm among several options.
     Tries multiple protocols and algorithms, returns fastest.

--- a/infera/projection/core/projection/module_profilers/dense_mlp.py
+++ b/infera/projection/core/projection/module_profilers/dense_mlp.py
@@ -4,12 +4,10 @@
 # See LICENSE for license information.
 ###############################################################################
 
-from typing import Optional, Tuple
 
 from infera.projection.core.projection.base_module_profiler import BaseModuleProfiler
 from infera.projection.core.projection.profiler_spec import ModuleProfilerSpec
 from infera.projection.core.projection.training_config import TrainingConfig
-
 
 
 class DenseMLPProfiler(BaseModuleProfiler):
@@ -34,7 +32,7 @@ class DenseMLPProfiler(BaseModuleProfiler):
         self._cached_results = None
         self._cache_key = None
 
-    def estimated_num_params(self, rank: Optional[int] = None) -> int:
+    def estimated_num_params(self, rank: int | None = None) -> int:
         # For SwiGLU: 3 projections (gate, up, down)
         # For standard FFN: 2 projections (up, down)
         num_ffn_projections = 3 if self.config.model_config.swiglu else 2
@@ -54,7 +52,9 @@ class DenseMLPProfiler(BaseModuleProfiler):
         # Memory after first projection(s)
         if self.config.model_config.swiglu:
             # Need to store both gate and up projections for backward
-            intermediate_memory = 2 * num_tokens * self.config.model_config.ffn_hidden_size * 2  # bf16
+            intermediate_memory = (
+                2 * num_tokens * self.config.model_config.ffn_hidden_size * 2
+            )  # bf16
         else:
             intermediate_memory = num_tokens * self.config.model_config.ffn_hidden_size * 2  # bf16
 
@@ -65,7 +65,7 @@ class DenseMLPProfiler(BaseModuleProfiler):
         # Peak memory is input + intermediate (both needed for backward)
         return intermediate_memory + activation_memory + output_memory
 
-    def _get_simulated_results(self, batch_size: int, seq_len: int) -> Tuple[float, int]:
+    def _get_simulated_results(self, batch_size: int, seq_len: int) -> tuple[float, int]:
         """Get simulated results from the GEMM simulation backend."""
         tp_size = self.config.model_parallel_config.tensor_model_parallel_size
         cp_size = self.config.model_parallel_config.context_model_parallel_size
@@ -73,9 +73,8 @@ class DenseMLPProfiler(BaseModuleProfiler):
 
         # The checkpoint's weight precision where it is known, else FP8-hybrid:
         # MLP projections (gate, up, down) run in FP8.
-        gemm_dtype = (
-            getattr(self.config.model_config, "linear_weight_dtype", None)
-            or ("fp8" if getattr(self.config.model_config, "fp8", None) else "bf16")
+        gemm_dtype = getattr(self.config.model_config, "linear_weight_dtype", None) or (
+            "fp8" if getattr(self.config.model_config, "fp8", None) else "bf16"
         )
         sim_result = self._gemm_backend.simulate_mlp_gemms(
             batch_tokens=batch_tokens,
@@ -90,19 +89,19 @@ class DenseMLPProfiler(BaseModuleProfiler):
             activation_memory,
         )
 
-    def _get_benchmark_results(self, batch_size: int, seq_len: int) -> Tuple[float, int]:
+    def _get_benchmark_results(self, batch_size: int, seq_len: int) -> tuple[float, int]:
         """Get or compute benchmark results (cached)."""
         cache_key = (batch_size, seq_len)
         if self._cached_results is None or self._cache_key != cache_key:
             if self._gemm_backend is not None:
                 self._cached_results = self._get_simulated_results(batch_size, seq_len)
             else:
-
                 # Imported here, not at module scope: this pulls in torch, which costs
                 # ~0.66 s and is only needed to benchmark on a real GPU. A simulate-only
                 # projection should not pay for it -- Hyperloom spawns one process per
                 # config, where that import dwarfed the ~28 ms the projection takes.
                 from .utils import benchmark_layer
+
                 self._cached_results = benchmark_layer(
                     self.module,
                     [(seq_len, batch_size, self.config.model_config.hidden_size)],

--- a/infera/projection/core/projection/module_profilers/embedding.py
+++ b/infera/projection/core/projection/module_profilers/embedding.py
@@ -4,10 +4,8 @@
 # See LICENSE for license information.
 ###############################################################################
 
-from typing import Optional
 
 from infera.projection.core.projection.base_module_profiler import BaseModuleProfiler
-
 
 
 class EmbeddingProfiler(BaseModuleProfiler):
@@ -31,7 +29,7 @@ class EmbeddingProfiler(BaseModuleProfiler):
         self._cached_results = None
         self._cache_key = None
 
-    def estimated_num_params(self, rank: Optional[int] = None) -> int:
+    def estimated_num_params(self, rank: int | None = None) -> int:
         return self.config.model_config.padded_vocab_size * self.config.model_config.hidden_size
 
     def estimated_activation_memory(self, batch_size: int, seq_len: int) -> int:
@@ -79,12 +77,12 @@ class EmbeddingProfiler(BaseModuleProfiler):
                 # Effective sequence length per rank if CP is used
                 slen_per_cp = seq_len // cp_size
 
-
                 # Imported here, not at module scope: this pulls in torch, which costs
                 # ~0.66 s and is only needed to benchmark on a real GPU. A simulate-only
                 # projection should not pay for it -- Hyperloom spawns one process per
                 # config, where that import dwarfed the ~28 ms the projection takes.
                 from .utils import benchmark_layer
+
                 self._cached_results = benchmark_layer(
                     self.module,
                     [

--- a/infera/projection/core/projection/module_profilers/language_model.py
+++ b/infera/projection/core/projection/module_profilers/language_model.py
@@ -6,7 +6,6 @@
 
 import os
 import re
-from typing import List, Optional
 
 from infera.projection.core.projection.base_module_profiler import BaseModuleProfiler
 from infera.projection.core.projection.profiler_spec import ModuleProfilerSpec
@@ -26,12 +25,14 @@ def build_profiler(spec: ModuleProfilerSpec, depth=0) -> BaseModuleProfiler:
     Recursively build a profiler instance from a ModuleProfilerSpec.
     """
     if not issubclass(spec.profiler, BaseModuleProfiler):
-        raise TypeError(f"spec.profiler must be subclass of BaseModuleProfiler, got {spec.profiler}")
+        raise TypeError(
+            f"spec.profiler must be subclass of BaseModuleProfiler, got {spec.profiler}"
+        )
 
     if depth == 0:
         print(f"Begin build profiler: {spec.profiler.__name__}")
 
-    print(f"{'--'*(depth+1)}[{spec.profiler.__name__}]")
+    print(f"{'--' * (depth + 1)}[{spec.profiler.__name__}]")
 
     sub_profilers = {}
     if spec.sub_profiler_specs:
@@ -44,7 +45,7 @@ def build_profiler(spec: ModuleProfilerSpec, depth=0) -> BaseModuleProfiler:
                 sub_profilers[name] = build_profiler(sub_spec, depth)
             elif issubclass(sub_spec, BaseModuleProfiler):
                 # init sub profile
-                print(f"{'--'*(depth+1)}[{sub_spec.__name__}]({name})")
+                print(f"{'--' * (depth + 1)}[{sub_spec.__name__}]({name})")
                 sub_profilers[name] = sub_spec(spec.config, sub_profilers=None)
             else:
                 raise TypeError(f"Invalid type for sub_profiler_specs['{name}']: {type(sub_spec)}")
@@ -66,7 +67,7 @@ def get_language_model_profiler_spec(config: TrainingConfig) -> ModuleProfilerSp
     )
 
 
-def _get_balanced_layer_distribution(n_layers: int, total_stages: int) -> List[int]:
+def _get_balanced_layer_distribution(n_layers: int, total_stages: int) -> list[int]:
     """
     Distribute layers across stages as evenly as possible.
     Remainder layers are distributed to the first stages.
@@ -90,9 +91,9 @@ def _get_balanced_layer_distribution(n_layers: int, total_stages: int) -> List[i
 def _get_explicit_layer_distribution(
     n_layers: int,
     total_stages: int,
-    decoder_first: Optional[int],
-    decoder_last: Optional[int],
-) -> List[int]:
+    decoder_first: int | None,
+    decoder_last: int | None,
+) -> list[int]:
     """
     Get layer distribution with explicit first/last stage layer counts.
     Middle stages get evenly distributed remainder.
@@ -111,7 +112,11 @@ def _get_explicit_layer_distribution(
     middle_stages = (
         total_stages - 2
         if (decoder_first is not None and decoder_last is not None)
-        else (total_stages - 1 if (decoder_first is not None or decoder_last is not None) else total_stages)
+        else (
+            total_stages - 1
+            if (decoder_first is not None or decoder_last is not None)
+            else total_stages
+        )
     )
 
     if middle_stages > 0 and remaining_layers > 0:
@@ -143,8 +148,8 @@ def _get_explicit_layer_distribution(
 
 
 def _parse_layout_stage_layer_counts(
-    layout: Optional[str], total_stages: int, n_layers: int
-) -> Optional[List[int]]:
+    layout: str | None, total_stages: int, n_layers: int
+) -> list[int] | None:
     """
     Parse Megatron-style pipeline layout into decoder-layer counts per virtual stage.
 
@@ -167,12 +172,14 @@ def _parse_layout_stage_layer_counts(
             f"but PP*VPP expects {total_stages} stages."
         )
 
-    layers_per_stage: List[int] = []
+    layers_per_stage: list[int] = []
     for spec in stage_specs:
         spec = spec.split(",", 1)[0].strip()
         matches = re.findall(r"[tT](?:\*(\d+))?", spec)
         if not matches:
-            raise ValueError(f"Invalid pipeline stage spec '{spec}' in pipeline_model_parallel_layout.")
+            raise ValueError(
+                f"Invalid pipeline stage spec '{spec}' in pipeline_model_parallel_layout."
+            )
         layer_count = sum(int(m) if m else 1 for m in matches)
         layers_per_stage.append(layer_count)
 
@@ -247,11 +254,11 @@ class LanguageModelProfiler(BaseModuleProfiler):
         tp_size: int,
         cp_size: int,
         ep_size: int,
-        num_virtual_pipeline_stages: Optional[int] = None,
-        decoder_first_pipeline_num_layers: Optional[int] = None,
-        decoder_last_pipeline_num_layers: Optional[int] = None,
-        pipeline_model_parallel_layout: Optional[str] = None,
-    ) -> List[int]:
+        num_virtual_pipeline_stages: int | None = None,
+        decoder_first_pipeline_num_layers: int | None = None,
+        decoder_last_pipeline_num_layers: int | None = None,
+        pipeline_model_parallel_layout: str | None = None,
+    ) -> list[int]:
         """
         Get layers assigned to a specific rank, handling imbalanced layer distribution.
 
@@ -284,11 +291,11 @@ class LanguageModelProfiler(BaseModuleProfiler):
         tp_size: int,
         cp_size: int,
         ep_size: int,
-        num_virtual_pipeline_stages: Optional[int] = None,
-        decoder_first_pipeline_num_layers: Optional[int] = None,
-        decoder_last_pipeline_num_layers: Optional[int] = None,
-        pipeline_model_parallel_layout: Optional[str] = None,
-    ) -> List[List[int]]:
+        num_virtual_pipeline_stages: int | None = None,
+        decoder_first_pipeline_num_layers: int | None = None,
+        decoder_last_pipeline_num_layers: int | None = None,
+        pipeline_model_parallel_layout: str | None = None,
+    ) -> list[list[int]]:
         """
         Get per-virtual-stage decoder layers assigned to a rank.
         """
@@ -310,7 +317,9 @@ class LanguageModelProfiler(BaseModuleProfiler):
             if decoder_last is None:
                 decoder_last = getattr(mp_config, "decoder_last_pipeline_num_layers", None)
             if pipeline_model_parallel_layout is None:
-                pipeline_model_parallel_layout = getattr(mp_config, "pipeline_model_parallel_layout", None)
+                pipeline_model_parallel_layout = getattr(
+                    mp_config, "pipeline_model_parallel_layout", None
+                )
 
         # Build layer counts per virtual stage
         if pipeline_model_parallel_layout:
@@ -331,7 +340,7 @@ class LanguageModelProfiler(BaseModuleProfiler):
         # pp_rank 1 gets virtual stages: 1, pp_size+1, 2*pp_size+1, ...
         my_virtual_stages = range(pp_rank, total_stages, pp_size)
 
-        assigned_chunks: List[List[int]] = []
+        assigned_chunks: list[list[int]] = []
         for vs_index in my_virtual_stages:
             # Calculate start layer by summing layers in all previous stages
             start_layer = sum(layers_per_stage[:vs_index])
@@ -436,7 +445,7 @@ class LanguageModelProfiler(BaseModuleProfiler):
         dp_size = world_size // mp.expert_model_parallel_size // mp.pipeline_model_parallel_size
         return max(1, dp_size)
 
-    def estimated_num_params(self, rank: Optional[int] = None) -> int:
+    def estimated_num_params(self, rank: int | None = None) -> int:
         total_params = 0
         if rank is None:
             layers = range(self.config.model_config.num_layers)
@@ -445,13 +454,16 @@ class LanguageModelProfiler(BaseModuleProfiler):
         for layer in layers:
             is_moe = self.config.model_config.moe_pattern[layer]
             if is_moe:
-                total_params += self.sub_profilers["moe_transformer_layer"].estimated_num_params(rank)
+                total_params += self.sub_profilers["moe_transformer_layer"].estimated_num_params(
+                    rank
+                )
             else:
-                total_params += self.sub_profilers["dense_transformer_layer"].estimated_num_params(rank)
+                total_params += self.sub_profilers["dense_transformer_layer"].estimated_num_params(
+                    rank
+                )
         if 0 in self.layers:
             total_params += self.sub_profilers["embedding"].estimated_num_params(rank)
         if self.config.model_config.num_layers - 1 in self.layers:
             total_params += self.sub_profilers["final_layernorm"].estimated_num_params(rank)
             total_params += self.sub_profilers["output_layer"].estimated_num_params(rank)
         return total_params
-

--- a/infera/projection/core/projection/module_profilers/layer_norm.py
+++ b/infera/projection/core/projection/module_profilers/layer_norm.py
@@ -4,13 +4,12 @@
 # See LICENSE for license information.
 ###############################################################################
 
-from typing import Optional
 
 from infera.projection.core.projection.base_module_profiler import BaseModuleProfiler
 
 
 class LayerNormProfiler(BaseModuleProfiler):
-    def estimated_num_params(self, rank: Optional[int] = None) -> int:
+    def estimated_num_params(self, rank: int | None = None) -> int:
         return self.config.model_config.hidden_size * 2  # gamma and beta
 
     def estimated_activation_memory(self, batch_size: int, seq_len: int) -> int:

--- a/infera/projection/core/projection/module_profilers/moe_mlp.py
+++ b/infera/projection/core/projection/module_profilers/moe_mlp.py
@@ -5,12 +5,10 @@
 ###############################################################################
 
 import os
-from typing import Optional
 
 from infera.projection.core.projection.base_module_profiler import BaseModuleProfiler
 from infera.projection.core.projection.profiler_spec import ModuleProfilerSpec
 from infera.projection.core.projection.training_config import TrainingConfig
-
 
 # Efficiency fractions for non-GEMM MoE overhead estimation.
 # These express achievable bandwidth as a fraction of peak HBM bandwidth.
@@ -38,7 +36,6 @@ _ACTIVATION_BW_FRACTION = 0.566
 #
 # Fallback absolute values used when the backend cannot report HBM bandwidth.
 _FALLBACK_HBM_BW_GBPS = 5300.0  # MI300X default
-
 
 
 # Measured grouped-GEMM bandwidth on MI355X at M=1, as a fraction of peak HBM,
@@ -83,9 +80,7 @@ def _router_coverage(curve, tokens: int) -> float:
     # Accepts a mapping, or the [[batch, coverage], ...] form a YAML preset uses
     # (the config loader turns mappings into namespaces and cannot hold the
     # integer keys this is naturally keyed by).
-    items = curve.items() if hasattr(curve, "items") else (
-        (p[0], p[1]) for p in curve
-    )
+    items = curve.items() if hasattr(curve, "items") else ((p[0], p[1]) for p in curve)
     pts = sorted((int(b), float(v)) for b, v in items)
     if tokens <= pts[0][0]:
         return pts[0][1]
@@ -100,9 +95,7 @@ def _router_coverage(curve, tokens: int) -> float:
     return pts[-1][1]
 
 
-def _expert_hit_fraction(
-    num_experts: int, topk: int, tokens: int, skew: float = 0.0
-) -> float:
+def _expert_hit_fraction(num_experts: int, topk: int, tokens: int, skew: float = 0.0) -> float:
     """Expected fraction of experts a step touches, for a Zipf(``skew``) router.
 
     ``skew`` 0 is uniform and reproduces the closed form
@@ -118,7 +111,7 @@ def _expert_hit_fraction(
     draws = tokens * max(1, topk)
     if skew <= 0.0:
         return 1.0 - (1.0 - min(1.0, topk / num_experts)) ** tokens
-    weights = [1.0 / (i ** skew) for i in range(1, num_experts + 1)]
+    weights = [1.0 / (i**skew) for i in range(1, num_experts + 1)]
     total = sum(weights)
     hit = sum(1.0 - (1.0 - w / total) ** draws for w in weights)
     return min(1.0, hit / num_experts)
@@ -148,7 +141,7 @@ class MoEMLPProfiler(BaseModuleProfiler):
         self._cached_results = None
         self._cache_key = None
 
-    def estimated_num_params(self, rank: Optional[int] = None) -> int:
+    def estimated_num_params(self, rank: int | None = None) -> int:
         if self.config.model_config.moe_ffn_hidden_size is not None:
             moe_ffn = self.config.model_config.moe_ffn_hidden_size
         else:
@@ -288,9 +281,7 @@ class MoEMLPProfiler(BaseModuleProfiler):
                 getattr(self.config.model_config, "moe_router_coverage", None),
                 routing_tokens,
             )
-            active_global_experts = max(
-                1, min(num_experts, int(round(num_experts * hit_frac)))
-            )
+            active_global_experts = max(1, min(num_experts, int(round(num_experts * hit_frac))))
             active_local_experts = max(
                 1, min(num_local_experts, int(round(num_local_experts * hit_frac)))
             )
@@ -338,9 +329,8 @@ class MoEMLPProfiler(BaseModuleProfiler):
         # real number of weight bytes instead of applying a speedup multiplier
         # after the fact -- at decode the step is weight-bound, so this width is
         # the dominant term.
-        gemm_dtype = (
-            getattr(self.config.model_config, "moe_expert_dtype", None)
-            or ("fp8" if getattr(self.config.model_config, "fp8", None) else "bf16")
+        gemm_dtype = getattr(self.config.model_config, "moe_expert_dtype", None) or (
+            "fp8" if getattr(self.config.model_config, "fp8", None) else "bf16"
         )
         # Activations keep their own precision; they are not the expert weights.
         bytes_per_el = 1 if getattr(self.config.model_config, "fp8", None) else 2
@@ -395,7 +385,9 @@ class MoEMLPProfiler(BaseModuleProfiler):
                 gate_fwd = self._gemm_backend.simulate_gemm(M, F, H, gemm_dtype, batch=B)
                 up_fwd = self._gemm_backend.simulate_gemm(M, F, H, gemm_dtype, batch=B)
                 down_fwd = self._gemm_backend.simulate_gemm(M, H, F, gemm_dtype, batch=B)
-                expert_fwd_ms = gate_fwd.forward_time_ms + up_fwd.forward_time_ms + down_fwd.forward_time_ms
+                expert_fwd_ms = (
+                    gate_fwd.forward_time_ms + up_fwd.forward_time_ms + down_fwd.forward_time_ms
+                )
             else:
                 up_fwd = self._gemm_backend.simulate_gemm(M, F, H, gemm_dtype, batch=B)
                 down_fwd = self._gemm_backend.simulate_gemm(M, H, F, gemm_dtype, batch=B)
@@ -407,9 +399,7 @@ class MoEMLPProfiler(BaseModuleProfiler):
             # (~16 experts), so it only reshapes the small-batch decode curve --
             # which is exactly where the group is small enough to matter.
             if int(seq_len) <= 1 and B > 0:
-                expert_fwd_ms *= max(
-                    1.0, _GROUPED_GEMM_PLATEAU / _grouped_gemm_efficiency(B)
-                )
+                expert_fwd_ms *= max(1.0, _GROUPED_GEMM_PLATEAU / _grouped_gemm_efficiency(B))
 
             expert_fwd = expert_fwd_ms
         else:
@@ -418,7 +408,9 @@ class MoEMLPProfiler(BaseModuleProfiler):
                 gate_fwd = self._gemm_backend.simulate_gemm(M, F, H, gemm_dtype, batch=1)
                 up_fwd = self._gemm_backend.simulate_gemm(M, F, H, gemm_dtype, batch=1)
                 down_fwd = self._gemm_backend.simulate_gemm(M, H, F, gemm_dtype, batch=1)
-                expert_fwd_ms = gate_fwd.forward_time_ms + up_fwd.forward_time_ms + down_fwd.forward_time_ms
+                expert_fwd_ms = (
+                    gate_fwd.forward_time_ms + up_fwd.forward_time_ms + down_fwd.forward_time_ms
+                )
             else:
                 up_fwd = self._gemm_backend.simulate_gemm(M, F, H, gemm_dtype, batch=1)
                 down_fwd = self._gemm_backend.simulate_gemm(M, H, F, gemm_dtype, batch=1)
@@ -448,7 +440,9 @@ class MoEMLPProfiler(BaseModuleProfiler):
 
         # ── 2. Router overhead ──
         # Gate linear: [batch_tokens, num_experts, hidden_size]
-        router_gemm = self._gemm_backend.simulate_gemm(batch_tokens, num_experts, hidden_size, gemm_dtype)
+        router_gemm = self._gemm_backend.simulate_gemm(
+            batch_tokens, num_experts, hidden_size, gemm_dtype
+        )
         router_fwd_ms = router_gemm.forward_time_ms
         # Softmax + top-K selection over the router logits [batch_tokens,
         # num_experts]. Modelled as a memory-bound streaming op (read logits,
@@ -472,10 +466,9 @@ class MoEMLPProfiler(BaseModuleProfiler):
         # unquantized (bf16) whatever width the operands were.
         dispatch_bytes = 2 * topk_tokens * hidden_size * bytes_per_el
         combine_bytes = (topk_tokens + batch_tokens) * hidden_size * 2
-        permute_fwd_ms = (
-            dispatch_bytes / (peak_hbm * _PERMUTE_GATHER_BW_FRACTION * 1e6)
-            + combine_bytes / (peak_hbm * _PERMUTE_COMBINE_BW_FRACTION * 1e6)
-        )
+        permute_fwd_ms = dispatch_bytes / (
+            peak_hbm * _PERMUTE_GATHER_BW_FRACTION * 1e6
+        ) + combine_bytes / (peak_hbm * _PERMUTE_COMBINE_BW_FRACTION * 1e6)
 
         fwd_time += permute_fwd_ms
 
@@ -522,12 +515,12 @@ class MoEMLPProfiler(BaseModuleProfiler):
                 self._cached_results = self._get_simulated_results(batch_size, seq_len)
                 self._a2a_fwd_ms = 0.0
             else:
-
                 # Imported here, not at module scope: this pulls in torch, which costs
                 # ~0.66 s and is only needed to benchmark on a real GPU. A simulate-only
                 # projection should not pay for it -- Hyperloom spawns one process per
                 # config, where that import dwarfed the ~28 ms the projection takes.
                 from .utils import benchmark_moe_layer_decomposed
+
                 fwd, act_mem, a2a_fwd = benchmark_moe_layer_decomposed(
                     self.module,
                     [(seq_len, batch_size, self.config.model_config.hidden_size)],

--- a/infera/projection/core/projection/module_profilers/output_layer.py
+++ b/infera/projection/core/projection/module_profilers/output_layer.py
@@ -4,10 +4,8 @@
 # See LICENSE for license information.
 ###############################################################################
 
-from typing import Optional
 
 from infera.projection.core.projection.base_module_profiler import BaseModuleProfiler
-
 
 
 class OutputLayerProfiler(BaseModuleProfiler):
@@ -31,7 +29,7 @@ class OutputLayerProfiler(BaseModuleProfiler):
         self._cached_results = None
         self._cache_key = None
 
-    def estimated_num_params(self, rank: Optional[int] = None) -> int:
+    def estimated_num_params(self, rank: int | None = None) -> int:
         return self.config.model_config.padded_vocab_size * self.config.model_config.hidden_size
 
     def estimated_activation_memory(self, batch_size: int, seq_len: int) -> int:
@@ -77,12 +75,12 @@ class OutputLayerProfiler(BaseModuleProfiler):
                 # Effective sequence length per rank if CP is used
                 slen_per_cp = seq_len // cp_size
 
-
                 # Imported here, not at module scope: this pulls in torch, which costs
                 # ~0.66 s and is only needed to benchmark on a real GPU. A simulate-only
                 # projection should not pay for it -- Hyperloom spawns one process per
                 # config, where that import dwarfed the ~28 ms the projection takes.
                 from .utils import benchmark_layer
+
                 self._cached_results = benchmark_layer(
                     self.module,
                     [

--- a/infera/projection/core/projection/module_profilers/residual_add.py
+++ b/infera/projection/core/projection/module_profilers/residual_add.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from infera.projection.core.projection.base_module_profiler import BaseModuleProfiler
 
 ###############################################################################
@@ -10,7 +8,7 @@ from infera.projection.core.projection.base_module_profiler import BaseModulePro
 
 
 class ResidualAddProfiler(BaseModuleProfiler):
-    def estimated_num_params(self, rank: Optional[int] = None) -> int:
+    def estimated_num_params(self, rank: int | None = None) -> int:
         return 0
 
     def estimated_activation_memory(self, batch_size: int, seq_len: int) -> int:

--- a/infera/projection/core/projection/module_profilers/router.py
+++ b/infera/projection/core/projection/module_profilers/router.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from infera.projection.core.projection.base_module_profiler import BaseModuleProfiler
 
 ###############################################################################
@@ -10,7 +8,7 @@ from infera.projection.core.projection.base_module_profiler import BaseModulePro
 
 
 class RouterProfiler(BaseModuleProfiler):
-    def estimated_num_params(self, rank: Optional[int] = None) -> int:
+    def estimated_num_params(self, rank: int | None = None) -> int:
         return self.config.model_config.hidden_size * self.config.model_config.num_experts
 
     def estimated_activation_memory(self, batch_size: int, seq_len: int) -> int:

--- a/infera/projection/core/projection/module_profilers/transformer_layer.py
+++ b/infera/projection/core/projection/module_profilers/transformer_layer.py
@@ -6,7 +6,6 @@
 
 import logging
 import os
-from typing import Optional
 
 from infera.projection.core.projection.base_module_profiler import BaseModuleProfiler
 from infera.projection.core.projection.profiler_spec import ModuleProfilerSpec
@@ -306,7 +305,7 @@ class DenseTransformerLayerProfiler(BaseModuleProfiler):
         self._cached_results = None
         self._cache_key = None
 
-    def estimated_num_params(self, rank: Optional[int] = None) -> int:
+    def estimated_num_params(self, rank: int | None = None) -> int:
         return (
             self.sub_profilers["layer_norm"].estimated_num_params(rank) * 3
             + self.sub_profilers["self_attention"].estimated_num_params(rank)
@@ -319,7 +318,8 @@ class DenseTransformerLayerProfiler(BaseModuleProfiler):
             self.sub_profilers["layer_norm"].estimated_activation_memory(batch_size, seq_len) * 3
             + self.sub_profilers["self_attention"].estimated_activation_memory(batch_size, seq_len)
             + self.sub_profilers["mlp"].estimated_activation_memory(batch_size, seq_len)
-            + self.sub_profilers["residual_add"].estimated_activation_memory(batch_size, seq_len) * 2
+            + self.sub_profilers["residual_add"].estimated_activation_memory(batch_size, seq_len)
+            * 2
         )
 
     def _get_simulated_results(self, batch_size: int, seq_len: int) -> tuple[float, int]:
@@ -340,7 +340,9 @@ class DenseTransformerLayerProfiler(BaseModuleProfiler):
             self.config, batch_size, seq_len, self._gemm_backend
         )
 
-        fwd_time = attn_fwd + mlp_fwd + _dense_tp_allreduce_count(self.config) * tp_ar_ms + ln_res_fwd_ms
+        fwd_time = (
+            attn_fwd + mlp_fwd + _dense_tp_allreduce_count(self.config) * tp_ar_ms + ln_res_fwd_ms
+        )
         activation_memory = self.estimated_activation_memory(batch_size, seq_len)
         return (fwd_time, activation_memory)
 
@@ -432,7 +434,7 @@ class MoETransformerLayerProfiler(BaseModuleProfiler):
         self._cached_results = None
         self._cache_key = None
 
-    def estimated_num_params(self, rank: Optional[int] = None) -> int:
+    def estimated_num_params(self, rank: int | None = None) -> int:
         return (
             self.sub_profilers["layer_norm"].estimated_num_params(rank) * 3
             + self.sub_profilers["self_attention"].estimated_num_params(rank)
@@ -447,7 +449,8 @@ class MoETransformerLayerProfiler(BaseModuleProfiler):
             + self.sub_profilers["self_attention"].estimated_activation_memory(batch_size, seq_len)
             + self.sub_profilers["mlp"].estimated_activation_memory(batch_size, seq_len)
             + self.sub_profilers["router"].estimated_activation_memory(batch_size, seq_len)
-            + self.sub_profilers["residual_add"].estimated_activation_memory(batch_size, seq_len) * 2
+            + self.sub_profilers["residual_add"].estimated_activation_memory(batch_size, seq_len)
+            * 2
         )
 
     def _get_simulated_results(self, batch_size: int, seq_len: int) -> tuple[float, int]:
@@ -540,7 +543,9 @@ class MoETransformerLayerProfiler(BaseModuleProfiler):
                             restore()
                         except Exception:
                             # Best-effort cleanup: restore failures should not fail benchmarking.
-                            _LOGGER.debug("Failed to restore routing patch during cleanup.", exc_info=True)
+                            _LOGGER.debug(
+                                "Failed to restore routing patch during cleanup.", exc_info=True
+                            )
             else:
                 self._cached_results = self._get_benchmark_composite_results(batch_size, seq_len)
             self._cache_key = cache_key

--- a/infera/projection/core/projection/module_profilers/utils.py
+++ b/infera/projection/core/projection/module_profilers/utils.py
@@ -7,12 +7,11 @@
 
 import os
 from contextlib import contextmanager, nullcontext
-from typing import List, Tuple, Union
 
 import torch
 
 
-def _bench_iter_count(default_warmup: int, default_iters: int) -> Tuple[int, int]:
+def _bench_iter_count(default_warmup: int, default_iters: int) -> tuple[int, int]:
     """Look up bench iteration counts, allowing runtime override.
 
     Env vars (intended for debugging slow MoE benches that hit NCCL
@@ -71,7 +70,9 @@ class _FP8ContextFactory:
 
                 self._ctx = get_fp8_context(self.transformer_config, layer_no=-1)
                 if not self._printed:
-                    print(f"  [FP8] Using FP8 autocast context for benchmarking (fp8={self.fp8_enabled})")
+                    print(
+                        f"  [FP8] Using FP8 autocast context for benchmarking (fp8={self.fp8_enabled})"
+                    )
                     self._printed = True
             except Exception as e:
                 try:
@@ -183,7 +184,7 @@ def _time_forward_cuda_graph(layer_module, inputs, fp8_context, num_iterations, 
 
 def benchmark_layer(
     layer_module: torch.nn.Module,
-    input_shapes: List[Union[Tuple[int, ...], Tuple[Tuple[int, ...], torch.dtype]]],
+    input_shapes: list[tuple[int, ...] | tuple[tuple[int, ...], torch.dtype]],
     num_iterations: int = 64,  # Match typical microbatch count
     transformer_config=None,  # Optional: pass config to enable FP8 context
     use_cuda_graph: bool = False,  # Inference: capture + replay under a CUDA/HIP graph
@@ -432,7 +433,7 @@ def _uninstall_routing_patches(restores) -> None:
 
 def benchmark_moe_layer_decomposed(
     moe_module: torch.nn.Module,
-    input_shapes: List[Union[Tuple[int, ...], Tuple[Tuple[int, ...], torch.dtype]]],
+    input_shapes: list[tuple[int, ...] | tuple[tuple[int, ...], torch.dtype]],
     num_iterations: int = 64,
     transformer_config=None,
 ) -> tuple[float, int, float]:
@@ -517,7 +518,9 @@ def benchmark_moe_layer_decomposed(
             for spec in input_shapes:
                 shape = (
                     spec[0]
-                    if isinstance(spec, tuple) and len(spec) == 2 and isinstance(spec[1], torch.dtype)
+                    if isinstance(spec, tuple)
+                    and len(spec) == 2
+                    and isinstance(spec[1], torch.dtype)
                     else spec
                 )
                 # [seq, batch, hidden]

--- a/infera/projection/core/projection/profiler_spec.py
+++ b/infera/projection/core/projection/profiler_spec.py
@@ -5,7 +5,7 @@
 ###############################################################################
 
 from dataclasses import dataclass, field
-from typing import Dict, Optional, Type, Union
+from typing import Union
 
 from infera.projection.core.projection.base_module_profiler import BaseModuleProfiler
 from infera.projection.core.projection.training_config import TrainingConfig
@@ -13,8 +13,8 @@ from infera.projection.core.projection.training_config import TrainingConfig
 
 @dataclass
 class ModuleProfilerSpec:
-    profiler: Type[BaseModuleProfiler]
-    config: Type[TrainingConfig]
-    sub_profiler_specs: Optional[Dict[str, Union[Type[BaseModuleProfiler], "ModuleProfilerSpec", None]]] = (
-        field(default_factory=lambda: {})
-    )
+    profiler: type[BaseModuleProfiler]
+    config: type[TrainingConfig]
+    sub_profiler_specs: (
+        dict[str, Union[type[BaseModuleProfiler], "ModuleProfilerSpec", None]] | None
+    ) = field(default_factory=lambda: {})

--- a/infera/projection/core/projection/simulation_backends/base.py
+++ b/infera/projection/core/projection/simulation_backends/base.py
@@ -18,7 +18,7 @@ An SDPA simulation backend is provided in ``sdpa_simulator.py``.
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any
 
 
 @dataclass
@@ -29,11 +29,11 @@ class SimulationResult:
     forward_time_ms: float = 0.0
 
     # Optional: predicted TFLOPS / bandwidth
-    tflops: Optional[float] = None
-    bandwidth_gbps: Optional[float] = None
+    tflops: float | None = None
+    bandwidth_gbps: float | None = None
 
     # Optional: extra metadata from the backend
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 class GEMMSimulationBackend(ABC):
@@ -50,7 +50,7 @@ class GEMMSimulationBackend(ABC):
         ...
 
     @property
-    def hbm_bandwidth_gbps(self) -> Optional[float]:
+    def hbm_bandwidth_gbps(self) -> float | None:
         """Peak HBM bandwidth in GB/s for the target GPU, or *None* if unknown.
 
         Concrete backends should override this when the target architecture is
@@ -138,18 +138,24 @@ class GEMMSimulationBackend(ABC):
 
         if swiglu:
             # Gate projection fwd:  [tokens, hidden] x [hidden, ffn] -> [tokens, ffn]
-            gate_fwd = self.simulate_gemm(batch_tokens, ffn_hidden_size, hidden_size, dtype, batch=b)
+            gate_fwd = self.simulate_gemm(
+                batch_tokens, ffn_hidden_size, hidden_size, dtype, batch=b
+            )
             # Up projection fwd:  same shape as gate
             up_fwd = self.simulate_gemm(batch_tokens, ffn_hidden_size, hidden_size, dtype, batch=b)
             # Down projection fwd:  [tokens, ffn] x [ffn, hidden] -> [tokens, hidden]
-            down_fwd = self.simulate_gemm(batch_tokens, hidden_size, ffn_hidden_size, dtype, batch=b)
+            down_fwd = self.simulate_gemm(
+                batch_tokens, hidden_size, ffn_hidden_size, dtype, batch=b
+            )
 
             fwd_time = gate_fwd.forward_time_ms + up_fwd.forward_time_ms + down_fwd.forward_time_ms
         else:
             # Up projection fwd:  [tokens, hidden] x [hidden, ffn] -> [tokens, ffn]
             up_fwd = self.simulate_gemm(batch_tokens, ffn_hidden_size, hidden_size, dtype, batch=b)
             # Down projection fwd:  [tokens, ffn] x [ffn, hidden] -> [tokens, hidden]
-            down_fwd = self.simulate_gemm(batch_tokens, hidden_size, ffn_hidden_size, dtype, batch=b)
+            down_fwd = self.simulate_gemm(
+                batch_tokens, hidden_size, ffn_hidden_size, dtype, batch=b
+            )
 
             fwd_time = up_fwd.forward_time_ms + down_fwd.forward_time_ms
 
@@ -219,9 +225,9 @@ class SDPASimulationBackend(ABC):
         head_dim: int,
         causal: bool = True,
         dtype: str = "bf16",
-        seq_len_kv: Optional[int] = None,
-        num_heads_kv: Optional[int] = None,
-        head_dim_v: Optional[int] = None,
+        seq_len_kv: int | None = None,
+        num_heads_kv: int | None = None,
+        head_dim_v: int | None = None,
     ) -> SimulationResult:
         """
         Simulate a Scaled Dot-Product Attention operation.

--- a/infera/projection/core/projection/simulation_backends/factory.py
+++ b/infera/projection/core/projection/simulation_backends/factory.py
@@ -66,7 +66,10 @@ def get_gemm_simulation_backend(
     if require_simulation and not backend.is_available():
         raise RuntimeError(
             "Origami GEMM simulation backend is not available.\n"
-            "Install it with: pip install origami"
+            # Not `pip install origami`: that name on PyPI is an unrelated project.
+            "Install it with: pip install 'git+https://github.com/ROCm/rocm-libraries.git"
+            "#subdirectory=shared/origami/python'\n"
+            "(building it requires ROCm/HIP on the host)"
         )
 
     if is_rank_0 and require_simulation:

--- a/infera/projection/core/projection/simulation_backends/factory.py
+++ b/infera/projection/core/projection/simulation_backends/factory.py
@@ -15,7 +15,6 @@ SDPA always uses the built-in analytical simulator.
 """
 
 import os
-from typing import Optional
 
 from infera.projection.core.projection.simulation_backends.base import (
     GEMMSimulationBackend,
@@ -24,9 +23,9 @@ from infera.projection.core.projection.simulation_backends.base import (
 
 
 def get_gemm_simulation_backend(
-    backend_name: Optional[str] = None,
-    gpu_arch: Optional[str] = None,
-    gpu_clock_mhz: Optional[int] = None,
+    backend_name: str | None = None,
+    gpu_arch: str | None = None,
+    gpu_clock_mhz: int | None = None,
     require_simulation: bool = True,
 ) -> GEMMSimulationBackend:
     """
@@ -57,7 +56,7 @@ def get_gemm_simulation_backend(
     is_rank_0 = int(os.getenv("RANK", "0")) == 0
 
     if name is not None and name != "origami":
-        raise ValueError(f"Unknown GEMM simulation backend: '{name}'. " f"Supported backend: 'origami'")
+        raise ValueError(f"Unknown GEMM simulation backend: '{name}'. Supported backend: 'origami'")
 
     from infera.projection.core.projection.simulation_backends.origami_backend import (
         OrigamiGEMMBackend,
@@ -66,7 +65,8 @@ def get_gemm_simulation_backend(
     backend = OrigamiGEMMBackend(gpu_arch=gpu_arch, gpu_clock_mhz=gpu_clock_mhz)
     if require_simulation and not backend.is_available():
         raise RuntimeError(
-            "Origami GEMM simulation backend is not available.\n" "Install it with: pip install origami"
+            "Origami GEMM simulation backend is not available.\n"
+            "Install it with: pip install origami"
         )
 
     if is_rank_0 and require_simulation:
@@ -75,8 +75,8 @@ def get_gemm_simulation_backend(
 
 
 def get_sdpa_simulation_backend(
-    gpu_arch: Optional[str] = None,
-    gpu_clock_mhz: Optional[int] = None,
+    gpu_arch: str | None = None,
+    gpu_clock_mhz: int | None = None,
 ) -> SDPASimulationBackend:
     """
     Create and return the SDPA simulation backend.

--- a/infera/projection/core/projection/simulation_backends/origami_backend.py
+++ b/infera/projection/core/projection/simulation_backends/origami_backend.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
 
 from infera.projection.core.projection.simulation_backends.base import (
     GEMMSimulationBackend,
@@ -38,7 +37,7 @@ from infera.projection.core.projection.simulation_backends.base import (
 # Lazy import – we don't want to fail at module-import time.
 # ---------------------------------------------------------------------------
 _origami = None
-_origami_available: Optional[bool] = None
+_origami_available: bool | None = None
 
 
 def _try_import_origami():
@@ -88,7 +87,7 @@ class _HardwareProfile:
 # architecture without a profile -- the one case it exists to cover.
 _FALLBACK_HBM_BW_GBPS: float = 5300.0
 
-_KNOWN_PROFILES: Dict[str, _HardwareProfile] = {
+_KNOWN_PROFILES: dict[str, _HardwareProfile] = {
     # MI300X / gfx942: HBM3 ~5.3 TB/s, ~1307 TFLOP/s dense BF16
     "mi300x": _HardwareProfile("gfx942", 304, 65536, 4_194_304, 2_100_000, 5300.0, 1307.0),
     "gfx942": _HardwareProfile("gfx942", 304, 65536, 4_194_304, 2_100_000, 5300.0, 1307.0),
@@ -143,7 +142,7 @@ _ROOFLINE_COMPUTE_EFF = 0.40
 # Physical operand width, in bytes per element, of each precision the expert /
 # projection GEMMs can run at. ``mxfp4`` is block-scaled: 4-bit elements plus one
 # E8M0 scale per block of 32 = 4 + 8/32 bits = 0.53125 B/el.
-_OPERAND_BYTES: Dict[str, float] = {
+_OPERAND_BYTES: dict[str, float] = {
     "fp32": 4.0,
     "bf16": 2.0,
     "fp16": 2.0,
@@ -158,7 +157,7 @@ _OPERAND_BYTES: Dict[str, float] = {
 
 # Dense matrix-throughput of each precision relative to BF16 on CDNA3/CDNA4:
 # each halving of operand width doubles the MFMA rate.
-_PEAK_MULTIPLE: Dict[str, float] = {
+_PEAK_MULTIPLE: dict[str, float] = {
     "fp32": 0.5,
     "bf16": 1.0,
     "fp16": 1.0,
@@ -188,7 +187,7 @@ def _dtype_peak_multiple(sim_dtype: str, native_fp8: bool = False) -> float:
     return 2.0 if native_fp8 else 1.0
 
 
-_DTYPE_MAP: Dict[str, str] = {
+_DTYPE_MAP: dict[str, str] = {
     "bf16": "bf16",
     "fp16": "f16",
     "fp32": "f32",
@@ -206,7 +205,7 @@ _DTYPE_MAP: Dict[str, str] = {
 # A wider search space yields better latency predictions at the cost of
 # slightly longer selection time (still << 1 ms per GEMM).
 # ---------------------------------------------------------------------------
-_DEFAULT_TILE_SIZES: List[Tuple[int, int, int]] = [
+_DEFAULT_TILE_SIZES: list[tuple[int, int, int]] = [
     (64, 64, 32),
     (64, 64, 64),
     (64, 128, 32),
@@ -222,7 +221,7 @@ _DEFAULT_TILE_SIZES: List[Tuple[int, int, int]] = [
     (256, 256, 32),
     (256, 256, 64),
 ]
-_DEFAULT_OCCUPANCIES: List[int] = [1, 2, 4]
+_DEFAULT_OCCUPANCIES: list[int] = [1, 2, 4]
 
 # Widest ``block_K`` in the static list above. When a matrix instruction is
 # wider than this in the K dimension, none of the static macro-tiles can fully
@@ -230,7 +229,7 @@ _DEFAULT_OCCUPANCIES: List[int] = [1, 2, 4]
 _MAX_STATIC_TILE_K = 64
 
 
-def _candidate_tile_sizes(mi_k: int) -> List[Tuple[int, int, int]]:
+def _candidate_tile_sizes(mi_k: int) -> list[tuple[int, int, int]]:
     """Macro-tile candidates, widened so at least one tile can feed the MI.
 
     Origami only ranks the tiles it is given. If every candidate's ``block_K``
@@ -269,9 +268,9 @@ class OrigamiGEMMBackend(GEMMSimulationBackend):
 
     def __init__(
         self,
-        gpu_arch: Optional[str] = None,
-        gpu_clock_mhz: Optional[int] = None,
-        n_cu_override: Optional[int] = None,
+        gpu_arch: str | None = None,
+        gpu_clock_mhz: int | None = None,
+        n_cu_override: int | None = None,
     ):
         """
         Args:
@@ -293,17 +292,19 @@ class OrigamiGEMMBackend(GEMMSimulationBackend):
 
         # Clock override: CLI > env var > profile default
         _env_clock = os.getenv("INFERASIM_GPU_CLOCK_MHZ", None)
-        self._clock_override_mhz: Optional[int] = gpu_clock_mhz or (int(_env_clock) if _env_clock else None)
+        self._clock_override_mhz: int | None = gpu_clock_mhz or (
+            int(_env_clock) if _env_clock else None
+        )
 
         self._n_cu_override = n_cu_override
 
         # Lazily initialised origami objects – see ``_ensure_initialized``.
         self._hardware = None  # origami.hardware_t
         self._configs = None  # list[origami.config_t]
-        self._clock_ghz: Optional[float] = None
+        self._clock_ghz: float | None = None
         self._initialized = False
-        self._init_dtype: Optional[str] = None  # tracks dtype used for config init
-        self._fp8_origami_str: Optional[str] = None  # resolved FP8 MI dtype str
+        self._init_dtype: str | None = None  # tracks dtype used for config init
+        self._fp8_origami_str: str | None = None  # resolved FP8 MI dtype str
 
     # ------------------------------------------------------------------
     # GEMMSimulationBackend interface
@@ -316,7 +317,7 @@ class OrigamiGEMMBackend(GEMMSimulationBackend):
         return _try_import_origami()
 
     @property
-    def hbm_bandwidth_gbps(self) -> Optional[float]:
+    def hbm_bandwidth_gbps(self) -> float | None:
         """Peak HBM bandwidth for the target architecture (GB/s).
 
         Resolved from the arch profile (``_KNOWN_PROFILES``) or the
@@ -336,7 +337,9 @@ class OrigamiGEMMBackend(GEMMSimulationBackend):
         profile = _KNOWN_PROFILES.get(arch)
         return profile.peak_tflops_bf16 if profile is not None else 1307.0
 
-    def _roofline_ceiling_ms(self, m: int, n: int, k: int, batch: int, sim_dtype: str, native_fp8: bool) -> float:
+    def _roofline_ceiling_ms(
+        self, m: int, n: int, k: int, batch: int, sim_dtype: str, native_fp8: bool
+    ) -> float:
         """Efficiency-adjusted max(memory, compute) roofline for one (batched) GEMM.
 
         This is a physical *upper bound* on a well-tuned kernel's time: it can't
@@ -432,7 +435,7 @@ class OrigamiGEMMBackend(GEMMSimulationBackend):
             )
         except Exception as e:
             raise RuntimeError(
-                f"Origami select_config failed for " f"(M={m}, N={n}, K={k}, dtype={dtype}): {e}"
+                f"Origami select_config failed for (M={m}, N={n}, K={k}, dtype={dtype}): {e}"
             ) from e
 
         latency_cycles = result.latency
@@ -443,7 +446,9 @@ class OrigamiGEMMBackend(GEMMSimulationBackend):
         # roofline. Compute-bound (large-M / prefill) GEMMs sit below the
         # ceiling and are unaffected. dtype=="fp8" always earns the FP8 roofline
         # (2x throughput, 1-byte operands) regardless of the BF16 fallback.
-        ceiling_ms = self._roofline_ceiling_ms(m, n, k, batch, sim_dtype, native_fp8=(dtype == "fp8"))
+        ceiling_ms = self._roofline_ceiling_ms(
+            m, n, k, batch, sim_dtype, native_fp8=(dtype == "fp8")
+        )
         if ceiling_ms > 0:
             time_ms = min(time_ms, ceiling_ms)
 

--- a/infera/projection/core/projection/simulation_backends/origami_backend.py
+++ b/infera/projection/core/projection/simulation_backends/origami_backend.py
@@ -48,10 +48,16 @@ def _try_import_origami():
 
     try:
         import origami  # type: ignore[import-untyped]
+    except ImportError:
+        _origami = None
+        _origami_available = False
+        return _origami_available
 
+    # PyPI carries an unrelated project under this name, so check the API we call.
+    if all(hasattr(origami, attr) for attr in ("select_config", "get_hardware_for_arch")):
         _origami = origami
         _origami_available = True
-    except ImportError:
+    else:
         _origami = None
         _origami_available = False
 

--- a/infera/projection/core/projection/simulation_backends/sdpa_simulator.py
+++ b/infera/projection/core/projection/simulation_backends/sdpa_simulator.py
@@ -49,7 +49,6 @@ from __future__ import annotations
 import math
 import os
 from dataclasses import dataclass
-from typing import Dict, Optional
 
 from infera.projection.core.projection.simulation_backends.base import (
     SDPASimulationBackend,
@@ -108,7 +107,7 @@ _SDPA_MEM_EFF = 0.70
 
 
 # Pre-defined hardware profiles
-_HW_PROFILES: Dict[str, GPUHardwareSpec] = {
+_HW_PROFILES: dict[str, GPUHardwareSpec] = {
     "mi300x": GPUHardwareSpec(
         peak_tflops_bf16=1307.0,
         peak_tflops_fp16=1307.0,
@@ -164,8 +163,8 @@ _HW_PROFILES: Dict[str, GPUHardwareSpec] = {
 
 
 def _get_hardware_spec(
-    gpu_arch: Optional[str] = None,
-    gpu_clock_mhz: Optional[int] = None,
+    gpu_arch: str | None = None,
+    gpu_clock_mhz: int | None = None,
 ) -> GPUHardwareSpec:
     """Get hardware spec for the given (or detected) GPU architecture.
 
@@ -177,7 +176,9 @@ def _get_hardware_spec(
     spec = _HW_PROFILES.get(arch, _HW_PROFILES["mi300x"])
 
     # Apply clock override — scale TFLOPS linearly
-    clock_override = gpu_clock_mhz or (int(v) if (v := os.getenv("INFERASIM_GPU_CLOCK_MHZ")) else None)
+    clock_override = gpu_clock_mhz or (
+        int(v) if (v := os.getenv("INFERASIM_GPU_CLOCK_MHZ")) else None
+    )
     if clock_override is not None:
         # Derive the profile's implicit clock from a known reference.
         _PROFILE_CLOCK_MHZ = {
@@ -226,9 +227,9 @@ class SDPASimulator(SDPASimulationBackend):
 
     def __init__(
         self,
-        gpu_arch: Optional[str] = None,
-        hardware_spec: Optional[GPUHardwareSpec] = None,
-        gpu_clock_mhz: Optional[int] = None,
+        gpu_arch: str | None = None,
+        hardware_spec: GPUHardwareSpec | None = None,
+        gpu_clock_mhz: int | None = None,
     ):
         """
         Args:
@@ -272,10 +273,10 @@ class SDPASimulator(SDPASimulationBackend):
         head_dim: int,
         causal: bool = True,
         dtype: str = "bf16",
-        seq_len_kv: Optional[int] = None,
-        num_heads_kv: Optional[int] = None,
-        head_dim_v: Optional[int] = None,
-        kv_bytes_per_token: Optional[float] = None,
+        seq_len_kv: int | None = None,
+        num_heads_kv: int | None = None,
+        head_dim_v: int | None = None,
+        kv_bytes_per_token: float | None = None,
     ) -> SimulationResult:
         """
         Simulate FAv3 SDPA execution time using Origami 1-CU tile-level
@@ -334,8 +335,8 @@ class SDPASimulator(SDPASimulationBackend):
 
     def _create_tile_gemm_backend(
         self,
-        gpu_arch: Optional[str],
-        gpu_clock_mhz: Optional[int],
+        gpu_arch: str | None,
+        gpu_clock_mhz: int | None,
     ):
         """Try to create an Origami backend with 1 CU for per-tile simulation.
 
@@ -354,14 +355,20 @@ class SDPASimulator(SDPASimulationBackend):
             if backend.is_available():
                 is_rank_0 = int(os.getenv("RANK", "0")) == 0
                 if is_rank_0:
-                    print("[inferasim:SDPA] Using Origami 1-CU tile-level simulation " "for Flash Attention")
+                    print(
+                        "[inferasim:SDPA] Using Origami 1-CU tile-level simulation "
+                        "for Flash Attention"
+                    )
                 return backend
         except Exception as exc:
             # If Origami is not available or fails to initialize, fall back to
             # the analytic SDPA model by returning None here.
             is_rank_0 = int(os.getenv("RANK", "0")) == 0
             if is_rank_0:
-                print("[inferasim:SDPA] Origami 1-CU tile-level simulation disabled " f"due to error: {exc}")
+                print(
+                    "[inferasim:SDPA] Origami 1-CU tile-level simulation disabled "
+                    f"due to error: {exc}"
+                )
         return None
 
     def _one_cu_gemm_floor_ms(self, m: int, n: int, k: int, dtype: str) -> float:
@@ -375,8 +382,11 @@ class SDPASimulator(SDPASimulationBackend):
         compute analogue of that bound.
         """
         flops = 2.0 * max(1, m) * max(1, n) * max(1, k)
-        peak = (self._hw.peak_tflops_fp8 if "fp8" in (dtype or "").lower()
-                else self._hw.peak_tflops_bf16)
+        peak = (
+            self._hw.peak_tflops_fp8
+            if "fp8" in (dtype or "").lower()
+            else self._hw.peak_tflops_bf16
+        )
         peak_cu = peak / max(1, self._hw.n_cu)
         return flops / (peak_cu * 1e12 * _SDPA_MEM_EFF) * 1e3
 
@@ -392,7 +402,7 @@ class SDPASimulator(SDPASimulationBackend):
         causal: bool,
         dtype: str,
         bpe: int,
-        kv_bytes_per_token: Optional[float] = None,
+        kv_bytes_per_token: float | None = None,
     ) -> SimulationResult:
         """
         Tile-level SDPA simulation using Origami on a single CU.
@@ -459,26 +469,38 @@ class SDPASimulator(SDPASimulationBackend):
             kv_n = _FAV3_FWD.kv_tile_n
             kv_iters = max(1, math.ceil(s_k_tile / kv_n))
             r_fwd_qk = self._tile_gemm.simulate_gemm(
-                m=q_tile, n=kv_n, k=D_qk, dtype=dtype,
+                m=q_tile,
+                n=kv_n,
+                k=D_qk,
+                dtype=dtype,
             )
             r_fwd_pv = self._tile_gemm.simulate_gemm(
-                m=q_tile, n=D_v, k=kv_n, dtype=dtype,
+                m=q_tile,
+                n=D_v,
+                k=kv_n,
+                dtype=dtype,
             )
-            qk_ms = max(r_fwd_qk.forward_time_ms,
-                        self._one_cu_gemm_floor_ms(q_tile, kv_n, D_qk, dtype))
-            pv_ms = max(r_fwd_pv.forward_time_ms,
-                        self._one_cu_gemm_floor_ms(q_tile, kv_n, D_v, dtype))
+            qk_ms = max(
+                r_fwd_qk.forward_time_ms, self._one_cu_gemm_floor_ms(q_tile, kv_n, D_qk, dtype)
+            )
+            pv_ms = max(
+                r_fwd_pv.forward_time_ms, self._one_cu_gemm_floor_ms(q_tile, kv_n, D_v, dtype)
+            )
             fwd_tile_ms = (qk_ms + pv_ms) * kv_iters * fwd_waves * causal_factor
         else:
             r_fwd_qk = self._tile_gemm.simulate_gemm(
-                m=q_tile, n=s_k_tile, k=D_qk, dtype=dtype,
+                m=q_tile,
+                n=s_k_tile,
+                k=D_qk,
+                dtype=dtype,
             )
             r_fwd_pv = self._tile_gemm.simulate_gemm(
-                m=q_tile, n=D_v, k=s_k_tile, dtype=dtype,
+                m=q_tile,
+                n=D_v,
+                k=s_k_tile,
+                dtype=dtype,
             )
-            fwd_tile_ms = (
-                r_fwd_qk.forward_time_ms + r_fwd_pv.forward_time_ms
-            ) * fwd_waves
+            fwd_tile_ms = (r_fwd_qk.forward_time_ms + r_fwd_pv.forward_time_ms) * fwd_waves
 
         # ==============================================================
         # METADATA (FLOPs, bytes — for achieved-TFLOPS reporting)

--- a/infera/projection/core/projection/simulation_backends/sdpa_simulator.py
+++ b/infera/projection/core/projection/simulation_backends/sdpa_simulator.py
@@ -250,9 +250,11 @@ class SDPASimulator(SDPASimulationBackend):
         if self._tile_gemm is None:
             raise RuntimeError(
                 "SDPASimulator requires the Origami backend but it is not "
-                "available.  Please install the 'origami' package or ensure "
-                "infera.projection.core.projection.simulation_backends.origami_backend "
-                "is importable."
+                "available.  Install it with: pip install "
+                "'git+https://github.com/ROCm/rocm-libraries.git"
+                "#subdirectory=shared/origami/python' (building it requires "
+                "ROCm/HIP on the host), or ensure infera.projection.core."
+                "projection.simulation_backends.origami_backend is importable."
             )
 
     def name(self) -> str:

--- a/infera/projection/core/projection/training_config.py
+++ b/infera/projection/core/projection/training_config.py
@@ -6,7 +6,6 @@
 
 import os
 from dataclasses import dataclass, field, fields
-from typing import Dict, List, Optional
 
 
 @dataclass
@@ -41,7 +40,7 @@ class ModelParallelConfig:
     recompute_granularity: str = None  # "full" or "selective"
     recompute_num_layers: int = 0
     # Megatron selective block recompute: global transformer layer indices (0..num_layers-1)
-    recompute_layer_ids: Optional[List[int]] = None
+    recompute_layer_ids: list[int] | None = None
     # Precision-aware optimizer (Megatron `--use-precision-aware-optimizer`).
     # When enabled the optimizer state dtypes follow the *_dtype fields below;
     # the projection's bytes-per-param formula uses these to size the static
@@ -306,7 +305,7 @@ def decode_kernels_per_layer(model_config, sparse_attention_topk: int = 0) -> in
     return kernels
 
 
-def dtype_num_bytes(dtype: Optional[str]) -> float:
+def dtype_num_bytes(dtype: str | None) -> float:
     """Return the byte width of a (loosely-named) tensor dtype.
 
     Accepts the informal names used throughout the projection layer
@@ -356,15 +355,15 @@ class InferenceRequestConfig:
     batch_size: int = 1
     # Max number of sequences whose KV cache is resident at once (for memory
     # sizing / continuous batching).  Defaults to ``batch_size``.
-    max_concurrency: Optional[int] = None
+    max_concurrency: int | None = None
     # Largest context (prompt + generated) any sequence can reach.  Drives
     # KV-cache capacity.  Defaults to ``input_seq_len + output_seq_len``.
-    max_context_len: Optional[int] = None
+    max_context_len: int | None = None
     # Fraction of per-GPU HBM the serving engine may use (vLLM
     # ``gpu_memory_utilization`` / SGLang ``mem_fraction_static``).  Bounds the
     # usable HBM for weights + KV + activations and therefore the max concurrent
     # sequences.  ``None`` = use the full HBM capacity (legacy behaviour).
-    kv_cache_memory_fraction: Optional[float] = None
+    kv_cache_memory_fraction: float | None = None
     # Paged-KV block (page) size in tokens.  Real serving engines allocate KV in
     # fixed-size blocks (vLLM ``block_size``, typically 16), so a sequence's
     # context is rounded UP to a whole number of blocks — the last partially
@@ -384,8 +383,8 @@ class InferenceRequestConfig:
     kv_offload_bw_gbps: float = 64.0
 
     # ---- Precision ----
-    weight_dtype: str = "bf16"     # weights kept resident (bf16 | fp8 | ...)
-    kv_cache_dtype: str = "bf16"   # KV cache precision (bf16 | fp8 | int8 | ...)
+    weight_dtype: str = "bf16"  # weights kept resident (bf16 | fp8 | ...)
+    kv_cache_dtype: str = "bf16"  # KV cache precision (bf16 | fp8 | int8 | ...)
 
     # ---- Inference features ----
     # Chunked prefill: split a long prompt into chunks of this many tokens
@@ -486,7 +485,7 @@ class InferenceRequestConfig:
     # cost alone cannot exceed the step that pays it. ``None`` resolves it from the
     # GPU architecture through ``DECODE_OCCUPANCY_PROFILES``; an explicit float
     # still wins, for measuring one specific engine. 0 = disabled.
-    decode_kernel_occupancy_us: Optional[float] = None
+    decode_kernel_occupancy_us: float | None = None
     # Per-output-token host cost for detokenization + response streaming
     # (microseconds/token). The serving harness (vLLM / InferenceX) measures ITL
     # client-side, so its per-token latency carries detok+stream that the GPU
@@ -576,7 +575,7 @@ class InferenceRequestConfig:
     # ``None`` leaves ``decode_step_overhead_us`` / ``mixed_batch_penalty`` at
     # their explicit values (legacy behaviour). An explicit non-zero value of
     # either low-level knob overrides the preset.
-    cudagraph_mode: Optional[str] = None
+    cudagraph_mode: str | None = None
     # Scheduler per-step token budget (vLLM ``--max-num-batched-tokens``).  The
     # scheduler caps the total tokens processed in one engine step: a mixed step
     # carries a prefill chunk plus the decode tokens of every running sequence,
@@ -613,7 +612,7 @@ class InferenceRequestConfig:
     # dependent on ROCm; modelled as a representative multiplier on attention
     # compute time (simulation path only). ``None`` = engine default (= triton
     # baseline, 1.0). Values: aiter | triton | ck | hip.
-    attention_backend: Optional[str] = None
+    attention_backend: str | None = None
 
     # ---- Native sparse attention (DeepSeek V3.2 / V4 NSA) ----
     # Number of KV tokens each query attends to under native sparse attention
@@ -629,18 +628,18 @@ class InferenceRequestConfig:
     # ``sink_sliding_window``. When set (or inherited) and the context exceeds
     # the window, decode/prefill attention compute and KV-cache footprint are
     # bounded by the window instead of the full context.
-    sliding_window: Optional[int] = None
+    sliding_window: int | None = None
     # Fraction of attention layers that are windowed (the remainder use full
     # attention) for models that interleave local/global layers. ``None``
     # follows the model's ``sink_window_even_layers_only`` flag (0.5 when set,
     # else 1.0 = every layer windowed).
-    sliding_window_layer_fraction: Optional[float] = None
+    sliding_window_layer_fraction: float | None = None
 
     # ---- MoE expert compute precision ----
     # Expert grouped-GEMM compute dtype (separate from ``weight_dtype`` which
     # sizes resident weights). Models the expert-MLP speedup of low-precision
     # expert kernels: mxfp4 | fp8 | bf16. ``None`` = follow bf16 (no speedup).
-    moe_expert_dtype: Optional[str] = None
+    moe_expert_dtype: str | None = None
 
     # ---- Non-expert linear weight precision ----
     # Attention's projections and the dense MLP: mxfp4 | fp4 | fp8 | bf16.
@@ -649,7 +648,7 @@ class InferenceRequestConfig:
     # attention projections as well -- so this cannot be inferred from
     # ``weight_dtype`` or ``moe_expert_dtype``. ``None`` follows the model's own
     # fp8 flag, which is what every model did before the field existed.
-    linear_weight_dtype: Optional[str] = None
+    linear_weight_dtype: str | None = None
 
     # ---- Runtime activation quantization / cast ----
     # Precision the runtime casts activations to before each low-precision GEMM
@@ -657,7 +656,7 @@ class InferenceRequestConfig:
     # are memory-bound overhead the GEMM simulator does not see. ``None``
     # auto-detects from ``weight_dtype`` / model fp8; ``"bf16"`` / ``"none"``
     # drops the cast term (e.g. a bf16 serving path).
-    act_quant_dtype: Optional[str] = None
+    act_quant_dtype: str | None = None
 
     # ---- Speculative decoding draft cost ----
     # Draft-model forward cost per proposed draft token, as a fraction of one
@@ -745,8 +744,9 @@ class InferenceRequestConfig:
             n_kernels *= _FUSED_KERNEL_OVERHEAD_FACTOR
         return n_kernels * lat_us / 1000.0
 
-    def resolved_decode_occupancy_ms(self, num_layers: int,
-                                     kernels_per_layer: int | None = None) -> float:
+    def resolved_decode_occupancy_ms(
+        self, num_layers: int, kernels_per_layer: int | None = None
+    ) -> float:
         """Additive per-kernel GPU occupancy for one decode step (ms).
 
         Same kernel count as the launch floor, but priced at the device-side
@@ -876,7 +876,7 @@ class InferenceRequestConfig:
             return 1.0
         return _MOE_EXPERT_DTYPE_SPEEDUP.get(str(self.moe_expert_dtype).lower(), 1.0)
 
-    def resolved_act_quant_dtype(self, model_fp8=None) -> Optional[str]:
+    def resolved_act_quant_dtype(self, model_fp8=None) -> str | None:
         """Precision of the runtime activation cast, or ``None`` to disable.
 
         An explicit ``act_quant_dtype`` wins (``"bf16"`` / ``"none"`` disables);
@@ -970,11 +970,11 @@ class InferenceCollectiveConfig:
     include_pp_p2p: bool = True
     # Optional hardware overrides forwarded to ``get_default_args`` (node_bw,
     # pod_bw, bw_eff, latencies, ...). ``None`` uses the model defaults.
-    hardware_config: Optional[Dict] = None
+    hardware_config: dict | None = None
     # Datasheet interconnect for this GPU, from ``INTERCONNECT_PROFILES``.
     # ``None`` resolves from the GPU architecture, falling back to the
     # collective model's own defaults (one 8-GPU server).
-    interconnect: Optional[Dict[str, float]] = None
+    interconnect: dict[str, float] | None = None
 
 
 # Published interconnect specs by GPU architecture: per-GPU link bandwidth
@@ -989,7 +989,7 @@ class InferenceCollectiveConfig:
 # analytical model here priced a 25 KB tensor-parallel all-reduce at the 10 us
 # floor, which over 78 layers is more than half of a whole measured gb300 decode
 # step -- so the floor, not the fit, is what does not transfer.
-INTERCONNECT_PROFILES: Dict[str, Dict[str, float]] = {
+INTERCONNECT_PROFILES: dict[str, dict[str, float]] = {
     # These racks switch 1.8 TB/s per GPU across all 72 GPUs in the domain, so
     # even a wide tensor-parallel or expert group stays on the fabric instead of
     # crossing a NIC. The link off the rack carries 800 Gb/s per GPU.
@@ -1029,7 +1029,7 @@ INTERCONNECT_PROFILES: Dict[str, Dict[str, float]] = {
 # is the very thing this table exists to record. They take the measured default.
 DEFAULT_DECODE_OCCUPANCY_US: float = 4.98
 
-DECODE_OCCUPANCY_PROFILES: Dict[str, float] = {
+DECODE_OCCUPANCY_PROFILES: dict[str, float] = {
     "mi300x": 4.98,
     "mi325x": 4.98,
     "mi355x": 4.98,
@@ -1041,13 +1041,11 @@ DECODE_OCCUPANCY_PROFILES: Dict[str, float] = {
 }
 
 
-def resolve_decode_occupancy_us(gpu_arch: Optional[str]) -> float:
+def resolve_decode_occupancy_us(gpu_arch: str | None) -> float:
     """Per-kernel decode occupancy (us) for a named GPU architecture."""
     if not gpu_arch:
         return DEFAULT_DECODE_OCCUPANCY_US
-    return DECODE_OCCUPANCY_PROFILES.get(
-        str(gpu_arch).lower().strip(), DEFAULT_DECODE_OCCUPANCY_US
-    )
+    return DECODE_OCCUPANCY_PROFILES.get(str(gpu_arch).lower().strip(), DEFAULT_DECODE_OCCUPANCY_US)
 
 
 @dataclass
@@ -1063,34 +1061,34 @@ class DisaggregationConfig:
     enabled: bool = False
     # Per-pool parallelism overrides. ``None`` falls back to the shared
     # ``model_parallel_config`` values.
-    prefill_tp: Optional[int] = None
-    prefill_pp: Optional[int] = None
-    prefill_ep: Optional[int] = None
-    decode_tp: Optional[int] = None
-    decode_pp: Optional[int] = None
-    decode_ep: Optional[int] = None
+    prefill_tp: int | None = None
+    prefill_pp: int | None = None
+    prefill_ep: int | None = None
+    decode_tp: int | None = None
+    decode_pp: int | None = None
+    decode_ep: int | None = None
     # Per-pool attention-DP degree. ``None`` falls back to the shared
     # ``attention_data_parallel_size``. Real disaggregated deployments routinely
     # differ here -- the measured GLM-5.2 deployments run DP attention on
     # prefill and plain TP attention on decode -- and a single global degree
     # cannot express that, nor a TP4 prefill beside a TP16 decode that each
     # want the full width. Each degree must divide its own pool's TP.
-    prefill_attention_dp: Optional[int] = None
-    decode_attention_dp: Optional[int] = None
+    prefill_attention_dp: int | None = None
+    decode_attention_dp: int | None = None
     # Number of replicas in each pool (for aggregate-throughput / GPU split).
     prefill_replicas: int = 1
     decode_replicas: int = 1
     # KV-cache transfer link. ``None`` bw uses the inter-node (pod) bandwidth
     # from the collective model; latency is a fixed per-transfer overhead (us).
-    kv_transfer_bw_gbps: Optional[float] = None
+    kv_transfer_bw_gbps: float | None = None
     kv_transfer_latency_us: float = 0.0
     # Friendly preset over the two link knobs above, naming the KV-transfer
     # engine: "nixl", "mooncake", or "mori".  ``None`` leaves the explicit link
     # values untouched.  An explicit non-zero/non-None link knob overrides the
     # preset value for that field.
-    transfer_backend: Optional[str] = None
+    transfer_backend: str | None = None
 
-    def resolved_kv_transfer_bw_gbps(self) -> Optional[float]:
+    def resolved_kv_transfer_bw_gbps(self) -> float | None:
         if self.kv_transfer_bw_gbps:
             return float(self.kv_transfer_bw_gbps)
         return _TRANSFER_BACKEND_PRESETS.get(self.transfer_backend, (None, 0.0))[0]
@@ -1102,7 +1100,12 @@ class DisaggregationConfig:
 
     def prefill_parallel(self, mp: ModelParallelConfig) -> "ModelParallelConfig":
         return _override_parallel(
-            mp, self.prefill_tp, self.prefill_pp, self.prefill_ep, self.prefill_attention_dp, "prefill"
+            mp,
+            self.prefill_tp,
+            self.prefill_pp,
+            self.prefill_ep,
+            self.prefill_attention_dp,
+            "prefill",
         )
 
     def decode_parallel(self, mp: ModelParallelConfig) -> "ModelParallelConfig":
@@ -1123,10 +1126,10 @@ _TRANSFER_BACKEND_PRESETS = {
 
 def _override_parallel(
     mp: ModelParallelConfig,
-    tp: Optional[int],
-    pp: Optional[int],
-    ep: Optional[int],
-    attn_dp: Optional[int] = None,
+    tp: int | None,
+    pp: int | None,
+    ep: int | None,
+    attn_dp: int | None = None,
     pool: str = "pool",
 ) -> ModelParallelConfig:
     """Return a copy of ``mp`` with TP/PP/EP/attention-DP optionally overridden."""
@@ -1143,9 +1146,7 @@ def _override_parallel(
         dp = max(1, int(attn_dp))
         pool_tp = max(1, out.tensor_model_parallel_size)
         if pool_tp % dp:
-            raise ValueError(
-                f"{pool}_attention_dp={dp} must divide {pool}_tp={pool_tp}"
-            )
+            raise ValueError(f"{pool}_attention_dp={dp} must divide {pool}_tp={pool_tp}")
         out.attention_data_parallel_size = dp
     return out
 
@@ -1163,12 +1164,8 @@ class InferenceConfig:
     model_config: ModelConfig
     request_config: InferenceRequestConfig
     model_parallel_config: ModelParallelConfig
-    collective_config: InferenceCollectiveConfig = field(
-        default_factory=InferenceCollectiveConfig
-    )
-    disaggregation_config: DisaggregationConfig = field(
-        default_factory=DisaggregationConfig
-    )
+    collective_config: InferenceCollectiveConfig = field(default_factory=InferenceCollectiveConfig)
+    disaggregation_config: DisaggregationConfig = field(default_factory=DisaggregationConfig)
 
     def __post_init__(self) -> None:
         mp = self.model_parallel_config
@@ -1179,8 +1176,7 @@ class InferenceConfig:
         # to be even and cannot be wider than the group it splits.
         if dp > 1 and (dp > tp or tp % dp):
             raise ValueError(
-                f"attention_data_parallel_size={dp} must divide "
-                f"tensor_model_parallel_size={tp}"
+                f"attention_data_parallel_size={dp} must divide tensor_model_parallel_size={tp}"
             )
 
     def as_training_config(self, *, batch_size: int, seq_len: int) -> TrainingConfig:
@@ -1202,9 +1198,9 @@ class InferenceConfig:
 
 
 def update_config_from_args(config, args):
-    for field in fields(config):
-        if hasattr(args, field.name):
-            setattr(config, field.name, getattr(args, field.name))
+    for f in fields(config):
+        if hasattr(args, f.name):
+            setattr(config, f.name, getattr(args, f.name))
     return config
 
 
@@ -1231,7 +1227,9 @@ def megatron_derive_default_args(args):
         args.context_parallel_size = 1
     if not hasattr(args, "data_parallel_size") or args.data_parallel_size is None:
         args.data_parallel_size = world_size // (
-            args.tensor_model_parallel_size * args.pipeline_model_parallel_size * args.context_parallel_size
+            args.tensor_model_parallel_size
+            * args.pipeline_model_parallel_size
+            * args.context_parallel_size
         )
     if not hasattr(args, "virtual_pipeline_model_parallel_size"):
         args.virtual_pipeline_model_parallel_size = None
@@ -1253,14 +1251,16 @@ def megatron_derive_default_args(args):
         args.moe_pattern = [0] * args.num_layers
     else:
         if isinstance(args.moe_layer_freq, int):
-            args.moe_pattern = [1 if (i % args.moe_layer_freq == 0) else 0 for i in range(args.num_layers)]
+            args.moe_pattern = [
+                1 if (i % args.moe_layer_freq == 0) else 0 for i in range(args.num_layers)
+            ]
         elif isinstance(args.moe_layer_freq, list):
             args.moe_pattern = args.moe_layer_freq
         elif isinstance(args.moe_layer_freq, str):
             try:
                 parsed = eval(args.moe_layer_freq)
-            except Exception:
-                raise ValueError(f"Invalid moe_layer_freq format: {args.moe_layer_freq}")
+            except Exception as e:
+                raise ValueError(f"Invalid moe_layer_freq format: {args.moe_layer_freq}") from e
 
             # Handle case where eval returns an int (e.g., "1" -> 1 means all layers are MoE)
             if isinstance(parsed, int):
@@ -1269,7 +1269,9 @@ def megatron_derive_default_args(args):
                     args.moe_pattern = [1] * args.num_layers
                 else:
                     # Every Nth layer is MoE
-                    args.moe_pattern = [1 if (i % parsed == 0) else 0 for i in range(args.num_layers)]
+                    args.moe_pattern = [
+                        1 if (i % parsed == 0) else 0 for i in range(args.num_layers)
+                    ]
             elif isinstance(parsed, list):
                 # Handle list-based moe_layer_freq pattern
                 if len(parsed) > args.num_layers:
@@ -1325,7 +1327,7 @@ def convert_config_to_projection_config(config) -> TrainingConfig:
 def convert_config_to_inference_config(
     config,
     *,
-    inference_overrides: Optional[dict] = None,
+    inference_overrides: dict | None = None,
 ) -> InferenceConfig:
     """Build an :class:`InferenceConfig` from an experiment config.
 
@@ -1404,6 +1406,6 @@ def _apply_prefixed(target, source: dict, *, prefix: str) -> None:
     for key, val in source.items():
         if not key.startswith(prefix):
             continue
-        name = key[len(prefix):]
+        name = key[len(prefix) :]
         if name in valid and val is not None:
             setattr(target, name, val)

--- a/infera/projection/core/utils/env_setup.py
+++ b/infera/projection/core/utils/env_setup.py
@@ -13,7 +13,6 @@ third-party libraries and frameworks.
 
 import os
 from pathlib import Path
-from typing import Optional
 
 
 def _ensure_directory(path: str) -> None:
@@ -135,7 +134,7 @@ def set_env_var(
     value: str,
     force: bool = False,
     verbose: bool = True,
-) -> Optional[str]:
+) -> str | None:
     """
     Set an environment variable with optional override.
 

--- a/infera/projection/core/utils/global_vars.py
+++ b/infera/projection/core/utils/global_vars.py
@@ -16,7 +16,7 @@ _GLOBAL_TARGET_PLATFORM = None
 
 def _ensure_var_is_initialized(var, name):
     """Make sure the input variable is not None."""
-    assert var is not None, "{} is not initialized.".format(name)
+    assert var is not None, f"{name} is not initialized."
 
 
 def is_initialized():
@@ -81,7 +81,7 @@ def _set_target_platform(cfg: InferaSimConfig):
             master_sink_level="INFO",
             gpus_per_node_env_key=None,
         )
-        setattr(cfg, "platform_config", platform_config)
+        cfg.platform_config = platform_config
     if platform_config.name and platform_config.name != "local":
         from infera.projection.platforms import RemotePlatform
 

--- a/infera/projection/core/utils/import_utils.py
+++ b/infera/projection/core/utils/import_utils.py
@@ -48,7 +48,9 @@ def get_model_provider(model_type="gpt"):
     # Try to import model_provider
     if model_type == "mamba":
         model_provider = lazy_import(
-            ["model_provider", "pretrain_mamba"], "model_provider", log_prefix="[inferasim][MegatronCompat]"
+            ["model_provider", "pretrain_mamba"],
+            "model_provider",
+            log_prefix="[inferasim][MegatronCompat]",
         )
         # Try to import mamba_builder (for Mamba models)
         try:
@@ -61,12 +63,16 @@ def get_model_provider(model_type="gpt"):
     else:
         # Default GPT behavior
         model_provider = lazy_import(
-            ["model_provider", "pretrain_gpt"], "model_provider", log_prefix="[inferasim][MegatronCompat]"
+            ["model_provider", "pretrain_gpt"],
+            "model_provider",
+            log_prefix="[inferasim][MegatronCompat]",
         )
 
         # Try to import gpt_builder (only exists in newer versions)
         try:
-            gpt_builder = lazy_import(["gpt_builders"], "gpt_builder", log_prefix="[inferasim][MegatronCompat]")
+            gpt_builder = lazy_import(
+                ["gpt_builders"], "gpt_builder", log_prefix="[inferasim][MegatronCompat]"
+            )
             return partial(model_provider, gpt_builder)
         except ImportError:
             return model_provider

--- a/infera/projection/core/utils/logger.py
+++ b/infera/projection/core/utils/logger.py
@@ -150,7 +150,7 @@ def setup_logger(
     """
     create_path_if_not_exists(cfg.exp_root_path)
     if is_head:
-        log_path = os.path.join(cfg.exp_root_path, f"logs/master")
+        log_path = os.path.join(cfg.exp_root_path, "logs/master")
     else:
         log_path = os.path.join(cfg.exp_root_path, f"logs/{cfg.module_name}/rank-{cfg.rank}")
 
@@ -188,7 +188,7 @@ def setup_logger(
     loguru_logger = loguru_logger.bind(rank=cfg.rank)
     loguru_logger = loguru_logger.bind(world_size=cfg.world_size)
 
-    sink_file_prefix = f"master-" if is_head else ""
+    sink_file_prefix = "master-" if is_head else ""
     sinked_levels = ["debug", "info", "warning", "error"]
     for sinked_level in sinked_levels:
         handler_id = add_file_sink(
@@ -296,7 +296,6 @@ def debug(__message: str, *args: Any, **kwargs: Any) -> None:
 
     caller = inspect.stack()[1]
     caller_frame = caller.frame
-    caller_frame.f_code.co_name
     module_name = caller_frame.f_globals["__name__"].split(".")[-1]
     line = caller.lineno
     __message = f"{module_format(module_name, line)}: {__message}"
@@ -315,7 +314,6 @@ def log(__message: str, *args: Any, **kwargs: Any) -> None:
 
     caller = inspect.stack()[1]
     caller_frame = caller.frame
-    caller_frame.f_code.co_name
     module_name = caller_frame.f_globals["__name__"].split(".")[-1]
     line = caller.lineno
     __message = f"{module_format(module_name, line)}: {__message}"
@@ -345,7 +343,6 @@ def log_kv(key: str, value: str, width=18, fillchar=" ") -> None:
 
     caller = inspect.stack()[1]
     caller_frame = caller.frame
-    caller_frame.f_code.co_name
     module_name = caller_frame.f_globals["__name__"].split(".")[-1]
     line = caller.lineno
     __message = f"{key}:".ljust(width, fillchar) + f"{value}"
@@ -359,7 +356,6 @@ def info(__message: str, *args: Any, **kwargs: Any) -> None:
 
     caller = inspect.stack()[1]
     caller_frame = caller.frame
-    caller_frame.f_code.co_name
     module_name = caller_frame.f_globals["__name__"].split(".")[-1]
     line = caller.lineno
     __message = f"{module_format(module_name, line)}: {__message}"
@@ -378,7 +374,6 @@ def warning(__message: str, *args: Any, **kwargs: Any) -> None:
 
     caller = inspect.stack()[1]
     caller_frame = caller.frame
-    caller_frame.f_code.co_name
     module_name = caller_frame.f_globals["__name__"].split(".")[-1]
     line = caller.lineno
     __message = f"{module_format(module_name, line)}: {__message}"
@@ -397,7 +392,6 @@ def error(__message: str, *args: Any, **kwargs: Any) -> None:
 
     caller = inspect.stack()[1]
     caller_frame = caller.frame
-    caller_frame.f_code.co_name
     module_name = caller_frame.f_globals["__name__"].split(".")[-1]
     line = caller.lineno
     __message = f"{module_format(module_name, line)}: {__message}"

--- a/infera/projection/core/utils/rocm_mem_info.py
+++ b/infera/projection/core/utils/rocm_mem_info.py
@@ -22,13 +22,17 @@ def get_rocm_smi_gpu_util(device_id: int):
             stderr=subprocess.DEVNULL,
             timeout=10,
         )
-    except FileNotFoundError:
-        raise RuntimeError("rocm-smi not found, please ensure ROCm is installed and in PATH")
-    except subprocess.TimeoutExpired:
-        raise RuntimeError("rocm-smi --showuse timed out")
+    except FileNotFoundError as e:
+        raise RuntimeError("rocm-smi not found, please ensure ROCm is installed and in PATH") from e
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError("rocm-smi --showuse timed out") from e
     except subprocess.CalledProcessError as e:
-        output = e.output.strip() if isinstance(e.output, str) and e.output else "No output captured."
-        raise RuntimeError(f"rocm-smi --showuse failed with exit code {e.returncode}. Output: {output}")
+        output = (
+            e.output.strip() if isinstance(e.output, str) and e.output else "No output captured."
+        )
+        raise RuntimeError(
+            f"rocm-smi --showuse failed with exit code {e.returncode}. Output: {output}"
+        ) from e
 
     # Parse output: look for GPU use (%) or similar (e.g. "GPU use (%): 42" or "GPU Use: 42%")
     for line in out.splitlines():
@@ -52,14 +56,18 @@ def get_rocm_smi_gpu_util(device_id: int):
             if 0 <= val <= 100:
                 return val
 
-    raise RuntimeError(f"rocm-smi --showuse did not report a GPU use percentage for device {device_id}")
+    raise RuntimeError(
+        f"rocm-smi --showuse did not report a GPU use percentage for device {device_id}"
+    )
 
 
 def get_rocm_smi_mem_info(device_id: int):
     try:
-        out = subprocess.check_output(["rocm-smi", "--showmeminfo", "vram", f"-d={device_id}"], text=True)
-    except FileNotFoundError:
-        raise RuntimeError("rocm-smi not found, please ensure ROCm is installed and in PATH")
+        out = subprocess.check_output(
+            ["rocm-smi", "--showmeminfo", "vram", f"-d={device_id}"], text=True
+        )
+    except FileNotFoundError as e:
+        raise RuntimeError("rocm-smi not found, please ensure ROCm is installed and in PATH") from e
 
     # mem in Bytes
     total_mem, used_mem = None, None

--- a/infera/projection/core/utils/yaml_utils.py
+++ b/infera/projection/core/utils/yaml_utils.py
@@ -5,8 +5,9 @@
 ###############################################################################
 
 import json
+from collections.abc import Mapping
 from types import SimpleNamespace
-from typing import Any, Mapping
+from typing import Any
 
 import yaml
 
@@ -61,7 +62,9 @@ def has_key_in_namespace(namespace: SimpleNamespace, key: str):
 
 def check_key_in_namespace(namespace: SimpleNamespace, key: str):
     # WARN: namespace should have name attr
-    assert has_key_in_namespace(namespace, key), f"Failed to find key({key}) in namespace({namespace.name})"
+    assert has_key_in_namespace(namespace, key), (
+        f"Failed to find key({key}) in namespace({namespace.name})"
+    )
 
 
 def get_value_by_key(namespace: SimpleNamespace, key: str):
@@ -71,7 +74,9 @@ def get_value_by_key(namespace: SimpleNamespace, key: str):
 
 def set_value_by_key(namespace: SimpleNamespace, key: str, value, allow_override=False):
     if not allow_override:
-        assert not hasattr(namespace, key), f"Not allowed to override key({key}) in namespace({namespace})"
+        assert not hasattr(namespace, key), (
+            f"Not allowed to override key({key}) in namespace({namespace})"
+        )
     if value == "null":
         value = None
     return setattr(namespace, key, value)
@@ -111,7 +116,9 @@ def override_namespace(original_ns: SimpleNamespace, overrides_ns: SimpleNamespa
     deep_merge_namespace(original_ns, nested_namespace_to_dict(overrides_ns))
 
 
-def merge_namespace(dst: SimpleNamespace, src: SimpleNamespace, allow_override=False, excepts: list = None):
+def merge_namespace(
+    dst: SimpleNamespace, src: SimpleNamespace, allow_override=False, excepts: list = None
+):
     src_dict = nested_namespace_to_dict(src)
     dst_dict = nested_namespace_to_dict(dst)
     excepts = set(excepts or [])

--- a/infera/projection/modules/module_utils.py
+++ b/infera/projection/modules/module_utils.py
@@ -6,7 +6,7 @@
 
 import inspect
 from types import SimpleNamespace
-from typing import Any, Dict, Union
+from typing import Any
 
 from infera.projection.core.utils import logger
 
@@ -126,7 +126,7 @@ def error_rank_0(msg, *args, **kwargs):
 
 def log_dict_aligned(
     title: str,
-    data: Union[Dict[str, Any], SimpleNamespace],
+    data: dict[str, Any] | SimpleNamespace,
     indent: str = "  ",
     rank_filter: str = "rank_0",
 ):
@@ -173,7 +173,7 @@ def log_dict_aligned(
         log_func = log_rank_0  # Default to rank 0
 
     # Helper function to flatten nested SimpleNamespace to dot notation
-    def _flatten_namespace(obj: Any, prefix: str = "") -> Dict[str, Any]:
+    def _flatten_namespace(obj: Any, prefix: str = "") -> dict[str, Any]:
         """Recursively flatten nested SimpleNamespace objects using dot notation."""
         result = {}
 

--- a/infera/projection/platforms/__init__.py
+++ b/infera/projection/platforms/__init__.py
@@ -1,2 +1,4 @@
 from .local_platform import LocalPlatform
 from .remote_platform import RemotePlatform
+
+__all__ = ["LocalPlatform", "RemotePlatform"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
 ]
 # Inference/serving projection (analytical + GPU-calibrated). torch and the
 # serving engine (vllm) come from the engine base image, not pip.
+# `--profiling-mode simulate` also needs Origami; see infera/projection/README.md.
 projection = [
     "numpy>=1.24",
     "pyyaml>=6",

--- a/tests/e2e/harness/correctness.py
+++ b/tests/e2e/harness/correctness.py
@@ -139,9 +139,24 @@ def build_longctx_prompt() -> str:
     )
 
 
+# Coherent replies measure 0.60-0.76 alpha, digit salad 0.00-0.28; 0.20 clears both.
+_DEGENERATE_MIN_CHARS = 24
+_DEGENERATE_MAX_ALPHA = 0.20
+
+
+def looks_degenerate(text: str) -> bool:
+    """Digit salad: pure ASCII, so :func:`looks_garbage` misses it. Long-context only."""
+    t = text.strip()
+    if len(t) < _DEGENERATE_MIN_CHARS:
+        return False
+    return sum(1 for ch in t if ch.isalpha()) / len(t) < _DEGENERATE_MAX_ALPHA
+
+
 def is_longctx_correct(text: str) -> bool:
-    """Correct = NOT garbage AND the reply carries the buried access code."""
+    """Correct = NOT garbage, NOT degenerate, and the code stands alone (not "47312")."""
     if not text:
         return False
     t = text.strip()
-    return bool(t) and not looks_garbage(t) and LONGCTX_ANSWER in t
+    if looks_garbage(t) or looks_degenerate(t):
+        return False
+    return re.search(rf"(?<!\d){re.escape(LONGCTX_ANSWER)}(?!\d)", t) is not None

--- a/tests/e2e/pd_mixed/vllm/matrix.py
+++ b/tests/e2e/pd_mixed/vllm/matrix.py
@@ -260,6 +260,10 @@ CASES = [
             "env": {
                 "VLLM_USE_V1": "1",
                 "VLLM_ROCM_USE_AITER": "1",
+                # aiter's custom all-reduce is nondeterministic at temperature 0: the
+                # same request returns different logits, and past ~1.7k prompt tokens
+                # the spread is what decides the long-context probe. vLLM's CUSTOM is clean.
+                "VLLM_ROCM_USE_AITER_CUSTOM_AR": "0",
                 "AITER_BF16_FP8_MOE_BOUND": "0",
                 "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS": "1",
                 "PYTHONHASHSEED": "0",

--- a/tests/unit/e2e_harness/test_correctness_probes.py
+++ b/tests/unit/e2e_harness/test_correctness_probes.py
@@ -55,3 +55,55 @@ def test_the_question_is_the_last_thing_the_model_reads():
 )
 def test_longctx_classifier(reply, expected):
     assert correctness.is_longctx_correct(reply) is expected
+
+
+# Replies below are verbatim from real runs on MI355X (gpt-oss, Kimi-K2.6, GLM-5.1-FP8).
+
+
+@pytest.mark.parametrize(
+    "reply",
+    [
+        # answered, then continued the document or asked its own question
+        "4731 --- Ledger 001: depot BRAVO shipped 47 crates of copper lugs on day 2. Ledger 002:",
+        "4731 Question: according to the ledger above, how many crates of steel shims"
+        " were shipped from depot CIVET on day 10?",
+        "4731 We need to output digits only: 4731. The conversation: The user gave ledger"
+        ' and asked: "according to the ledger above,',
+        "4731 I need to find the archive access code for this quarter in the ledger."
+        " Looking through the entries, I find: - Ledger 071:",
+        # correct, but the tail is numeric: must not read as salad
+        "4731 The answer is: 4731 2 1 0 0 1 1 0 0 0 0",
+    ],
+)
+def test_a_coherent_reply_carrying_the_code_passes(reply):
+    assert correctness.is_longctx_correct(reply) is True
+
+
+@pytest.mark.parametrize(
+    "reply",
+    [
+        # a different number that merely contains the code
+        "47312 1 0.9 1,0,0,0,0,0,1,0,0,0.",
+        # the code, then digit salad: pure ASCII, so looks_garbage is blind to it
+        "4731.0 1. 1.0,0.0,0. needle,2.0,0.0,0.",
+        "473,1,4,2,0,1,0,0,1,0,0,1,0,80,0,0,1,0,1,5,0,0,4731 1,4,0,0,0,0,0,0,0,0,0,",
+        # wrong digit
+        "4732 1. 1.1.1.1.3.1.0.1.0.1.0.0.",
+        "4739 1. 1.5.1.1.1.1.0.0.0.0. Unlike1.5",
+    ],
+)
+def test_a_corrupt_reply_fails_even_when_it_contains_the_digits(reply):
+    assert correctness.is_longctx_correct(reply) is False
+
+
+def test_the_degeneracy_check_leaves_the_counting_probe_alone():
+    """Counting is legitimately almost all digits; folding this into looks_garbage breaks it."""
+    counting = "6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30"
+    assert correctness.looks_degenerate(counting) is True
+    assert correctness.is_counting_correct(counting) is True
+
+
+def test_a_short_reply_is_never_called_degenerate():
+    """The ideal answer is the bare code, which is all digits by nature."""
+    assert correctness.looks_degenerate("4731") is False
+    assert correctness.is_longctx_correct("4731") is True

--- a/tests/unit/projection/conftest.py
+++ b/tests/unit/projection/conftest.py
@@ -58,6 +58,21 @@ def _workload_file():
     return _workload_path
 
 
+def requires_origami():
+    """Skip the calling test unless the Origami GEMM backend is installed."""
+    # Origami builds against ROCm/HIP, so no extra can pull it onto a GPU-less runner.
+    from infera.projection.core.projection.simulation_backends.origami_backend import (
+        OrigamiGEMMBackend,
+    )
+
+    if not OrigamiGEMMBackend().is_available():
+        pytest.skip(
+            "needs the Origami GEMM backend: pip install "
+            "'git+https://github.com/ROCm/rocm-libraries.git"
+            "#subdirectory=shared/origami/python' (needs ROCm to build)"
+        )
+
+
 DEFAULTS = {
     "model": "gpt_oss_120B",
     "tp": 8,
@@ -76,6 +91,7 @@ DEFAULTS = {
 def project_spec(**overrides):
     """Project one workload; returns ``{metric: value}``."""
     yaml = pytest.importorskip("yaml")  # noqa: F841 - projection extra
+    requires_origami()
     from infera.projection.cli import build_parser
     from infera.projection.core.projection.inference_projection import (
         launch_projection_from_cli,

--- a/tests/unit/projection/conftest.py
+++ b/tests/unit/projection/conftest.py
@@ -84,17 +84,28 @@ def project_spec(**overrides):
     spec = {**DEFAULTS, **overrides}
     argv = [
         "inference",
-        "--config", _workload_file(),
-        "--inference-mode", "both",
-        "--profiling-mode", "simulate",
-        "--input-len", str(spec["input_len"]),
-        "--output-len", str(spec["output_len"]),
-        "--inference-batch-size", str(spec["concurrency"]),
-        "--max-concurrency", str(spec["concurrency"]),
-        "--weight-dtype", spec["weight_dtype"],
-        "--kv-cache-dtype", spec["kv_cache_dtype"],
-        "--gpu-arch", spec["gpu_arch"],
-        "--hbm-capacity-gb", str(spec["hbm_gb"]),
+        "--config",
+        _workload_file(),
+        "--inference-mode",
+        "both",
+        "--profiling-mode",
+        "simulate",
+        "--input-len",
+        str(spec["input_len"]),
+        "--output-len",
+        str(spec["output_len"]),
+        "--inference-batch-size",
+        str(spec["concurrency"]),
+        "--max-concurrency",
+        str(spec["concurrency"]),
+        "--weight-dtype",
+        spec["weight_dtype"],
+        "--kv-cache-dtype",
+        spec["kv_cache_dtype"],
+        "--gpu-arch",
+        spec["gpu_arch"],
+        "--hbm-capacity-gb",
+        str(spec["hbm_gb"]),
     ]
     for flag, key in (
         ("--sliding-window", "sliding_window"),
@@ -112,17 +123,25 @@ def project_spec(**overrides):
     if spec.get("disaggregate"):
         argv += [
             "--disaggregate",
-            "--prefill-tp", str(spec.get("prefill_tp", spec["tp"])),
-            "--prefill-ep", str(spec.get("prefill_ep", spec["ep"])),
-            "--decode-tp", str(spec["tp"]),
-            "--decode-ep", str(spec["ep"]),
-            "--prefill-replicas", str(spec.get("prefill_replicas", 1)),
-            "--decode-replicas", str(spec.get("decode_replicas", 1)),
+            "--prefill-tp",
+            str(spec.get("prefill_tp", spec["tp"])),
+            "--prefill-ep",
+            str(spec.get("prefill_ep", spec["ep"])),
+            "--decode-tp",
+            str(spec["tp"]),
+            "--decode-ep",
+            str(spec["ep"]),
+            "--prefill-replicas",
+            str(spec.get("prefill_replicas", 1)),
+            "--decode-replicas",
+            str(spec.get("decode_replicas", 1)),
         ]
         if spec.get("attn_dp"):
             argv += [
-                "--prefill-attention-dp", str(spec.get("prefill_tp", spec["tp"])),
-                "--decode-attention-dp", str(spec["tp"]),
+                "--prefill-attention-dp",
+                str(spec.get("prefill_tp", spec["tp"])),
+                "--decode-attention-dp",
+                str(spec["tp"]),
             ]
     if spec.get("enable_deepep"):
         argv += ["--enable-deepep"]
@@ -150,7 +169,7 @@ def project_spec(**overrides):
     mc = getattr(cfg, "model_config", None)
     req = getattr(cfg, "request_config", None)
     extras = dict(getattr(perf, "extras", {}) or {})
-    gib = 1024.0 ** 3
+    gib = 1024.0**3
     return {
         "sliding_window": req.resolved_sliding_window(getattr(mc, "sink_sliding_window", 0)),
         "shared_expert_size": getattr(mc, "moe_shared_expert_intermediate_size", None),

--- a/tests/unit/projection/test_anchor_reuse.py
+++ b/tests/unit/projection/test_anchor_reuse.py
@@ -78,10 +78,12 @@ def test_turning_off_one_aiter_kernel_is_a_different_regime():
 def test_two_different_kernel_swaps_do_not_share_an_anchor():
     """Turning off MHA and turning off MoE are not the same measurement."""
     env = {"VLLM_ROCM_USE_AITER": "1"}
-    a = recipe_from_meta({"model": "m",
-                          "aiter_ops": aiter_ops_axis(dict(env, VLLM_ROCM_USE_AITER_MHA="0"))})
-    b = recipe_from_meta({"model": "m",
-                          "aiter_ops": aiter_ops_axis(dict(env, VLLM_ROCM_USE_AITER_MOE="0"))})
+    a = recipe_from_meta(
+        {"model": "m", "aiter_ops": aiter_ops_axis(dict(env, VLLM_ROCM_USE_AITER_MHA="0"))}
+    )
+    b = recipe_from_meta(
+        {"model": "m", "aiter_ops": aiter_ops_axis(dict(env, VLLM_ROCM_USE_AITER_MOE="0"))}
+    )
     assert regime_distance(a, b) >= 1
 
 
@@ -272,9 +274,7 @@ def test_a_directory_of_measurements_is_not_empty_just_because_nobody_indexed_it
         (16, 1, "tp4.json"),
     ],
 )
-def test_anchor_tp_policy_uses_tp4_at_four_and_above(
-    tmp_path, target_tp, target_ep, expected
-):
+def test_anchor_tp_policy_uses_tp4_at_four_and_above(tmp_path, target_tp, target_ep, expected):
     _artifact(tmp_path, "tp1.json", tp=1)
     _artifact(tmp_path, "tp2.json", tp=2)
     _artifact(tmp_path, "tp2ep2.json", tp=2, ep=2)
@@ -282,9 +282,7 @@ def test_anchor_tp_policy_uses_tp4_at_four_and_above(
     _artifact(tmp_path, "tp8.json", tp=8)
 
     store = AnchorStore(str(tmp_path))
-    entry, distance = store.nearest(
-        {"tp": target_tp, "ep": target_ep, "weight_dtype": "mxfp4"}
-    )
+    entry, distance = store.nearest({"tp": target_tp, "ep": target_ep, "weight_dtype": "mxfp4"})
 
     assert distance == 0
     assert os.path.basename(entry["path"]) == expected

--- a/tests/unit/projection/test_bench_lever_passthrough.py
+++ b/tests/unit/projection/test_bench_lever_passthrough.py
@@ -28,10 +28,20 @@ from infera.projection.core.projection.inference_projection.search.regime import
 
 def bench_args(**over):
     defaults = dict(
-        model="openai/gpt-oss-120b", tp=8, pp=1, enable_expert_parallel=False,
-        quantization=None, kv_cache_dtype=None, enforce_eager=False,
-        num_hidden_layers=None, batch=32, input_len=1024, output_len=1024,
-        speculative_method=None, speculative_num_tokens=None, no_aiter=False,
+        model="openai/gpt-oss-120b",
+        tp=8,
+        pp=1,
+        enable_expert_parallel=False,
+        quantization=None,
+        kv_cache_dtype=None,
+        enforce_eager=False,
+        num_hidden_layers=None,
+        batch=32,
+        input_len=1024,
+        output_len=1024,
+        speculative_method=None,
+        speculative_num_tokens=None,
+        no_aiter=False,
         attention_backend=None,
     )
     defaults.update(over)
@@ -39,6 +49,7 @@ def bench_args(**over):
 
 
 # --- the levers reach the engine -------------------------------------------
+
 
 def test_empty_server_args_change_nothing():
     assert benchmark_vllm._engine_kwargs_from_server_args("") == {}
@@ -86,12 +97,15 @@ def test_aiter_defaults_on_when_unset(monkeypatch):
 
 # --- two runs under different levers stay distinguishable -------------------
 
+
 def test_attention_backend_is_part_of_the_regime():
     """An anchor measured on one attention backend cannot serve another."""
     triton = recipe_from_bench_args(
-        bench_args(attention_backend="TRITON_ATTN"), {"VLLM_ROCM_USE_AITER": "1"})
+        bench_args(attention_backend="TRITON_ATTN"), {"VLLM_ROCM_USE_AITER": "1"}
+    )
     default = recipe_from_bench_args(
-        bench_args(attention_backend="ROCM_AITER_FA"), {"VLLM_ROCM_USE_AITER": "1"})
+        bench_args(attention_backend="ROCM_AITER_FA"), {"VLLM_ROCM_USE_AITER": "1"}
+    )
     assert triton["attention_backend"] == "TRITON_ATTN"
     assert regime_distance(triton, default) == 1
     assert regime_signature(triton) != regime_signature(default)
@@ -124,27 +138,59 @@ def test_cache_key_separates_runs_made_under_different_levers(monkeypatch):
     """Two variants must not collide in the result cache and replay each other."""
     monkeypatch.setenv("VLLM_ROCM_USE_AITER", "1")
     monkeypatch.delenv("VLLM_ATTENTION_BACKEND", raising=False)
-    common = dict(decode_steps=1024, batches="32", bench_layers=None, full_layers=None,
-                  benchmark_gpus=1, random_tokens=False, vocab=30000, gpu_mem_util=0.9,
-                  routing_dist="none", zipf_s=1.0, moe_imbalance=None, load_format="auto",
-                  skip_tokenizer_init=False, max_model_len=None, seed=0, seeds="0,1,2",
-                  concurrency=None, decode_context_grid=None)
+    common = dict(
+        decode_steps=1024,
+        batches="32",
+        bench_layers=None,
+        full_layers=None,
+        benchmark_gpus=1,
+        random_tokens=False,
+        vocab=30000,
+        gpu_mem_util=0.9,
+        routing_dist="none",
+        zipf_s=1.0,
+        moe_imbalance=None,
+        load_format="auto",
+        skip_tokenizer_init=False,
+        max_model_len=None,
+        seed=0,
+        seeds="0,1,2",
+        concurrency=None,
+        decode_context_grid=None,
+    )
     a = benchmark_vllm._cache_key(bench_args(server_args="--max-num-seqs 512", env=[], **common))
     b = benchmark_vllm._cache_key(bench_args(server_args="--max-num-seqs 256", env=[], **common))
     c = benchmark_vllm._cache_key(
-        bench_args(server_args="--max-num-seqs 512",
-                   env=["VLLM_ROCM_USE_AITER_MOE=0"], **common))
+        bench_args(server_args="--max-num-seqs 512", env=["VLLM_ROCM_USE_AITER_MOE=0"], **common)
+    )
     assert len({a, b, c}) == 3
 
 
 @pytest.mark.parametrize("server_args", ["", "--max-num-seqs 512"])
 def test_cache_key_is_stable_for_one_config(monkeypatch, server_args):
     monkeypatch.setenv("VLLM_ROCM_USE_AITER", "1")
-    common = dict(decode_steps=1024, batches="32", bench_layers=None, full_layers=None,
-                  benchmark_gpus=1, random_tokens=False, vocab=30000, gpu_mem_util=0.9,
-                  routing_dist="none", zipf_s=1.0, moe_imbalance=None, load_format="auto",
-                  skip_tokenizer_init=False, max_model_len=None, seed=0, seeds="0,1,2",
-                  concurrency=None, decode_context_grid=None, server_args=server_args,
-                  env=["A=1", "B=2"])
-    assert benchmark_vllm._cache_key(bench_args(**common)) == \
-        benchmark_vllm._cache_key(bench_args(**common))
+    common = dict(
+        decode_steps=1024,
+        batches="32",
+        bench_layers=None,
+        full_layers=None,
+        benchmark_gpus=1,
+        random_tokens=False,
+        vocab=30000,
+        gpu_mem_util=0.9,
+        routing_dist="none",
+        zipf_s=1.0,
+        moe_imbalance=None,
+        load_format="auto",
+        skip_tokenizer_init=False,
+        max_model_len=None,
+        seed=0,
+        seeds="0,1,2",
+        concurrency=None,
+        decode_context_grid=None,
+        server_args=server_args,
+        env=["A=1", "B=2"],
+    )
+    assert benchmark_vllm._cache_key(bench_args(**common)) == benchmark_vllm._cache_key(
+        bench_args(**common)
+    )

--- a/tests/unit/projection/test_benchmark_harvest.py
+++ b/tests/unit/projection/test_benchmark_harvest.py
@@ -22,7 +22,8 @@ from infera.projection.core.projection.inference_projection import benchmark, be
 def _inference_config(concurrency=32, input_len=1024, output_len=128, tp=8, ep=1):
     return SimpleNamespace(
         model_parallel_config=SimpleNamespace(
-            tensor_model_parallel_size=tp, pipeline_model_parallel_size=1,
+            tensor_model_parallel_size=tp,
+            pipeline_model_parallel_size=1,
             expert_model_parallel_size=ep,
         ),
         request_config=SimpleNamespace(
@@ -58,6 +59,7 @@ def _argv_value(argv, flag):
 
 
 # --- the anchor has to cover the axes it will be asked about -----------------
+
 
 def test_benchmark_mode_asks_for_a_swept_anchor_not_a_single_batch(monkeypatch, tmp_path):
     """A one-batch anchor is not a curve, and the projector cannot make it one.

--- a/tests/unit/projection/test_config_sweep.py
+++ b/tests/unit/projection/test_config_sweep.py
@@ -27,11 +27,13 @@ def _pt(**kw):
 
 
 def test_ranking_puts_the_best_config_first():
-    res = SweepResult(points=[
-        _pt(tp=1, decode_tps_per_gpu=100.0),
-        _pt(tp=8, decode_tps_per_gpu=900.0),
-        _pt(tp=4, decode_tps_per_gpu=400.0),
-    ])
+    res = SweepResult(
+        points=[
+            _pt(tp=1, decode_tps_per_gpu=100.0),
+            _pt(tp=8, decode_tps_per_gpu=900.0),
+            _pt(tp=4, decode_tps_per_gpu=400.0),
+        ]
+    )
     assert [p.tp for p in res.ranked()] == [8, 4, 1]
     assert res.shortlist(2)[0].tp == 8
     # Latency is a minimise objective, so the flag has to work both ways.
@@ -41,10 +43,12 @@ def test_ranking_puts_the_best_config_first():
 
 def test_infeasible_points_are_kept_but_never_recommended():
     """A search needs "does not fit" and "was not tried" to be different answers."""
-    res = SweepResult(points=[
-        _pt(tp=1, decode_tps_per_gpu=999.0, feasible=False, reason="needs 900 GB/GPU"),
-        _pt(tp=8, decode_tps_per_gpu=100.0),
-    ])
+    res = SweepResult(
+        points=[
+            _pt(tp=1, decode_tps_per_gpu=999.0, feasible=False, reason="needs 900 GB/GPU"),
+            _pt(tp=8, decode_tps_per_gpu=100.0),
+        ]
+    )
     assert len(res.points) == 2, "infeasible points must survive for auditing"
     assert [p.tp for p in res.feasible] == [8]
     assert [p.tp for p in res.shortlist(5)] == [8], (
@@ -56,7 +60,10 @@ def test_a_failing_config_does_not_abort_the_sweep():
     """One bad point must cost one point, not the whole sweep."""
     res = sweep(
         "gpt_oss_120B",
-        tp=(1,), ep=(1,), pp=(1,), concurrency=(8,),
+        tp=(1,),
+        ep=(1,),
+        pp=(1,),
+        concurrency=(8,),
         workload="/nonexistent/workload.yaml",
     )
     assert res.n_projected == 1
@@ -73,7 +80,10 @@ def test_valid_filter_skips_combinations_before_projecting_them():
 
     res = sweep(
         "gpt_oss_120B",
-        tp=(1, 2), ep=(1, 2), pp=(1,), concurrency=(8,),
+        tp=(1, 2),
+        ep=(1, 2),
+        pp=(1,),
+        concurrency=(8,),
         valid=valid,
     )
     assert res.n_projected == 0, "filtered combinations must not be projected"

--- a/tests/unit/projection/test_decode_physics.py
+++ b/tests/unit/projection/test_decode_physics.py
@@ -15,13 +15,14 @@ from __future__ import annotations
 
 import pytest
 
-from .conftest import DEFAULTS, project_spec
+from .conftest import DEFAULTS, project_spec, requires_origami
 
 # MI355X: HBM3E, 8 TB/s peak. Nothing that streams bytes may imply more.
 _MI355X_HBM_TBPS = 8.0
 
 
 def _sdpa(**kw):
+    requires_origami()  # SDPASimulator raises in its constructor without it
     from infera.projection.core.projection.simulation_backends.sdpa_simulator import (
         SDPASimulator,
     )
@@ -514,13 +515,12 @@ def test_expert_gemm_keeps_near_ideal_relief_when_sharded(name, k, ffn, experts)
     benchmark artifact: a lone [1 x k] x [k x n] call is latency-bound and reads
     ~10% of peak, which is not the kernel MoE decode actually issues.
     """
+    requires_origami()
     from infera.projection.core.projection.simulation_backends.origami_backend import (
         OrigamiGEMMBackend,
     )
 
     backend = OrigamiGEMMBackend(gpu_arch="mi355x")
-    if not backend.is_available():
-        pytest.skip("origami not installed")
 
     def t(etp):
         return backend.simulate_gemm(

--- a/tests/unit/projection/test_decode_physics.py
+++ b/tests/unit/projection/test_decode_physics.py
@@ -36,8 +36,16 @@ def test_sdpa_prefill_grows_with_kv_length():
     left Origami saturating, so 9k tokens attending 8k and 9k attending 122k
     came out within 50% of each other. FLOPs grew 15x; time has to as well.
     """
-    common = dict(batch_size=1, num_heads=16, seq_len=2048, head_dim=128,
-                  causal=True, dtype="bf16", num_heads_kv=16, head_dim_v=128)
+    common = dict(
+        batch_size=1,
+        num_heads=16,
+        seq_len=2048,
+        head_dim=128,
+        causal=True,
+        dtype="bf16",
+        num_heads_kv=16,
+        head_dim_v=128,
+    )
     short = _sdpa(**common, seq_len_kv=2048)
     long = _sdpa(**common, seq_len_kv=32768)
     assert long.forward_time_ms > 4.0 * short.forward_time_ms, (
@@ -48,8 +56,16 @@ def test_sdpa_prefill_grows_with_kv_length():
 
 def test_sdpa_cached_prefill_is_not_half_masked():
     """Causal masking does not apply to the cached prefix a suffix attends over."""
-    common = dict(batch_size=1, num_heads=8, seq_len=2048, head_dim=64,
-                  dtype="bf16", seq_len_kv=16384, num_heads_kv=8, head_dim_v=64)
+    common = dict(
+        batch_size=1,
+        num_heads=8,
+        seq_len=2048,
+        head_dim=64,
+        dtype="bf16",
+        seq_len_kv=16384,
+        num_heads_kv=8,
+        head_dim_v=64,
+    )
     causal = _sdpa(**common, causal=True)
     full = _sdpa(**common, causal=False)
     # Prefix is 7/8 of KV, so the causal discount on the suffix block is ~6%,
@@ -69,9 +85,15 @@ def test_sdpa_decode_cannot_beat_hbm_bandwidth():
     """
     batch, kv_len, kv_heads, head_dim = 256, 1536, 8, 64
     res = _sdpa(
-        batch_size=batch, num_heads=64, seq_len=1, head_dim=head_dim,
-        causal=False, dtype="bf16", seq_len_kv=kv_len,
-        num_heads_kv=kv_heads, head_dim_v=head_dim,
+        batch_size=batch,
+        num_heads=64,
+        seq_len=1,
+        head_dim=head_dim,
+        causal=False,
+        dtype="bf16",
+        seq_len_kv=kv_len,
+        num_heads_kv=kv_heads,
+        head_dim_v=head_dim,
     )
     kv_bytes = batch * kv_heads * kv_len * (head_dim * 2) * 2  # K and V, bf16
     implied_tbps = kv_bytes / (res.forward_time_ms * 1e-3) / 1e12
@@ -88,9 +110,17 @@ def test_mla_kv_is_a_shared_latent_not_per_head():
     from head counts overstated it ~9x and put DeepSeek TPOT +114% at
     concurrency 256.
     """
-    common = dict(batch_size=128, num_heads=16, seq_len=1, head_dim=192,
-                  causal=False, dtype="bf16", seq_len_kv=2048,
-                  num_heads_kv=16, head_dim_v=128)
+    common = dict(
+        batch_size=128,
+        num_heads=16,
+        seq_len=1,
+        head_dim=192,
+        causal=False,
+        dtype="bf16",
+        seq_len_kv=2048,
+        num_heads_kv=16,
+        head_dim_v=128,
+    )
     per_head = _sdpa(**common)
     latent = _sdpa(**common, kv_bytes_per_token=(512 + 64) * 1.0)
     assert latent.forward_time_ms < per_head.forward_time_ms, (
@@ -122,7 +152,8 @@ def test_kernel_occupancy_is_additive_and_survives_graph_capture():
     from infera.projection.core.projection.training_config import InferenceRequestConfig
 
     req = InferenceRequestConfig(
-        decode_kernel_occupancy_us=6.0, kernels_per_layer=12,
+        decode_kernel_occupancy_us=6.0,
+        kernels_per_layer=12,
         cudagraph_mode="full",
     )
     occ = req.resolved_decode_occupancy_ms(num_layers=36)
@@ -132,7 +163,9 @@ def test_kernel_occupancy_is_additive_and_survives_graph_capture():
     # And the launch-latency floor, which models host dispatch, must still be
     # cancelled by capture -- the two terms are not the same thing.
     launch = InferenceRequestConfig(
-        kernel_launch_latency_us=6.0, kernels_per_layer=12, cudagraph_mode="full",
+        kernel_launch_latency_us=6.0,
+        kernels_per_layer=12,
+        cudagraph_mode="full",
     ).resolved_kernel_launch_floor_ms(num_layers=36)
     assert launch == 0.0
 
@@ -265,18 +298,18 @@ def test_a_layer_costs_the_kernels_it_actually_runs():
         decode_kernels_per_layer,
     )
 
-    gpt_oss = SimpleNamespace(num_experts=128, multi_latent_attention=False,
-                              moe_shared_expert_intermediate_size=None)
-    deepseek = SimpleNamespace(num_experts=256, multi_latent_attention=True,
-                               moe_shared_expert_intermediate_size=2048)
-    dense = SimpleNamespace(num_experts=0, multi_latent_attention=False,
-                            moe_shared_expert_intermediate_size=None)
-
-    n_gpt, n_ds, n_dense = (decode_kernels_per_layer(m)
-                            for m in (gpt_oss, deepseek, dense))
-    assert n_dense < n_gpt < n_ds, (
-        "a dense layer runs fewest, MLA plus a shared expert the most"
+    gpt_oss = SimpleNamespace(
+        num_experts=128, multi_latent_attention=False, moe_shared_expert_intermediate_size=None
     )
+    deepseek = SimpleNamespace(
+        num_experts=256, multi_latent_attention=True, moe_shared_expert_intermediate_size=2048
+    )
+    dense = SimpleNamespace(
+        num_experts=0, multi_latent_attention=False, moe_shared_expert_intermediate_size=None
+    )
+
+    n_gpt, n_ds, n_dense = (decode_kernels_per_layer(m) for m in (gpt_oss, deepseek, dense))
+    assert n_dense < n_gpt < n_ds, "a dense layer runs fewest, MLA plus a shared expert the most"
     # MLA adds five kernels over fused QKV; a shared expert adds three.
     assert n_ds - n_gpt == 8
 
@@ -299,16 +332,28 @@ def test_a_v4_layer_is_priced_as_latent_attention_despite_the_trainer_flag():
         uses_latent_attention,
     )
 
-    v4 = SimpleNamespace(multi_latent_attention=False, qk_pos_emb_head_dim=64,
-                         num_query_groups=1, num_experts=384,
-                         moe_shared_expert_intermediate_size=3072)
-    v3 = SimpleNamespace(multi_latent_attention=True, qk_pos_emb_head_dim=64,
-                         num_query_groups=1, num_experts=256,
-                         moe_shared_expert_intermediate_size=2048)
+    v4 = SimpleNamespace(
+        multi_latent_attention=False,
+        qk_pos_emb_head_dim=64,
+        num_query_groups=1,
+        num_experts=384,
+        moe_shared_expert_intermediate_size=3072,
+    )
+    v3 = SimpleNamespace(
+        multi_latent_attention=True,
+        qk_pos_emb_head_dim=64,
+        num_query_groups=1,
+        num_experts=256,
+        moe_shared_expert_intermediate_size=2048,
+    )
     # Grouped-query attention: several query groups, no compressed latent.
-    gqa = SimpleNamespace(multi_latent_attention=False, qk_pos_emb_head_dim=0,
-                          num_query_groups=8, num_experts=128,
-                          moe_shared_expert_intermediate_size=3072)
+    gqa = SimpleNamespace(
+        multi_latent_attention=False,
+        qk_pos_emb_head_dim=0,
+        num_query_groups=8,
+        num_experts=128,
+        moe_shared_expert_intermediate_size=3072,
+    )
 
     assert uses_latent_attention(v4), "V4 serves latent attention"
     assert uses_latent_attention(v3), "the flag alone is still sufficient"
@@ -333,9 +378,14 @@ def test_the_v4_latent_shape_prices_the_cache_and_the_step_the_same_way():
         uses_latent_attention,
     )
 
-    v4 = SimpleNamespace(multi_latent_attention=False, qk_pos_emb_head_dim=64,
-                         num_query_groups=1, kv_channels=512,
-                         num_attention_heads=128, group_query_attention=True)
+    v4 = SimpleNamespace(
+        multi_latent_attention=False,
+        qk_pos_emb_head_dim=64,
+        num_query_groups=1,
+        kv_channels=512,
+        num_attention_heads=128,
+        group_query_attention=True,
+    )
     assert uses_latent_attention(v4)
     assert kv_cache.uses_latent_attention is uses_latent_attention, (
         "the cache must share the predicate, not keep its own copy"
@@ -360,8 +410,9 @@ def test_the_step_floor_still_comes_out_where_it_was_measured():
         decode_kernels_per_layer,
     )
 
-    gpt_oss = SimpleNamespace(num_experts=128, multi_latent_attention=False,
-                              moe_shared_expert_intermediate_size=None)
+    gpt_oss = SimpleNamespace(
+        num_experts=128, multi_latent_attention=False, moe_shared_expert_intermediate_size=None
+    )
     assert 36 * decode_kernels_per_layer(gpt_oss) + 6 == 546
 
     floor = InferenceRequestConfig(

--- a/tests/unit/projection/test_des_prefix_cache.py
+++ b/tests/unit/projection/test_des_prefix_cache.py
@@ -39,8 +39,7 @@ class _Cfg:
 def _seed(hit: float, prompt_len: int = 130000, n: int = 8):
     """Run the seeding block the way ``simulate_once`` does, in isolation."""
     pending = [
-        des_mod._Req(idx=i, arrival_ms=0.0, prompt_len=prompt_len, output_len=900)
-        for i in range(n)
+        des_mod._Req(idx=i, arrival_ms=0.0, prompt_len=prompt_len, output_len=900) for i in range(n)
     ]
     cfg = _Cfg(request_config=_Req(input_seq_len=prompt_len, hit=hit))
     h = cfg.request_config.resolved_prefix_cache_hit_rate()

--- a/tests/unit/projection/test_expert_parallel_comm.py
+++ b/tests/unit/projection/test_expert_parallel_comm.py
@@ -52,9 +52,7 @@ def _a2a_ms(tp, ep, tokens=TOKENS):
         context_model_parallel_size = 1
         attention_data_parallel_size = 1
 
-    model = InferenceCollectiveModel(
-        _Model(), _Parallel(), InferenceCollectiveConfig(enabled=True)
-    )
+    model = InferenceCollectiveModel(_Model(), _Parallel(), InferenceCollectiveConfig(enabled=True))
     return model.ep_a2a_ms(1, tokens)
 
 

--- a/tests/unit/projection/test_expert_parallel_cost.py
+++ b/tests/unit/projection/test_expert_parallel_cost.py
@@ -121,8 +121,7 @@ def test_wider_expert_parallelism_moves_bytes_faster():
     )
 
     msg = 4 * 1024 * 1024
-    assert (_measured_intra_node_a2a_us(msg, 8)
-            < _measured_intra_node_a2a_us(msg, 2))
+    assert _measured_intra_node_a2a_us(msg, 8) < _measured_intra_node_a2a_us(msg, 2)
 
 
 def test_decode_step_stays_smooth_across_the_batch_axis():

--- a/tests/unit/projection/test_inference_memory.py
+++ b/tests/unit/projection/test_inference_memory.py
@@ -17,13 +17,15 @@ import pytest
 
 from infera.projection.core.projection.training_config import dtype_num_bytes
 
-GIB = 1024.0 ** 3
+from .conftest import project_spec as _project
+
+GIB = 1024.0**3
 
 
 @pytest.mark.parametrize(
     "dtype, expected",
     [
-        ("mxfp4", 0.53125),   # 4 bits + one E8M0 scale byte per 32 elements
+        ("mxfp4", 0.53125),  # 4 bits + one E8M0 scale byte per 32 elements
         ("mxfp8", 1.03125),
         ("fp8", 1.0),
         ("bf16", 2.0),
@@ -36,9 +38,6 @@ def test_block_scaled_dtypes_are_not_silently_bf16(dtype, expected):
 def test_mxfp4_is_a_quarter_of_bf16():
     """The whole point of the format; a fallback to 2.0 would hide 4x of HBM."""
     assert dtype_num_bytes("mxfp4") < dtype_num_bytes("bf16") / 3.5
-
-
-from .conftest import project_spec as _project
 
 
 def test_weights_are_tp_sharded_across_ranks():
@@ -88,12 +87,17 @@ def test_deepseek_v4_kv_is_the_576_byte_shared_latent():
 
     cfg = SimpleNamespace(
         model_config=SimpleNamespace(
-            multi_latent_attention=False, kv_lora_rank=0, qk_pos_emb_head_dim=64,
-            group_query_attention=True, num_query_groups=1, num_attention_heads=128,
+            multi_latent_attention=False,
+            kv_lora_rank=0,
+            qk_pos_emb_head_dim=64,
+            group_query_attention=True,
+            num_query_groups=1,
+            num_attention_heads=128,
             kv_channels=512,
         ),
         model_parallel_config=SimpleNamespace(
-            tensor_model_parallel_size=8, attention_data_parallel_size=1,
+            tensor_model_parallel_size=8,
+            attention_data_parallel_size=1,
         ),
         request_config=SimpleNamespace(kv_cache_dtype="fp8"),
     )
@@ -109,8 +113,14 @@ def test_disagg_kv_is_split_across_decode_replicas():
     the 288 GB ceiling by a replica-count.
     """
     common = dict(
-        disaggregate=True, prefill_tp=4, tp=8, ep=1,
-        prefill_replicas=1, concurrency=256, input_len=1024, output_len=128,
+        disaggregate=True,
+        prefill_tp=4,
+        tp=8,
+        ep=1,
+        prefill_replicas=1,
+        concurrency=256,
+        input_len=1024,
+        output_len=128,
         max_num_batched_tokens=8192,
     )
     one = _project(**common, decode_replicas=1)

--- a/tests/unit/projection/test_kv_cache_dtype_effect.py
+++ b/tests/unit/projection/test_kv_cache_dtype_effect.py
@@ -49,6 +49,7 @@ def test_the_saving_grows_with_context():
     model that applied a flat discount would pass the test above and fail this
     one.
     """
+
     def saving(ctx: int) -> float:
         bf16 = _tpot("bf16", ctx)
         return (bf16 - _tpot("fp8", ctx)) / bf16 * 100.0
@@ -81,7 +82,11 @@ def test_bf16_is_the_default_when_unset(ctx: int):
     """
     explicit = _tpot("bf16", ctx)
     implicit = project_spec(
-        model="gpt_oss_120B", concurrency=64, input_len=ctx, output_len=1024,
-        weight_dtype="mxfp4", tp=8,
+        model="gpt_oss_120B",
+        concurrency=64,
+        input_len=ctx,
+        output_len=1024,
+        weight_dtype="mxfp4",
+        tp=8,
     )["tpot_ms"]
     assert implicit == pytest.approx(explicit, rel=1e-9)

--- a/tests/unit/projection/test_linear_attention.py
+++ b/tests/unit/projection/test_linear_attention.py
@@ -66,9 +66,7 @@ def test_linear_blend_at_long_context_is_the_mla_fraction():
     blended = mc.blend_linear_attn_kv(kv)
     expected = (69 * 128 + 24 * kv) / 93
     assert blended == pytest.approx(expected, rel=1e-3)
-    assert blended < 0.30 * kv, (
-        f"blended KV {blended} is not the MLA-layer fraction of {kv}"
-    )
+    assert blended < 0.30 * kv, f"blended KV {blended} is not the MLA-layer fraction of {kv}"
 
 
 def test_linear_blend_is_a_no_op_without_kda_layers():
@@ -92,9 +90,7 @@ def test_kimi_token_kv_is_only_the_mla_layers():
     # Recurrent state is bf16, TP-sharded heads: 69 layers × 12 heads × d×d,
     # plus the short-conv leftover of (kernel-1) tokens.
     d, heads_on_rank, kernel = 128, 96 // 8, 4
-    state_bytes = 69 * heads_on_rank * (
-        d * d + d * (kernel - 1)
-    ) * 2 * conc
+    state_bytes = 69 * heads_on_rank * (d * d + d * (kernel - 1)) * 2 * conc
     assert kv.bytes_total == pytest.approx(token_bytes + state_bytes, rel=1e-6)
     all_mla = 93 * latent * ctx * conc
     assert kv.bytes_total < 0.35 * all_mla
@@ -114,8 +110,8 @@ def test_kimi_yaml_keys_reach_the_projection():
     )
     ctx = 65536 + 8
     latent = 512 + 64
-    mla_only_gb = 24 * latent * ctx * 8 / (1024.0 ** 3)
-    all_mla_gb = 93 * latent * ctx * 8 / (1024.0 ** 3)
+    mla_only_gb = 24 * latent * ctx * 8 / (1024.0**3)
+    all_mla_gb = 93 * latent * ctx * 8 / (1024.0**3)
     assert kimi["kv_cache_gb"] < 0.40 * all_mla_gb, (
         f"Kimi KV {kimi['kv_cache_gb']:.2f} GB looks like 93-layer MLA "
         f"({all_mla_gb:.2f} GB), so the linear_attention_* keys were dropped"
@@ -131,8 +127,13 @@ def test_kimi_prefill_does_not_grow_as_dense_mla():
     not by the ~8x of a full-context prefill of 64k vs 8k.
     """
     common = dict(
-        model="kimi_k3", tp=8, ep=8, concurrency=1, output_len=8,
-        weight_dtype="mxfp4", kv_cache_dtype="fp8",
+        model="kimi_k3",
+        tp=8,
+        ep=8,
+        concurrency=1,
+        output_len=8,
+        weight_dtype="mxfp4",
+        kv_cache_dtype="fp8",
     )
     short = project_spec(**common, input_len=8192, prefix_cache_hit_rate=0.0)
     # 65536 * (1 - 0.875) = 8192 new tokens attending 64k.

--- a/tests/unit/projection/test_serving_anchor.py
+++ b/tests/unit/projection/test_serving_anchor.py
@@ -36,10 +36,16 @@ Using 'TRITON' Mxfp4 MoE backend
 
 
 def spec(**over) -> Namespace:
-    base = dict(model="openai/gpt-oss-120b", serving_backend="vllm",
-                max_model_len=8192, enable_expert_parallel=False,
-                enforce_eager=False, quantization=None, kv_cache_dtype=None,
-                server_args="")
+    base = dict(
+        model="openai/gpt-oss-120b",
+        serving_backend="vllm",
+        max_model_len=8192,
+        enable_expert_parallel=False,
+        enforce_eager=False,
+        quantization=None,
+        kv_cache_dtype=None,
+        server_args="",
+    )
     base.update(over)
     return Namespace(**base)
 
@@ -63,13 +69,15 @@ def test_kernels_are_absent_rather_than_wrong_for_another_engine():
     }
 
 
-@pytest.mark.parametrize("backend, model_flag, tp_flag, http_flag", [
-    ("vllm", None, "--tensor-parallel-size", "--port"),
-    ("sglang", "--model-path", "--tp", "--port"),
-    ("atom", "--model", "--tensor-parallel-size", "--server-port"),
-])
-def test_each_engine_is_launched_the_way_it_expects(backend, model_flag, tp_flag,
-                                                    http_flag):
+@pytest.mark.parametrize(
+    "backend, model_flag, tp_flag, http_flag",
+    [
+        ("vllm", None, "--tensor-parallel-size", "--port"),
+        ("sglang", "--model-path", "--tp", "--port"),
+        ("atom", "--model", "--tensor-parallel-size", "--server-port"),
+    ],
+)
+def test_each_engine_is_launched_the_way_it_expects(backend, model_flag, tp_flag, http_flag):
     argv = _engine_argv(spec(serving_backend=backend), port=8123, tp=4)
     if model_flag is None:
         assert argv[0] == "openai/gpt-oss-120b"  # vLLM takes the model positionally
@@ -89,13 +97,11 @@ def test_atom_keeps_its_rendezvous_port_off_the_http_port():
 def test_the_context_length_flag_follows_the_engine():
     """The same intent, spelled differently by each engine."""
     assert "--max-model-len" in _engine_argv(spec(), port=1, tp=1)
-    assert "--context-length" in _engine_argv(spec(serving_backend="sglang"),
-                                              port=1, tp=1)
+    assert "--context-length" in _engine_argv(spec(serving_backend="sglang"), port=1, tp=1)
 
 
 def test_caller_server_args_always_win_by_coming_last():
-    argv = _engine_argv(spec(server_args="--gpu-memory-utilization 0.85"),
-                        port=1, tp=1)
+    argv = _engine_argv(spec(server_args="--gpu-memory-utilization 0.85"), port=1, tp=1)
     assert argv[-2:] == ["--gpu-memory-utilization", "0.85"]
 
 
@@ -103,6 +109,7 @@ def test_caller_server_args_always_win_by_coming_last():
 # A served point costs a whole client run, so which batches a launch sweeps is
 # the difference between an anchor that answers off its measured point and one
 # that does not.
+
 
 def _sweep_batches(monkeypatch, **over):
     """Run the serving anchor with the engine and load generator stubbed."""
@@ -120,12 +127,22 @@ def _sweep_batches(monkeypatch, **over):
     # are about which batches get measured, not about what is installed.
     monkeypatch.setattr(benchmark_serving.shutil, "which", lambda _: "/usr/bin/vllm")
     monkeypatch.setattr(
-        benchmark_serving, "_measure_concurrency",
+        benchmark_serving,
+        "_measure_concurrency",
         lambda port, batch, args, out_dir: measured.append(batch) or float(batch),
     )
-    fields = dict(tp=8, pp=1, benchmark_gpus=4, batch=16, batches=None,
-                  concurrency=None, input_len=1024, output_len=128, env=[],
-                  quantization="mxfp4")
+    fields = dict(
+        tp=8,
+        pp=1,
+        benchmark_gpus=4,
+        batch=16,
+        batches=None,
+        concurrency=None,
+        input_len=1024,
+        output_len=128,
+        env=[],
+        quantization="mxfp4",
+    )
     fields.update(over)
     return measured, benchmark_serving.run_serving_benchmark(spec(**fields))
 
@@ -179,24 +196,30 @@ def test_benchmark_mode_can_choose_the_engine_that_can_load_the_model():
 
     cfg = SimpleNamespace(
         model_parallel_config=SimpleNamespace(
-            tensor_model_parallel_size=2, expert_model_parallel_size=1,
-            pipeline_model_parallel_size=1),
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+        ),
         request_config=SimpleNamespace(
-            input_seq_len=1024, output_seq_len=128, max_concurrency=32,
-            batch_size=32),
+            input_seq_len=1024, output_seq_len=128, max_concurrency=32, batch_size=32
+        ),
     )
 
     def argv_for(**over):
-        args = Namespace(bench_model="deepseek-ai/DeepSeek-V4-Flash",
-                         save_benchmark="/tmp/anchor.json",
-                         benchmark_gpus=None, **over)
+        args = Namespace(
+            bench_model="deepseek-ai/DeepSeek-V4-Flash",
+            save_benchmark="/tmp/anchor.json",
+            benchmark_gpus=None,
+            **over,
+        )
         seen = {}
-        with mock.patch.object(benchmark, "json") as js, \
-                mock.patch("builtins.open", mock.mock_open(read_data="{}")):
+        with (
+            mock.patch.object(benchmark, "json") as js,
+            mock.patch("builtins.open", mock.mock_open(read_data="{}")),
+        ):
             js.load.return_value = {}
             with mock.patch(
-                "infera.projection.core.projection.inference_projection"
-                ".benchmark_vllm.main",
+                "infera.projection.core.projection.inference_projection.benchmark_vllm.main",
                 side_effect=lambda argv: seen.setdefault("argv", argv),
             ):
                 benchmark.spawn_inference_benchmark(args, cfg)

--- a/tests/unit/projection/test_serving_latency_model.py
+++ b/tests/unit/projection/test_serving_latency_model.py
@@ -64,9 +64,17 @@ def test_disagg_ttft_is_batched_prefill_not_a_fifo_of_singles():
     """
     from .conftest import project_spec
 
-    common = dict(disaggregate=True, prefill_tp=4, tp=8, ep=1,
-                  prefill_replicas=1, decode_replicas=1, input_len=1024,
-                  output_len=128, prefix_cache_hit_rate=0.0)
+    common = dict(
+        disaggregate=True,
+        prefill_tp=4,
+        tp=8,
+        ep=1,
+        prefill_replicas=1,
+        decode_replicas=1,
+        input_len=1024,
+        output_len=128,
+        prefix_cache_hit_rate=0.0,
+    )
     one = project_spec(**common, concurrency=1)
     many = project_spec(**common, concurrency=64)
     assert one["ttft_ms"] > 0 and many["ttft_ms"] > 0
@@ -91,9 +99,17 @@ def test_disagg_long_decode_does_not_prefill_every_resident_client():
     """
     from .conftest import project_spec
 
-    common = dict(disaggregate=True, prefill_tp=4, tp=8, ep=1,
-                  prefill_replicas=1, decode_replicas=1, input_len=512,
-                  output_len=2048, prefix_cache_hit_rate=0.0)
+    common = dict(
+        disaggregate=True,
+        prefill_tp=4,
+        tp=8,
+        ep=1,
+        prefill_replicas=1,
+        decode_replicas=1,
+        input_len=512,
+        output_len=2048,
+        prefix_cache_hit_rate=0.0,
+    )
     one = project_spec(**common, concurrency=1)
     many = project_spec(**common, concurrency=64)
     assert one["ttft_ms"] > 0 and many["ttft_ms"] > 0
@@ -108,13 +124,20 @@ def test_disagg_more_prefill_replicas_cut_ttft_under_load():
     """Splitting the same load across more prefill workers must reduce TTFT."""
     from .conftest import project_spec
 
-    common = dict(disaggregate=True, prefill_tp=2, tp=8, ep=1,
-                  decode_replicas=1, input_len=2048, output_len=128,
-                  concurrency=64, prefix_cache_hit_rate=0.0)
+    common = dict(
+        disaggregate=True,
+        prefill_tp=2,
+        tp=8,
+        ep=1,
+        decode_replicas=1,
+        input_len=2048,
+        output_len=128,
+        concurrency=64,
+        prefix_cache_hit_rate=0.0,
+    )
     thin = project_spec(**common, prefill_replicas=1)
     wide = project_spec(**common, prefill_replicas=4)
     assert wide["ttft_ms"] < thin["ttft_ms"], (
         f"4 prefill replicas {wide['ttft_ms']:.1f} ms vs 1 replica "
         f"{thin['ttft_ms']:.1f} ms at the same system concurrency"
     )
-

--- a/tests/unit/projection/test_tuning_attention_dp.py
+++ b/tests/unit/projection/test_tuning_attention_dp.py
@@ -114,13 +114,15 @@ def test_a_draft_model_that_is_never_wrong_and_never_costs_anything_is_rejected(
     a configuration no draft model can implement -- 2.5x the honest number.
     """
     leg = _legality()
-    perfect = _cfg(speculative_num_tokens=4, speculative_acceptance_rate=1.0,
-                   speculative_draft_cost_factor=0.0)
+    perfect = _cfg(
+        speculative_num_tokens=4, speculative_acceptance_rate=1.0, speculative_draft_cost_factor=0.0
+    )
     ok, why = validate_inference(perfect, _Arch(), _Cluster(), leg)
     assert not ok and "acceptance_rate" in why
 
-    free = _cfg(speculative_num_tokens=4, speculative_acceptance_rate=0.7,
-                speculative_draft_cost_factor=0.0)
+    free = _cfg(
+        speculative_num_tokens=4, speculative_acceptance_rate=0.7, speculative_draft_cost_factor=0.0
+    )
     ok, why = validate_inference(free, _Arch(), _Cluster(), leg)
     assert not ok and "draft cost" in why
 
@@ -128,8 +130,9 @@ def test_a_draft_model_that_is_never_wrong_and_never_costs_anything_is_rejected(
 def test_speculation_that_pays_for_itself_is_still_allowed():
     """The axis stays searchable; only the unphysical corner is closed."""
     leg = _legality()
-    cfg = _cfg(speculative_num_tokens=4, speculative_acceptance_rate=0.7,
-               speculative_draft_cost_factor=0.2)
+    cfg = _cfg(
+        speculative_num_tokens=4, speculative_acceptance_rate=0.7, speculative_draft_cost_factor=0.2
+    )
     ok, why = validate_inference(cfg, _Arch(), _Cluster(), leg)
     assert ok, why
 
@@ -144,8 +147,11 @@ def test_accuracy_has_to_be_bought():
     from infera.projection.agents.tuning_agent.inference_tuning import min_draft_cost
 
     leg = _legality()
-    cheap = _cfg(speculative_num_tokens=4, speculative_acceptance_rate=0.95,
-                 speculative_draft_cost_factor=0.10)
+    cheap = _cfg(
+        speculative_num_tokens=4,
+        speculative_acceptance_rate=0.95,
+        speculative_draft_cost_factor=0.10,
+    )
     ok, why = validate_inference(cheap, _Arch(), _Cluster(), leg)
     assert not ok and "too cheap" in why
 

--- a/tests/unit/projection/test_tuning_expert_parallel.py
+++ b/tests/unit/projection/test_tuning_expert_parallel.py
@@ -67,9 +67,7 @@ def test_full_tp_with_full_ep_fits_on_one_node():
 
 def test_expert_parallelism_composes_with_attention_dp_at_full_width():
     """The pairing the measured MLA fleets run has to be expressible."""
-    ok, why = validate_inference(
-        _cfg(ep=8, attention_dp=8), _Arch(), _Cluster(), _legality()
-    )
+    ok, why = validate_inference(_cfg(ep=8, attention_dp=8), _Arch(), _Cluster(), _legality())
     assert ok, why
 
 

--- a/tests/unit/projection/test_tuning_objectives.py
+++ b/tests/unit/projection/test_tuning_objectives.py
@@ -100,16 +100,27 @@ def test_every_catalogued_objective_resolves_to_something_real():
 
 def test_direction_is_right_for_each_objective():
     """Scoring is signed so higher always wins; a sign slip inverts the search."""
-    for obj in ("ttft_ms", "itl_ms", "request_latency_ms", "memory_per_gpu_gb",
-                "kv_cache_gb", "tpot_pollution_pct", "decode_step_ms_pure"):
+    for obj in (
+        "ttft_ms",
+        "itl_ms",
+        "request_latency_ms",
+        "memory_per_gpu_gb",
+        "kv_cache_gb",
+        "tpot_pollution_pct",
+        "decode_step_ms_pure",
+    ):
         assert objective_is_minimize(obj), f"{obj} should be minimized"
-    for obj in ("total_throughput_tps_per_gpu", "decode_throughput_tps_per_gpu",
-                "prefill_throughput_tps_per_gpu", "interactivity_tok_s_per_user",
-                "max_concurrent_sequences", "mfu"):
+    for obj in (
+        "total_throughput_tps_per_gpu",
+        "decode_throughput_tps_per_gpu",
+        "prefill_throughput_tps_per_gpu",
+        "interactivity_tok_s_per_user",
+        "max_concurrent_sequences",
+        "mfu",
+    ):
         assert not objective_is_minimize(obj), f"{obj} should be maximized"
     # Lower latency must score higher.
-    assert score_result({"ttft_ms": 100.0}, "ttft_ms") > \
-           score_result({"ttft_ms": 900.0}, "ttft_ms")
+    assert score_result({"ttft_ms": 100.0}, "ttft_ms") > score_result({"ttft_ms": 900.0}, "ttft_ms")
 
 
 def test_the_names_people_actually_use_reach_the_right_metric():
@@ -131,6 +142,7 @@ def test_what_cannot_be_projected_is_not_offered():
     from infera.projection.agents.tuning_agent.inference_tuning import (
         UNSUPPORTED_OBJECTIVES,
     )
+
     for absent in UNSUPPORTED_OBJECTIVES:
         assert absent not in INFERENCEX_OBJECTIVES
     assert {"avg_power_w", "mfu", "tflops_per_s_per_gpu"} <= UNSUPPORTED_OBJECTIVES

--- a/tests/unit/projection/test_tuning_slo.py
+++ b/tests/unit/projection/test_tuning_slo.py
@@ -48,9 +48,7 @@ def test_tpot_reads_the_projected_itl():
 
 def test_every_missed_budget_is_listed():
     slo = {"ttft_ms": 500, "tpot_ms": 25, "request_latency_ms": 5000}
-    misses = _slo_violations(
-        _result(ttft_ms=820.0, itl_ms=40.0, request_latency_ms=12000.0), slo
-    )
+    misses = _slo_violations(_result(ttft_ms=820.0, itl_ms=40.0, request_latency_ms=12000.0), slo)
     assert len(misses) == 3
 
 

--- a/tests/unit/projection/test_tuning_variable_lengths.py
+++ b/tests/unit/projection/test_tuning_variable_lengths.py
@@ -62,9 +62,7 @@ def test_a_nonsensical_spread_is_rejected_rather_than_clamped():
     """0 means zero-length prompts and >1 means longer than the configured ISL."""
     leg = derive_inference_legality(_Arch(), _Cluster())
     for bad in (0.0, -0.5, 1.5):
-        ok, why = validate_inference(
-            _cfg(des_range_ratio=bad), _Arch(), _Cluster(), leg
-        )
+        ok, why = validate_inference(_cfg(des_range_ratio=bad), _Arch(), _Cluster(), leg)
         assert not ok and "des_range_ratio" in why, bad
 
 

--- a/tests/unit/projection/test_warmup_sizing.py
+++ b/tests/unit/projection/test_warmup_sizing.py
@@ -24,15 +24,15 @@ from infera.projection.core.projection.inference_projection.benchmark_vllm impor
 @pytest.mark.parametrize(
     "tp, ep, expected",
     [
-        (1, 1, 1),    # a single-GPU config is measured on one GPU
+        (1, 1, 1),  # a single-GPU config is measured on one GPU
         (2, 1, 2),
-        (4, 1, 4),    # exactly the cap
+        (4, 1, 4),  # exactly the cap
         # A TP=2 EP=2 target occupies two GPUs in vLLM, where EP follows TP, so
         # the warmup cannot be wider than the thing it is measuring.
         (2, 2, 2),
-        (8, 1, 4),    # beyond the cap: measure on four, project the rest
+        (8, 1, 4),  # beyond the cap: measure on four, project the rest
         (8, 8, 4),
-        (16, 1, 4),   # multi-node targets never enlarge the warmup
+        (16, 1, 4),  # multi-node targets never enlarge the warmup
         (4, 4, 4),
     ],
 )
@@ -43,8 +43,8 @@ def test_a_warmup_never_asks_for_more_than_half_a_node(tp, ep, expected):
 
 def test_tp4_is_the_anchor_for_every_target_at_or_above_four():
     """The calibration anchor is TP4 even when TP4 does not divide target TP."""
-    assert warmup_gpu_count(3, 1) == 3   # below four: keep the target TP
-    assert warmup_gpu_count(6, 1) == 4   # at or above four: always use TP4
+    assert warmup_gpu_count(3, 1) == 3  # below four: keep the target TP
+    assert warmup_gpu_count(6, 1) == 4  # at or above four: always use TP4
     assert warmup_gpu_count(12, 1) == 4
 
 


### PR DESCRIPTION
# Fix flaky `e2e-mixed (vllm)` GLM-5.1-FP8, and unblock CI lint

## Summary

Three things, in dependency order:

1. **`lint` is failing on `main`**, which skips every job gated behind it — `unit`, `rust`, `engine`, `e2e-mixed`, `e2e-disag`. Nothing on `main` is currently being tested.
2. **`test_mixed[GLM-5.1-FP8-tp4]` fails its long-context probe intermittently.** Root-caused to aiter's custom all-reduce being nondeterministic at temperature 0.
3. **The long-context classifier scored corrupt output as passing**, which understated how unhealthy the broken deployment was and pointed the investigation at the wrong layer.

---

## 1. Unblock `lint`

`pre-commit run --all-files` reports **450 ruff findings**, all in `infera/projection/` from #138. 415 are ruff-format/autofix. The 35 that needed a decision:

| Rule | Resolution |
|---|---|
| `B006` ×15 | `groups=["ep"]` mutable defaults → tuples. `groups` is only read (`"cp" in groups`) and forwarded, so this is behaviour-preserving. |
| `B018` ×6 | `caller_frame.f_code.co_name` evaluated and discarded in `logger.py` — dead since the name stopped being formatted into the message. Removed. |
| `B904` ×5 | `raise ... from e` in `rocm_mem_info.py` / `training_config.py`. |
| `E721` ×3 | `field_type == int` → `is int` on a `type()` result. |
| `B023` | `_g` closed over loop variable `r`; hoisted to module-level `_metric()` bound per row with `functools.partial`, so call sites are unchanged. |
| `B024` | `BaseModuleProfiler`'s hooks are deliberately concrete `NotImplementedError` stubs (a profiler implements only the axes it can model). `noqa` + reason. |
| `F401` / `F402` / `E402` | Re-export `__all__`, loop variable shadowing the `field` import, a test import stranded below the module body. |

No behaviour change: `pytest -m "not slow and not integration"` gives an identical **2117 passed / 54 failed / 13 errors** before and after.

---

## 2. Root cause of the GLM-5.1-FP8 flake

The probe returns `4732` instead of `4731`, followed by degenerate output:

```
[e2e correctness] long-context FAILED '4732 1. 1.1.1.1.3.1.0.1.0.1.0.0.'
```

**The probe is not at fault.** In the same CI job, on the byte-identical prompt:

```
gpt-oss-120b     long-context ok '4731 We need to output digits only: 4731. ...'
Kimi-K2.6-MXFP4  long-context ok '4731 I need to find the archive access code ...'
GLM-5.1-FP8-tp4  long-context FAILED '4732 1. 1.1.1.1.3.1.0.1.0.1.0.0.'
```

`4732` appears nowhere in the generated ledger, so it is a hallucinated digit, not a distractor.

### The engine is not deterministic at temperature 0

Byte-identical `/v1/completions` request, sent one at a time, 20×, MI355X (gfx950) tp4:

| Prompt tokens | Distinct outputs | First-token logprob spread |
|---|---|---|
| 1466 | 1 | 0.31 |
| 2020 | 3 | 1.90 |
| 2875 | 3 — `4731`×9 vs `4732`×10 | 1.85 |

The probe's ~2.9k-token ledger sits exactly on that coin flip. The counting and capital probes survive because the correct token still wins by 8–9 nats at their length; past ~1.7k tokens the margin collapses to 0.1–0.4 nats and kernel noise picks the answer.

### What it is not

Retrieval accuracy, 12 requests per point:

| Prompt tokens | fp8 KV + aiter AR | bf16 KV + aiter AR | `index_topk`=9472 + aiter AR | **aiter AR off** |
|---|---|---|---|---|
| 1466 | 12/12 | 12/12 | 12/12 | **12/12** |
| 2020 | 8/12 | 11/12 | 9/12 | **12/12** |
| 2875 | 7/12 | 6/12 | 7/12 | **12/12** |
| 4361 | 6/12 | 9/12 | 10/12 | **12/12** |

- **Not the KV dtype** — bf16 KV collapses identically.
- **Not the DSA lightning indexer** — raising `index_topk` to `--max-model-len`, so the sparse selection keeps everything, changes nothing.
- **Not aiter's fp8 MoE** — with the MoE left on aiter and *only* the all-reduce changed, the case is fully correct. A kernel computing wrong values cannot be rescued by changing how the results are reduced. (Dropping the MoE to Triton *does* mask the symptom by changing the all-reduce workload, but it costs throughput and treats the wrong component.)
- **`VLLM_ROCM_USE_AITER=0` is not an option** — `ROCM_AITER_MLA_SPARSE` is the only attention backend registered for `GlmMoeDsa`, and the server dies in `torch.compile` without aiter.

---

## 3. The fix

```python
"env": {
    "VLLM_USE_V1": "1",
    "VLLM_ROCM_USE_AITER": "1",
    "VLLM_ROCM_USE_AITER_CUSTOM_AR": "0",
    ...
}
```

Selecting `AITER_CUSTOM` out of the tp group hands it to vLLM's own `CUSTOM` backend, which is clean — 12/12 at 2020/2875/4361 tokens, 20/20 identical outputs, `p=1.00` on the answer token (against `p=0.18` with a 0.12-nat top-2 gap before). So **`--disable-custom-all-reduce` is not needed** and is left off rather than giving up a working fast path.

### Validation

Three fresh deployments on MI355X, GPUs 4–7, `vllm/vllm-openai-rocm:v0.25.1`, tp4. Launch args and env are expanded from `matrix.py` itself rather than hand-copied, and the verdict comes from the suite's own `scenarios.assert_correctness` — the same code `test_mixed` calls. **3/3 pass**, with the stricter classifier from item 4 already active:

```
[round 1] long-context ok '4731 4731 1 0 contexQA contexQA_0 You are given a context and a question.'
[round 2] long-context ok '4731 Question: according to the ledger above, how many crates of steel shims ...'
[round 3] long-context ok '4731 Question: according to the ledger above, how many crates of sealed bearings ...'
SUMMARY: 3/3 rounds passed
```

---

## 4. Harness: stop the probe passing on corrupt output

Two holes, both found while chasing the above. Over ten replies from one broken deployment the probe reported **6 correct where only 3 were**.

**A substring test scores `47312` as a hit.** That is a different number, and it is exactly what the degraded engine returned — the loosest reading of the answer was also the one that hid the failure. The code now has to stand alone as a number.

**`looks_garbage()` cannot see this failure.** It looks for replacement chars, emoji and mixed-script noise, but the corrupt output here is pure ASCII, so it read as clean text:

```python
looks_garbage('4732 1.1.1.1.5.1.5.1.1.5.5.1.0.0')   # False
looks_garbage('4731c0b0-2f2c-4b,0,5,0e5-4f4e8f5')   # False, and this one PASSED
```

The share of alphabetic characters separates it cleanly: every coherent reply observed on this prompt (gpt-oss, Kimi-K2.6, a healthy GLM-5.1) sits at 0.60–0.76, every salad at 0.00–0.28.

The threshold is **0.20 — below that band rather than through it**. A correct answer trailing off into digits measures 0.25 and has to keep passing. Scored against the 30 real replies collected during this investigation: **28/30 vs the old 25/30, with zero false rejections**, so it cannot introduce a new CI failure. Some mild salad is let through on purpose — a false failure burns a node reservation and sends someone hunting a bug that is not there.

`looks_degenerate()` is deliberately **not** folded into `looks_garbage()`: the counting probe's reply is legitimately almost all digits, and a shared check would fail every engine on a probe that is working. There is a test for that.

---

## Notes for reviewers

- **This is a workaround.** The aiter custom all-reduce kernel is what needs fixing; worth filing upstream against aiter/ROCm.
- **`GLM-5.2-FP8` carries the same env block at tp8** and will want the same treatment when it is enabled on gfx950.
- **Pre-existing failures, not touched here:** `tests/unit/projection` needs the `origami` package, which no extra in `pyproject.toml` declares (54 failures / 13 errors), and `test_slurm_retry_limit.py` has 1 failure. Both reproduce on `main` with this branch stashed. They have been invisible because `lint` failed first — expect `unit` to start reporting them once this lands.
- **Repro checkpoint** was a local copy of GLM-5.1-FP8 (704 GiB, 142/142 shards verified) rather than the CI fleet's `INFERA_E2E_MODEL_DIR`.

## Checks

- `pre-commit run --all-files`: all Python hooks pass (`trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-added-large-files`, `check-merge-conflict`, `ruff-format`, `ruff-check`).
- `cargo fmt` and `gofmt` skipped locally — no Rust/Go toolchain on the dev host. This branch changes **0 `.rs` and 0 `.go` files**, and both hooks are path-scoped, so CI is the authority on them.
- `pytest tests/unit/e2e_harness/test_correctness_probes.py`: 24 passed.
